### PR TITLE
fix uncompress by requesting all packets if uncompress requested

### DIFF
--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -488,7 +488,8 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     req.query.base = req.query.base || 'ascii';
     req.query.showFrames = req.query.showFrames === 'true' || false;
     // displaying images and uncompressing require all the packets from a session
-    req.query.packets = req.query.needimage || req.query.needgzip ? 10000 : +req.query.packets;
+    // *2 because the packets can be out of order, we truncate again in the reassemble call
+    req.query.packets = req.query.needimage || req.query.needgzip ? 10000 : +req.query.packets * 2;
 
     const packets = [];
     sModule.processSessionId(req.params.id, !req.packetsOnly, null, (pcap, buffer, cb, i) => {

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -487,9 +487,12 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     req.query.line = req.query.line || false;
     req.query.base = req.query.base || 'ascii';
     req.query.showFrames = req.query.showFrames === 'true' || false;
-    // displaying images and uncompressing require all the packets from a session
-    // *2 because the packets can be out of order, we truncate again in the reassemble call
-    req.query.packets = req.query.needimage || req.query.needgzip ? 10000 : +req.query.packets * 2;
+
+    req.query.packets = req.query.packets || 200;
+    if (req.query.needimage || req.query.needgzip) {
+      // displaying images & uncompressing require all packets from a session
+      req.query.packets = 10000;
+    }
 
     const packets = [];
     sModule.processSessionId(req.params.id, !req.packetsOnly, null, (pcap, buffer, cb, i) => {
@@ -581,7 +584,9 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         localSessionDetailReturn(req, res, session, []);
       }
     },
-    req.query.packets, 10);
+    // *2 because the packets can be out of order, we truncate again
+    // (using req.query.packets) in the reassemble call
+    +req.query.packets * 2, 10);
   }
 
   function processSessionIdDisk (session, headerCb, packetCb, endCb, limit) {

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -487,6 +487,8 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
     req.query.line = req.query.line || false;
     req.query.base = req.query.base || 'ascii';
     req.query.showFrames = req.query.showFrames === 'true' || false;
+    // displaying images and uncompressing require all the packets from a session
+    req.query.packets = req.query.needimage || req.query.needgzip ? 10000 : +req.query.packets;
 
     const packets = [];
     sModule.processSessionId(req.params.id, !req.packetsOnly, null, (pcap, buffer, cb, i) => {
@@ -578,7 +580,7 @@ module.exports = (Config, Db, internals, molochparser, Pcap, version, ViewerUtil
         localSessionDetailReturn(req, res, session, []);
       }
     },
-    req.query.needimage ? 10000 : 400, 10);
+    req.query.packets, 10);
   }
 
   function processSessionIdDisk (session, headerCb, packetCb, endCb, limit) {

--- a/viewer/vueapp/src/components/sessions/PacketOptions.vue
+++ b/viewer/vueapp/src/components/sessions/PacketOptions.vue
@@ -3,12 +3,12 @@
     <div class="form-group">
       <!-- # packets -->
       <span v-b-tooltip.hover
-        :title="params.gzip || params.image ? 'Cannot select number of packets because uncompress might need them all. To select the number of packets returned, disable uncompressing from the Packet Options menu' : ''">
+        :title="numPacketsInfo">
         <b-form-select
           size="sm"
           role="listbox"
           :value="params.packets"
-          :disabled="params.gzip"
+          :disabled="params.gzip || params.image"
           class="mr-1 form-control"
           :class="{'disabled':params.gzip}"
           :options="[
@@ -190,6 +190,27 @@ export default {
       decodingForm: false,
       decodingsClone: JSON.parse(JSON.stringify(this.decodings))
     };
+  },
+  computed: {
+    numPacketsInfo () {
+      let toggle;
+
+      if (this.params.gzip && this.params.image) {
+        toggle = 'uncompress and images & files';
+      } else if (this.params.gzip) {
+        toggle = 'uncompress';
+      } else if (this.params.image) {
+        toggle = 'images and files';
+      } else {
+        return '';
+      }
+
+      return `
+        Displaying all packets for this session.
+        You cannot select the number of packets because ${toggle} might need them all.
+        To select the number of packets returned, disable ${toggle} from the Packet Options menu.
+      `;
+    }
   },
   watch: {
     decodings (newVal) {

--- a/viewer/vueapp/src/components/sessions/PacketOptions.vue
+++ b/viewer/vueapp/src/components/sessions/PacketOptions.vue
@@ -2,20 +2,25 @@
   <span>
     <div class="form-group">
       <!-- # packets -->
-      <b-form-select
-        size="sm"
-        role="listbox"
-        :value="params.packets"
-        class="mr-1 form-control"
-        :options="[
-          { value: 50, text: '50 packets' },
-          { value: 200, text: '200 packets' },
-          { value: 500, text: '500 packets' },
-          { value: 1000, text: '1,000 packets' },
-          { value: 2000, text: '2,000 packets' }
-        ]"
-        @change="$emit('updateNumPackets', $event)"
-      /> <!-- /# packets -->
+      <span v-b-tooltip.hover
+        :title="params.gzip || params.image ? 'Cannot select number of packets because uncompress might need them all. To select the number of packets returned, disable uncompressing from the Packet Options menu' : ''">
+        <b-form-select
+          size="sm"
+          role="listbox"
+          :value="params.packets"
+          :disabled="params.gzip"
+          class="mr-1 form-control"
+          :class="{'disabled':params.gzip}"
+          :options="[
+            { value: 50, text: '50 packets' },
+            { value: 200, text: '200 packets' },
+            { value: 500, text: '500 packets' },
+            { value: 1000, text: '1,000 packets' },
+            { value: 2000, text: '2,000 packets' }
+          ]"
+          @change="$emit('updateNumPackets', $event)"
+        />
+      </span> <!-- /# packets -->
       <!-- packet display type -->
       <b-form-select
         size="sm"
