### PR TITLE
simplify encoding, initSimple now does load

### DIFF
--- a/wiseService/source.alienvault.js
+++ b/wiseService/source.alienvault.js
@@ -67,11 +67,13 @@ class AlienVaultSource extends WISESource {
           continue;
         }
 
-        const encoded = WISESource.encode(this.idField, data[i][7],
-                                          this.reliabilityField, data[i][1],
-                                          this.threatlevelField, data[i][2],
-                                          this.activityField, data[i][3]);
-        this.ips.set(data[i][0], { num: 4, buffer: encoded });
+        const encoded = WISESource.encodeResult(
+          this.idField, data[i][7],
+          this.reliabilityField, data[i][1],
+          this.threatlevelField, data[i][2],
+          this.activityField, data[i][3]
+        );
+        this.ips.set(data[i][0], encoded);
         count++;
       }
       console.log(this.section, '- Done Loading', count, 'elements');
@@ -139,7 +141,7 @@ class AlienVaultSource extends WISESource {
   dump (res) {
     this.ips.forEach((value, key) => {
       const str = '{key: "' + key + '", ops:\n' +
-                 WISESource.result2Str(WISESource.combineResults([value])) + '},\n';
+                 WISESource.result2JSON(value) + '},\n';
       res.write(str);
     });
     res.end();

--- a/wiseService/source.elasticesearch.js
+++ b/wiseService/source.elasticesearch.js
@@ -101,7 +101,7 @@ class ElasticsearchSource extends WISESource {
           }
         }
       }
-      const newresult = { num: args.length / 2 + this.tagsResult.num, buffer: Buffer.concat([WISESource.encode.apply(null, args), this.tagsResult.buffer]) };
+      const newresult = WISESource.combineResults([WISESource.encodeResult.apply(null, args), this.tagsResult]);
       return cb(null, newresult);
     });
   };

--- a/wiseService/source.emergingthreats.js
+++ b/wiseService/source.emergingthreats.js
@@ -82,15 +82,18 @@ class EmergingThreatsSource extends WISESource {
           continue;
         }
 
-        const encoded = WISESource.encode(this.categoryField, this.categories[data[i][1]] || ('Unknown - ' + data[i][1]),
-                                          this.scoreField, '' + data[i][2]);
+        let encoded = WISESource.encodeResult(
+          this.categoryField, this.categories[data[i][1]] || ('Unknown - ' + data[i][1]),
+          this.scoreField, '' + data[i][2]
+        );
+
+        // Already have something for this item, add the new one
         const value = hash.get(data[i][0]);
         if (value) {
-          value.num += 2;
-          value.buffer = Buffer.concat([value.buffer, encoded]);
-        } else {
-          hash.set(data[i][0], { num: 2, buffer: encoded });
+          encoded = WISESource.combineResults([value, encoded]);
         }
+
+        hash.set(data[i][0], encoded);
       }
       console.log(this.section, '- Done Loading', fn);
     });
@@ -137,7 +140,7 @@ class EmergingThreatsSource extends WISESource {
       res.write(`${ckey}:\n`);
       this[ckey].forEach((value, key) => {
         const str = `{key: "${key}", ops:\n` +
-          WISESource.result2Str(WISESource.combineResults([value])) + '},\n';
+          WISESource.result2JSON(value) + '},\n';
         res.write(str);
       });
     });

--- a/wiseService/source.file.js
+++ b/wiseService/source.file.js
@@ -41,8 +41,6 @@ class FileSource extends SimpleSource {
       return;
     }
 
-    setImmediate(this.load.bind(this));
-
     // Watch file for changes, combine multiple changes into one, on move restart watch after a pause
     this.watchTimeout = null;
     let watchCb = (event, filename) => {
@@ -74,7 +72,7 @@ class FileSource extends SimpleSource {
     });
   }
   // ----------------------------------------------------------------------------
