### PR TITLE
Fix incorrect path of package-lock file in wiseService install target

### DIFF
--- a/wiseService/Makefile.in
+++ b/wiseService/Makefile.in
@@ -20,7 +20,7 @@ install:
 	$(CP) -pr favicon.ico $(WISEDIR)
 	$(CP) -pr vueapp/dist "$(WISEDIR)/vueapp"
 	(cd $(WISEDIR) ; npm ci --production)
-	rm -f $(VIEWERDIR)/package-lock.json
+	rm -f $(WISEDIR)/package-lock.json
 
 distclean realclean clean:
 	rm -f *.o *.so


### PR DESCRIPTION
The path `$(VIEWERDIR)/package-lock.json` seems to be a left-over from copy-pasting the Makefile. This should be `$(WISEDIR)/package-lock.json` to clean-up the package-lock file of this build.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
