### PR TITLE
add bad status codes for failing to fetch pcap

### DIFF
--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -876,7 +876,9 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     }, (err, session) => {
       if (err) {
         res.status(500);
-        console.trace('writePcap', err);
+        if (!Config.get('regressionTests', false)) {
+          console.trace('writePcap', err);
+        }
         return doneCb(err);
       }
       res.write(b.slice(0, boffset));

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -684,6 +684,9 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       list = list.sort((a, b) => {
         return a._source.lastPacket - b._source.lastPacket;
       });
+    } else if (list.length === 0) {
+      res.status(404);
+      return res.end(JSON.stringify({ success: false, text: 'no sessions found' }));
     }
 
     const writerOptions = { writeHeader: true };
@@ -830,7 +833,6 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
 
     if (req.query.ids) {
       const ids = ViewerUtils.queryValueToArray(req.query.ids);
-
       sModule.sessionsListFromIds(req, ids, fields, (err, list) => {
         sessionsPcapList(req, res, list, pcapWriter, extension);
       });
@@ -873,6 +875,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
       cb(null);
     }, (err, session) => {
       if (err) {
+        res.status(500);
         console.trace('writePcap', err);
         return doneCb(err);
       }

--- a/viewer/vueapp/src/components/sessions/SessionsService.js
+++ b/viewer/vueapp/src/components/sessions/SessionsService.js
@@ -268,11 +268,12 @@ export default {
    */
   exportPcap: function (params, routeParams) {
     return new Promise((resolve, reject) => {
-      const baseUrl = `api/sessions/pcap/${params.filename}`;
+      const filename = params.filename || 'sessions.pcap';
+      delete params.filename; // don't need this anymore
+
+      const baseUrl = `api/sessions/pcap/${filename}`;
       // save segments for later because getReqOptions deletes it
       const segments = params.segments;
-
-      delete params.filename; // don't need this anymore
 
       const options = this.getReqOptions(baseUrl, '', params, routeParams);
 
@@ -289,7 +290,12 @@ export default {
 
       const url = `${baseUrl}?${qs.stringify(options.params)}`;
 
-      window.location = url;
+      // use a link so any errors do not redirect to a broken page
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      link.click();
+      link.remove();
 
       return resolve({ text: 'PCAP now exporting' });
     });


### PR DESCRIPTION
- adds 404 for failing to get a list of sessions to write pcap
- adds 500 for failing to process session id
- uses a link in the client instead of opening a new window for the download so that an error doesn't redirect to a broken page

**_Limitations:_** 
- This **will not** set a bad status code if there is even one successful session that can be written as pcap. This is because the response is already writing the pcap file to the client, so a successful status code has already been sent.
- This **will not** display the error text sent from the server since a download is not a web page and the page that initiated the download cannot monitor the download response. If there is an error, the browser will display an error on its downloads page (depending on browser implementation, Chrome displays "Server Error"). Check logs for pcap download errors.

fixes #1719