-  getRaw (cb) {
+  getSourceRaw (cb) {
     fs.readFile(this.file, (err, body) => {
       if (err) {
         return cb(err);
@@ -83,7 +81,7 @@ class FileSource extends SimpleSource {
     });
   }
   // ----------------------------------------------------------------------------
-  putRaw (body, cb) {
+  putSourceRaw (body, cb) {
     fs.writeFile(this.file, body, (err) => {
       return cb(err);
     });

--- a/wiseService/source.hodiredis.js
+++ b/wiseService/source.hodiredis.js
@@ -41,10 +41,10 @@ class HODIRedisSource extends WISESource {
     this.api.addSource(section, this);
 
     const tagsField = this.api.addField('field:tags');
-    this.tagsDomain = { num: 1, buffer: WISESource.encode(tagsField, 'nbs-domain') };
-    this.tagsMd5 = { num: 1, buffer: WISESource.encode(tagsField, 'nbs-md5') };
-    this.tagsEmail = { num: 1, buffer: WISESource.encode(tagsField, 'nbs-email') };
-    this.tagsIp = { num: 1, buffer: WISESource.encode(tagsField, 'nbs-ip') };
+    this.tagsDomain = WISESource.encodeResult(tagsField, 'nbs-domain');
+    this.tagsMd5 = WISESource.encodeResult(tagsField, 'nbs-md5');
+    this.tagsEmail = WISESource.encodeResult(tagsField, 'nbs-email');
+    this.tagsIp = WISESource.encodeResult(tagsField, 'nbs-ip');
   }
 
   // ----------------------------------------------------------------------------

--- a/wiseService/source.opendns.js
+++ b/wiseService/source.opendns.js
@@ -155,7 +155,7 @@ class OpenDNSSource extends WISESource {
             });
           }
 
-          result = { num: args.length / 2, buffer: WISESource.encode.apply(null, args) };
+          result = WISESource.encodeResult.apply(null, args);
 
           let cb;
           while ((cb = cbs.shift())) {

--- a/wiseService/source.passivetotal.js
+++ b/wiseService/source.passivetotal.js
@@ -102,7 +102,7 @@ class PassiveTotalSource extends WISESource {
             }
           }
 
-          wiseResult = { num: args.length / 2, buffer: WISESource.encode.apply(null, args) };
+          wiseResult = WISESource.encodeResult.apply(null, args);
         }
 
         let cb;

--- a/wiseService/source.redis.js
+++ b/wiseService/source.redis.js
@@ -56,7 +56,7 @@ class RedisSource extends WISESource {
       }
 
       this.parse(reply, (ignorekey, result) => {
-        const newresult = { num: result.num + this.tagsResult.num, buffer: Buffer.concat([result.buffer, this.tagsResult.buffer]) };
+        const newresult = WISESource.combineResults([result, this.tagsResult]);
         return cb(null, newresult);
       }, () => {});
     });

--- a/wiseService/source.redisfile.js
+++ b/wiseService/source.redisfile.js
@@ -22,14 +22,13 @@ const SimpleSource = require('./simpleSource.js');
 class RedisFileSource extends SimpleSource {
   // ----------------------------------------------------------------------------
   constructor (api, section) {
-    super(api, section, { dontCache: true });
+    super(api, section, { dontCache: true, reload: true });
     this.url = api.getConfig(section, 'url');
     if (this.url === undefined) {
       console.log(this.section, '- ERROR not loading since no url specified in config file');
       return;
     }
     this.key = api.getConfig(section, 'key');
-    this.reload = +api.getConfig(section, 'reload', -1);
     this.headers = {};
     const headers = api.getConfig(section, 'headers');
     this.client = api.createRedisClient(api.getConfig(section, 'redisType', 'redis'), section);
@@ -48,16 +47,7 @@ class RedisFileSource extends SimpleSource {
       });
     }
 
-    if (!this.initSimple()) {
-      return;
-    }
-
-    setImmediate(this.load.bind(this));
-
-    // Reload key every so often
-    if (this.reload > 0) {
-      setInterval(this.load.bind(this), this.reload * 1000 * 60);
-    }
+    this.initSimple();
   }
 
   // ----------------------------------------------------------------------------
@@ -72,12 +62,12 @@ class RedisFileSource extends SimpleSource {
   }
 
   // ----------------------------------------------------------------------------
-  getRaw (cb) {
+  getSourceRaw (cb) {
     this.client.get(this.key, cb);
   }
 
   // ----------------------------------------------------------------------------
-  putRaw (file, cb) {
+  putSourceRaw (file, cb) {
     this.client.set(this.key, file, cb);
   }
 }

--- a/wiseService/source.reversedns.js
+++ b/wiseService/source.reversedns.js
@@ -93,7 +93,7 @@ class ReverseDNSSource extends WISESource {
           }
         }
       }
-      const wiseResult = { num: args.length / 2, buffer: WISESource.encode.apply(null, args) };
+      const wiseResult = WISESource.encodeResult.apply(null, args);
       cb(null, wiseResult);
     });
   };

--- a/wiseService/source.splunk.js
+++ b/wiseService/source.splunk.js
@@ -105,7 +105,7 @@ class SplunkSource extends WISESource {
           }
         }
 
