### PR TITLE
Add fuzzloch improvements for fuzzing sessions

### DIFF
--- a/capture/Makefile.in
+++ b/capture/Makefile.in
@@ -34,7 +34,7 @@ bindir          = @prefix@/bin
 installinclude  = @prefix@/include
 
 SANITIZE_FLAGS  = -DMOLOCH_USE_MALLOC -fno-common -fsanitize=address -fsanitize=integer -fsanitize=nullability
-FUZZ_FLAGS      = -DMOLOCH_USE_MALLOC -DFUZZLOCH -fno-common -fsanitize=fuzzer,address -fstack-protector-all -fsanitize-address-use-after-scope
+FUZZ_FLAGS      = -DMOLOCH_USE_MALLOC -DFUZZLOCH -O2 -g -fno-common -fsanitize=fuzzer,address -fstack-protector-all -fsanitize-address-use-after-scope
 
 all:thirdparty/js0n.o thirdparty/http_parser.o thirdparty/patricia.o
 	$(CC) -fno-strict-aliasing -pthread -fPIC @CFLAGS@ -Wall -Wextra -D_GNU_SOURCE -std=gnu99 -c $(C_FILES) \
@@ -64,7 +64,7 @@ sanitize:thirdparty/js0n.o thirdparty/http_parser.o thirdparty/patricia.o
 	(cd plugins; $(MAKE) SANITIZE_FLAGS="$(SANITIZE_FLAGS)")
 
 fuzzloch:thirdparty/js0n.o thirdparty/http_parser.o thirdparty/patricia.o
-	$(CC) $(FUZZ_FLAGS) -fno-strict-aliasing -pthread -fPIC -g -O0 -Wall -Wextra -D_GNU_SOURCE -std=gnu99 -c $(C_FILES) \
+	$(CC) $(FUZZ_FLAGS) -fno-strict-aliasing -pthread -fPIC -g -O2 -Wall -Wextra -D_GNU_SOURCE -std=gnu99 -c $(C_FILES) \
 	    $(INCLUDE_PCAP) \
 	    $(INCLUDE_OTHER) \
 	    -DBUILD_VERSION='"$(BUILD_VERSION)"'

--- a/capture/session.c
+++ b/capture/session.c
@@ -54,11 +54,17 @@ typedef struct {
 
 LOCAL MolochSesCmdHead_t   sessionCmds[MOLOCH_MAX_PACKET_THREADS];
 
+#ifdef FUZZLOCH
+extern uint64_t fuzzloch_sessionid;
+#endif
 
 /******************************************************************************/
 void moloch_session_id (char *buf, uint32_t addr1, uint16_t port1, uint32_t addr2, uint16_t port2)
 {
     buf[0] = 13;
+#ifdef FUZZLOCH
+    memcpy(buf+1, &fuzzloch_sessionid, sizeof(fuzzloch_sessionid));
+#else
     if (addr1 < addr2) {
         memcpy(buf+1, &addr1, 4);
         memcpy(buf+5, &port1, 2);
@@ -80,11 +86,15 @@ void moloch_session_id (char *buf, uint32_t addr1, uint16_t port1, uint32_t addr
         memcpy(buf+7, &addr1, 4);
         memcpy(buf+11, &port1, 2);
     }
+#endif
 }
 /******************************************************************************/
 void moloch_session_id6 (char *buf, uint8_t *addr1, uint16_t port1, uint8_t *addr2, uint16_t port2)
 {
     buf[0] = 37;
+#ifdef FUZZLOCH
+    memcpy(buf+1, &fuzzloch_sessionid, sizeof(fuzzloch_sessionid));
+#else
     int cmp = memcmp(addr1, addr2, 16);
     if (cmp < 0) {
         memcpy(buf+1, addr1, 16);
@@ -107,6 +117,7 @@ void moloch_session_id6 (char *buf, uint8_t *addr1, uint16_t port1, uint8_t *add
         memcpy(buf+19, addr1, 16);
         memcpy(buf+35, &port1, 2);
     }
+#endif
 }
 /******************************************************************************/
 char *moloch_session_id_string (char *sessionId, char *buf)


### PR DESCRIPTION
This patch adds improvements to "fuzzloch" that let it fuzz multiple packets in the same session.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
