### PR TITLE
Add http s3 connection

### DIFF
--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -80,7 +80,7 @@ LOCAL  char                   s3WriteGzip;
 LOCAL  char                  *s3StorageClass;
 LOCAL  uint32_t               s3MaxConns;
 LOCAL  uint32_t               s3MaxRequests;
-LOCAL  char                   s3AllowInsecure;
+LOCAL  char                   s3UseHttp;
 
 LOCAL  int                    inprogress;
 
@@ -694,7 +694,7 @@ void writer_s3_init(char *UNUSED(name))
     s3StorageClass        = moloch_config_str(NULL, "s3StorageClass", "STANDARD");
     s3MaxConns            = moloch_config_int(NULL, "s3MaxConns", 20, 5, 1000);
     s3MaxRequests         = moloch_config_int(NULL, "s3MaxRequests", 500, 10, 5000);
-    s3AllowInsecure       = moloch_config_boolean(NULL, "s3AllowInsecure", FALSE);
+    s3UseHttp             = moloch_config_boolean(NULL, "s3UseHttp", FALSE);
     s3Token               = NULL;
     s3TokenTime           = 0;
     s3Role                = NULL;
@@ -760,7 +760,7 @@ void writer_s3_init(char *UNUSED(name))
     }
 
     char host[200];
-    if (s3AllowInsecure) {
+    if (s3UseHttp) {
         snprintf(host, sizeof(host), "http://%s", s3Host);
     } else {
         snprintf(host, sizeof(host), "https://%s", s3Host);

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -80,6 +80,7 @@ LOCAL  char                   s3WriteGzip;
 LOCAL  char                  *s3StorageClass;
 LOCAL  uint32_t               s3MaxConns;
 LOCAL  uint32_t               s3MaxRequests;
+LOCAL  char                   s3AllowInsecure;
 
 LOCAL  int                    inprogress;
 
@@ -693,6 +694,7 @@ void writer_s3_init(char *UNUSED(name))
     s3StorageClass        = moloch_config_str(NULL, "s3StorageClass", "STANDARD");
     s3MaxConns            = moloch_config_int(NULL, "s3MaxConns", 20, 5, 1000);
     s3MaxRequests         = moloch_config_int(NULL, "s3MaxRequests", 500, 10, 5000);
+    s3AllowInsecure       = moloch_config_boolean(NULL, "s3AllowInsecure", FALSE);
     s3Token               = NULL;
     s3TokenTime           = 0;
     s3Role                = NULL;
@@ -758,7 +760,11 @@ void writer_s3_init(char *UNUSED(name))
     }
 
     char host[200];
-    snprintf(host, sizeof(host), "https://%s", s3Host);
+    if (!s3AllowInsecure) {
+        snprintf(host, sizeof(host), "https://%s", s3Host);
+    } else {
+        snprintf(host, sizeof(host), "http://%s", s3Host);
+    }
     s3Server = moloch_http_create_server(host, s3MaxConns, s3MaxRequests, s3Compress);
     moloch_http_set_print_errors(s3Server);
     moloch_http_set_header_cb(s3Server, writer_s3_header_cb);

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -760,10 +760,10 @@ void writer_s3_init(char *UNUSED(name))
     }
 
     char host[200];
-    if (!s3AllowInsecure) {
-        snprintf(host, sizeof(host), "https://%s", s3Host);
-    } else {
+    if (s3AllowInsecure) {
         snprintf(host, sizeof(host), "http://%s", s3Host);
+    } else {
+        snprintf(host, sizeof(host), "https://%s", s3Host);
     }
     s3Server = moloch_http_create_server(host, s3MaxConns, s3MaxRequests, s3Compress);
     moloch_http_set_print_errors(s3Server);

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -70,7 +70,7 @@ function makeS3 (node, region) {
     s3Params.s3ForcePathStyle = true;
   }
 
-  if (Config.getBoolFull(node, 's3AllowInsecure', false) === true) {
+  if (Config.getBoolFull(node, 's3UseHttp', false) === true) {
     s3Params.sslEnabled = false;
   }
 

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -70,6 +70,10 @@ function makeS3 (node, region) {
     s3Params.s3ForcePathStyle = true;
   }
 
+  if (Config.getBoolFull(node, 's3AllowInsecure', false) === true) {
+    s3Params.sslEnabled = false;
+  }
+
   // Lets hope that we can find a credential provider elsewhere
   var rv = S3s[region + key] = new AWS.S3(s3Params);
   return rv;


### PR DESCRIPTION
Allow insecure connections to S3 when deploying in docker (or Kubernetes) with S3 on-prem (MinIO e.g.) mainly.