### PR TITLE
Localindex

### DIFF
--- a/capture/bsb.h
+++ b/capture/bsb.h
@@ -48,6 +48,17 @@ do {                                              \
         BSB_SET_ERROR(b);                         \
 } while (0)
 
+#define BSB_EXPORT_u24(b, x)                      \
+do {                                              \
+    if ((b).ptr && (b).ptr + 3 <= (b).end) {      \
+        uint32_t t = x;                           \
+        *(((b).ptr)++) = (t & 0x00ff0000) >> 16;  \
+        *(((b).ptr)++) = (t & 0x0000ff00) >> 8;   \
+        *(((b).ptr)++) = (t & 0x000000ff);        \
+    } else                                        \
+        BSB_SET_ERROR(b);                         \
+} while (0)
+
 #define BSB_EXPORT_u32(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 4 <= (b).end) {      \
@@ -56,6 +67,19 @@ do {                                              \
         *(((b).ptr)++) = (t & 0x00ff0000) >> 16;  \
         *(((b).ptr)++) = (t & 0x0000ff00) >> 8;   \
         *(((b).ptr)++) = (t & 0x000000ff);        \
+    } else                                        \
+        BSB_SET_ERROR(b);                         \
+} while (0)
+
+#define BSB_EXPORT_u40(b, x)                      \
+do {                                              \
+    if ((b).ptr && (b).ptr + 5 <= (b).end) {      \
+        uint64_t t = x;                           \
+        *(((b).ptr)++) = (t & 0xff00000000) >> 32;  \
+        *(((b).ptr)++) = (t & 0x00ff000000) >> 24;  \
+        *(((b).ptr)++) = (t & 0x0000ff0000) >> 16;  \
+        *(((b).ptr)++) = (t & 0x000000ff00) >> 8;   \
+        *(((b).ptr)++) = (t & 0x00000000ff);        \
     } else                                        \
         BSB_SET_ERROR(b);                         \
 } while (0)
@@ -214,6 +238,17 @@ do {                                              \
         BSB_SET_ERROR(b);                         \
 } while (0)
 
