### PR TITLE
Tag API Test Cases for Multi-Viewer

### DIFF
--- a/tests/MolochTest.pm
+++ b/tests/MolochTest.pm
@@ -3,7 +3,7 @@ use Exporter;
 use strict;
 use Test::More;
 @MolochTest::ISA = qw(Exporter);
-@MolochTest::EXPORT = qw (esGet esPost esPut esDelete esCopy viewerGet viewerGetToken viewerGet2 viewerDelete viewerDeleteToken viewerPost viewerPost2 viewerPostToken viewerPostToken2 countTest countTest2 errTest bin2hex mesGet mesPost multiGet getTokenCookie getTokenCookie2 parliamentGet parliamentGetToken parliamentPost parliamentPut parliamentDelete parliamentDeleteToken waitFor viewerPutToken);
+@MolochTest::EXPORT = qw (esGet esPost esPut esDelete esCopy viewerGet viewerGetToken viewerGet2 viewerDelete viewerDeleteToken viewerPost viewerPost2 viewerPostToken viewerPostToken2 countTest countTest2 errTest bin2hex mesGet mesPost multiGet multiPost getTokenCookie getTokenCookie2 parliamentGet parliamentGetToken parliamentPost parliamentPut parliamentDelete parliamentDeleteToken waitFor viewerPutToken);
 
 use LWP::UserAgent;
 use HTTP::Request::Common;
@@ -80,6 +80,21 @@ my ($url, $content, $debug) = @_;
         $response = $MolochTest::userAgent->post("http://$MolochTest::host:8123$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8");
     } else {
         $response = $MolochTest::userAgent->post("http://$MolochTest::host:8123$url", Content => $content);
+    }
+
+    diag $url, " response:", $response->content if ($debug);
+    my $json = from_json($response->content);
+    return ($json);
+}
+################################################################################
+sub multiPost {
+my ($url, $content, $debug) = @_;
+
+    my $response;
+    if (substr($content, 0, 2) eq '{"') {
+        $response = $MolochTest::userAgent->post("http://$MolochTest::host:8125$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8");
+    } else {
+        $response = $MolochTest::userAgent->post("http://$MolochTest::host:8125$url", Content => $content);
     }
 
     diag $url, " response:", $response->content if ($debug);

--- a/tests/api-tagging.t
+++ b/tests/api-tagging.t
@@ -1,4 +1,4 @@
-use Test::More tests => 64;
+use Test::More tests => 72;
 use Cwd;
 use URI::Escape;
 use MolochTest;
@@ -14,6 +14,12 @@ my $json;
     countTest(3, "date=-1&expression=" . uri_escape("file=$pwd/socks-http-example.pcap"));
     countTest(0, "date=-1&expression=" . uri_escape("tags==TAGTEST1"));
     countTest(0, "date=-1&expression=" . uri_escape("tags==TAGTEST2"));
+    countTest(0, "date=-1&expression=" . uri_escape("tags==TAGTEST3"));
+
+    countTest(0, "date=-1&expression=" . uri_escape("tags==MTAGTEST1"));
+    countTest(0, "date=-1&expression=" . uri_escape("tags==MTAGTEST2"));
+    countTest(0, "date=-1&expression=" . uri_escape("tags==MTAGTEST3"));
+
     countTest(3, "date=-1&expression=" . uri_escape("file=$pwd/socks-http-example.pcap && tags==domainwise"));
 
 # adding/removing tags test expression
@@ -33,16 +39,16 @@ my $json;
     }
 
 # adding/removing tags test expression for MultiViewer
-    multiPost("/addTags?date=-1&expression=file=$pwd/socks-http-example.pcap", "tags=TAGTEST1");
+    multiPost("/addTags?date=-1&expression=file=$pwd/socks-http-example.pcap", "tags=MTAGTEST1");
     esGet("/_refresh");
-    $json = countTest(3, "date=-1&fields=tags,tagsCnt&expression=" . uri_escape("tags==TAGTEST1"));
+    $json = countTest(3, "date=-1&fields=tags,tagsCnt&expression=" . uri_escape("tags==MTAGTEST1"));
     foreach my $item (@{$json->{data}}) {
         is ($item->{tagsCnt}, scalar @{$item->{"tags"}}, "add: tagsCnt and array size match");
     }
 
-    multiPost("/removeTags?date=-1&expression=file=$pwd/socks-http-example.pcap", "tags=TAGTEST1");
+    multiPost("/removeTags?date=-1&expression=file=$pwd/socks-http-example.pcap", "tags=MTAGTEST1");
     esGet("/_refresh");
-    countTest(0, "date=-1&expression=" . uri_escape("tags==TAGTEST1"));
+    countTest(0, "date=-1&expression=" . uri_escape("tags==MTAGTEST1"));
     $json = countTest(3, "date=-1&fields=tags,tagsCnt&expression=" . uri_escape("file=$pwd/socks-http-example.pcap && tags==domainwise"));
     foreach my $item (@{$json->{data}}) {
         is ($item->{tagsCnt}, scalar @{$item->{"tags"}}, "remove: tagsCnt and array size match");
@@ -60,12 +66,12 @@ my $json;
 
 # adding/removing tags test ids for MultiViewer - remove doesn't work on ES 2.4
     my $idQuery = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("file=$pwd/socks-http-example.pcap"));
