### PR TITLE
add wise ui startup time to the stats page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11755,6 +11755,15 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
+    "moment-timezone": {
+      "version": "0.5.32",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "html-webpack-plugin": "^3.2.0",
     "js-yaml": "^3.14.0",
     "jsdoc-to-markdown": "^6.0.1",
+    "moment-timezone": "^0.5.32",
     "node-notifier": "^8.0.1",
     "nodemon": "^2.0.3",
     "optimize-css-assets-webpack-plugin": "^5.0.3",

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -1154,6 +1154,15 @@
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true
     },
+    "moment-timezone": {
+      "version": "0.5.32",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
+      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/viewer/package-lock.json
+++ b/viewer/package-lock.json
@@ -1154,15 +1154,6 @@
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
       "dev": true
     },
-    "moment-timezone": {
-      "version": "0.5.32",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
-      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
-      "dev": true,
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "d3": "^5.16.0",
     "jquery": "^3.5.1",
+    "moment-timezone": "^0.5.32",
     "qs": "^6.9.4",
     "sanitize-html": "^1.27.5",
     "vue-bootstrap-datetimepicker": "^5.0.1",

--- a/viewer/package.json
+++ b/viewer/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "d3": "^5.16.0",
     "jquery": "^3.5.1",
-    "moment-timezone": "^0.5.31",
     "qs": "^6.9.4",
     "sanitize-html": "^1.27.5",
     "vue-bootstrap-datetimepicker": "^5.0.1",

--- a/wiseService/vueapp/src/components/Stats.vue
+++ b/wiseService/vueapp/src/components/Stats.vue
@@ -6,15 +6,27 @@
       <b-tabs content-class="mt-3">
         <b-tab title="Sources" active>
           <div v-if="sourceStats.length > 0">
-            <b-table striped hover small borderless :items="sourceStats" :fields="sourceTableFields"></b-table>
+            <b-table striped hover small borderless
+              :items="sourceStats"
+              :fields="sourceTableFields">
+            </b-table>
           </div>
         </b-tab>
-
         <b-tab title="Types">
           <div v-if="typeStats.length > 0">
-            <b-table striped hover small borderless :items="typeStats" :fields="typeTableFields"></b-table>
+            <b-table striped hover small borderless
+              :items="typeStats"
+              :fields="typeTableFields">
+            </b-table>
           </div>
         </b-tab>
+        <template #tabs-end>
+          <li role="presentation"
+            class="nav-item align-self-center startup-time">
+            WISE UI started at
+            <strong>{{ startTime }}</strong>
+          </li>
+        </template>
       </b-tabs>
     </div>
 
@@ -22,6 +34,8 @@
 </template>
 
 <script>
+import moment from 'moment-timezone';
+
 import WiseService from './wise.service';
 import Alert from './Alert';
 
@@ -36,7 +50,8 @@ export default {
       sourceStats: [],
       typeStats: [],
       sourceTableFields: [],
-      typeTableFields: []
+      typeTableFields: [],
+      startTime: undefined
     };
   },
   mounted: function () {
@@ -47,6 +62,9 @@ export default {
       WiseService.getResourceStats()
         .then((data) => {
           this.alertMessage = '';
+          if (data && data.startTime) {
+            this.startTime = moment.tz(data.startTime, Intl.DateTimeFormat().resolvedOptions().timeZone).format('YYYY/MM/DD HH:mm:ss z');
+          }
           if (data && data.sources && data.sources.length > 0) {
             this.sourceStats = data.sources;
             Object.keys(this.sourceStats[0]).forEach(key => {
@@ -80,3 +98,10 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+.startup-time {
+  right: 15px;
+  position: absolute;
+}
+</style>

--- a/wiseService/vueapp/src/components/Stats.vue
+++ b/wiseService/vueapp/src/components/Stats.vue
@@ -23,7 +23,7 @@
         <template #tabs-end>
           <li role="presentation"
             class="nav-item align-self-center startup-time">
-            WISE UI started at
+            Started at
             <strong>{{ startTime }}</strong>
           </li>
         </template>


### PR DESCRIPTION
put moment-timezone in the top level package.json

<img width="1080" alt="Screen Shot 2021-01-08 at 11 12 33 AM" src="https://user-images.githubusercontent.com/1235082/104037817-d2e97880-51a2-11eb-83a4-f3d1781e0ed3.png">

fixes #1580