### PR TITLE
Do caching when getting pcap data from S3

### DIFF
--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -21,12 +21,18 @@ const AWS = require('aws-sdk');
 const async = require('async');
 const zlib = require('zlib');
 const S3s = {};
+const LRU = require('lru-cache');
+const CacheInProgress = {};
 let Config;
 let Db;
 let Pcap;
 
 const COMPRESSED_BLOCK_SIZE = 100000;
 const COMPRESSED_WITHIN_BLOCK_BITS = 20;
+
+const S3DEBUG = false;
+// Store up to 100 items
+const lru = new LRU({ max: 100 });
 
 /// ///////////////////////////////////////////////////////////////////////////////
 // https://coderwall.com/p/pq0usg/javascript-string-split-that-ll-return-the-remainder
@@ -95,24 +101,39 @@ function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
       Key: parts[4],
       Range: 'bytes=0-128'
     };
-    // console.log("HEADER", params);
-    s3.getObject(params, function (err, data) {
-      if (err) {
-        console.log(err, info);
-        return endCb("Couldn't open s3 file, save might not be complete yet - " + info.name, fields);
-      }
-      if (params.Key.endsWith('.gz')) {
-        header = zlib.gunzipSync(data.Body, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
-      } else {
-        header = data.Body;
-      }
-      header = header.subarray(0, 24);
-      pcap = Pcap.make(info.name, header);
+    let cacheKey = "pcap:" + fields.node + ":" + fields.packetPos[0];
+    let headerData = lru.get(cacheKey);
+    if (headerData) {
+      // console.log("CACHED-HEADER", cacheKey);
+      header = headerData.header;
+      pcap = headerData.pcap;
       if (headerCb) {
         headerCb(pcap, header);
       }
       readyToProcess();
-    });
+    } else {
+      if (S3DEBUG) {
+        console.log("s3.getObject for header", params);
+      }
+      s3.getObject(params, function (err, data) {
+        if (err) {
+          console.log(err, info);
+          return endCb("Couldn't open s3 file, save might not be complete yet - " + info.name, fields);
+        }
+        if (params.Key.endsWith('.gz')) {
+          header = zlib.gunzipSync(data.Body, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
+        } else {
+          header = data.Body;
+        }
+        header = header.subarray(0, 24);
+        pcap = Pcap.make(info.name, header);
+        lru.set(cacheKey, { pcap: pcap, header: header });
+        if (headerCb) {
+          headerCb(pcap, header);
+        }
+        readyToProcess();
+      });
+    }
   });
 
   function readyToProcess () {
@@ -120,42 +141,101 @@ function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
 
     function doProcess (data, nextCb) {
       // console.log("NEXT", data);
-      data.params.Range = 'bytes=' + data.rangeStart + '-' + (data.rangeEnd - 1);
-      s3.getObject(data.params, function (err, s3data) {
-        if (err) {
-          console.log('WARNING - Only have SPI data, PCAP file no longer available', data.info.name, err);
-          return nextCb('Only have SPI data, PCAP file no longer available for ' + data.info.name);
-        }
-        if (data.compressed) {
-          // Need to decompress the block(s)
-          const decompressed = {};
-          // First build a map from rangeStart to the decompressed block
-          for (let i = 0; i < data.subPackets.length; i++) {
-            const sp = data.subPackets[i];
-            if (!decompressed[sp.rangeStart]) {
-              const offset = sp.rangeStart - data.rangeStart;
-              decompressed[sp.rangeStart] = zlib.inflateRawSync(s3data.Body.subarray(offset, offset + COMPRESSED_BLOCK_SIZE),
-                { finishFlush: zlib.constants.Z_SYNC_FLUSH });
+
+      let haveAllCached = true;
+      // See if we have all the required decompressed blocks
+      for (let i = 0; i < data.subPackets.length; i++) {
+        const sp = data.subPackets[i];
+        const decompressedCacheKey = "data:" + data.params.Bucket +":" + data.params.Key + ":" + sp.rangeStart;
+        const cachedDecompressed = lru.get(decompressedCacheKey);
+        if (!cachedDecompressed) {
+          // console.log("CACHE-MISS", decompressedCacheKey);
+          haveAllCached = false;
+          if (CacheInProgress[decompressedCacheKey]) {
+            // We need to wait for this to complete
+            if (CacheInProgress[decompressedCacheKey] == true) {
+              CacheInProgress[decompressedCacheKey] = [];
             }
+            CacheInProgress[decompressedCacheKey].push(function() { doProcess(data, nextCb); });
+            return;
           }
-          async.each(data.subPackets, (sp, nextSubCb) => {
-            const block = decompressed[sp.rangeStart];
-            const subPacketData = block.subarray(sp.packetStart, sp.packetEnd);
-            const len = (pcap.bigEndian ? subPacketData.readUInt32BE(8) : subPacketData.readUInt32LE(8));
-
-            packetCb(pcap, subPacketData.subarray(0, len + 16), nextSubCb, sp.itemPos);
-          },
-          nextCb);
-        } else {
-          async.each(data.subPackets, (sp, nextSubCb) => {
-            const subPacketData = s3data.Body.subarray(sp.packetStart - data.packetStart, sp.packetEnd - data.packetStart);
-            const len = (pcap.bigEndian ? subPacketData.readUInt32BE(8) : subPacketData.readUInt32LE(8));
-
-            packetCb(pcap, subPacketData.subarray(0, len + 16), nextSubCb, sp.itemPos);
-          },
-          nextCb);
+          break;
         }
-      });
+      }
+
+      if (haveAllCached) {
+        // We have all the data that we need
+        // console.log("ALL-CACHED");
+        async.each(data.subPackets, (sp, nextSubCb) => {
+          const decompressedCacheKey = "data:" + data.params.Bucket +":" + data.params.Key + ":" + sp.rangeStart;
+          const block = lru.get(decompressedCacheKey);
+          const subPacketData = block.subarray(sp.packetStart, sp.packetEnd);
+          const len = (pcap.bigEndian ? subPacketData.readUInt32BE(8) : subPacketData.readUInt32LE(8));
+
+          // console.log("CACHED-PACKET", sp);
+          packetCb(pcap, subPacketData.subarray(0, len + 16), nextSubCb, sp.itemPos);
+        },
+        nextCb);
+      } else {
+        for (let i = 0; i < data.subPackets.length; i++) {
+          const sp = data.subPackets[i];
+          const decompressedCacheKey = "data:" + data.params.Bucket +":" + data.params.Key + ":" + sp.rangeStart;
+          if (!CacheInProgress[decompressedCacheKey]) {
+            CacheInProgress[decompressedCacheKey] = true;
+          }
+        }
+        data.params.Range = 'bytes=' + data.rangeStart + '-' + (data.rangeEnd - 1);
+        if (S3DEBUG) {
+          console.log("s3.getObject for pcap data", data.params);
+        }
+        s3.getObject(data.params, function (err, s3data) {
+          if (err) {
+            console.log('WARNING - Only have SPI data, PCAP file no longer available', data.info.name, err);
+            return nextCb('Only have SPI data, PCAP file no longer available for ' + data.info.name);
+          }
+          if (data.compressed) {
+            // Need to decompress the block(s)
+            const decompressed = {};
+            // First build a map from rangeStart to the decompressed block
+            for (let i = 0; i < data.subPackets.length; i++) {
+              const sp = data.subPackets[i];
+              if (!decompressed[sp.rangeStart]) {
+                const offset = sp.rangeStart - data.rangeStart;
+                decompressed[sp.rangeStart] = zlib.inflateRawSync(s3data.Body.subarray(offset, offset + COMPRESSED_BLOCK_SIZE),
+                  { finishFlush: zlib.constants.Z_SYNC_FLUSH });
+                const decompressedCacheKey = "data:" + data.params.Bucket +":" + data.params.Key + ":" + sp.rangeStart;
+                lru.set(decompressedCacheKey, decompressed[sp.rangeStart]);
+                // console.log("Decompressed offset", sp.rangeStart, "set cache", decompressedCacheKey);
+                const cip = CacheInProgress[decompressedCacheKey];
+                delete CacheInProgress[decompressedCacheKey];
+                if (cip && cip != true) {
+                  for (let i = 0; i < cip.length; i++) {
+                    cip[i]();
+                  }
+                }
+              }
+            }
+            async.each(data.subPackets, (sp, nextSubCb) => {
+              const block = decompressed[sp.rangeStart];
+              const subPacketData = block.subarray(sp.packetStart, sp.packetEnd);
+              const len = (pcap.bigEndian ? subPacketData.readUInt32BE(8) : subPacketData.readUInt32LE(8));
+
+              // console.log("PACKET", sp);
+              packetCb(pcap, subPacketData.subarray(0, len + 16), nextSubCb, sp.itemPos);
+            },
+            nextCb);
+          } else {
+            async.each(data.subPackets, (sp, nextSubCb) => {
+              const subPacketData = s3data.Body.subarray(sp.packetStart - data.packetStart, sp.packetEnd - data.packetStart);
+              const len = (pcap.bigEndian ? subPacketData.readUInt32BE(8) : subPacketData.readUInt32LE(8));
+
+              // console.log("UN-PACKET", sp);
+              packetCb(pcap, subPacketData.subarray(0, len + 16), nextSubCb, sp.itemPos);
+            },
+            nextCb);
+          }
+        });
+      }
     }
 
     // FIrst pass, convert packetPos and packetLen (if we have it) into packetData

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "lint": "eslint --ext .js,.vue parliament viewer wiseService capture/plugins common",
-    "lint-fix": "eslint --fix --ext .js,.vue parliament viewer wiseService",
+    "lint-fix": "eslint --fix --ext .js,.vue parliament viewer wiseService capture/plugins common",
     "common:lint": "eslint --ext .js,.vue common",
     "viewer:addtestuser": "cd viewer && node addUser.js -c ../tests/config.test.ini -n testuser admin admin admin --admin --packetSearch",
     "viewer:build": "cd viewer && node vueapp/build/build.js",


### PR DESCRIPTION
The current `writer-s3/index.js` is fairly dumb when it comes to getting data from S3. This means that it takes a long time to actually get a single packet. A little bit of caching improves this dramatically. This PR only does the caching for compressed PCAPs in S3.  It turns out that caching for uncompressed is a bit more complicated -- you would probably want to fetch the 128k block (aligned on a 128k boundary) for each packet. The hassle is then dealing with packets that straddle a 128k boundary. Maybe you always fetch a bit extra....

`npm lint` was run (and this PR also adds the `capture/plugins` directory to the `lint-fix` target.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Well, I tried. It complained about elasticsearch not running locally. It also complained about `iptrie` not being found from `wiseService.js`. 

I did run this in my local test environment and it appears to work.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
