### PR TITLE
send shallower queries to ES when possible

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,8 @@ NOTICE: Restart wiseService before capture when upgrading
   - viewer - dark theme improvements
   - viewer - can now toggle on/off capture start times
   - viewer - improve toolbar for packet display
+  - viewer - standardize on . ipv6 and : ipv4 por separator
+  - viewer - send shallower queries to ES when possible
   - wise - new config UI, enable with --webconfig
   - wise - more moloch->arkime changes
   - wise - for json data can now set arrayPath for start of where to parse
@@ -66,6 +68,7 @@ NOTICE: Restart wiseService before capture when upgrading
   - wise - new urlinfile://filepath where config is the first line of filepath file
   - wise - help page
   - all - renamed rightclicks to valueactions
+  - all - many typos fixed
   - esproxy - first version, see https://arkime.com/esproxy
 
 2.7.1 2020/12/01


### PR DESCRIPTION
Newer versions of ES have a query depth max, this tries to collapse queries. Has to do in JS because I couldn't figure out how to do in jison