-        const newitem = { num: args.length / 2, buffer: WISESource.encode.apply(null, args) };
+        const newitem = WISESource.encode.apply(null, args);
 
         if (this.type === 'ip') {
           const parts = key.split('/');
@@ -128,7 +128,7 @@ class SplunkSource extends WISESource {
     const cache = this.type === 'ip' ? this.cache.items : this.cache;
     cache.forEach((value, key) => {
       const str = `{key: "${key}", ops:\n` +
-        WISESource.result2Str(WISESource.combineResults([this.tagsResult, value])) + '},\n';
+        WISESource.result2JSON(WISESource.combineResults([this.tagsResult, value])) + '},\n';
       res.write(str);
     });
     res.end();
@@ -146,12 +146,12 @@ class SplunkSource extends WISESource {
     if (!result) {
       return cb(null, undefined);
     }
-    if (result.num === 0) {
+    if (result[0] === 0) {
       return cb(null, this.tagsResult);
     }
 
     // Found, so combine the two results (per item, and per source)
-    const newresult = { num: result.num + this.tagsResult.num, buffer: Buffer.concat([result.buffer, this.tagsResult.buffer]) };
+    const newresult = WISESource.combineResults([result, this.tagsResult]);
     return cb(null, newresult);
   };
 
@@ -182,7 +182,7 @@ class SplunkSource extends WISESource {
           }
         }
       }
-      const newresult = { num: args.length / 2 + this.tagsResult.num, buffer: Buffer.concat([WISESource.encode.apply(null, args), this.tagsResult.buffer]) };
+      const newresult = WISESource.combineResults([WISESource.encodeResult.apply(null, args), this.tagsResult]);
       return cb(null, newresult);
     });
   };

--- a/wiseService/source.threatq.js
+++ b/wiseService/source.threatq.js
@@ -100,17 +100,17 @@ class ThreatQSource extends WISESource {
               });
             }
 
-            const encoded = WISESource.encode.apply(null, args);
+            const encoded = WISESource.encodeResult.apply(null, args);
 
             count++;
             if (item.type === 'IP Address') {
-              this.ips.set(item.indicator, { num: args.length / 2, buffer: encoded });
+              this.ips.set(item.indicator, encoded);
             } else if (item.type === 'FQDN') {
-              this.domains.set(item.indicator, { num: args.length / 2, buffer: encoded });
+              this.domains.set(item.indicator, encoded);
             } else if (item.type === 'Email Address') {
-              this.emails.set(item.indicator, { num: args.length / 2, buffer: encoded });
+              this.emails.set(item.indicator, encoded);
             } else if (item.type === 'MD5') {
-              this.md5s.set(item.indicator, { num: args.length / 2, buffer: encoded });
+              this.md5s.set(item.indicator, encoded);
             }
           });
         });
@@ -158,7 +158,7 @@ class ThreatQSource extends WISESource {
       res.write(`${ckey}:\n`);
       this[ckey].forEach((value, key) => {
         const str = `{key: "${key}", ops:\n` +
-          WISESource.result2Str(WISESource.combineResults([value])) + '},\n';
+          WISESource.result2JSON(value) + '},\n';
         res.write(str);
       });
     });

--- a/wiseService/source.threatstream.js
+++ b/wiseService/source.threatstream.js
@@ -150,23 +150,20 @@ class ThreatStreamSource extends WISESource {
             }
 
             let encoded;
-            let num;
             try {
               if (item.maltype && item.maltype !== 'null') {
-                encoded = WISESource.encode(this.severityField, item.severity.toLowerCase(),
+                encoded = WISESource.encodeResult(this.severityField, item.severity.toLowerCase(),
                                             this.confidenceField, '' + item.confidence,
                                             this.idField, '' + item.id,
                                             this.typeField, item.itype.toLowerCase(),
                                             this.maltypeField, item.maltype.toLowerCase(),
                                             this.sourceField, item.source);
-                num = 6;
               } else {
-                encoded = WISESource.encode(this.severityField, item.severity.toLowerCase(),
+                encoded = WISESource.encodeResult(this.severityField, item.severity.toLowerCase(),
                                             this.confidenceField, '' + item.confidence,
                                             this.idField, '' + item.id,
                                             this.typeField, item.itype.toLowerCase(),
                                             this.sourceField, item.source);
-                num = 5;
               }
             } catch (e) {
               console.log(this.section, 'ERROR -', entry.path, e, item, e.stack);
@@ -174,18 +171,18 @@ class ThreatStreamSource extends WISESource {
             }
 
             if (item.itype.match(/(_ip|anon_proxy|anon_vpn)/)) {
-              this.ips.set(item.srcip, { num: num, buffer: encoded });
+              this.ips.set(item.srcip, encoded);
             } else if (item.itype.match(/_domain|_dns/)) {
-              this.domains.set(item.domain, { num: num, buffer: encoded });
+              this.domains.set(item.domain, encoded);
             } else if (item.itype.match(/_email/)) {
-              this.emails.set(item.email, { num: num, buffer: encoded });
+              this.emails.set(item.email, encoded);
             } else if (item.itype.match(/_md5/)) {
-              this.md5s.set(item.md5, { num: num, buffer: encoded });
+              this.md5s.set(item.md5, encoded);
             } else if (item.itype.match(/_url/)) {
               if (item.url.lastIndexOf('http://', 0) === 0) {
                 item.url = item.url.substring(7);
               }
-              this.urls.set(item.url, { num: num, buffer: encoded });
+              this.urls.set(item.url, encoded);
             }
           });
           // console.log(this.section, "- Done", entry.path);
@@ -242,7 +239,7 @@ class ThreatStreamSource extends WISESource {
       res.write(`${ckey}: [\n`);
       this[ckey].forEach((value, key) => {
         const str = `{key: "${key}", ops:\n` +
-          WISESource.result2Str(WISESource.combineResults([value])) + '},\n';
+          WISESource.result2JSON(value) + '},\n';
         res.write(str);
       });
       res.write('],\n');
@@ -296,7 +293,7 @@ class ThreatStreamSource extends WISESource {
           args.push(this.severityField, item.severity.toLowerCase());
         }
       });
