### PR TITLE
Hi Andy, I have made these commits to accommodate authorization headers. We have come across scenarios where both the headers: authorization and proxy-authorization are present. The authString will not get populated if proxy-authorization headers are present as part the request.  

### DIFF
--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -770,7 +770,7 @@ LOCAL void http_free(MolochSession_t UNUSED(*session), void *uw)
         g_string_free(http->authString[0], TRUE);
 	if (http->authString[1])
 		g_string_free(http->authString[1], TRUE);
-    if (http->valueString[0])
+	if (http->valueString[0])
         g_string_free(http->valueString[0], TRUE);
     if (http->valueString[1])
         g_string_free(http->valueString[1], TRUE);


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->
 Parse proxy-authorization header to read the header value for proxy-authorization field

**Clearly describe the problem and solution**
---proxy-authorization headers that are present in the request are not getting parsed and the corresponding value is not getting populated because authString are not getting populated. I have made these commits to accommodate proxy-authorization headers. We have come across scenarios where both the headers: authorization and proxy-authorization are present. The authString will not get populated if proxy-authorization headers are present as part of the request. 

**Relevant issue number(s) if applicable**
---NA 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
--- My changes are only present in capture/parsers/http.c file. 

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
---- ./test.pl was run on the pcap directory.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