+#define BSB_LEXPORT_u32(b, x)                     \
+do {                                              \
+    if ((b).ptr + 4 <= (b).end) {                 \
+        uint32_t t = x;                           \
+        *(((b).ptr)++) = (t & 0x000000ff);        \
+        *(((b).ptr)++) = (t & 0x0000ff00) >> 8;   \
+        *(((b).ptr)++) = (t & 0x00ff0000) >> 16;  \
+        *(((b).ptr)++) = (t & 0xff000000) >> 24;  \
+    } else                                        \
+        BSB_SET_ERROR(b);                         \
+} while (0)
 #define BSB_LEXPORT_u32(b, x)                     \
 do {                                              \
     if ((b).ptr + 4 <= (b).end) {                 \

--- a/capture/db.c
+++ b/capture/db.c
@@ -475,6 +475,10 @@ void moloch_db_save_session(MolochSession_t *session, int final)
         return;
     }
 
+    if (moloch_writer_index) {
+        moloch_writer_index(session);
+    }
+
     /* jsonSize is an estimate of how much space it will take to encode the session */
     jsonSize = 1100 + session->filePosArray->len*17 + 10*session->fileNumArray->len;
     if (config.enablePacketLen) {
@@ -761,6 +765,7 @@ void moloch_db_save_session(MolochSession_t *session, int final)
             }
         }
     } else {
+        // Do NOT remove this, S3 and others use this
         for(i = 0; i < session->filePosArray->len; i++) {
             if (i != 0)
                 BSB_EXPORT_u08(jbsb, ',');

--- a/capture/db.c
+++ b/capture/db.c
@@ -1741,6 +1741,8 @@ LOCAL void moloch_db_mkpath(char *path)
 /******************************************************************************/
 char *moloch_db_create_file_full(time_t firstPacket, const char *name, uint64_t size, int locked, uint32_t *id, ...)
 {
+    static GRegex     *numRegex;
+    static GRegex     *numHexRegex;
     char               key[100];
     int                key_len;
     uint32_t           num;
@@ -1749,6 +1751,10 @@ char *moloch_db_create_file_full(time_t firstPacket, const char *name, uint64_t 
     BSB                jbsb;
     const uint64_t     fp = firstPacket;
 
+    if (!numRegex) {
+        numRegex = g_regex_new("#NUM#", 0, 0, 0);
+        numHexRegex = g_regex_new("#NUMHEX#", 0, 0, 0);
+    }
 
     BSB_INIT(jbsb, json, MOLOCH_HTTP_BUFFER_SIZE);
 
@@ -1765,22 +1771,16 @@ char *moloch_db_create_file_full(time_t firstPacket, const char *name, uint64_t 
     }
 
 
-    if (name) {
-        static GRegex     *numRegex;
-        static GRegex     *numHexRegex;
-        if (!numRegex) {
-            numRegex = g_regex_new("#NUM#", 0, 0, 0);
-            numHexRegex = g_regex_new("#NUMHEX#", 0, 0, 0);
-        }
-        char numstr[100];
-        snprintf(numstr, sizeof(numstr), "%u", num);
+    char numstr[100];
+    snprintf(numstr, sizeof(numstr), "%u", num);
 
+    if (name) {
         char *name1 = g_regex_replace_literal(numRegex, name, -1, 0, numstr, 0, NULL);
         name = g_regex_replace_literal(numHexRegex, name1, -1, 0, (char *)moloch_char_to_hexstr[num%256], 0, NULL);
         g_free(name1);
 
         BSB_EXPORT_sprintf(jbsb, "{\"num\":%d, \"name\":\"%s\", \"first\":%" PRIu64 ", \"node\":\"%s\", \"filesize\":%" PRIu64 ", \"locked\":%d", num, name, fp, config.nodeName, size, locked);
-        key_len = snprintf(key, sizeof(key), "/%sfiles/_doc/%s-%u?refresh=true", config.prefix, config.nodeName,num);
+        key_len = snprintf(key, sizeof(key), "/%sfiles/_doc/%s-%u?refresh=true", config.prefix, config.nodeName, num);
     } else {
 
         uint16_t flen = strlen(config.pcapDir[config.pcapDirPos]);
@@ -1876,8 +1876,18 @@ char *moloch_db_create_file_full(time_t firstPacket, const char *name, uint64_t 
         if (!value)
             break;
 
+        if (value == MOLOCH_VAR_ARG_SKIP)
+            continue;
+
+
         BSB_EXPORT_sprintf(jbsb, ", \"%s\": ", field);
-        if (*value == '{' || *value == '[')
+
+        // HACK: But need num as we create this
+        if (strcmp(field, "indexFilename") == 0) {
+            char *value1 = g_regex_replace_literal(numRegex, value, -1, 0, numstr, 0, NULL);
+            BSB_EXPORT_sprintf(jbsb, "\"%s\"", value1);
+            g_free(value1);
+        } else if (*value == '{' || *value == '[')
             BSB_EXPORT_sprintf(jbsb, "%s", value);
         else
             BSB_EXPORT_sprintf(jbsb, "\"%s\"", value);
@@ -2491,6 +2501,7 @@ void moloch_db_exit()
         if (!config.noStats) {
             moloch_db_update_stats(0, 1);
         }
+        moloch_http_get(esServer, "/_refresh", 9, NULL);
         moloch_http_free_server(esServer);
     }
 

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -1260,10 +1260,12 @@ typedef void (*MolochWriterInit)(char *name);
 typedef uint32_t (*MolochWriterQueueLength)();
 typedef void (*MolochWriterWrite)(const MolochSession_t * const session, MolochPacket_t * const packet);
 typedef void (*MolochWriterExit)();
+typedef void (*MolochWriterIndex)(MolochSession_t * session);
 
 extern MolochWriterQueueLength moloch_writer_queue_length;
 extern MolochWriterWrite moloch_writer_write;
 extern MolochWriterExit moloch_writer_exit;
+extern MolochWriterIndex moloch_writer_index;
 
 
 void moloch_writers_init();

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -72,6 +72,8 @@
 
 #define MOLOCH_SESSION_v6(s) ((s)->sessionId[0] == 37)
 
+#define MOLOCH_VAR_ARG_SKIP (char *)1LL
+
 /******************************************************************************/
 /*
  * Base Hash Table Types
@@ -831,7 +833,6 @@ void moloch_config_monitor_files(char *desc, char **names, MolochFilesChange_cb 
 /*
  * db.c
  */
-
 void     moloch_db_init();
 char    *moloch_db_create_file(time_t firstPacket, const char *name, uint64_t size, int locked, uint32_t *id);
 char    *moloch_db_create_file_full(time_t firstPacket, const char *name, uint64_t size, int locked, uint32_t *id, ...);

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -621,25 +621,25 @@ void writer_simple_index (MolochSession_t * session)
             BSB_EXPORT_u08(bsb, 0x80 | (val & 0x7f));
 
             if (val <= 0x3fff) {
-                BSB_EXPORT_u08(bsb, val >> 7);
+                BSB_EXPORT_u08(bsb, (val >> 7) & 0x7f);
                 continue;
             }
             BSB_EXPORT_u08(bsb, 0x80 | ((val >> 7) & 0x7f));
 
             if (val <= 0x1fffff) {
-                BSB_EXPORT_u08(bsb, val >> 14);
+                BSB_EXPORT_u08(bsb, (val >> 14) & 0x7f);
                 continue;
             }
             BSB_EXPORT_u08(bsb, 0x80 | ((val >> 14) & 0x7f));
 
             if (val <= 0x0fffffff) {
-                BSB_EXPORT_u08(bsb, val >> 21);
+                BSB_EXPORT_u08(bsb, (val >> 21) & 0x7f);
                 continue;
             }
             BSB_EXPORT_u08(bsb, 0x80 | ((val >> 21) & 0x7f));
 
             if (val <= 0x07ffffffffLL) {
-                BSB_EXPORT_u08(bsb, val >> 28);
+                BSB_EXPORT_u08(bsb, (val >> 28) & 0x7f);
                 continue;
             }
             BSB_EXPORT_u08(bsb, 0x80 | ((val >> 28) & 0x7f));

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -693,15 +693,15 @@ void writer_simple_init(char *name)
 
     config.gapPacketPos = moloch_config_boolean(NULL, "gapPacketPos", TRUE);
 
-    localPcapIndex = moloch_config_boolean(NULL, "localPcapIndex", TRUE);
+    localPcapIndex = moloch_config_boolean(NULL, "localPcapIndex", FALSE);
     if (localPcapIndex) {
         if (config.pcapDir[1]) {
-            LOG("Don't support index with more than 1 pcap dir for now");
-        } else {
-            config.maxFileSizeB = MIN(config.maxFileSizeB, 0x07ffffffffL);
-            config.gapPacketPos = FALSE;
-            moloch_writer_index = writer_simple_index;
+            LOG("WARNING - Will always use first pcap directory for local index");
         }
+
+        config.maxFileSizeB = MIN(config.maxFileSizeB, 0x07ffffffffL);
+        config.gapPacketPos = FALSE;
+        moloch_writer_index = writer_simple_index;
     }
 
     DLL_INIT(simple_, &simpleQ);

--- a/capture/writers.c
+++ b/capture/writers.c
@@ -22,6 +22,7 @@
 MolochWriterQueueLength moloch_writer_queue_length;
 MolochWriterWrite moloch_writer_write;
 MolochWriterExit moloch_writer_exit;
+MolochWriterIndex moloch_writer_index;
 
 /******************************************************************************/
 extern MolochConfig_t        config;

--- a/viewer/db.js
+++ b/viewer/db.js
@@ -18,9 +18,10 @@
 
 'use strict';
 
-var ESC = require('elasticsearch');
-var os = require('os');
-var fs = require('fs');
+const ESC = require('elasticsearch');
+const os = require('os');
+const fs = require('fs');
+const async = require('async');
 const { Client } = require('@elastic/elasticsearch');
 
 var internals = { fileId2File: {},
@@ -208,41 +209,46 @@ exports.getSession = function (id, options, cb) {
             }
           }
         } else if (fileInfo.packetPosEncoding === 'localIndex') {
-          let pcapDir = internals.info.Config.getFull(fields.node, 'pcapDir').split(';')[0];
           let newPacketPos = [];
-          for (let i = 0, ilen = fields.packetPos.length - 2; i < ilen; i += 3) {
-            newPacketPos.push(fields.packetPos[i]);
-            const filename = `${pcapDir}/${fields.node}-${fields.packetPos[i] * -1}.index`;
-            const fd = fs.openSync(filename, 'r');
-            if (!fd) {
-              fields.packetPos = [];
-            }
+          async.forEachOfSeries(fields.packetPos, (item, key, nextCb) => {
+            if (key % 3 !== 0) { return nextCb(); } // Only look at every 3rd item
 
-            const buffer = Buffer.alloc(fields.packetPos[i + 2]);
-            fs.readSync(fd, buffer, 0, buffer.length, fields.packetPos[i + 1]);
-            let last = 0;
-            let lastgap = 0;
-            let num = 0;
-            let mult = 1;
-            for (let i = 0; i < buffer.length; i++) {
-              let x = buffer.readUInt8(i);
-              if (x & 0x80) {
-                num = num + (x & 0x7f) * mult;
-                mult *= 128;
-              } else {
-                num = num + x * mult;
-                if (num !== 0) {
-                  lastgap = num;
+            exports.fileIdToFile(fields.node, -1 * item, (fileInfo) => {
+              try {
+                const fd = fs.openSync(fileInfo.indexFilename, 'r');
+                if (!fd) { return nextCb(); }
+                const buffer = Buffer.alloc(fields.packetPos[key + 2]);
+                fs.readSync(fd, buffer, 0, buffer.length, fields.packetPos[key + 1]);
+                let last = 0;
+                let lastgap = 0;
+                let num = 0;
+                let mult = 1;
+                newPacketPos.push(item);
+                for (let i = 0; i < buffer.length; i++) {
+                  let x = buffer.readUInt8(i);
+                  if (x & 0x80) {
+                    num = num + (x & 0x7f) * mult;
+                    mult *= 128;
+                  } else {
+                    num = num + x * mult;
+                    if (num !== 0) {
+                      lastgap = num;
+                    }
+                    last += lastgap;
+                    newPacketPos.push(last);
+                    num = 0;
+                    mult = 1;
+                  }
                 }
-                last += lastgap;
-                newPacketPos.push(last);
-                num = 0;
-                mult = 1;
+                fs.closeSync(fd);
+                return nextCb();
+              } catch (e) {
+                console.log(e);
               }
-            }
-            fs.closeSync(fd);
-          }
-          fields.packetPos = newPacketPos;
+            });
+          }, () => {
+            fields.packetPos = newPacketPos;
+          });
         } else {
           console.log('Unsupported packetPosEncoding', fileInfo);
         }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1118,6 +1118,9 @@ function expireDevice (nodes, dirs, minFreeSpaceG, nextCb) {
       if (freeG < minFreeSpaceG) {
         data.hits.total--;
         console.log('Deleting', item);
+        if (item.indexFilename) {
+          fs.unlink(item.indexFilename, () => {});
+        }
         return Db.deleteFile(fields.node, item._id, fields.name, forNextCb);
       } else {
         return forNextCb('DONE');

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2467,6 +2467,5 @@ Db.initialize({ host: internals.elasticBase,
   requestTimeout: Config.get('elasticsearchTimeout', 300),
   esProfile: Config.esProfile,
   debug: Config.debug,
-  getSessionBySearch: Config.get('getSessionBySearch', ''),
-  Config: Config
+  getSessionBySearch: Config.get('getSessionBySearch', '')
 }, main);

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2467,5 +2467,6 @@ Db.initialize({ host: internals.elasticBase,
   requestTimeout: Config.get('elasticsearchTimeout', 300),
   esProfile: Config.esProfile,
   debug: Config.debug,
-  getSessionBySearch: Config.get('getSessionBySearch', '')
+  getSessionBySearch: Config.get('getSessionBySearch', ''),
+  Config: Config
 }, main);


### PR DESCRIPTION
New setting "localPcapIndex" that when set will create pcap index files on the capture nodes instead of elasticsearch. Elasticsearch will only have the [filenum, index pos, index length] for each file used. The index file uses variable length integers for packet positions. For single packet per file sessions this may use slightly more storage in total, otherwise it will use less. Index files will be about 0.2% the pcap file size I hope.