-      const result = { num: args.length / 2, buffer: WISESource.encode.apply(null, args) };
+      const result = WISESource.encodeResult.apply(null, args);
       return cb(null, result);
     });
   };
@@ -353,7 +350,7 @@ class ThreatStreamSource extends WISESource {
           args.push(this.importIdField, '' + item.import_session_id);
         }
       });
-      const result = { num: args.length / 2, buffer: WISESource.encode.apply(null, args) };
+      const result = WISESource.encodeResult.apply(null, args);
       return cb(null, result);
     });
   };

--- a/wiseService/source.url.js
+++ b/wiseService/source.url.js
@@ -23,9 +23,8 @@ const request = require('request');
 class URLSource extends SimpleSource {
 // ----------------------------------------------------------------------------
   constructor (api, section) {
-    super(api, section, { dontCache: true });
+    super(api, section, { dontCache: true, reload: true });
     this.url = api.getConfig(section, 'url');
-    this.reload = +api.getConfig(section, 'reload', -1);
     this.headers = {};
     const headers = api.getConfig(section, 'headers');
 
@@ -43,16 +42,7 @@ class URLSource extends SimpleSource {
       });
     }
 
-    if (!this.initSimple()) {
-      return;
-    }
-
-    setImmediate(this.load.bind(this));
-
-    // Reload url every so often
-    if (this.reload > 0) {
-      setInterval(this.load.bind(this), this.reload * 1000 * 60);
-    }
+    this.initSimple();
   }
 
   // ----------------------------------------------------------------------------

--- a/wiseService/source.virustotal.js
+++ b/wiseService/source.virustotal.js
@@ -132,7 +132,7 @@ class VirusTotalSource extends WISESource {
             }
           }
 
-          wiseResult = { num: args.length / 2, buffer: WISESource.encode.apply(null, args) };
+          wiseResult = WISESource.encodeResult.apply(null, args);
         }
 
         cb(null, wiseResult);
@@ -161,15 +161,15 @@ class VirusTotalSource extends WISESource {
 const reportApi = function (req, res) {
   source.getMd5(req.query.resource, (err, result) => {
     // console.log(err, result);
-    if (result.num === 0) {
+    if (result[0] === 0) {
       res.send({ response_code: 0, resource: req.query.resource, verbose_msg: 'The requested resource is not among the finished, queued or pending scans' });
     } else {
       const obj = { scans: {} };
-      let offset = 0;
-      for (let i = 0; i < result.num; i++) {
-        const pos = result.buffer[offset];
-        const len = result.buffer[offset + 1];
-        const value = result.buffer.toString('utf8', offset + 2, offset + 2 + len - 1);
+      let offset = 1;
+      for (let i = 0; i < result[0]; i++) {
+        const pos = result[offset];
+        const len = result[offset + 1];
+        const value = result.toString('utf8', offset + 2, offset + 2 + len - 1);
         offset += 2 + len;
         switch (pos) {
         case source.hitsField:

--- a/wiseService/source.wiseproxy.js
+++ b/wiseService/source.wiseproxy.js
@@ -115,7 +115,7 @@ class WiseProxySource extends WISESource {
           const str = body.toString('ascii', offset, offset + len - 1); offset += len;
           args.push(this.mapping[field], str);
         }
-        const result = { num: args.length / 2, buffer: WISESource.encode.apply(null, args) };
+        const result = WISESource.encodeResult.apply(null, args);
         return bi.cb(null, result);
       }
     });


### PR DESCRIPTION
* results are always encoded now with leading count, no more {num:, buffer:}
* result2Str => result2JSON
* encode => encodeResult
* getRaw/putRaw => getSourceRaw/putSourceRaw
* initSimple now handles the initial load and reloading