### PR TITLE
Fix sessions col resize

### DIFF
--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -218,7 +218,7 @@
               <th v-for="header of headers"
                 :key="header.dbField"
                 class="moloch-col-header"
-                :style="{'width': header.width > 0 ? `${header.width}px` : '50px'}"
+                :style="{'width': header.width > 0 ? `${header.width}px` : '100px'}"
                 :class="{'active':isSorted(header.sortBy || header.dbField) >= 0, 'info-col-header': header.dbField === 'info'}">
                 <div class="grip"
                   v-if="header.dbField !== 'info'">
@@ -241,7 +241,7 @@
                     <template slot="button-content">
                       <span class="fa fa-th-list"
                         v-b-tooltip.hover.left
-                        title="Toggle visible fields">
+                        title="Toggle visible info column fields">
                       </span>
                     </template>
                     <b-dropdown-header>
@@ -597,13 +597,13 @@ function gripUnclick (e, vueThis) {
   if (selectedColElem && selectedGripElem) {
     vueThis.loading = true;
 
-    const newWidth = colStartOffset + e.pageX;
+    const newWidth = Math.max(colStartOffset + e.pageX, 70); // min col width is 70px
     selectedColElem.style.width = `${newWidth}px`;
 
     let hasInfo = false;
     for (let i = 0; i < cols.length; i++) { // get width of each col
       const col = cols[i];
-      const colW = Math.max(parseInt(col.style.width.slice(0, -2)), 50); // min col width is 50px
+      const colW = parseInt(col.style.width.slice(0, -2));
       if (vueThis.headers[i]) {
         const header = vueThis.headers[i];
         if (header.exp === 'info') { // ignore info col, it resizes to fit the window
@@ -758,7 +758,7 @@ export default {
       return this.$store.state.views;
     },
     tableWidthStyle () {
-      return { width: `${table.clientWidth - 2}px` };
+      return { width: `${table.clientWidth}px` };
     },
     showToolBars: function () {
       return this.$store.state.showToolBars;

--- a/viewer/vueapp/src/components/utils/KeyboardShortcuts.vue
+++ b/viewer/vueapp/src/components/utils/KeyboardShortcuts.vue
@@ -76,7 +76,7 @@ export default {
   position: fixed;
   top: 155px;
   width: 465px;
-  z-index: 1;
+  z-index: 9;
   background: var(--color-background, white);
   border: 1px solid var(--color-gray);
   border-left: none;

--- a/viewer/vueapp/src/components/utils/Navbar.vue
+++ b/viewer/vueapp/src/components/utils/Navbar.vue
@@ -16,17 +16,18 @@
         <router-link
           :to="{ path: helpLink.href, query: helpLink.query, params: { nav: true } }">
           <div id="helpTooltipContainer">
-            <img :src="userLogo"
-              class="arkime-logo"
+            <img
               alt="hoot"
-              v-b-tooltip.hover
-              title="HOOT! Can I help you? Click me to see the help page"
+              :src="userLogo"
               id="tooltipHelp"
+              class="arkime-logo"
+              v-b-tooltip.hover="'HOOT! Can I help you? Click me to see the help page'"
             />
           </div>
         </router-link>
-        <b-tooltip :show="shiftKeyHold"
+        <b-tooltip
           triggers=""
+          :show="shiftKeyHold"
           target="tooltipHelp"
           placement="leftbottom"
           container="helpTooltipContainer">
@@ -233,16 +234,17 @@ export default {
 /* add an H tooltip by the owl but move it down a bit so
    that the links in the navbar are not covered up */
 #helpTooltipContainer > div.tooltip {
-  top: 16px !important;
+  top: 12px !important;
 }
 /* move the arrow up to line up with the owl (since the
    tooltip was moved down) */
 #helpTooltipContainer > div.tooltip > div.arrow {
-  top: 2px !important;
+  top: -2px !important;
 }
 /* make the tooltip smaller */
 #helpTooltipContainer > div.tooltip > div.tooltip-inner {
   padding: 0 0.2rem !important;
+  color: var(--color-tertiary-lighter) !important;
 }
 </style>
 
@@ -319,11 +321,7 @@ li.nav-item.router-link-active > a.nav-link p.shortcut-letter::first-letter {
 }
 /* style the sortcut letter */
 p.shortcut-letter.holding-shift::first-letter {
-  color: var(--color-foreground-accent-dark) !important;
-}
-/* color the help shortcut letter in the tooltip */
-.help-shortcut {
-  color: var(--color-foreground-accent-dark);
+  color: var(--color-gray-dark) !important;
 }
 
 /* move the top nav content to the left to accommodate the sticky sessions


### PR DESCRIPTION
improve column resize functionality by removing colresize lib
allow table to overflow the window width and scroll horizontally
columns take default width when setting back to default columns
session detail always inherits the width of the table
make fit button smaller and not obscured when navbars are collapsed
fix top margin issues for sticky header (with and without navs)
remove margin from right of table
scroll header and body of table when sticky header is activated
don't display scroll bar on header