### PR TITLE
docs: fix simple typo, quiting -> quitting

### DIFF
--- a/capture/plugins/netflow.c
+++ b/capture/plugins/netflow.c
@@ -229,7 +229,7 @@ LOCAL void netflow_plugin_save(MolochSession_t *session, int UNUSED(final))
 
 /******************************************************************************/
 /* 
- * Called by moloch when moloch is quiting
+ * Called by moloch when moloch is quitting
  */
 LOCAL void netflow_plugin_exit()
 {

--- a/capture/plugins/suricata.c
+++ b/capture/plugins/suricata.c
@@ -190,7 +190,7 @@ LOCAL void suricata_plugin_save(MolochSession_t *session, int UNUSED(final))
 
 /******************************************************************************/
 /*
- * Called by moloch when moloch is quiting
+ * Called by moloch when moloch is quitting
  */
 LOCAL void suricata_plugin_exit()
 {

--- a/capture/plugins/tagger.c
+++ b/capture/plugins/tagger.c
@@ -292,7 +292,7 @@ LOCAL void tagger_free_ip (TaggerIP_t *tip)
 }
 /******************************************************************************/
 /*
- * Called by moloch when moloch is quiting
+ * Called by moloch when moloch is quitting
  */
 LOCAL void tagger_plugin_exit()
 {


### PR DESCRIPTION
There is a small typo in capture/plugins/netflow.c, capture/plugins/suricata.c, capture/plugins/tagger.c.

Should read `quitting` rather than `quiting`.

