### PR TITLE
Corrected SMB1 match for smb.lua example.

### DIFF
--- a/capture/plugins/lua/samples/smb.lua
+++ b/capture/plugins/lua/samples/smb.lua
@@ -205,7 +205,7 @@ end
 function smbClassify(session, str, direction)
   if str:len() >= 64 then
     local tbl = session:table()
-    if str:sub(5,8) == string.char(0xfe, 0x53, 0x4d, 0x42) then
+    if str:sub(5,8) == string.char(0xff, 0x53, 0x4d, 0x42) then
       if tbl['ver'] == nil then
         tbl.opcodes = {} 
         tbl.cmd = {}


### PR DESCRIPTION
Previously SMB2 was all being parsed as SMB1. Lines 208 and 220 were the same. Changes 208 to match SMB1 hex values.

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
SMB2 was all being parsed as SMB1

**Relevant issue number(s) if applicable**
None

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
No, example file.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
No, example file.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
