### PR TITLE
display field value even if field is missing

### DIFF
--- a/viewer/vueapp/src/components/search/FieldService.js
+++ b/viewer/vueapp/src/components/search/FieldService.js
@@ -65,23 +65,22 @@ export default {
       }
 
       // there is no cached result, so we need to fetch the fields
-      Vue.axios.get(`api/fields${array ? '?array=true' : ''}`)
-        .then((response) => {
-          queryInProgress.promise = undefined;
+      Vue.axios.get(`api/fields${array ? '?array=true' : ''}`).then((response) => {
+        queryInProgress.promise = undefined;
 
-          if (array) {
-            _fieldsArrayCache = response.data;
-          } else {
-            _fieldsMapCache = response.data;
-          }
+        if (array) {
+          _fieldsArrayCache = response.data;
+        } else {
+          _fieldsMapCache = response.data;
+        }
 
-          let result = response.data;
-          if (addIpDstPort) { result = addIpDstPortFieldToResults(response.data); }
-          return resolve(result);
-        }, (error) => {
-          queryInProgress.promise = undefined;
-          return reject(error);
-        });
+        let result = response.data;
+        if (addIpDstPort) { result = addIpDstPortFieldToResults(response.data); }
+        return resolve(result);
+      }).catch((error) => {
+        queryInProgress.promise = undefined;
+        return reject(error);
+      });
     });
 
     return queryInProgress.promise;

--- a/viewer/vueapp/src/components/sessions/SessionField.vue
+++ b/viewer/vueapp/src/components/sessions/SessionField.vue
@@ -2,7 +2,31 @@
 
   <span>
 
-    <span v-if="!field.children && parsed !== undefined">
+    <span v-if="!field">
+      <span
+        class="cursor-help text-danger"
+        :id="`tooltip-${expr}-${uuid}`">
+        <span class="fa fa-exclamation-triangle fa-fw" />
+        {{ missingFieldValue }}
+      </span>
+      <b-tooltip
+        variant="danger"
+        :target="`tooltip-${expr}-${uuid}`">
+        <h6 class="mb-1">
+          We cannot locate this field: <strong>{{ this.expr }}</strong>
+        </h6>
+        Maybe viewer crashed? Or a proxy or firewall is blocking?
+        Or you're using an
+        <a target="_blank"
+          rel="noreferrer noopener nofollow"
+          href="https://arkime.com/faq#what-browsers-are-supported">
+          unsupported browser</a>?
+        <br>
+        <em>Please contact your administrator.</em>
+      </b-tooltip>
+    </span>
+
+    <span v-else-if="!field.children && parsed !== undefined">
       <span v-for="pd of parsed"
         :key="pd.id">
 
@@ -170,6 +194,7 @@
 import Vue from 'vue';
 import ConfigService from '../utils/ConfigService';
 import MolochSessionInfo from './SessionInfo';
+import Utils from '../utils/utils';
 
 const noCommas = { vlan: true, 'suricata.signatureId': true };
 
@@ -274,6 +299,12 @@ export default {
       }
 
       return result;
+    },
+    missingFieldValue () {
+      return this.value ?? 'unknown';
+    },
+    uuid () {
+      return Utils.createRandomString();
     }
   },
   methods: {


### PR DESCRIPTION
note that field is missing and ways to solve the problem

<img width="1273" alt="Screen Shot 2021-08-20 at 2 03 47 PM" src="https://user-images.githubusercontent.com/1235082/130275284-0f92e5c5-6ec8-4f6c-8208-b45fcff5bf8e.png">

If a field cannot be found:
- Fields with values will be displayed but not parsed, because we don't know the field so we don't know how to parse it.
- Fields without values (custom fields with children fields) will just display "unknown" because we don't know the field to find the children to display the appropriate values.

fixes #1738 
