### PR TITLE
Start up delay to allow ES to finish loading

### DIFF
--- a/release/arkimeviewer.systemd.service
+++ b/release/arkimeviewer.systemd.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 Restart=on-failure
 StandardOutput=tty
+ExecStartPre=/bin/sleep 15
 EnvironmentFile=-ARKIME_INSTALL_DIR/etc/molochviewer.env
 ExecStart=/bin/sh -c 'ARKIME_INSTALL_DIR/bin/node viewer.js -c ARKIME_INSTALL_DIR/etc/config.ini ${OPTIONS} >> ARKIME_INSTALL_DIR/logs/viewer.log 2>&1'
 WorkingDirectory=ARKIME_INSTALL_DIR/viewer


### PR DESCRIPTION
Service can fail to come up upon boot if ES is not available. This adds a 15 second delay which can help solve the issue. It may be too brute force, and may not work in some circumstances, but it worked in my case.

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
See issue 

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