@@ -58,13 +63,15 @@
         <b-dropdown-item
           v-if="!params.showFrames"
           @click="$emit('toggleCompression')"
-          :title="params.gzip ? 'Disable Uncompressing' : 'Enable Uncompressing'">
+          v-b-tooltip.hover.right="{ disabled: params.gzip }"
+          :title="params.gzip ? 'Disable Uncompressing' : 'Enable Uncompressing (Note: all packets will be requested)'">
           {{ params.gzip ? 'Disable Uncompressing' : 'Enable Uncompressing' }}
         </b-dropdown-item>
         <b-dropdown-item
           v-if="!params.showFrames"
           @click="$emit('toggleImages')"
-          :title="params.image ? 'Hide Images & Files' : 'Show Images & Files'">
+          v-b-tooltip.hover.right="{ disabled: params.image }"
+          :title="params.image ? 'Hide Images & Files' : 'Show Images & Files (Note: all packets will be requested)'">
           {{ params.image ? 'Hide' : 'Show'}}
           Images &amp; Files
         </b-dropdown-item>

--- a/viewer/vueapp/tests/sessions.packetoptions.test.js
+++ b/viewer/vueapp/tests/sessions.packetoptions.test.js
@@ -70,7 +70,7 @@ test('sessions - packet options', async () => {
   expect(emitted()).toHaveProperty('toggleLineNumbers');
 
   // click compressing toggle emits toggleCompression ---------------------- //
-  const compressingToggle = getByTitle('Enable Uncompressing');
+  const compressingToggle = getByTitle(/Enable Uncompressing/);
   await fireEvent.click(compressingToggle);
   expect(emitted()).toHaveProperty('toggleCompression');
 
@@ -110,14 +110,21 @@ test('sessions - packet options', async () => {
     cyberChefDstUrl: `cyberchef.html?nodeId=test&sessionId=${sessions[0].id}&type=dst`
   });
 
-  expect(getAllByRole('listbox')[0].value).toBe('200');
+  // gzip should disable the num packets select and display why
+  expect(numPacketsSelect).toHaveClass('disabled');
+  getByTitle(/Cannot select number of packets/);
+
+  // updated values
+  expect(numPacketsSelect.value).toBe('200');
   expect(getAllByRole('listbox')[1].value).toBe('ascii');
+
+  // updated titles
   getByTitle('Show Raw Packets');
   getByTitle('Hide Packet Info');
   expect(queryByTitle('Show Line Numbers')).not.toBeInTheDocument();
   expect(queryByTitle('Hide Line Numbers')).not.toBeInTheDocument();
   getByTitle('Disable Uncompressing');
-  getByTitle('Show Images & Files');
+  getByTitle(/Show Images & Files/);
   expect(getByTitle('Toggle source packet visibility')).not.toHaveClass('active');
   expect(getByTitle('Toggle destination packet visibility')).not.toHaveClass('active');
 
@@ -161,8 +168,8 @@ test('sessions - packet options', async () => {
   });
 
   expect(queryByTitle('Disable Uncompressing')).not.toBeInTheDocument();
-  expect(queryByTitle('Enable Uncompressing')).not.toBeInTheDocument();
-  expect(queryByTitle('Show Images & Files')).not.toBeInTheDocument();
+  expect(queryByTitle(/Enable Uncompressing/)).not.toBeInTheDocument();
+  expect(queryByTitle(/Show Images & Files/)).not.toBeInTheDocument();
   expect(queryByTitle('Hide Images & Files')).not.toBeInTheDocument();
 
   // toggle decoding without form ------------------------------------------ //

--- a/viewer/vueapp/tests/sessions.packetoptions.test.js
+++ b/viewer/vueapp/tests/sessions.packetoptions.test.js
@@ -19,7 +19,7 @@ const props = {
     line: true,
     base: 'hex',
     gzip: false,
-    image: true,
+    image: false,
     packets: '50',
     showDst: true,
     showSrc: true,
@@ -75,7 +75,7 @@ test('sessions - packet options', async () => {
   expect(emitted()).toHaveProperty('toggleCompression');
 
   // click image toggle emits imagesToggle --------------------------------- //
-  const imagesToggle = getByTitle('Hide Images & Files');
+  const imagesToggle = getByTitle(/Show Images & Files/);
   await fireEvent.click(imagesToggle);
   expect(emitted()).toHaveProperty('toggleImages');
 
@@ -98,7 +98,7 @@ test('sessions - packet options', async () => {
       line: false,
       base: 'ascii', // line numbers should only be availble for 'hex'
       gzip: true,
-      image: false,
+      image: true,
       packets: '200',
       showDst: false,
       showSrc: false,
@@ -112,7 +112,7 @@ test('sessions - packet options', async () => {
 
   // gzip should disable the num packets select and display why
   expect(numPacketsSelect).toHaveClass('disabled');
-  getByTitle(/Cannot select number of packets/);
+  getByTitle(/You cannot select the number of packets/);
 
   // updated values
   expect(numPacketsSelect.value).toBe('200');
@@ -124,7 +124,7 @@ test('sessions - packet options', async () => {
   expect(queryByTitle('Show Line Numbers')).not.toBeInTheDocument();
   expect(queryByTitle('Hide Line Numbers')).not.toBeInTheDocument();
   getByTitle('Disable Uncompressing');
-  getByTitle(/Show Images & Files/);
+  getByTitle('Hide Images & Files');
   expect(getByTitle('Toggle source packet visibility')).not.toHaveClass('active');
   expect(getByTitle('Toggle destination packet visibility')).not.toHaveClass('active');
 


### PR DESCRIPTION
disable packet length select input if uncompress or images requested
display reason for disabling packet length select
display warning that all packets will be requested when toggling on images or uncompress
