### PR TITLE
fix typo at bottom of settings page

### DIFF
--- a/viewer/vueapp/src/components/settings/Settings.vue
+++ b/viewer/vueapp/src/components/settings/Settings.vue
@@ -1428,7 +1428,7 @@
 
           <!-- custom theme -->
           <p v-if="!creatingCustom">
-            Want to more control
+            Want more control
             <small>(to make the UI completely unusable)</small>?
             <a href="javascript:void(0)"
               class="cursor-pointer"


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

Simple typo in the footer on the settings page

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
Yep

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
Yep

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
