### PR TITLE
When running on EC2, use Instance Metadata Service v2 (IMDSv2) by default

### DIFF
--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -183,12 +183,16 @@ unsigned char *moloch_get_instance_metadata(void *serverV, char *key, int key_le
     tokenRequestHeaders[1] = NULL;
     requestHeaders[1] = NULL;
     if (s3UseTokenForMetadata) {
-        LOG("Requesting metadata token");
+        if (config.debug)
+            LOG("Requesting IMDSv2 metadata token");
         token = moloch_http_send_sync(serverV, "PUT", "/latest/api/token", -1, NULL, 0, tokenRequestHeaders, mlen);
-        LOG("Metadata token received");
+        if (config.debug)
+            LOG("IMDSv2 metadata token received");
         snprintf(tokenHeader, sizeof(tokenHeader), "X-aws-ec2-metadata-token: %s", token);
         requestHeaders[0] = tokenHeader;
     } else {
+        if (config.debug)
+            LOG("Using IMDSv1");
         requestHeaders[0] = NULL;
     }
     return moloch_http_send_sync(serverV, "GET", key, key_len, NULL, 0, requestHeaders, mlen);

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -176,9 +176,12 @@ void writer_s3_part_cb (int code, unsigned char *data, int len, gpointer uw)
 unsigned char *moloch_get_instance_metadata(void *serverV, char *key, int key_len, size_t *mlen)
 {
     unsigned char *token;
-    char *requestHeaders[1];
+    char *requestHeaders[2];
     char tokenHeader[200];
-    char *tokenRequestHeaders[1] = {"X-aws-ec2-metadata-token-ttl-seconds: 30"};
+    char *tokenRequestHeaders[2];
+    tokenRequestHeaders[0] = "X-aws-ec2-metadata-token-ttl-seconds: 30";
+    tokenRequestHeaders[1] = NULL;
+    requestHeaders[1] = NULL;
     if (s3UseTokenForMetadata) {
         LOG("Requesting metadata token");
         token = moloch_http_send_sync(serverV, "PUT", "/latest/api/token", -1, NULL, 0, tokenRequestHeaders, mlen);
@@ -186,7 +189,7 @@ unsigned char *moloch_get_instance_metadata(void *serverV, char *key, int key_le
         snprintf(tokenHeader, sizeof(tokenHeader), "X-aws-ec2-metadata-token: %s", token);
         requestHeaders[0] = tokenHeader;
     } else {
-        requestHeaders [0] = NULL;
+        requestHeaders[0] = NULL;
     }
     return moloch_http_send_sync(serverV, "GET", key, key_len, NULL, 0, requestHeaders, mlen);
 }

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -178,7 +178,7 @@ unsigned char *moloch_get_instance_metadata(void *serverV, char *key, int key_le
     unsigned char *token;
     char *requestHeaders[1];
     char tokenHeader[200];
-    char *tokenRequestHeaders[] = {"X-aws-ec2-metadata-token-ttl-seconds: 30"};
+    char *tokenRequestHeaders[1] = {"X-aws-ec2-metadata-token-ttl-seconds: 30"};
     if (s3UseTokenForMetadata) {
         LOG("Requesting metadata token");
         token = moloch_http_send_sync(serverV, "PUT", "/latest/api/token", -1, NULL, 0, tokenRequestHeaders, mlen);

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -717,7 +717,7 @@ void writer_s3_init(char *UNUSED(name))
     s3MaxConns            = moloch_config_int(NULL, "s3MaxConns", 20, 5, 1000);
     s3MaxRequests         = moloch_config_int(NULL, "s3MaxRequests", 500, 10, 5000);
     s3UseHttp             = moloch_config_boolean(NULL, "s3UseHttp", FALSE);
-    s3UseTokenForMetadata = moloch_config_boolean(NULL, "s3UseHttp", TRUE);
+    s3UseTokenForMetadata = moloch_config_boolean(NULL, "s3UseTokenForMetadata", TRUE);
     s3Token               = NULL;
     s3TokenTime           = 0;
     s3Role                = NULL;


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
AWS [recommends](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/) using Instance Metadata Service v2 ([IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html)) as a security best practice for EC2.

This pull request adds support for IMDSv2 and enables it by default. It can be disabled by setting the `s3UseTokenForMetadata` parameter to `false` in `config.ini`.

**Relevant issue number(s) if applicable**

N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

N/A

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
N/A

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