-    multiPost("/addTags?date=-1", "tags=TAGTEST2&ids=" . $idQuery->{data}->[0]->{id});
+    multiPost("/addTags?date=-1", "tags=MTAGTEST2&ids=" . $idQuery->{data}->[0]->{id});
     esGet("/_refresh");
-    countTest(1, "date=-1&expression=" . uri_escape("tags==TAGTEST2"));
-    multiPost("/removeTags?date=-1", "tags=TAGTEST2&ids=" . $idQuery->{data}->[0]->{id});
+    countTest(1, "date=-1&expression=" . uri_escape("tags==MTAGTEST2"));
+    multiPost("/removeTags?date=-1", "tags=MTAGTEST2&ids=" . $idQuery->{data}->[0]->{id});
     esGet("/_refresh");
-    countTest(0, "date=-1&expression=" . uri_escape("tags==TAGTEST2"));
+    countTest(0, "date=-1&expression=" . uri_escape("tags==MTAGTEST2"));
     countTest(3, "date=-1&expression=" . uri_escape("file=$pwd/socks-http-example.pcap && tags==domainwise"));
 
 # adding tag to no tag item - remove doesn't work on ES 2.4
@@ -81,11 +87,11 @@ my $json;
 
 # adding tag to no tag item for MultiViewer - remove doesn't work on ES 2.4
     countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags!=EXISTS!"));
-    multiPost("/addTags?date=-1&expression=file=$pwd/irc.pcap", "tags=TAGTEST3");
+    multiPost("/addTags?date=-1&expression=file=$pwd/irc.pcap", "tags=MTAGTEST3");
     esGet("/_refresh");
-    countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags==TAGTEST3"));
+    countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags==MTAGTEST3"));
     countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags!=EXISTS!"));
-    multiPost("/removeTags?date=-1&expression=file=$pwd/irc.pcap", "tags=TAGTEST3");
+    multiPost("/removeTags?date=-1&expression=file=$pwd/irc.pcap", "tags=MTAGTEST3");
     esGet("/_refresh");
-    countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags==TAGTEST3"));
+    countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags==MTAGTEST3"));
     countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/irc.pcap && tags!=EXISTS!"));

--- a/tests/api-tagging.t
+++ b/tests/api-tagging.t
@@ -1,4 +1,4 @@
-use Test::More tests => 36;
+use Test::More tests => 64;
 use Cwd;
 use URI::Escape;
 use MolochTest;

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -749,7 +749,7 @@ function msearch (req, res) {
   });
 }
 
-app.post('/:index/:type/:id/_update', function (req, res) {
+app.post(['/:index/:type/:id/_update','/:index/_update/:id'], function (req, res) {
   var body = JSON.parse(req.body);
   if (body._node && clients[body._node]) {
     var node = body._node;
@@ -758,7 +758,10 @@ app.post('/:index/:type/:id/_update', function (req, res) {
     var prefix = node2Prefix(node);
     var index = req.params.index.replace(/MULTIPREFIX_/g, prefix);
 
-    clients[node].update({ index: index, type: req.params.type, id: req.params.id, body: body }, (err, result) => {
+    clients[node].update({ index: index, id: req.params.id, body: body }, (err, result) => {
+      if (err) {
+        console.log('ERROR - failed to update the document' + ' err:' + err);
+      }
       return res.send(result);
     });
   } else {
@@ -805,7 +808,7 @@ nodes.forEach((node) => {
   }
   clients[node] = new ESC.Client({
     host: node.split(',')[0],
-    apiVersion: '6.8',
+    apiVersion: '7.4',
     requestTimeout: 300000,
     keepAlive: true,
     ssl: esSSLOptions

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -757,8 +757,16 @@ app.post(['/:index/:type/:id/_update', '/:index/_update/:id'], function (req, re
 
     var prefix = node2Prefix(node);
     var index = req.params.index.replace(/MULTIPREFIX_/g, prefix);
+    var id = req.params.id;
+    let params = {
+      retry_on_conflict: 3,
+      index: index,
+      body: body,
+      id: id,
+      timeout: '10m'
+    };
 
-    clients[node].update({ index: index, id: req.params.id, body: body }, (err, result) => {
+    clients[node].update(params, (err, result) => {
       if (err) {
         console.log('ERROR - failed to update the document' + ' err:' + err);
       }

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -749,7 +749,7 @@ function msearch (req, res) {
   });
 }
 
-app.post(['/:index/:type/:id/_update','/:index/_update/:id'], function (req, res) {
+app.post(['/:index/:type/:id/_update', '/:index/_update/:id'], function (req, res) {
   var body = JSON.parse(req.body);
   if (body._node && clients[body._node]) {
     var node = body._node;


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
New Test Cases for TAG APIs for Multi-Viewer

**Clearly describe the problem and solution**
Issue: The test cases for adding/removing Tags do not consider Multi-viewer
Solution: New  test cases are added that add/remove tags using Multi-viewer

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
Yes

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
