### PR TITLE
Arch linux installer support

### DIFF
--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -109,7 +109,19 @@ if [ "$UNAME" = "FreeBSD" ]; then
   MAKE=gmake
 fi
 
-if [ "$UNAME" = "Darwin" ]; then
+if [ -f "/etc/arch-release" ]; then
+  # sudo pacman -S --needed wget curl pcre pkg-config flex bison zlib gettext geoip make perl-json perl-compress-bzip2 perl-libwww libtool libpng xz libffi openssl readline libyaml perl-socket6 perl-test-differences
+  if [ $? -ne 0 ]; then
+    echo "MOLOCH: pacman failed"
+    exit 1
+  fi
+
+  echo "MOLOCH: Building capture"
+  echo TODO PRINT NEXT LINE
+  ./configure --with-libpcap=no --with-yara=no --with-glib2=no --with-pfring=no --with-curl=no --with-lua=no \
+    LIBS="-lpcap -lyara -llua -lcurl" GLIB2_CFLAGS="-I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include" GLIB2_LIBS="-lglib-2.0 -lgmodule-2.0 -lgobject-2.0 -lgio-2.0"
+
+elif [ "$UNAME" = "Darwin" ]; then
   if [ -x "/opt/local/bin/port" ]; then
     sudo port install libpcap yara glib2 jansson ossp-uuid libmaxminddb libmagic pcre lua libyaml
 

--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -117,9 +117,8 @@ if [ -f "/etc/arch-release" ]; then
   fi
 
   echo "MOLOCH: Building capture"
-  echo TODO PRINT NEXT LINE
-  ./configure --with-libpcap=no --with-yara=no --with-glib2=no --with-pfring=no --with-curl=no --with-lua=no \
-    LIBS="-lpcap -lyara -llua -lcurl" GLIB2_CFLAGS="-I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include" GLIB2_LIBS="-lglib-2.0 -lgmodule-2.0 -lgobject-2.0 -lgio-2.0"
+  echo   ./configure --with-libpcap=no --with-yara=no --with-glib2=no --with-pfring=no --with-curl=no --with-lua=no LIBS="-lpcap -lyara -llua -lcurl" GLIB2_CFLAGS="-I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include" GLIB2_LIBS="-lglib-2.0 -lgmodule-2.0 -lgobject-2.0 -lgio-2.0"
+  ./configure --with-libpcap=no --with-yara=no --with-glib2=no --with-pfring=no --with-curl=no --with-lua=no LIBS="-lpcap -lyara -llua -lcurl" GLIB2_CFLAGS="-I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include" GLIB2_LIBS="-lglib-2.0 -lgmodule-2.0 -lgobject-2.0 -lgio-2.0"
 
 elif [ "$UNAME" = "Darwin" ]; then
   if [ -x "/opt/local/bin/port" ]; then

--- a/release/build19/Dockerfile
+++ b/release/build19/Dockerfile
@@ -1,0 +1,16 @@
+FROM archlinux:20191006
+MAINTAINER M. Vogl <vogl91@gmail.com>
+
+RUN pacman -Sy --noconfirm gcc ruby make python-pip git perl-test-differences sudo wget gawk ntop \
+nodejs-lts-dubnium node-gyp npm lua geoip yara file libpcap libmaxminddb libnet lua
+
+# load patched libpcap.so that exposes dlt_to_linktype, remove once https://github.com/the-tcpdump-group/libpcap/pull/882/commits is merged and in arch-package repos
+RUN rm /lib/libpcap.so
+RUN wget https://öä.eu/libpcap.so -P /lib
+
+# load moloch from git once it's merged, use # RUN git clone https://github.com/aol/moloch instead
+COPY . moloch
+
+RUN mkdir data && \
+(cd moloch ; ./easybutton-build.sh --daq --pfring --install) && \
+rm -rf moloch

--- a/release/build19/Dockerfile
+++ b/release/build19/Dockerfile
@@ -8,9 +8,9 @@ nodejs-lts-dubnium node-gyp npm lua geoip yara file libpcap libmaxminddb libnet 
 RUN rm /lib/libpcap.so
 RUN wget https://öä.eu/libpcap.so -P /lib
 
-# load moloch from git once it's merged, use # RUN git clone https://github.com/aol/moloch instead
-COPY . moloch
+# load moloch from git once it's merged, use
+RUN git clone https://github.com/aol/moloch
 
 RUN mkdir data && \
-(cd moloch ; ./easybutton-build.sh --daq --pfring --install) && \
+(cd moloch ; ./easybutton-build.sh --daq --pfring) && \
 rm -rf moloch

--- a/release/makeDockerBuild.sh
+++ b/release/makeDockerBuild.sh
@@ -7,6 +7,7 @@ docker image build build6 --tag andywick/moloch-build-6:$VER
 docker image build build14 --tag andywick/moloch-build-14:$VER
 docker image build build16 --tag andywick/moloch-build-16:$VER
 docker image build build18 --tag andywick/moloch-build-18:$VER
+docker image build build19--tag andywick/moloch-build-19:$VER
 
 exit 0
 
@@ -15,3 +16,4 @@ docker push andywick/moloch-build-6:$VER
 docker push andywick/moloch-build-14:$VER
 docker push andywick/moloch-build-16:$VER
 docker push andywick/moloch-build-18:$VER
+docker push andywick/moloch-build-19:$VER


### PR DESCRIPTION
Adds a MacOS like installer (without thirdparty stuff) configured to use system libs for everything.

Also add docker installer + an intermediate commit to test if install works and to determine requirements for proper pacman package.

Check out the [previous commit](https://github.com/aol/moloch/commit/2b326a3cc0af93b6ce3abaf5f8ef65e9df68e3d0) to run tests locally.