### PR TITLE
Wrap Up API Documentation & Standardization

### DIFF
--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -580,7 +580,7 @@ function getStats (cluster) {
     let timeout = getGeneralSetting('esQueryTimeout') * 1000;
 
     let options = {
-      url: `${cluster.localUrl || cluster.url}/api/parliament`,
+      url: `${cluster.localUrl || cluster.url}/parliament.json`,
       method: 'GET',
       rejectUnauthorized: false,
       timeout: timeout

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -580,7 +580,7 @@ function getStats (cluster) {
     let timeout = getGeneralSetting('esQueryTimeout') * 1000;
 
     let options = {
-      url: `${cluster.localUrl || cluster.url}/parliament.json`,
+      url: `${cluster.localUrl || cluster.url}/api/parliament`,
       method: 'GET',
       rejectUnauthorized: false,
       timeout: timeout

--- a/tests/api-scrub.t
+++ b/tests/api-scrub.t
@@ -37,7 +37,7 @@ countTest(3, "date=-1&expression=" . uri_escape("file=$copytest"));
     countTest(1, "date=-1&expression=" . uri_escape("file=$copytest&&scrubbed.by==/Anon.*mous/"));
 
 # scrub expression
-    viewerPostToken("/delete?removePcap=true&removeSpi=false&date=-1&expression=" . uri_escape("file=$copytest"), {}, $token);
+    viewerPostToken("/api/delete?removePcap=true&removeSpi=false&date=-1&expression=" . uri_escape("file=$copytest"), {}, $token);
 
     esGet("/_refresh");
     esGet("/_flush");

--- a/tests/api-stats.t
+++ b/tests/api-stats.t
@@ -124,7 +124,7 @@ my $test1Token = getTokenCookie("test1");
     cmp_ok (@{$recovery->{data}}, "==", 0, "tasks array size");
 
 # parliament.json
-    my $stats = viewerGet("/parliament.json");
+    my $stats = viewerGet("/api/parliament");
     is (@{$stats->{data}}, 1, "parliament.json data set ");
     is ($stats->{recordsTotal}, 1, "parliament.json recordsTotal");
     is ($stats->{data}->[0]->{id}, "test", "parliament.json name");

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,4 +1,4 @@
-use Test::More tests => 100;
+use Test::More tests => 104;
 use Cwd;
 use URI::Escape;
 use MolochTest;
@@ -294,11 +294,20 @@ my $pwd = "*/pcap";
     is (exists $json->{data}, 1, "user can make a query within their time range");
 
 # valueActions tests
-    $json = viewerGet("/api/valueActions?molochRegressionUser=test1");
-    eq_or_diff($json->{reverseDNS}, from_json('{"url": "reverseDNS.txt?ip=%TEXT%", "name": "Get Reverse DNS", "actionType": "fetch", "category": "ip"}'), 'test1 valueActions');
+    $json = viewerGet("/api/valueactions?molochRegressionUser=test1");
+    eq_or_diff($json->{reverseDNS}, from_json('{"url": "api/reversedns?ip=%TEXT%", "name": "Get Reverse DNS", "actionType": "fetch", "category": "ip"}'), 'test1 valueActions');
 
-    $json = viewerGet("/api/valueActions?molochRegressionUser=test2");
+    $json = viewerGet("/api/valueactions?molochRegressionUser=test2");
     eq_or_diff($json, from_json('{"text": "You do not have permission to access this resource", "success": false}'), 'test2 valueActions');
+
+# state tests
+    $json = viewerPostToken("/api/user/state/state1?molochRegressionUser=test1", '{"order":"test","visibleHeaders":["firstPacket","lastPacket","src","srcPort","dst","dstPort","totPackets","dbby","node"]}', $test1Token);
+    ok($json->{success}, "state create success");
+    $json = viewerPostToken("/api/user/state/state1?molochRegressionUser=test1", '{"order":[["firstPacket","asc"]],"visibleHeaders":["firstPacket","lastPacket"]}', $test1Token);
+    ok($json->{success}, "state update success");
+    $json = viewerGetToken("/api/user/state/state1?molochRegressionUser=test1", $test1Token);
+    eq_or_diff($json->{order}, from_json('[["firstPacket","asc"]]'), "share fetch success");
+    eq_or_diff($json->{visibleHeaders}, from_json('["firstPacket","lastPacket"]'), "share fetch success");
 
 # Delete Users
     $json = viewerDeleteToken("/api/user/test1", $token);

--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -2,8 +2,9 @@
 
 const dns = require('dns');
 const fs = require('fs');
+const unzipper = require('unzipper');
 
-module.exports = (Config, Db, internals) => {
+module.exports = (Config, Db, internals, sessionAPIs, ViewerUtils) => {
   const module = {};
 
   // field apis ---------------------------------------------------------------
@@ -111,6 +112,7 @@ module.exports = (Config, Db, internals) => {
     });
   };
 
+  // title apis ---------------------------------------------------------------
   /**
    * GET - /api/title
    *
@@ -129,6 +131,7 @@ module.exports = (Config, Db, internals) => {
     res.send(titleConfig);
   };
 
+  // value actions apis -------------------------------------------------------
   /**
    * GET - /api/valueactions
    *
@@ -148,7 +151,7 @@ module.exports = (Config, Db, internals) => {
         return {name: "Decoded:", value: atob(value.substring(6))};
       return undefined;
     }` };
-    actions.reverseDNS = { category: 'ip', name: 'Get Reverse DNS', url: 'reverseDNS.txt?ip=%TEXT%', actionType: 'fetch' };
+    actions.reverseDNS = { category: 'ip', name: 'Get Reverse DNS', url: 'api/reversedns?ip=%TEXT%', actionType: 'fetch' };
     actions.bodyHashMd5 = { category: 'md5', url: '%NODE%/%ID%/bodyHash/%TEXT%', name: 'Download File' };
     actions.bodyHashSha256 = { category: 'sha256', url: '%NODE%/%ID%/bodyHash/%TEXT%', name: 'Download File' };
 
@@ -162,6 +165,7 @@ module.exports = (Config, Db, internals) => {
     return res.send(actions);
   };
 
+  // reverse dns apis ---------------------------------------------------------
   /**
    * GET - /api/reversedns
    *
@@ -176,6 +180,144 @@ module.exports = (Config, Db, internals) => {
         return res.send('reverse error');
       }
       return res.send(data.join(', '));
+    });
+  };
+
+  // upload apis --------------------------------------------------------------
+  /**
+   * POST - /api/upload
+   *
+   * Uploads PCAP files.
+   * @name /upload
+   * @param {string} tags - A comma separated list of tags to add to each session created.
+   */
+  module.upload = (req, res) => {
+    const exec = require('child_process').exec;
+
+    let tags = '';
+    if (req.body.tags) {
+      const t = req.body.tags.replace(/[^-a-zA-Z0-9_:,]/g, '').split(',');
+      t.forEach((tag) => {
+        if (tag.length > 0) {
+          tags += ' --tag ' + tag;
+        }
+      });
+    }
+
+    const cmd = Config.get('uploadCommand')
+      .replace('{TAGS}', tags)
+      .replace('{NODE}', Config.nodeName())
+      .replace('{TMPFILE}', req.file.path)
+      .replace('{CONFIG}', Config.getConfigFile());
+
+    console.log('upload command: ', cmd);
+    exec(cmd, (error, stdout, stderr) => {
+      if (error !== null) {
+        console.log('<b>exec error: ' + error);
+        res.status(500);
+        res.write('<b>Upload command failed:</b><br>');
+      }
+      res.write(ViewerUtils.safeStr(cmd));
+      res.write('<br>');
+      res.write('<pre>');
+      res.write(stdout);
+      res.end('</pre>');
+      fs.unlinkSync(req.file.path);
+    });
+  };
+
+  // cluster apis -------------------------------------------------------------
+  /**
+   * GET - /api/clusters
+   *
+   * Retrieves a list of known configured Arkime clusters (if in
+   * <a href="https://arkime.com/settings#multi-viewer-settings">Mulit ES mode</a>).
+   * @name /clusters
+   * @returns {Array} active - The active Arkime clusters.
+   * @returns {Array} inactive - The inactive Arkime clusters.
+   */
+  module.getClusters = (req, res) => {
+    const clusters = { active: [], inactive: [] };
+    if (Config.get('multiES', false)) {
+      Db.getClusterDetails((err, results) => {
+        if (err) {
+          console.log('Error: ' + err);
+        } else if (results) {
+          clusters.active = results.active;
+          clusters.inactive = results.inactive;
+        }
+        res.send(clusters);
+      });
+    } else {
+      res.send(clusters);
+    }
+  };
+
+  // cyberchef apis -----------------------------------------------------------
+  /**
+   * GET - /api/cyberchef/:nodeName/session/:id
+   *
+   * Loads the src or dst packets for a session and sends them to
+   * <a href="https://github.com/gchq/CyberChef">CyberChef</a> for analysis.
+   * @name /cyberchef/:nodeName/session/:id
+   * @param {string} type=src - Whether to send the source (src) or destination (dst) packets.
+   */
+  module.cyberchef = (req, res) => {
+    sessionAPIs.processSessionIdAndDecode(req.params.id, 10000, (err, session, results) => {
+      if (err) {
+        console.log(`ERROR - /${req.params.nodeName}/session/${req.params.id}/cyberchef`, err);
+        return res.end('Error - ' + err);
+      }
+
+      let data = '';
+      for (let i = (req.query.type !== 'dst' ? 0 : 1), ilen = results.length; i < ilen; i += 2) {
+        data += results[i].data.toString('hex');
+      }
+
+      res.send({ data: data });
+    });
+  };
+
+  /**
+   * @ignore
+   *
+   * Loads the CyberChef UI.
+   * @name /cyberchef
+   */
+  module.getCyberchefUI = (req, res) => {
+    let found = false;
+    let path = req.path.substring(1);
+
+    if (req.baseUrl === '/modules') {
+      res.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
+      path = 'modules/' + path;
+    }
+
+    if (path === '') {
+      path = `CyberChef_v${internals.CYBERCHEFVERSION}.html`;
+    }
+
+    if (path === 'assets/main.js') {
+      res.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
+    } else if (path === 'assets/main.css') {
+      res.setHeader('Content-Type', 'text/css');
+    } else if (path.endsWith('.png')) {
+      res.setHeader('Content-Type', 'image/png');
+    }
+
+    fs.createReadStream(
+      `public/CyberChef_v${internals.CYBERCHEFVERSION}.zip`
+    ).pipe(unzipper.Parse()).on('entry', (entry) => {
+      if (entry.path === path) {
+        entry.pipe(res);
+        found = true;
+      } else {
+        entry.autodrain();
+      }
+    }).on('finish', () => {
+      if (!found) {
+        res.status(404).end('Page not found');
+      }
     });
   };
 

--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -261,7 +261,7 @@ module.exports = (Config, Db, internals, sessionAPIs, ViewerUtils) => {
    * @name /cyberchef/:nodeName/session/:id
    * @param {string} type=src - Whether to send the source (src) or destination (dst) packets.
    */
-  module.cyberchef = (req, res) => {
+  module.cyberChef = (req, res) => {
     sessionAPIs.processSessionIdAndDecode(req.params.id, 10000, (err, session, results) => {
       if (err) {
         console.log(`ERROR - /${req.params.nodeName}/session/${req.params.id}/cyberchef`, err);
@@ -283,7 +283,7 @@ module.exports = (Config, Db, internals, sessionAPIs, ViewerUtils) => {
    * Loads the CyberChef UI.
    * @name /cyberchef
    */
-  module.getCyberchefUI = (req, res) => {
+  module.getCyberChefUI = (req, res) => {
     let found = false;
     let path = req.path.substring(1);
 

--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -231,7 +231,7 @@ module.exports = (Config, Db, internals, sessionAPIs, ViewerUtils) => {
    * GET - /api/clusters
    *
    * Retrieves a list of known configured Arkime clusters (if in
-   * <a href="https://arkime.com/settings#multi-viewer-settings">Mulit ES mode</a>).
+   * <a href="https://arkime.com/settings#multi-viewer-settings">Mulit Viewer mode</a>).
    * @name /clusters
    * @returns {Array} active - The active Arkime clusters.
    * @returns {Array} inactive - The inactive Arkime clusters.
@@ -255,10 +255,9 @@ module.exports = (Config, Db, internals, sessionAPIs, ViewerUtils) => {
 
   // cyberchef apis -----------------------------------------------------------
   /**
-   * GET - /api/cyberchef/:nodeName/session/:id
+   * @ignore
    *
-   * Loads the src or dst packets for a session and sends them to
-   * <a href="https://github.com/gchq/CyberChef">CyberChef</a> for analysis.
+   * Retrieves the source or destination packets for a session for CyberChef.
    * @name /cyberchef/:nodeName/session/:id
    * @param {string} type=src - Whether to send the source (src) or destination (dst) packets.
    */

--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -1,0 +1,183 @@
+'use strict';
+
+const dns = require('dns');
+const fs = require('fs');
+
+module.exports = (Config, Db, internals) => {
+  const module = {};
+
+  // field apis ---------------------------------------------------------------
+  /**
+   * GET - /api/fields
+   *
+   * Gets available database field objects pertaining to sessions.
+   * @name /fields
+   * @param {boolean} array=false Whether to return an array of fields, otherwise returns a map
+   * @returns {array/map} The map or list of database fields
+   */
+  module.getFields = (req, res) => {
+    if (!internals.fieldsMap) {
+      res.status(404);
+      res.send('Cannot locate fields');
+    }
+
+    if (req.query && req.query.array) {
+      res.send(internals.fieldsArr);
+    } else {
+      res.send(internals.fieldsMap);
+    }
+  };
+
+  // file apis ----------------------------------------------------------------
+  /**
+   * GET - /api/files
+   *
+   * Gets a list of PCAP files that Arkime knows about.
+   * @name /files
+   * @param {number} length=100 - The number of items to return. Defaults to 500, Max is 10,000
+   * @param {number} start=0 - The entry to start at. Defaults to 0
+   * @returns {Array} data - The list of files
+   * @returns {number} recordsTotal - The total number of files Arkime knows about
+   * @returns {number} recordsFiltered - The number of files returned in this result
+   */
+  module.getFiles = (req, res) => {
+    const columns = ['num', 'node', 'name', 'locked', 'first', 'filesize', 'encoding', 'packetPosEncoding'];
+
+    const query = {
+      _source: columns,
+      from: +req.query.start || 0,
+      size: +req.query.length || 10,
+      sort: {}
+    };
+
+    query.sort[req.query.sortField || 'num'] = {
+      order: req.query.desc === 'true' ? 'desc' : 'asc'
+    };
+
+    if (req.query.filter) {
+      query.query = { wildcard: { name: `*${req.query.filter}*` } };
+    }
+
+    Promise.all([
+      Db.search('files', 'file', query),
+      Db.numberOfDocuments('files')
+    ]).then(([files, total]) => {
+      if (files.error) { throw files.error; }
+
+      const results = { total: files.hits.total, results: [] };
+      for (const file of files.hits.hits) {
+        const fields = file._source || files.fields;
+        if (fields.locked === undefined) {
+          fields.locked = 0;
+        }
+        fields.id = fields._id;
+        results.results.push(fields);
+      }
+
+      const r = {
+        recordsTotal: total.count,
+        recordsFiltered: results.total,
+        data: results.results
+      };
+
+      res.logCounts(r.data.length, r.recordsFiltered, r.total);
+      res.send(r);
+    }).catch((err) => {
+      console.log('ERROR - /file/list', err);
+      return res.send({ recordsTotal: 0, recordsFiltered: 0, data: [] });
+    });
+  };
+
+  /**
+   * GET - /api/:nodeName/:fileNum/filesize
+   *
+   * Retrieves the filesize of a PCAP file.
+   * @name /:nodeName/:fileNum/filesize
+   * @returns {number} filesize - The size of the file (-1 if the file cannot be found).
+   */
+  module.getFileSize = (req, res) => {
+    Db.fileIdToFile(req.params.nodeName, req.params.fileNum, (file) => {
+      if (!file) {
+        return res.send({ filesize: -1 });
+      }
+
+      fs.stat(file.name, (err, stats) => {
+        if (err || !stats) {
+          return res.send({ filesize: -1 });
+        } else {
+          return res.send({ filesize: stats.size });
+        }
+      });
+    });
+  };
+
+  /**
+   * GET - /api/title
+   *
+   * Retrieves the browser page title for the Arkime app.
+   * Configure it using <a href="https://arkime.com/settings#titletemplate">the titleTemplate setting</a>
+   * @name /title
+   * @returns {string} title - The title of the app based on the configured setting.
+   */
+  module.getPageTitle = (req, res) => {
+    let titleConfig = Config.get('titleTemplate', '_cluster_ - _page_ _-view_ _-expression_');
+
+    titleConfig = titleConfig.replace(/_cluster_/g, internals.clusterName)
+      .replace(/_userId_/g, req.user ? req.user.userId : '-')
+      .replace(/_userName_/g, req.user ? req.user.userName : '-');
+
+    res.send(titleConfig);
+  };
+
+  /**
+   * GET - /api/valueactions
+   *
+   * Retrives the actions that can be preformed on meta data values.
+   * @name /valueactions
+   * @returns {object} - The list of actions that can be preformed on data values.
+   */
+  module.getValueActions = (req, res) => {
+    if (!req.user || !req.user.userId) {
+      return res.send({});
+    }
+
+    const actions = {};
+
+    actions.httpAuthorizationDecode = { fields: 'http.authorization', func: `{
+      if (value.substring(0,5) === "Basic")
+        return {name: "Decoded:", value: atob(value.substring(6))};
+      return undefined;
+    }` };
+    actions.reverseDNS = { category: 'ip', name: 'Get Reverse DNS', url: 'reverseDNS.txt?ip=%TEXT%', actionType: 'fetch' };
+    actions.bodyHashMd5 = { category: 'md5', url: '%NODE%/%ID%/bodyHash/%TEXT%', name: 'Download File' };
+    actions.bodyHashSha256 = { category: 'sha256', url: '%NODE%/%ID%/bodyHash/%TEXT%', name: 'Download File' };
+
+    for (const key in internals.rightClicks) {
+      const rc = internals.rightClicks[key];
+      if (!rc.users || rc.users[req.user.userId]) {
+        actions[key] = rc;
+      }
+    }
+
+    return res.send(actions);
+  };
+
+  /**
+   * GET - /api/reversedns
+   *
+   * Retrives the domain names associated with an IP address.
+   * @name /reversedns
+   * @param {string} ip - The IP to search domain names for.
+   * @returns {string} domains - A comma separated string list of all the matching domain names.
+   */
+  module.getReverseDNS = (req, res) => {
+    dns.reverse(req.query.ip, (err, data) => {
+      if (err) {
+        return res.send('reverse error');
+      }
+      return res.send(data.join(', '));
+    });
+  };
+
+  return module;
+};

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2938,22 +2938,6 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
   };
 
   /**
-   * GET - /api/:nodeName/delete/:whatToRemove/:sid
-   *
-   * Scrub packet data by overwriting the packets (remove persmission required).
-   * @name /session/:nodeName/delete/:whatToRemove/:sid
-   */
-  module.scrubPcap = (req, res) => {
-    ViewerUtils.noCache(req, res);
-
-    res.statusCode = 200;
-
-    pcapScrub(req, res, req.params.sid, req.params.whatToRemove, (err) => {
-      res.end();
-    });
-  };
-
-  /**
    * GET - /api/delete
    *
    * Delete SPI and/or scrub PCAP data (remove persmission required).

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -15,8 +15,39 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
   const module = {};
 
   // --------------------------------------------------------------------------
-  // HELPERS
+  // INTERNAL HELPERS
   // --------------------------------------------------------------------------
+  function sessionsListFromQuery (req, res, fields, cb) {
+    if (req.query.segments && req.query.segments.match(/^(time|all)$/) && fields.indexOf('rootId') === -1) {
+      fields.push('rootId');
+    }
+
+    module.buildSessionQuery(req, (err, query, indices) => {
+      if (err) {
+        return res.send('Could not build query.  Err: ' + err);
+      }
+      query._source = fields;
+      if (Config.debug) {
+        console.log('sessionsListFromQuery query', JSON.stringify(query, null, 1));
+      }
+      const options = ViewerUtils.addCluster(req.query.cluster);
+      Db.searchPrimary(indices, 'session', query, options, (err, result) => {
+        if (err || result.error) {
+          console.log('ERROR - Could not fetch list of sessions.  Err: ', err, ' Result: ', result, 'query:', query);
+          return res.send('Could not fetch list of sessions.  Err: ' + err + ' Result: ' + result);
+        }
+        const list = result.hits.hits;
+        if (req.query.segments && req.query.segments.match(/^(time|all)$/)) {
+          sessionsListAddSegments(req, indices, query, list, (err, list) => {
+            cb(err, list);
+          });
+        } else {
+          cb(err, list);
+        }
+      });
+    });
+  };
+
   /**
    * Adds the sort options to the elasticsearch query
    * @ignore
@@ -54,7 +85,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         query.sort = [];
       }
 
-      info.order.split(',').forEach(function (item) {
+      info.order.split(',').forEach((item) => {
         const parts = item.split(':');
         const field = parts[0];
 
@@ -167,9 +198,9 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
   function csvListWriter (req, res, list, fields, pcapWriter, extension) {
     if (list.length > 0 && list[0].fields) {
-      list = list.sort(function (a, b) { return a.fields.lastPacket - b.fields.lastPacket; });
+      list = list.sort((a, b) => { return a.fields.lastPacket - b.fields.lastPacket; });
     } else if (list.length > 0 && list[0]._source) {
-      list = list.sort(function (a, b) { return a._source.lastPacket - b._source.lastPacket; });
+      list = list.sort((a, b) => { return a._source.lastPacket - b._source.lastPacket; });
     }
 
     const fieldObjects = Config.getDBFieldsMap();
@@ -226,7 +257,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
     // Index all the ids we have, so we don't include them again
     const haveIds = {};
-    list.forEach(function (item) {
+    list.forEach((item) => {
       haveIds[item._id] = true;
     });
 
@@ -234,7 +265,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
     // Do a ro search on each item
     let writes = 0;
-    async.eachLimit(list, 10, function (item, nextCb) {
+    async.eachLimit(list, 10, (item, nextCb) => {
       const fields = item._source || item.fields;
       if (!fields.rootId || processedRo[fields.rootId]) {
         if (writes++ > 100) {
@@ -249,12 +280,12 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
       const options = ViewerUtils.addCluster(req.query.cluster);
       query.query.bool.filter.push({ term: { rootId: fields.rootId } });
-      Db.searchPrimary(indices, 'session', query, options, function (err, result) {
+      Db.searchPrimary(indices, 'session', query, options, (err, result) => {
         if (err || result === undefined || result.hits === undefined || result.hits.hits === undefined) {
           console.log('ERROR fetching matching sessions', err, result);
           return nextCb(null);
         }
-        result.hits.hits.forEach(function (item) {
+        result.hits.hits.forEach((item) => {
           if (!haveIds[item._id]) {
             haveIds[item._id] = true;
             list.push(item);
@@ -263,7 +294,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         return nextCb(null);
       });
       query.query.bool.filter.pop();
-    }, function (err) {
+    }, (err) => {
       cb(err, list);
     });
   }
@@ -288,6 +319,57 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     }
   }
 
+  function reqGetRawBody (req, cb) {
+    module.processSessionIdAndDecode(req.params.id, 10000, (err, session, incoming) => {
+      if (err) {
+        return cb(err);
+      }
+
+      if (incoming.length === 0) {
+        return cb(null, null);
+      }
+
+      const options = {
+        id: session.id,
+        nodeName: req.params.nodeName,
+        order: [],
+        'ITEM-HTTP': {
+          order: []
+        },
+        'ITEM-SMTP': {
+          order: ['BODY-UNBASE64']
+        },
+        'ITEM-CB': {
+        },
+        'ITEM-RAWBODY': {
+          bodyNumber: +req.params.bodyNum
+        }
+      };
+
+      if (req.query.needgzip) {
+        options['ITEM-HTTP'].order.push('BODY-UNCOMPRESS');
+        options['ITEM-SMTP'].order.push('BODY-UNCOMPRESS');
+      }
+
+      options.order.push('ITEM-HTTP');
+      options.order.push('ITEM-SMTP');
+
+      options.order.push('ITEM-RAWBODY');
+      options.order.push('ITEM-CB');
+      options['ITEM-CB'].cb = (err, items) => {
+        if (err) {
+          return cb(err);
+        }
+        if (items === undefined || items.length === 0) {
+          return cb('No match');
+        }
+        cb(err, items[0].data);
+      };
+
+      decode.createPipeline(options, options.order, new decode.Pcap2ItemStream(options, incoming));
+    });
+  };
+
   function localSessionDetailReturnFull (req, res, session, incoming) {
     if (req.packetsOnly) { // only return packets
       res.render('sessionPackets.pug', {
@@ -304,7 +386,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         resFields: Config.headers('headers-http-response'),
         emailFields: Config.headers('headers-email'),
         showFrames: req.query.showFrames
-      }, function (err, data) {
+      }, (err, data) => {
         if (err) {
           console.trace('ERROR - localSession - ', err);
           return req.next(err);
@@ -383,7 +465,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       options.order.push('ITEM-NATURAL');
     }
     options.order.push('ITEM-CB');
-    options['ITEM-CB'].cb = function (err, outgoing) {
+    options['ITEM-CB'].cb = (err, outgoing) => {
       localSessionDetailReturnFull(req, res, session, outgoing);
     };
 
@@ -406,7 +488,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     req.query.showFrames = req.query.showFrames === 'true' || false;
 
     const packets = [];
-    module.processSessionId(req.params.id, !req.packetsOnly, null, function (pcap, buffer, cb, i) {
+    module.processSessionId(req.params.id, !req.packetsOnly, null, (pcap, buffer, cb, i) => {
       let obj = {};
       if (buffer.length > 16) {
         try {
@@ -420,8 +502,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       }
       packets[i] = obj;
       cb(null);
-    },
-    function (err, session) {
+    }, (err, session) => {
       if (err) {
         return res.end('Problem loading packets for ' + ViewerUtils.safeStr(req.params.id) + ' Error: ' + err);
       }
@@ -429,7 +510,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       sortFields(session);
 
       if (req.query.showFrames && packets.length !== 0) {
-        Pcap.packetFlow(session, packets, +req.query.packets || 200, function (err, results, sourceKey, destinationKey) {
+        Pcap.packetFlow(session, packets, +req.query.packets || 200, (err, results, sourceKey, destinationKey) => {
           session._err = err;
           session.sourceKey = sourceKey;
           session.destinationKey = destinationKey;
@@ -439,7 +520,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         session._err = 'No pcap data found';
         localSessionDetailReturn(req, res, session, []);
       } else if (packets[0].ether !== undefined && packets[0].ether.data !== undefined) {
-        Pcap.reassemble_generic_ether(packets, +req.query.packets || 200, function (err, results) {
+        Pcap.reassemble_generic_ether(packets, +req.query.packets || 200, (err, results) => {
           session._err = err;
           localSessionDetailReturn(req, res, session, results || []);
         });
@@ -447,38 +528,38 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         session._err = "Couldn't decode pcap file, check viewer log";
         localSessionDetailReturn(req, res, session, []);
       } else if (packets[0].ip.p === 1) {
-        Pcap.reassemble_icmp(packets, +req.query.packets || 200, function (err, results) {
+        Pcap.reassemble_icmp(packets, +req.query.packets || 200, (err, results) => {
           session._err = err;
           localSessionDetailReturn(req, res, session, results || []);
         });
       } else if (packets[0].ip.p === 6) {
         const key = session.srcIp;
-        Pcap.reassemble_tcp(packets, +req.query.packets || 200, key + ':' + session.srcPort, function (err, results) {
+        Pcap.reassemble_tcp(packets, +req.query.packets || 200, key + ':' + session.srcPort, (err, results) => {
           session._err = err;
           localSessionDetailReturn(req, res, session, results || []);
         });
       } else if (packets[0].ip.p === 17) {
-        Pcap.reassemble_udp(packets, +req.query.packets || 200, function (err, results) {
+        Pcap.reassemble_udp(packets, +req.query.packets || 200, (err, results) => {
           session._err = err;
           localSessionDetailReturn(req, res, session, results || []);
         });
       } else if (packets[0].ip.p === 132) {
-        Pcap.reassemble_sctp(packets, +req.query.packets || 200, function (err, results) {
+        Pcap.reassemble_sctp(packets, +req.query.packets || 200, (err, results) => {
           session._err = err;
           localSessionDetailReturn(req, res, session, results || []);
         });
       } else if (packets[0].ip.p === 50) {
-        Pcap.reassemble_esp(packets, +req.query.packets || 200, function (err, results) {
+        Pcap.reassemble_esp(packets, +req.query.packets || 200, (err, results) => {
           session._err = err;
           localSessionDetailReturn(req, res, session, results || []);
         });
       } else if (packets[0].ip.p === 58) {
-        Pcap.reassemble_icmp(packets, +req.query.packets || 200, function (err, results) {
+        Pcap.reassemble_icmp(packets, +req.query.packets || 200, (err, results) => {
           session._err = err;
           localSessionDetailReturn(req, res, session, results || []);
         });
       } else if (packets[0].ip.data !== undefined) {
-        Pcap.reassemble_generic_ip(packets, +req.query.packets || 200, function (err, results) {
+        Pcap.reassemble_generic_ip(packets, +req.query.packets || 200, (err, results) => {
           session._err = err;
           localSessionDetailReturn(req, res, session, results || []);
         });
@@ -495,7 +576,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
     function processFile (pcap, pos, i, nextCb) {
       pcap.ref();
-      pcap.readPacket(pos, function (packet) {
+      pcap.readPacket(pos, (packet) => {
         switch (packet) {
         case null:
           const msg = util.format(session._id, 'in file', pcap.filename, "couldn't read packet at", pos, 'packet #', i, 'of', fields.packetPos.length);
@@ -516,7 +597,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
     let fileNum;
     let itemPos = 0;
-    async.eachLimit(fields.packetPos, limit || 1, function (pos, nextCb) {
+    async.eachLimit(fields.packetPos, limit || 1, (pos, nextCb) => {
       if (pos < 0) {
         fileNum = pos * -1;
         return nextCb(null);
@@ -525,7 +606,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       // Get the pcap file for this node a filenum, if it isn't opened then do the filename lookup and open it
       const opcap = Pcap.get(fields.node + ':' + fileNum);
       if (!opcap.isOpen()) {
-        Db.fileIdToFile(fields.node, fileNum, function (file) {
+        Db.fileIdToFile(fields.node, fileNum, (file) => {
           if (!file) {
             console.log("WARNING - Only have SPI data, PCAP file no longer available.  Couldn't look up in file table", fields.node + '-' + fileNum);
             return nextCb('Only have SPI data, PCAP file no longer available for ' + fields.node + '-' + fileNum);
@@ -588,8 +669,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         }
         processFile(opcap, pos, itemPos++, nextCb);
       }
-    },
-    function (pcapErr, results) {
+    }, (pcapErr, results) => {
       endCb(pcapErr, fields);
     });
   }
@@ -657,7 +737,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
   }
 
   function localGetItemByHash (nodeName, sessionID, hash, cb) {
-    module.processSessionIdAndDecode(sessionID, 10000, function (err, session, incoming) {
+    module.processSessionIdAndDecode(sessionID, 10000, (err, session, incoming) => {
       if (err) {
         return cb(err);
       }
@@ -738,6 +818,255 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     });
   }
 
+  function sessionsPcap (req, res, pcapWriter, extension) {
+    ViewerUtils.noCache(req, res, 'application/vnd.tcpdump.pcap');
+
+    const fields = ['lastPacket', 'node', 'totBytes', 'totPackets', 'rootId'];
+
+    if (req.query.ids) {
+      const ids = ViewerUtils.queryValueToArray(req.query.ids);
+
+      module.sessionsListFromIds(req, ids, fields, (err, list) => {
+        sessionsPcapList(req, res, list, pcapWriter, extension);
+      });
+    } else {
+      sessionsListFromQuery(req, res, fields, (err, list) => {
+        sessionsPcapList(req, res, list, pcapWriter, extension);
+      });
+    }
+  }
+
+  function writePcap (res, id, options, doneCb) {
+    let b = Buffer.alloc(0xfffe);
+    let nextPacket = 0;
+    let boffset = 0;
+    const packets = {};
+
+    module.processSessionId(id, false, (pcap, buffer) => {
+      if (options.writeHeader) {
+        res.write(buffer);
+        options.writeHeader = false;
+      }
+    }, (pcap, buffer, cb, i) => {
+      // Save this packet in its spot
+      packets[i] = buffer;
+
+      // Send any packets we have in order
+      while (packets[nextPacket]) {
+        buffer = packets[nextPacket];
+        delete packets[nextPacket];
+        nextPacket++;
+
+        if (boffset + buffer.length > b.length) {
+          res.write(b.slice(0, boffset));
+          boffset = 0;
+          b = Buffer.alloc(0xfffe);
+        }
+        buffer.copy(b, boffset, 0, buffer.length);
+        boffset += buffer.length;
+      }
+      cb(null);
+    }, (err, session) => {
+      if (err) {
+        console.trace('writePcap', err);
+        return doneCb(err);
+      }
+      res.write(b.slice(0, boffset));
+      doneCb(err);
+    }, undefined, 10);
+  }
+
+  function writePcapNg (res, id, options, doneCb) {
+    let b = Buffer.alloc(0xfffe);
+    let boffset = 0;
+
+    module.processSessionId(id, true, (pcap, buffer) => {
+      if (options.writeHeader) {
+        res.write(pcap.getHeaderNg());
+        options.writeHeader = false;
+      }
+    }, (pcap, buffer, cb) => {
+      if (boffset + buffer.length + 20 > b.length) {
+        res.write(b.slice(0, boffset));
+        boffset = 0;
+        b = Buffer.alloc(0xfffe);
+      }
+
+      /* Need to write the ng block, and conver the old timestamp */
+      b.writeUInt32LE(0x00000006, boffset); // Block Type
+      const len = ((buffer.length + 20 + 3) >> 2) << 2;
+      b.writeUInt32LE(len, boffset + 4); // Block Len 1
+      b.writeUInt32LE(0, boffset + 8); // Interface Id
+
+      // js has 53 bit numbers, this will over flow on Jun 05 2255
+      const time = buffer.readUInt32LE(0) * 1000000 + buffer.readUInt32LE(4);
+      b.writeUInt32LE(Math.floor(time / 0x100000000), boffset + 12); // Block Len 1
+      b.writeUInt32LE(time % 0x100000000, boffset + 16); // Interface Id
+
+      buffer.copy(b, boffset + 20, 8, buffer.length - 8); // cap_len, packet_len
+      b.fill(0, boffset + 12 + buffer.length, boffset + 12 + buffer.length + (4 - (buffer.length % 4)) % 4); // padding
+      boffset += len - 8;
+
+      b.writeUInt32LE(0, boffset); // Options
+      b.writeUInt32LE(len, boffset + 4); // Block Len 2
+      boffset += 8;
+
+      cb(null);
+    }, (err, session) => {
+      if (err) {
+        console.log('writePcapNg', err);
+        return;
+      }
+      res.write(b.slice(0, boffset));
+
+      session.version = version.version;
+      delete session.packetPos;
+      const json = JSON.stringify(session);
+
+      const len = ((json.length + 20 + 3) >> 2) << 2;
+      b = Buffer.alloc(len);
+
+      b.writeUInt32LE(0x80808080, 0); // Block Type
+      b.writeUInt32LE(len, 4); // Block Len 1
+      b.write('MOWL', 8); // Magic
+      b.writeUInt32LE(json.length, 12); // Block Len 1
+      b.write(json, 16); // Magic
+      b.fill(0, 16 + json.length, 16 + json.length + (4 - (json.length % 4)) % 4); // padding
+      b.writeUInt32LE(len, len - 4); // Block Len 2
+      res.write(b);
+
+      doneCb(err);
+    });
+  }
+
+  function pcapScrub (req, res, sid, whatToRemove, endCb) {
+    if (pcapScrub.scrubbingBuffers === undefined) {
+      pcapScrub.scrubbingBuffers = [Buffer.alloc(5000), Buffer.alloc(5000), Buffer.alloc(5000)];
+      pcapScrub.scrubbingBuffers[0].fill(0);
+      pcapScrub.scrubbingBuffers[1].fill(1);
+      const str = 'Scrubbed! Hoot! ';
+      for (let i = 0; i < 5000;) {
+        i += pcapScrub.scrubbingBuffers[2].write(str, i);
+      }
+    }
+
+    function processFile (pcap, pos, i, nextCb) {
+      pcap.ref();
+      pcap.readPacket(pos, (packet) => {
+        pcap.unref();
+        if (packet) {
+          if (packet.length > 16) {
+            try {
+              let obj = {};
+              pcap.decode(packet, obj);
+              pcap.scrubPacket(obj, pos, pcapScrub.scrubbingBuffers[0], whatToRemove === 'all');
+              pcap.scrubPacket(obj, pos, pcapScrub.scrubbingBuffers[1], whatToRemove === 'all');
+              pcap.scrubPacket(obj, pos, pcapScrub.scrubbingBuffers[2], whatToRemove === 'all');
+            } catch (e) {
+              console.log(`Couldn't scrub packet at ${pos} -`, e);
+            }
+            return nextCb(null);
+          } else {
+            console.log(`Couldn't scrub packet at ${pos}`);
+            return nextCb(null);
+          }
+        }
+      });
+    }
+
+    Db.getSession(sid, { _source: 'node,ipProtocol,packetPos' }, (err, session) => {
+      let fileNum;
+      let itemPos = 0;
+      const fields = session._source || session.fields;
+
+      if (whatToRemove === 'spi') { // just removing es data for session
+        Db.deleteDocument(session._index, 'session', session._id, (err, data) => {
+          return endCb(err, fields);
+        });
+      } else { // scrub the pcap
+        async.eachLimit(fields.packetPos, 10, (pos, nextCb) => {
+          if (pos < 0) {
+            fileNum = pos * -1;
+            return nextCb(null);
+          }
+
+          // Get the pcap file for this node a filenum, if it isn't opened then do the filename lookup and open it
+          const opcap = Pcap.get(`write${fields.node}:${fileNum}`);
+          if (!opcap.isOpen()) {
+            Db.fileIdToFile(fields.node, fileNum, (file) => {
+              if (!file) {
+                console.log(`WARNING - Only have SPI data, PCAP file no longer available.  Couldn't look up in file table ${fields.node}-${fileNum}`);
+                return nextCb(`Only have SPI data, PCAP file no longer available for ${fields.node}-${fileNum}`);
+              }
+
+              const ipcap = Pcap.get(`write${fields.node}:${file.num}`);
+
+              try {
+                ipcap.openReadWrite(file.name, file);
+              } catch (err) {
+                const errorMsg = `Couldn't open file for writing: ${err}`;
+                console.log(`Error - ${errorMsg}`);
+                return nextCb(errorMsg);
+              }
+              processFile(ipcap, pos, itemPos++, nextCb);
+            });
+          } else {
+            processFile(opcap, pos, itemPos++, nextCb);
+          }
+        }, (pcapErr, results) => {
+          if (whatToRemove === 'all') { // also remove the session data
+            Db.deleteDocument(session._index, 'session', session._id, (err, data) => {
+              return endCb(pcapErr, fields);
+            });
+          } else { // just set who/when scrubbed the pcap
+            // Do the ES update
+            const document = {
+              doc: {
+                scrubby: req.user.userId || '-',
+                scrubat: new Date().getTime()
+              }
+            };
+            Db.updateSession(session._index, session._id, document, (err, data) => {
+              return endCb(pcapErr, fields);
+            });
+          }
+        });
+      }
+    });
+  }
+
+  function scrubList (req, res, whatToRemove, list) {
+    if (!list) { return res.molochError(200, 'Missing list of sessions'); }
+
+    async.eachLimit(list, 10, (item, nextCb) => {
+      const fields = item._source || item.fields;
+
+      module.isLocalView(fields.node, () => {
+        // Get from our DISK
+        pcapScrub(req, res, Db.session2Sid(item), whatToRemove, nextCb);
+      }, () => {
+        // Get from remote DISK
+        const path = `${fields.node}/delete/${whatToRemove}/${Db.session2Sid(item)}`;
+        ViewerUtils.makeRequest(fields.node, path, req.user, (err, response) => {
+          setImmediate(nextCb);
+        });
+      });
+    }, (err) => {
+      let text;
+      if (whatToRemove === 'all') {
+        text = `Deletion PCAP and SPI of ${list.length} sessions complete. Give Elasticsearch 60 seconds to complete SPI deletion.`;
+      } else if (whatToRemove === 'spi') {
+        text = `Deletion SPI of ${list.length} sessions complete. Give Elasticsearch 60 seconds to complete SPI deletion.`;
+      } else {
+        text = `Scrubbing PCAP of ${list.length} sessions complete`;
+      }
+      return res.end(JSON.stringify({ success: true, text: text }));
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // EXPOSED HELPERS
+  // --------------------------------------------------------------------------
   module.processSessionId = (id, fullSession, headerCb, packetCb, endCb, maxPackets, limit) => {
     let options;
     if (!fullSession) {
@@ -787,7 +1116,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
           psid = writer.processSessionId;
         }
 
-        psid(session, headerCb, packetCb, function (err, fields) {
+        psid(session, headerCb, packetCb, (err, fields) => {
           if (!fields) {
             return endCb(err, fields);
           }
@@ -799,37 +1128,6 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
           ViewerUtils.fixFields(fields, endCb);
         }, limit);
       }
-    });
-  };
-
-  module.sessionsListFromQuery = (req, res, fields, cb) => {
-    if (req.query.segments && req.query.segments.match(/^(time|all)$/) && fields.indexOf('rootId') === -1) {
-      fields.push('rootId');
-    }
-
-    module.buildSessionQuery(req, (err, query, indices) => {
-      if (err) {
-        return res.send('Could not build query.  Err: ' + err);
-      }
-      query._source = fields;
-      if (Config.debug) {
-        console.log('sessionsListFromQuery query', JSON.stringify(query, null, 1));
-      }
-      const options = ViewerUtils.addCluster(req.query.cluster);
-      Db.searchPrimary(indices, 'session', query, options, function (err, result) {
-        if (err || result.error) {
-          console.log('ERROR - Could not fetch list of sessions.  Err: ', err, ' Result: ', result, 'query:', query);
-          return res.send('Could not fetch list of sessions.  Err: ' + err + ' Result: ' + result);
-        }
-        const list = result.hits.hits;
-        if (req.query.segments && req.query.segments.match(/^(time|all)$/)) {
-          sessionsListAddSegments(req, indices, query, list, function (err, list) {
-            cb(err, list);
-          });
-        } else {
-          cb(err, list);
-        }
-      });
     });
   };
 
@@ -1046,11 +1344,11 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
     const list = [];
     const nonArrayFields = ['ipProtocol', 'firstPacket', 'lastPacket', 'srcIp', 'srcPort', 'srcGEO', 'dstIp', 'dstPort', 'dstGEO', 'totBytes', 'totDataBytes', 'totPackets', 'node', 'rootId', 'http.xffGEO'];
-    const fixFields = nonArrayFields.filter(function (x) { return fields.indexOf(x) !== -1; });
+    const fixFields = nonArrayFields.filter((x) => { return fields.indexOf(x) !== -1; });
 
     const options = ViewerUtils.addCluster(req ? req.query.cluster : undefined, { _source: fields.join(',') });
-    async.eachLimit(ids, 10, function (id, nextCb) {
-      Db.getSession(id, options, function (err, session) {
+    async.eachLimit(ids, 10, (id, nextCb) => {
+      Db.getSession(id, options, (err, session) => {
         if (err) {
           return nextCb(null);
         }
@@ -1065,11 +1363,11 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         list.push(session);
         nextCb(null);
       });
-    }, function (err) {
+    }, (err) => {
       if (processSegments) {
         module.buildSessionQuery(req, (err, query, indices) => {
           query._source = fields;
-          sessionsListAddSegments(req, indices, query, list, function (err, list) {
+          sessionsListAddSegments(req, indices, query, list, (err, list) => {
             cb(err, list);
           });
         });
@@ -1101,7 +1399,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
   module.proxyRequest = (req, res, errCb) => {
     ViewerUtils.noCache(req, res);
 
-    ViewerUtils.getViewUrl(req.params.nodeName, function (err, viewUrl, client) {
+    ViewerUtils.getViewUrl(req.params.nodeName, (err, viewUrl, client) => {
       if (err) {
         if (errCb) {
           return errCb(err);
@@ -1116,22 +1414,22 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       ViewerUtils.addAuth(info, req.user, req.params.nodeName);
       ViewerUtils.addCaTrust(info, req.params.nodeName);
 
-      const preq = client.request(info, function (pres) {
+      const preq = client.request(info, (pres) => {
         if (pres.headers['content-type']) {
           res.setHeader('content-type', pres.headers['content-type']);
         }
         if (pres.headers['content-disposition']) {
           res.setHeader('content-disposition', pres.headers['content-disposition']);
         }
-        pres.on('data', function (chunk) {
+        pres.on('data', (chunk) => {
           res.write(chunk);
         });
-        pres.on('end', function () {
+        pres.on('end', () => {
           res.end();
         });
       });
 
-      preq.on('error', function (e) {
+      preq.on('error', (e) => {
         if (errCb) {
           return errCb(e);
         }
@@ -1199,8 +1497,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       }
       packets[i] = obj;
       cb(null);
-    },
-    (err, session) => {
+    }, (err, session) => {
       if (err) {
         console.log('ERROR - processSessionIdAndDecode', err);
         return doneCb(err);
@@ -1230,182 +1527,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       } else {
         return doneCb(null, session, []);
       }
-    },
-    numPackets, 10);
-  };
-
-  module.reqGetRawBody = (req, cb) => {
-    module.processSessionIdAndDecode(req.params.id, 10000, (err, session, incoming) => {
-      if (err) {
-        return cb(err);
-      }
-
-      if (incoming.length === 0) {
-        return cb(null, null);
-      }
-
-      const options = {
-        id: session.id,
-        nodeName: req.params.nodeName,
-        order: [],
-        'ITEM-HTTP': {
-          order: []
-        },
-        'ITEM-SMTP': {
-          order: ['BODY-UNBASE64']
-        },
-        'ITEM-CB': {
-        },
-        'ITEM-RAWBODY': {
-          bodyNumber: +req.params.bodyNum
-        }
-      };
-
-      if (req.query.needgzip) {
-        options['ITEM-HTTP'].order.push('BODY-UNCOMPRESS');
-        options['ITEM-SMTP'].order.push('BODY-UNCOMPRESS');
-      }
-
-      options.order.push('ITEM-HTTP');
-      options.order.push('ITEM-SMTP');
-
-      options.order.push('ITEM-RAWBODY');
-      options.order.push('ITEM-CB');
-      options['ITEM-CB'].cb = (err, items) => {
-        if (err) {
-          return cb(err);
-        }
-        if (items === undefined || items.length === 0) {
-          return cb('No match');
-        }
-        cb(err, items[0].data);
-      };
-
-      decode.createPipeline(options, options.order, new decode.Pcap2ItemStream(options, incoming));
-    });
-  };
-
-  module.sessionsPcap = (req, res, pcapWriter, extension) => {
-    ViewerUtils.noCache(req, res, 'application/vnd.tcpdump.pcap');
-
-    const fields = ['lastPacket', 'node', 'totBytes', 'totPackets', 'rootId'];
-
-    if (req.query.ids) {
-      const ids = ViewerUtils.queryValueToArray(req.query.ids);
-
-      module.sessionsListFromIds(req, ids, fields, (err, list) => {
-        sessionsPcapList(req, res, list, pcapWriter, extension);
-      });
-    } else {
-      module.sessionsListFromQuery(req, res, fields, (err, list) => {
-        sessionsPcapList(req, res, list, pcapWriter, extension);
-      });
-    }
-  };
-
-  module.writePcap = (res, id, options, doneCb) => {
-    let b = Buffer.alloc(0xfffe);
-    let nextPacket = 0;
-    let boffset = 0;
-    const packets = {};
-
-    module.processSessionId(id, false, function (pcap, buffer) {
-      if (options.writeHeader) {
-        res.write(buffer);
-        options.writeHeader = false;
-      }
-    },
-    (pcap, buffer, cb, i) => {
-      // Save this packet in its spot
-      packets[i] = buffer;
-
-      // Send any packets we have in order
-      while (packets[nextPacket]) {
-        buffer = packets[nextPacket];
-        delete packets[nextPacket];
-        nextPacket++;
-
-        if (boffset + buffer.length > b.length) {
-          res.write(b.slice(0, boffset));
-          boffset = 0;
-          b = Buffer.alloc(0xfffe);
-        }
-        buffer.copy(b, boffset, 0, buffer.length);
-        boffset += buffer.length;
-      }
-      cb(null);
-    },
-    (err, session) => {
-      if (err) {
-        console.trace('writePcap', err);
-        return doneCb(err);
-      }
-      res.write(b.slice(0, boffset));
-      doneCb(err);
-    }, undefined, 10);
-  };
-
-  module.writePcapNg = (res, id, options, doneCb) => {
-    let b = Buffer.alloc(0xfffe);
-    let boffset = 0;
-
-    module.processSessionId(id, true, (pcap, buffer) => {
-      if (options.writeHeader) {
-        res.write(pcap.getHeaderNg());
-        options.writeHeader = false;
-      }
-    }, (pcap, buffer, cb) => {
-      if (boffset + buffer.length + 20 > b.length) {
-        res.write(b.slice(0, boffset));
-        boffset = 0;
-        b = Buffer.alloc(0xfffe);
-      }
-
-      /* Need to write the ng block, and conver the old timestamp */
-      b.writeUInt32LE(0x00000006, boffset); // Block Type
-      const len = ((buffer.length + 20 + 3) >> 2) << 2;
-      b.writeUInt32LE(len, boffset + 4); // Block Len 1
-      b.writeUInt32LE(0, boffset + 8); // Interface Id
-
-      // js has 53 bit numbers, this will over flow on Jun 05 2255
-      const time = buffer.readUInt32LE(0) * 1000000 + buffer.readUInt32LE(4);
-      b.writeUInt32LE(Math.floor(time / 0x100000000), boffset + 12); // Block Len 1
-      b.writeUInt32LE(time % 0x100000000, boffset + 16); // Interface Id
-
-      buffer.copy(b, boffset + 20, 8, buffer.length - 8); // cap_len, packet_len
-      b.fill(0, boffset + 12 + buffer.length, boffset + 12 + buffer.length + (4 - (buffer.length % 4)) % 4); // padding
-      boffset += len - 8;
-
-      b.writeUInt32LE(0, boffset); // Options
-      b.writeUInt32LE(len, boffset + 4); // Block Len 2
-      boffset += 8;
-
-      cb(null);
-    }, (err, session) => {
-      if (err) {
-        console.log('writePcapNg', err);
-        return;
-      }
-      res.write(b.slice(0, boffset));
-
-      session.version = version.version;
-      delete session.packetPos;
-      const json = JSON.stringify(session);
-
-      const len = ((json.length + 20 + 3) >> 2) << 2;
-      b = Buffer.alloc(len);
-
-      b.writeUInt32LE(0x80808080, 0); // Block Type
-      b.writeUInt32LE(len, 4); // Block Len 1
-      b.write('MOWL', 8); // Magic
-      b.writeUInt32LE(json.length, 12); // Block Len 1
-      b.write(json, 16); // Magic
-      b.fill(0, 16 + json.length, 16 + json.length + (4 - (json.length % 4)) % 4); // padding
-      b.writeUInt32LE(len, len - 4); // Block Len 2
-      res.write(b);
-
-      doneCb(err);
-    });
+    }, numPackets, 10);
   };
 
   // --------------------------------------------------------------------------
@@ -1540,12 +1662,12 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
             results.results.push(fields);
             return hitCb();
           } else {
-            ViewerUtils.fixFields(fields, function () {
+            ViewerUtils.fixFields(fields, () => {
               results.results.push(fields);
               return hitCb();
             });
           }
-        }, function () {
+        }, () => {
           try {
             response.map = map;
             response.graph = graph;
@@ -1600,7 +1722,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         csvListWriter(req, res, list, reqFields);
       });
     } else {
-      module.sessionsListFromQuery(req, res, fields, (err, list) => {
+      sessionsListFromQuery(req, res, fields, (err, list) => {
         csvListWriter(req, res, list, reqFields);
       });
     }
@@ -1655,7 +1777,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         };
       }
 
-      ViewerUtils.queryValueToArray(req.query.spi).forEach(function (item) {
+      ViewerUtils.queryValueToArray(req.query.spi).forEach((item) => {
         const parts = item.split(':');
         if (parts[0] === 'fileand') {
           query.aggregations[parts[0]] = { terms: { field: 'node', size: 1000 }, aggregations: { fileId: { terms: { field: 'fileId', size: parts.length > 1 ? parseInt(parts[1], 10) : 10 } } } };
@@ -1713,7 +1835,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         }
 
         if (sessions.aggregations.ipProtocol) {
-          sessions.aggregations.ipProtocol.buckets.forEach(function (item) {
+          sessions.aggregations.ipProtocol.buckets.forEach((item) => {
             item.key = Pcap.protocol2Name(item.key);
           });
         }
@@ -1722,7 +1844,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
           protocols = {};
           map = ViewerUtils.mapMerge(sessions.aggregations);
           graph = ViewerUtils.graphMerge(req, query, sessions.aggregations);
-          sessions.aggregations.protocols.buckets.forEach(function (item) {
+          sessions.aggregations.protocols.buckets.forEach((item) => {
             protocols[item.key] = item.doc_count;
           });
 
@@ -1759,20 +1881,20 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
         let sodc = 0;
         let nresults = [];
-        async.each(sessions.aggregations.fileand.buckets, function (nobucket, cb) {
+        async.each(sessions.aggregations.fileand.buckets, (nobucket, cb) => {
           sodc += nobucket.fileId.sum_other_doc_count;
-          async.each(nobucket.fileId.buckets, function (fsitem, cb) {
-            Db.fileIdToFile(nobucket.key, fsitem.key, function (file) {
+          async.each(nobucket.fileId.buckets, (fsitem, cb) => {
+            Db.fileIdToFile(nobucket.key, fsitem.key, (file) => {
               if (file && file.name) {
                 nresults.push({ key: file.name, doc_count: fsitem.doc_count });
               }
               cb();
             });
-          }, function () {
+          }, () => {
             cb();
           });
-        }, function () {
-          nresults = nresults.sort(function (a, b) {
+        }, () => {
+          nresults = nresults.sort((a, b) => {
             if (a.doc_count === b.doc_count) {
               return a.key.localeCompare(b.key);
             }
@@ -1864,12 +1986,12 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
           queriesInfo = queriesInfo.sort((a, b) => { return b.doc_count - a.doc_count; }).slice(0, size * 2);
           const queries = queriesInfo.map((item) => { return item.query; });
 
-          Db.msearch(indices, 'session', queries, options, function (err, result) {
+          Db.msearch(indices, 'session', queries, options, (err, result) => {
             if (!result.responses) {
               return res.send(results);
             }
 
-            result.responses.forEach(function (item, i) {
+            result.responses.forEach((item, i) => {
               const response = {
                 name: queriesInfo[i].key,
                 count: queriesInfo[i].doc_count
@@ -1920,7 +2042,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
               if (results.items.length === result.responses.length) {
                 const s = req.query.sort || 'sessionsHisto';
-                results.items = results.items.sort(function (a, b) {
+                results.items = results.items.sort((a, b) => {
                   let result;
                   if (s === 'name') {
                     result = a.name.localeCompare(b.name);
@@ -1937,17 +2059,17 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
         const intermediateResults = [];
         function findFileNames () {
-          async.each(intermediateResults, function (fsitem, cb) {
+          async.each(intermediateResults, (fsitem, cb) => {
             const split = fsitem.key.split(':');
             const node = split[0];
             const fileId = split[1];
-            Db.fileIdToFile(node, fileId, function (file) {
+            Db.fileIdToFile(node, fileId, (file) => {
               if (file && file.name) {
                 queriesInfo.push({ key: file.name, doc_count: fsitem.doc_count, query: fsitem.query });
               }
               cb();
             });
-          }, function () {
+          }, () => {
             endCb();
           });
         }
@@ -2040,7 +2162,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       }
 
       const options = ViewerUtils.addCluster(req.query.cluster);
-      Db.searchPrimary(indices, 'session', query, options, function (err, result) {
+      Db.searchPrimary(indices, 'session', query, options, (err, result) => {
         if (err) {
           console.log('spigraphpie ERROR', err);
           res.status(400);
@@ -2143,18 +2265,18 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       }
 
       aggSize = 1000; // lower agg size for autocomplete
-      doneCb = function () {
+      doneCb = () => {
         res.send(items);
       };
-      writeCb = function (item) {
+      writeCb = (item) => {
         items.push(item.key);
       };
     } else if (parseInt(req.query.counts, 10) || 0) {
-      writeCb = function (item) {
+      writeCb = (item) => {
         res.write(`${item.key}, ${item.doc_count}\n`);
       };
     } else {
-      writeCb = function (item) {
+      writeCb = (item) => {
         res.write(`${item.key}\n`);
       };
     }
@@ -2163,7 +2285,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     let eachCb = writeCb;
 
     if (req.query.field.match(/(ip.src:port.src|a1:p1|srcIp:srtPort|ip.src:srcPort|ip.dst:port.dst|a2:p2|dstIp:dstPort|ip.dst:dstPort)/)) {
-      eachCb = function (item) {
+      eachCb = (item) => {
         const sep = (item.key.indexOf(':') === -1) ? ':' : '.';
         item.field2.buckets.forEach((item2) => {
           item2.key = item.key + sep + item2.key;
@@ -2202,19 +2324,19 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
           const split = fsitem.key.split(':');
           const node = split[0];
           const fileId = split[1];
-          Db.fileIdToFile(node, fileId, function (file) {
+          Db.fileIdToFile(node, fileId, (file) => {
             if (file && file.name) {
               eachCb({ key: file.name, doc_count: fsitem.doc_count });
             }
             cb();
           });
-        }, function () {
+        }, () => {
           return res.end();
         });
       }
 
       const options = ViewerUtils.addCluster(req.query.cluster);
-      Db.searchPrimary(indices, 'session', query, options, function (err, result) {
+      Db.searchPrimary(indices, 'session', query, options, (err, result) => {
         if (err) {
           console.log('Error', query, err);
           return doneCb ? doneCb() : res.end();
@@ -2303,7 +2425,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       }
 
       const options = ViewerUtils.addCluster(req.query.cluster);
-      Db.searchPrimary(indices, 'session', query, options, function (err, result) {
+      Db.searchPrimary(indices, 'session', query, options, (err, result) => {
         if (err) {
           console.log('multiunique ERROR', err);
           res.status(400);
@@ -2316,7 +2438,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         printUnique(result.aggregations.field.buckets, '');
 
         if (req.query.sort !== 'field') {
-          results = results.sort(function (a, b) { return b.count - a.count; });
+          results = results.sort((a, b) => { return b.count - a.count; });
         }
 
         if (doCounts) {
@@ -2342,7 +2464,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
    */
   module.getDetail = (req, res) => {
     const options = ViewerUtils.addCluster(req.query.cluster);
-    Db.getSession(req.params.id, options, function (err, session) {
+    Db.getSession(req.params.id, options, (err, session) => {
       if (err || !session.found) {
         return res.end("Couldn't look up SPI data, error for session " + ViewerUtils.safeStr(req.params.id) + ' Error: ' + err);
       }
@@ -2368,7 +2490,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
           reqFields: Config.headers('headers-http-request'),
           resFields: Config.headers('headers-http-response'),
           emailFields: Config.headers('headers-email')
-        }, function (err, data) {
+        }, (err, data) => {
           if (err) {
             console.trace('ERROR - fixFields - ', err);
             return req.next(err);
@@ -2394,8 +2516,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       ViewerUtils.noCache(req, res);
       req.packetsOnly = true;
       localSessionDetail(req, res);
-    },
-    function () {
+    }, () => {
       return module.proxyRequest(req, res);
     });
   };
@@ -2440,7 +2561,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         });
       });
     } else {
-      module.sessionsListFromQuery(req, res, ['tags', 'node'], (err, list) => {
+      sessionsListFromQuery(req, res, ['tags', 'node'], (err, list) => {
         if (!list.length) {
           return res.molochError(200, 'No sessions to add tags to');
         }
@@ -2486,7 +2607,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         module.removeTagsList(res, tags, list);
       });
     } else {
-      module.sessionsListFromQuery(req, res, ['tags'], (err, list) => {
+      sessionsListFromQuery(req, res, ['tags'], (err, list) => {
         module.removeTagsList(res, tags, list);
       });
     }
@@ -2500,7 +2621,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
    * @returns {file} file - The file in the session
    */
   module.getRawBody = (req, res) => {
-    module.reqGetRawBody(req, function (err, data) {
+    reqGetRawBody(req, (err, data) => {
       if (err) {
         console.trace(err);
         return res.end('Error');
@@ -2521,7 +2642,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
    * @returns {image/png} image - The bitmap image.
    */
   module.getFilePNG = (req, res) => {
-    module.reqGetRawBody(req, function (err, data) {
+    reqGetRawBody(req, (err, data) => {
       if (err || data === null || data.length === 0) {
         return res.send(internals.emptyPNG);
       }
@@ -2532,6 +2653,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         width: internals.PNG_LINE_WIDTH,
         height: Math.ceil(data.length / internals.PNG_LINE_WIDTH)
       });
+
       png.data = data;
 
       res.send(PNG.sync.write(png, { inputColorType: 0, colorType: 0, bitDepth: 8, inputHasAlpha: false }));
@@ -2549,7 +2671,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
    * @returns {pcap} A PCAP file with the sessions requested
    */
   module.getPCAP = (req, res) => {
-    return module.sessionsPcap(req, res, module.writePcap, 'pcap');
+    return sessionsPcap(req, res, writePcap, 'pcap');
   };
 
   /**
@@ -2563,7 +2685,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
    * @returns {pcap} A PCAPNG file with the sessions requested
    */
   module.getPCAPNG = (req, res) => {
-    return module.sessionsPcap(req, res, module.writePcapNg, 'pcapng');
+    return sessionsPcap(req, res, writePcapNg, 'pcapng');
   };
 
   /**
@@ -2576,7 +2698,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
   module.getPCAPFromNode = (req, res) => {
     ViewerUtils.noCache(req, res, 'application/vnd.tcpdump.pcap');
     const writeHeader = !req.query || !req.query.noHeader || req.query.noHeader !== 'true';
-    module.writePcap(res, req.params.id, { writeHeader: writeHeader }, () => {
+    writePcap(res, req.params.id, { writeHeader: writeHeader }, () => {
       res.end();
     });
   };
@@ -2591,7 +2713,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
   module.getPCAPNGFromNode = (req, res) => {
     ViewerUtils.noCache(req, res, 'application/vnd.tcpdump.pcap');
     const writeHeader = !req.query || !req.query.noHeader || req.query.noHeader !== 'true';
-    module.writePcapNg(res, req.params.id, { writeHeader: writeHeader }, () => {
+    writePcapNg(res, req.params.id, { writeHeader: writeHeader }, () => {
       res.end();
     });
   };
@@ -2621,7 +2743,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
     Db.searchPrimary('sessions2-*', 'session', query, null, (err, data) => {
       async.forEachSeries(data.hits.hits, (item, nextCb) => {
-        module.writePcap(res, Db.session2Sid(item), options, nextCb);
+        writePcap(res, Db.session2Sid(item), options, nextCb);
       }, (err) => {
         res.end();
       });
@@ -2816,6 +2938,60 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
   };
 
   /**
+   * GET - /api/:nodeName/delete/:whatToRemove/:sid
+   *
+   * Scrub packet data by overwriting the packets (remove persmission required).
+   * @name /session/:nodeName/delete/:whatToRemove/:sid
+   */
+  module.scrubPcap = (req, res) => {
+    ViewerUtils.noCache(req, res);
+
+    res.statusCode = 200;
+
+    pcapScrub(req, res, req.params.sid, req.params.whatToRemove, (err) => {
+      res.end();
+    });
+  };
+
+  /**
+   * GET - /api/delete
+   *
+   * Delete SPI and/or scrub PCAP data (remove persmission required).
+   * @name /delete
+   * @param {string} removeSpi=false - Whether to remove the SPI data.
+   * @param {string} removePcap=true - Whether to remove the PCAP data.
+   * @returns {boolean} success - Whether the operation was successful
+   * @returns {string} text - The success/error message to (optionally) display to the user
+   */
+  module.deleteData = (req, res) => {
+    if (req.query.removeSpi !== 'true' && req.query.removePcap !== 'true') {
+      return res.molochError(403, `You can't delete nothing`);
+    }
+
+    let whatToRemove;
+    if (req.query.removeSpi === 'true' && req.query.removePcap === 'true') {
+      whatToRemove = 'all';
+    } else if (req.query.removeSpi === 'true') {
+      whatToRemove = 'spi';
+    } else {
+      whatToRemove = 'pcap';
+    }
+
+    if (req.body.ids) {
+      const ids = ViewerUtils.queryValueToArray(req.body.ids);
+      module.sessionsListFromIds(req, ids, ['node'], (err, list) => {
+        scrubList(req, res, whatToRemove, list);
+      });
+    } else if (req.query.expression) {
+      sessionsListFromQuery(req, res, ['node'], (err, list) => {
+        scrubList(req, res, whatToRemove, list);
+      });
+    } else {
+      return res.molochError(403, `Error: Missing expression. An expression is required so you don't delete everything.`);
+    }
+  };
+
+  /**
    * @ignore
    * GET - /api/session/:nodeName/:id/send
    *
@@ -2896,11 +3072,11 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     if (req.body.ids) {
       const ids = ViewerUtils.queryValueToArray(req.body.ids);
 
-      module.sessionsListFromIds(req, ids, ['node'], function (err, list) {
+      module.sessionsListFromIds(req, ids, ['node'], (err, list) => {
         sendSessionsList(req, res, list);
       });
     } else {
-      module.sessionsListFromQuery(req, res, ['node'], function (err, list) {
+      sessionsListFromQuery(req, res, ['node'], (err, list) => {
         sendSessionsList(req, res, list);
       });
     }
@@ -2946,10 +3122,10 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       }
 
       saveId.inProgress = 1;
-      Db.getSequenceNumber('fn-' + Config.nodeName(), function (err, seq) {
+      Db.getSequenceNumber('fn-' + Config.nodeName(), (err, seq) => {
         const filename = Config.get('pcapDir') + '/' + Config.nodeName() + '-' + seq + '-' + req.query.saveId + '.pcap';
         saveId.seq = seq;
-        Db.indexNow('files', 'file', Config.nodeName() + '-' + saveId.seq, { num: saveId.seq, name: filename, first: session.firstPacket, node: Config.nodeName(), filesize: -1, locked: 1 }, function () {
+        Db.indexNow('files', 'file', Config.nodeName() + '-' + saveId.seq, { num: saveId.seq, name: filename, first: session.firstPacket, node: Config.nodeName(), filesize: -1, locked: 1 }, () => {
           cb(filename);
           saveId.filename = filename; // Don't set the saveId.filename until after the first request completes its callback.
         });
@@ -2973,7 +3149,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       written += chunk.length; // Pretend we wrote it all
     }
 
-    req.on('data', function (chunk) {
+    req.on('data', (chunk) => {
       // If the file is open, just write the current chunk
       if (file) {
         return chunkWrite(chunk);
@@ -3002,7 +3178,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         if (filelen > 0) {
           req.pause();
 
-          makeFilename(function (filename) {
+          makeFilename((filename) => {
             req.resume();
             session.packetPos[0] = -saveId.seq;
             session.fileId = [saveId.seq];

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1986,12 +1986,12 @@ app.get(
 
 // cyberchef apis -------------------------------------------------------------
 app.get( // cyberchef endpoint
-  ['/api/cyberchef/:nodeName/session/:id', '/cyberchef/:nodeName/session/:id'],
+  '/cyberchef/:nodeName/session/:id',
   [checkPermissions(['webEnabled']), checkProxyRequest, unsafeInlineCspHeader],
   miscAPIs.cyberchef
 );
 
-app.get( // cyberchef UI endpoint
+app.use( // cyberchef UI endpoint
   ['/cyberchef/', '/modules/'],
   unsafeInlineCspHeader,
   miscAPIs.getCyberchefUI

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -38,7 +38,6 @@ try {
   var http = require('http');
   var https = require('https');
   var onHeaders = require('on-headers');
-  var unzipper = require('unzipper');
   var helmet = require('helmet');
   var uuid = require('uuidv4').default;
   var path = require('path');
@@ -96,7 +95,7 @@ const huntAPIs = require('./apiHunts')(Config, Db, internals, notifierAPIs, Pcap
 const userAPIs = require('./apiUsers')(Config, Db, internals, ViewerUtils);
 const historyAPIs = require('./apiHistory')(Db);
 const shortcutAPIs = require('./apiShortcuts')(Db, internals, ViewerUtils);
-const miscAPIs = require('./apiMisc')(Config, Db, internals); // TODO ECR
+const miscAPIs = require('./apiMisc')(Config, Db, internals, sessionAPIs, ViewerUtils);
 
 // registers a get and a post
 app.getpost = (route, mw, func) => { app.get(route, mw, func); app.post(route, mw, func); };
@@ -1066,134 +1065,6 @@ function sendSessionsListQL (pOptions, list, nextQLCb) {
   });
 }
 
-// packet/spi scrub helpers ---------------------------------------------------
-function pcapScrub (req, res, sid, whatToRemove, endCb) {
-  if (pcapScrub.scrubbingBuffers === undefined) {
-    pcapScrub.scrubbingBuffers = [Buffer.alloc(5000), Buffer.alloc(5000), Buffer.alloc(5000)];
-    pcapScrub.scrubbingBuffers[0].fill(0);
-    pcapScrub.scrubbingBuffers[1].fill(1);
-    const str = 'Scrubbed! Hoot! ';
-    for (let i = 0; i < 5000;) {
-      i += pcapScrub.scrubbingBuffers[2].write(str, i);
-    }
-  }
-
-  function processFile (pcap, pos, i, nextCb) {
-    pcap.ref();
-    pcap.readPacket(pos, function (packet) {
-      pcap.unref();
-      if (packet) {
-        if (packet.length > 16) {
-          try {
-            let obj = {};
-            pcap.decode(packet, obj);
-            pcap.scrubPacket(obj, pos, pcapScrub.scrubbingBuffers[0], whatToRemove === 'all');
-            pcap.scrubPacket(obj, pos, pcapScrub.scrubbingBuffers[1], whatToRemove === 'all');
-            pcap.scrubPacket(obj, pos, pcapScrub.scrubbingBuffers[2], whatToRemove === 'all');
-          } catch (e) {
-            console.log(`Couldn't scrub packet at ${pos} -`, e);
-          }
-          return nextCb(null);
-        } else {
-          console.log(`Couldn't scrub packet at ${pos}`);
-          return nextCb(null);
-        }
-      }
-    });
-  }
-
-  Db.getSession(sid, { _source: 'node,ipProtocol,packetPos' }, function (err, session) {
-    let fileNum;
-    let itemPos = 0;
-    const fields = session._source || session.fields;
-
-    if (whatToRemove === 'spi') { // just removing es data for session
-      Db.deleteDocument(session._index, 'session', session._id, function (err, data) {
-        return endCb(err, fields);
-      });
-    } else { // scrub the pcap
-      async.eachLimit(fields.packetPos, 10, function (pos, nextCb) {
-        if (pos < 0) {
-          fileNum = pos * -1;
-          return nextCb(null);
-        }
-
-        // Get the pcap file for this node a filenum, if it isn't opened then do the filename lookup and open it
-        let opcap = Pcap.get(`write${fields.node}:${fileNum}`);
-        if (!opcap.isOpen()) {
-          Db.fileIdToFile(fields.node, fileNum, function (file) {
-            if (!file) {
-              console.log(`WARNING - Only have SPI data, PCAP file no longer available.  Couldn't look up in file table ${fields.node}-${fileNum}`);
-              return nextCb(`Only have SPI data, PCAP file no longer available for ${fields.node}-${fileNum}`);
-            }
-
-            let ipcap = Pcap.get(`write${fields.node}:${file.num}`);
-
-            try {
-              ipcap.openReadWrite(file.name, file);
-            } catch (err) {
-              const errorMsg = `Couldn't open file for writing: ${err}`;
-              console.log(`Error - ${errorMsg}`);
-              return nextCb(errorMsg);
-            }
-            processFile(ipcap, pos, itemPos++, nextCb);
-          });
-        } else {
-          processFile(opcap, pos, itemPos++, nextCb);
-        }
-      },
-      function (pcapErr, results) {
-        if (whatToRemove === 'all') { // also remove the session data
-          Db.deleteDocument(session._index, 'session', session._id, function (err, data) {
-            return endCb(pcapErr, fields);
-          });
-        } else { // just set who/when scrubbed the pcap
-          // Do the ES update
-          const document = {
-            doc: {
-              scrubby: req.user.userId || '-',
-              scrubat: new Date().getTime()
-            }
-          };
-          Db.updateSession(session._index, session._id, document, function (err, data) {
-            return endCb(pcapErr, fields);
-          });
-        }
-      });
-    }
-  });
-}
-
-function scrubList (req, res, whatToRemove, list) {
-  if (!list) { return res.molochError(200, 'Missing list of sessions'); }
-
-  async.eachLimit(list, 10, function (item, nextCb) {
-    const fields = item._source || item.fields;
-
-    sessionAPIs.isLocalView(fields.node, function () {
-      // Get from our DISK
-      pcapScrub(req, res, Db.session2Sid(item), whatToRemove, nextCb);
-    },
-    function () {
-      // Get from remote DISK
-      let path = `${fields.node}/delete/${whatToRemove}/${Db.session2Sid(item)}`;
-      ViewerUtils.makeRequest(fields.node, path, req.user, function (err, response) {
-        setImmediate(nextCb);
-      });
-    });
-  }, function (err) {
-    let text;
-    if (whatToRemove === 'all') {
-      text = `Deletion PCAP and SPI of ${list.length} sessions complete. Give Elasticsearch 60 seconds to complete SPI deletion.`;
-    } else if (whatToRemove === 'spi') {
-      text = `Deletion SPI of ${list.length} sessions complete. Give Elasticsearch 60 seconds to complete SPI deletion.`;
-    } else {
-      text = `Scrubbing PCAP of ${list.length} sessions complete`;
-    }
-    return res.end(JSON.stringify({ success: true, text: text }));
-  });
-}
-
 // ============================================================================
 // EXPIRING
 // ============================================================================
@@ -1570,6 +1441,18 @@ app.post( // update user endpoint
   userAPIs.updateUser
 );
 
+app.get( // user state endpoint
+  ['/api/user/state/:name', '/state/:name'],
+  [noCacheJson, checkCookieToken, logAction()],
+  userAPIs.getUserState
+);
+
+app.post( // update/create user state endpoint
+  ['/api/user/state/:name', '/state/:name'],
+  [noCacheJson, checkCookieToken, logAction()],
+  userAPIs.updateUserState
+);
+
 // notifier apis --------------------------------------------------------------
 app.get( // notifier types endpoint
   ['/api/notifiertypes', '/notifierTypes'],
@@ -1620,107 +1503,12 @@ app.delete( // delete history endpoint
   historyAPIs.deleteHistory
 );
 
-/**
- * The Elasticsearch cluster health status and information.
- * @typedef ESHealth
- * @type {object}
- * @property {number} active_primary_shards - The number of active primary shards.
- * @property {number} active_shards - The total number of active primary and replica shards.
- * @property {number} active_shards_percent_as_number - The ratio of active shards in the cluster expressed as a percentage.
- * @property {string} cluster_name - The name of the arkime cluster
- * @property {number} delayed_unassigned_shards - The number of shards whose allocation has been delayed by the timeout settings.
- * @property {number} initializing_shards - The number of shards that are under initialization.
- * @property {number} molochDbVersion - The arkime database version
- * @property {number} number_of_data_nodes - The number of nodes that are dedicated data nodes.
- * @property {number} number_of_in_flight_fetch - The number of unfinished fetches.
- * @property {number} number_of_nodes - The number of nodes within the cluster.
- * @property {number} number_of_pending_tasks - The number of cluster-level changes that have not yet been executed.
- * @property {number} relocating_shards - The number of shards that are under relocation.
- * @property {string} status - Health status of the cluster, based on the state of its primary and replica shards. Statuses are:
-    "green" - All shards are assigned.
-    "yellow" - All primary shards are assigned, but one or more replica shards are unassigned. If a node in the cluster fails, some data could be unavailable until that node is repaired.
-    "red" - One or more primary shards are unassigned, so some data is unavailable. This can occur briefly during cluster startup as primary shards are assigned.
- * @property {number} task_max_waiting_in_queue_millis - The time expressed in milliseconds since the earliest initiated task is waiting for being performed.
- * @property {boolean} timed_out - If false the response returned within the period of time that is specified by the timeout parameter (30s by default).
- * @property {number} unassigned_shards - The number of shards that are not allocated.
- * @property {string} version - the elasticsearch version number
- * @property {number} _timeStamp - timestamps in ms from unix epoc
- */
-
-/**
- * GET - /api/eshealth
- *
- * Retrive Elasticsearch health and stats
- * There is no auth necessary to retrieve eshealth
- * @name /eshealth
- * @returns {ESHealth} health - The elasticsearch cluster health status and info
- */
-// TODO ECR - in stats
-app.get(['/api/eshealth', '/eshealth.json'], [noCacheJson], (req, res) => {
-  Db.healthCache(function (err, health) {
-    res.send(health);
-  });
-});
-
-// parliament apis ------------------------------------------------------------
-// TODO ECR STATS
-// No auth necessary for parliament.json
-app.get('/parliament.json', [noCacheJson], (req, res) => {
-  let query = {
-    size: 1000,
-    query: {
-      bool: {
-        must_not: [
-          { term: { hide: true } }
-        ]
-      }
-    },
-    _source: [
-      'ver', 'nodeName', 'currentTime', 'monitoring', 'deltaBytes', 'deltaPackets', 'deltaMS',
-      'deltaESDropped', 'deltaDropped', 'deltaOverloadDropped'
-    ]
-  };
-
-  Promise.all([Db.search('stats', 'stat', query), Db.numberOfDocuments('stats')])
-    .then(([stats, total]) => {
-      if (stats.error) { throw stats.error; }
-
-      let results = { total: stats.hits.total, results: [] };
-
-      for (let i = 0, ilen = stats.hits.hits.length; i < ilen; i++) {
-        let fields = stats.hits.hits[i]._source || stats.hits.hits[i].fields;
-
-        if (stats.hits.hits[i]._source) {
-          ViewerUtils.mergeUnarray(fields, stats.hits.hits[i].fields);
-        }
-        fields.id = stats.hits.hits[i]._id;
-
-        // make sure necessary fields are not undefined
-        let keys = [ 'deltaOverloadDropped', 'monitoring', 'deltaESDropped' ];
-        for (const key of keys) {
-          fields[key] = fields[key] || 0;
-        }
-
-        fields.deltaBytesPerSec = Math.floor(fields.deltaBytes * 1000.0 / fields.deltaMS);
-        fields.deltaPacketsPerSec = Math.floor(fields.deltaPackets * 1000.0 / fields.deltaMS);
-        fields.deltaESDroppedPerSec = Math.floor(fields.deltaESDropped * 1000.0 / fields.deltaMS);
-        fields.deltaTotalDroppedPerSec = Math.floor((fields.deltaDropped + fields.deltaOverloadDropped) * 1000.0 / fields.deltaMS);
-
-        results.results.push(fields);
-      }
-
-      res.send({
-        data: results.results,
-        recordsTotal: total.count,
-        recordsFiltered: results.total
-      });
-    }).catch((err) => {
-      console.log('ERROR - /parliament.json', err);
-      res.send({ recordsTotal: 0, recordsFiltered: 0, data: [] });
-    });
-});
-
 // stats apis -----------------------------------------------------------------
+app.get( // es health endpoint
+  ['/api/eshealth', '/eshealth.json'],
+  statsAPIs.getESHealth
+);
+
 app.get( // stats endpoint
   ['/api/stats', '/stats.json'],
   [noCacheJson, recordResponseTime, checkPermissions(['hideStats']), setCookie],
@@ -1858,6 +1646,13 @@ app.get( // elasticsearch recovery endpoint
   ['/api/esrecovery', '/esrecovery/list'],
   [noCacheJson, recordResponseTime, checkPermissions(['hideStats']), setCookie],
   statsAPIs.getESRecovery
+);
+
+// parliament apis ------------------------------------------------------------
+app.get( // parliament endpoint (no auth necessary)
+  ['/api/parliament', '/parliament.json'],
+  [noCacheJson],
+  statsAPIs.getParliament
 );
 
 // session apis ---------------------------------------------------------------
@@ -2036,6 +1831,18 @@ app.post( // sessions recieve endpoint
   sessionAPIs.receiveSession
 );
 
+app.get( // scrub pcap endpoint
+  ['/api/:nodeName/delete/:whatToRemove/:sid', '/:nodeName/delete/:whatToRemove/:sid'],
+  [checkProxyRequest, checkPermissions(['removeEnabled'])],
+  sessionAPIs.scrubPcap
+);
+
+app.post( // delete data endpoint
+  ['/api/delete', '/delete'],
+  [noCacheJson, checkCookieToken, logAction(), checkPermissions(['removeEnabled'])],
+  sessionAPIs.deleteData
+);
+
 // connections apis -----------------------------------------------------------
 app.getpost( // connections endpoint (POST or GET) - uses fillQueryFromBody to
   // fill the query parameters if the client uses POST to support POST and GET
@@ -2050,49 +1857,6 @@ app.getpost( // connections csv endpoint (POST or GET) - uses fillQueryFromBody 
   [logAction('connections.csv'), fillQueryFromBody],
   connectionAPIs.getConnectionsCSV
 );
-
-// state apis ----------------------------------------------------------------
-// TODO ECR - put in users
-app.post('/state/:name', [noCacheJson, checkCookieToken, logAction()], (req, res) => {
-  Db.getUser(req.user.userId, function (err, user) {
-    if (err || !user.found) {
-      console.log('save state failed', err, user);
-      return res.molochError(403, 'Unknown user');
-    }
-    user = user._source;
-
-    if (!user.tableStates) {
-      user.tableStates = {};
-    }
-    user.tableStates[req.params.name] = req.body;
-    Db.setUser(user.userId, user, function (err, info) {
-      if (err) {
-        console.log('state error', err, info);
-        return res.molochError(403, 'state update failed');
-      }
-      return res.send(JSON.stringify({ success: true, text: 'updated state successfully' }));
-    });
-  });
-});
-
-app.get('/state/:name', [noCacheJson], function (req, res) {
-  if (!req.user.tableStates || !req.user.tableStates[req.params.name]) {
-    return res.send('{}');
-  }
-
-  // Fix for new names
-  if (req.params.name === 'sessionsNew' && req.user.tableStates && req.user.tableStates.sessionsNew) {
-    let item = req.user.tableStates.sessionsNew;
-    if (item.visibleHeaders) {
-      item.visibleHeaders = item.visibleHeaders.map(ViewerUtils.oldDB2newDB);
-    }
-    if (item.order && item.order.length > 0) {
-      item.order[0][0] = ViewerUtils.oldDB2newDB(item.order[0][0]);
-    }
-  }
-
-  return res.send(req.user.tableStates[req.params.name]);
-});
 
 // hunt apis ------------------------------------------------------------------
 app.get( // hunts endpoint
@@ -2168,140 +1932,7 @@ app.delete( // delete shortcut endpoint
   shortcutAPIs.deleteShortcut
 );
 
-// packet/spi scrub apis ------------------------------------------------------
-// TODO ECR - in sessions
-app.get('/:nodeName/delete/:whatToRemove/:sid', [checkProxyRequest, checkPermissions(['removeEnabled'])], (req, res) => {
-  ViewerUtils.noCache(req, res);
-
-  res.statusCode = 200;
-
-  pcapScrub(req, res, req.params.sid, req.params.whatToRemove, (err) => {
-    res.end();
-  });
-});
-
-app.post('/delete', [noCacheJson, checkCookieToken, logAction(), checkPermissions(['removeEnabled'])], (req, res) => {
-  if (req.query.removeSpi !== 'true' && req.query.removePcap !== 'true') {
-    return res.molochError(403, `You can't delete nothing`);
-  }
-
-  let whatToRemove;
-  if (req.query.removeSpi === 'true' && req.query.removePcap === 'true') {
-    whatToRemove = 'all';
-  } else if (req.query.removeSpi === 'true') {
-    whatToRemove = 'spi';
-  } else {
-    whatToRemove = 'pcap';
-  }
-
-  if (req.body.ids) {
-    const ids = ViewerUtils.queryValueToArray(req.body.ids);
-    sessionAPIs.sessionsListFromIds(req, ids, ['node'], function (err, list) {
-      scrubList(req, res, whatToRemove, list);
-    });
-  } else if (req.query.expression) {
-    sessionAPIs.sessionsListFromQuery(req, res, ['node'], function (err, list) {
-      scrubList(req, res, whatToRemove, list);
-    });
-  } else {
-    return res.molochError(403, `Error: Missing expression. An expression is required so you don't delete everything.`);
-  }
-});
-
-// upload apis ----------------------------------------------------------------
-// TODO ECR - in misc
-app.post('/upload', [checkCookieToken, multer({ dest: '/tmp', limits: internals.uploadLimits }).single('file')], function (req, res) {
-  var exec = require('child_process').exec;
-
-  var tags = '';
-  if (req.body.tags) {
-    var t = req.body.tags.replace(/[^-a-zA-Z0-9_:,]/g, '').split(',');
-    t.forEach(function (tag) {
-      if (tag.length > 0) {
-        tags += ' --tag ' + tag;
-      }
-    });
-  }
-
-  var cmd = Config.get('uploadCommand')
-    .replace('{TAGS}', tags)
-    .replace('{NODE}', Config.nodeName())
-    .replace('{TMPFILE}', req.file.path)
-    .replace('{CONFIG}', Config.getConfigFile());
-
-  console.log('upload command: ', cmd);
-  exec(cmd, function (error, stdout, stderr) {
-    if (error !== null) {
-      console.log('<b>exec error: ' + error);
-      res.status(500);
-      res.write('<b>Upload command failed:</b><br>');
-    }
-    res.write(ViewerUtils.safeStr(cmd));
-    res.write('<br>');
-    res.write('<pre>');
-    res.write(stdout);
-    res.end('</pre>');
-    fs.unlinkSync(req.file.path);
-  });
-});
-
-// cyberchef apis -------------------------------------------------------------
-// TODO ECR - in misc
-// loads the src or dst packets for a session and sends them to cyberchef
-app.get('/cyberchef/:nodeName/session/:id', checkPermissions(['webEnabled']), checkProxyRequest, unsafeInlineCspHeader, (req, res) => {
-  sessionAPIs.processSessionIdAndDecode(req.params.id, 10000, function (err, session, results) {
-    if (err) {
-      console.log(`ERROR - /${req.params.nodeName}/session/${req.params.id}/cyberchef`, err);
-      return res.end('Error - ' + err);
-    }
-
-    let data = '';
-    for (let i = (req.query.type !== 'dst' ? 0 : 1), ilen = results.length; i < ilen; i += 2) {
-      data += results[i].data.toString('hex');
-    }
-
-    res.send({ data: data });
-  });
-});
-
-app.use(['/cyberchef/', '/modules/'], unsafeInlineCspHeader, (req, res) => {
-  let found = false;
-  let path = req.path.substring(1);
-
-  if (req.baseUrl === '/modules') {
-    res.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
-    path = 'modules/' + path;
-  }
-  if (path === '') {
-    path = `CyberChef_v${internals.CYBERCHEFVERSION}.html`;
-  }
-
-  if (path === 'assets/main.js') {
-    res.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
-  } else if (path === 'assets/main.css') {
-    res.setHeader('Content-Type', 'text/css');
-  } else if (path.endsWith('.png')) {
-    res.setHeader('Content-Type', 'image/png');
-  }
-
-  fs.createReadStream(`public/CyberChef_v${internals.CYBERCHEFVERSION}.zip`)
-    .pipe(unzipper.Parse())
-    .on('entry', function (entry) {
-      if (entry.path === path) {
-        entry.pipe(res);
-        found = true;
-      } else {
-        entry.autodrain();
-      }
-    })
-    .on('finish', function () {
-      if (!found) {
-        res.status(404).end('Page not found');
-      }
-    });
-});
-
-// misc apis ------------------------------------------------------------------
+// file apis ------------------------------------------------------------------
 app.get( // fields endpoint
   ['/api/fields', '/fields'],
   miscAPIs.getFields
@@ -2319,25 +1950,51 @@ app.get( // filesize endpoint
   miscAPIs.getFileSize
 );
 
-// TODO ECR update UI
+// title apis -----------------------------------------------------------------
 app.get( // titleconfig endpoint
   ['/api/title', '/titleconfig'],
   checkPermissions(['webEnabled']),
   miscAPIs.getPageTitle
 );
 
-// TODO ECR update UI
+// value actions apis ---------------------------------------------------------
 app.get( // value actions endpoint
-  ['/api/valueactions', '/molochRightClick'],
+  ['/api/valueactions', '/api/valueActions', '/molochRightClick'],
   [noCacheJson, checkPermissions(['webEnabled'])],
   miscAPIs.getValueActions
 );
 
-// TODO ECR update UI
+// reverse dns apis -----------------------------------------------------------
 app.get( // reverse dns endpoint
   ['/api/reversedns', '/reverseDNS.txt'],
   [noCacheJson, logAction()],
   miscAPIs.getReverseDNS
+);
+
+// uploads apis ---------------------------------------------------------------
+app.post(
+  ['/api/updload', '/upload'],
+  [checkCookieToken, multer({ dest: '/tmp', limits: internals.uploadLimits }).single('file')],
+  miscAPIs.upload
+);
+
+// clusters apis --------------------------------------------------------------
+app.get(
+  ['/api/clusters', '/clusters'],
+  miscAPIs.getClusters
+);
+
+// cyberchef apis -------------------------------------------------------------
+app.get( // cyberchef endpoint
+  ['/api/cyberchef/:nodeName/session/:id', '/cyberchef/:nodeName/session/:id'],
+  [checkPermissions(['webEnabled']), checkProxyRequest, unsafeInlineCspHeader],
+  miscAPIs.cyberchef
+);
+
+app.get( // cyberchef UI endpoint
+  ['/cyberchef/', '/modules/'],
+  unsafeInlineCspHeader,
+  miscAPIs.getCyberchefUI
 );
 
 // ============================================================================
@@ -2378,26 +2035,6 @@ if (Config.get('regressionTests')) {
     }, 1000);
   });
 }
-
-// ----------------------------------------------------------------------------
-// MultiES
-// ----------------------------------------------------------------------------
-app.get('/clusters', (req, res) => {
-  var clusters = { active: [], inactive: [] };
-  if (Config.get('multiES', false)) {
-    Db.getClusterDetails((err, results) => {
-      if (err) {
-        console.log('Error: ' + err);
-      } else if (results) {
-        clusters.active = results.active;
-        clusters.inactive = results.inactive;
-      }
-      res.send(clusters);
-    });
-  } else {
-    res.send(clusters);
-  }
-});
 
 // ============================================================================
 // VUE APP

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1831,12 +1831,6 @@ app.post( // sessions recieve endpoint
   sessionAPIs.receiveSession
 );
 
-app.get( // scrub pcap endpoint
-  ['/api/:nodeName/delete/:whatToRemove/:sid', '/:nodeName/delete/:whatToRemove/:sid'],
-  [checkProxyRequest, checkPermissions(['removeEnabled'])],
-  sessionAPIs.scrubPcap
-);
-
 app.post( // delete data endpoint
   ['/api/delete', '/delete'],
   [noCacheJson, checkCookieToken, logAction(), checkPermissions(['removeEnabled'])],
@@ -1988,13 +1982,13 @@ app.get(
 app.get( // cyberchef endpoint
   '/cyberchef/:nodeName/session/:id',
   [checkPermissions(['webEnabled']), checkProxyRequest, unsafeInlineCspHeader],
-  miscAPIs.cyberchef
+  miscAPIs.cyberChef
 );
 
 app.use( // cyberchef UI endpoint
   ['/cyberchef/', '/modules/'],
   unsafeInlineCspHeader,
-  miscAPIs.getCyberchefUI
+  miscAPIs.getCyberChefUI
 );
 
 // ============================================================================

--- a/viewer/vueapp/src/components/sessions/SessionsService.js
+++ b/viewer/vueapp/src/components/sessions/SessionsService.js
@@ -212,7 +212,7 @@ export default {
    */
   remove: function (params, routeParams) {
     return new Promise((resolve, reject) => {
-      let options = this.getReqOptions('delete', 'POST', params, routeParams);
+      const options = this.getReqOptions('api/delete', 'POST', params, routeParams);
 
       if (options.error) { return reject({ text: options.error }); }
 

--- a/viewer/vueapp/src/components/upload/Upload.vue
+++ b/viewer/vueapp/src/components/upload/Upload.vue
@@ -138,7 +138,7 @@ export default {
       formData.append('tags', this.tags);
 
       Vue.axios.post(
-        'upload',
+        'api/upload',
         formData, {
           headers: { 'Content-Type': 'multipart/form-data' }
         }

--- a/viewer/vueapp/src/components/users/UserService.js
+++ b/viewer/vueapp/src/components/users/UserService.js
@@ -689,7 +689,7 @@ export default {
    */
   getState (name) {
     return new Promise((resolve, reject) => {
-      Vue.axios.get(`state/${name}`)
+      Vue.axios.get(`api/user/state/${name}`)
         .then((response) => {
           resolve(response);
         }, (error) => {
@@ -708,7 +708,7 @@ export default {
   saveState (state, name) {
     return new Promise((resolve, reject) => {
       const options = {
-        url: `state/${name}`,
+        url: `api/user/state/${name}`,
         method: 'POST',
         data: state
       };

--- a/viewer/vueapp/src/components/utils/ConfigService.js
+++ b/viewer/vueapp/src/components/utils/ConfigService.js
@@ -43,7 +43,7 @@ export default {
     getMolochClickablesQIP = new Promise((resolve, reject) => {
       if (_molochClickablesCache) { resolve(_molochClickablesCache); }
 
-      Vue.axios.get('api/valueActions')
+      Vue.axios.get('api/valueactions')
         .then((response) => {
           getMolochClickablesQIP = undefined;
 
@@ -83,9 +83,14 @@ export default {
     });
   },
 
+  /**
+   * Retrieves a list of active and inactive Arkime clusters.
+   * @returns {Promise} Promise A promise object that signals the completion
+   *                            or rejection of the request.
+   */
   getClusters: function () {
     return new Promise((resolve, reject) => {
-      Vue.axios.get('clusters')
+      Vue.axios.get('api/clusters')
         .then((response) => {
           resolve(response.data);
         }, (error) => {

--- a/viewer/vueapp/src/components/utils/Table.vue
+++ b/viewer/vueapp/src/components/utils/Table.vue
@@ -262,11 +262,11 @@ export default {
       type: Boolean,
       required: true
     },
-    tableStateName: { // api endpoint to save table state (/state/:tableStateName)
+    tableStateName: { // api endpoint to save table state (api/user/state/:tableStateName)
       type: String,
       required: true
     },
-    tableWidthsStateName: { // api endpoint to save table state (/state/:tableWidthsStateName)
+    tableWidthsStateName: { // api endpoint to save table state (api/user/state/:tableWidthsStateName)
       type: String,
       required: true
     },


### PR DESCRIPTION
Put miscellaneous APIs in `apiMisc.js`.
Add eshealth and parliament endpoints to `apiStats.js`.
Add state endpoints to `apiUsers.js`.
Organize `apiSessions.js` a bit better and replace `function (x) {` with `(x) => {`.