### PR TITLE
fix tests & libcurl changes

### DIFF
--- a/capture/config.c
+++ b/capture/config.c
@@ -520,7 +520,7 @@ void moloch_config_load()
     config.maxPacketsInQueue     = moloch_config_int(keyfile, "maxPacketsInQueue", 200000, 10000, 5000000);
     config.dbBulkSize            = moloch_config_int(keyfile, "dbBulkSize", 200000, MOLOCH_HTTP_BUFFER_SIZE*2, 10000000);
     config.dbFlushTimeout        = moloch_config_int(keyfile, "dbFlushTimeout", 5, 1, 60*30);
-    config.maxESConns            = moloch_config_int(keyfile, "maxESConns", 20, 5, 500);
+    config.maxESConns            = moloch_config_int(keyfile, "maxESConns", 20, 3, 500);
     config.maxESRequests         = moloch_config_int(keyfile, "maxESRequests", 500, 10, 2500);
     config.logEveryXPackets      = moloch_config_int(keyfile, "logEveryXPackets", 50000, 1000, 0xffffffff);
     config.pcapBufferSize        = moloch_config_int(keyfile, "pcapBufferSize", 300000000, 100000, 0xffffffff);

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -503,7 +503,7 @@ LOCAL gboolean reader_libpcapfile_read()
     }
 
     // pause reading if too many waiting ES operations
-    if (moloch_http_queue_length(esServer) > 40) {
+    if (moloch_http_queue_length(esServer) > 30) {
         if (config.debug)
             LOG("Waiting to process more packets, es q: %d", moloch_http_queue_length(esServer));
         return G_SOURCE_CONTINUE;

--- a/db/db.pl
+++ b/db/db.pl
@@ -7348,3 +7348,5 @@ if ($DOHOTWARM) {
 logmsg "Finished\n";
 
 sleep 1;
+esGet("/_flush", 1);
+esGet("/_refresh", 1);

--- a/tests/MolochTest.pm
+++ b/tests/MolochTest.pm
@@ -262,9 +262,8 @@ sub esCopy
 
         $id = $incoming->{_scroll_id};
 
-        esPost("/_bulk", $out);
+        esPost("/_bulk?refresh=wait_for", $out);
     }
-    esGet("/_flush");
 }
 ################################################################################
 sub countTest {

--- a/tests/api-history.t
+++ b/tests/api-history.t
@@ -27,15 +27,17 @@ my ($url) = @_;
 # Clear all history
     esDelete("/tests*_history_v1*");
     sleep(1);
-    esGet("/_refresh");
     esGet("/_flush");
+    esGet("/_refresh");
     sleep(1);
 
 # Make a request
+    esGet("/_flush");
+    esGet("/_refresh");
     countTest(4, "molochRegressionUser=historytest1&date=-1&expression=" . uri_escape("(file=$pwd/socks-https-example.pcap||file=$pwd/dns-mx.pcap)&&tags=domainwise"));
     sleep(1);
-    esGet("/_refresh");
     esGet("/_flush");
+    esGet("/_refresh");
     sleep(1);
 
 # See if recorded, should be the only item that is ours

--- a/tests/api-hunt.t
+++ b/tests/api-hunt.t
@@ -305,7 +305,7 @@ my $hToken = getTokenCookie('huntuser');
   createHunts("hexregex", "766..63d");
 
   # create a hunt for regex dos
-  $HUNTS{"raw-regex-both-(.*a){25}x"} = viewerPostToken("/hunt?molochRegressionUser=huntuser", '{"totalSessions":67,"name":"' . "raw-regex-both-(.*a){25}x-$$" . '", "size":"50","search":"(.*a){25}x","searchType":"regex","type":"raw","src":true,"dst":true,"query":{"startTime":1430916462,"stopTime":1569170858}}', $hToken);
+  $HUNTS{"raw-regex-both-(.*a){25}x"} = viewerPostToken("/hunt?molochRegressionUser=huntuser", '{"totalSessions":67,"name":"' . "raw-regex-both-(.*a){25}x-$$" . '", "size":"50","search":"(.*a){25}x","searchType":"regex","type":"raw","src":true,"dst":true,"query":{"startTime":1430916462,"stopTime":1569170858,"expression":"tags != bdat*"}}', $hToken);
 
   # Actually process the hunts
   viewerGet("/regressionTests/processHuntJobs");

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -35,6 +35,8 @@ enablePacketLen=true
 ja3Strings=true
 maxReqBody=2000
 disableParsers=
+maxESConns=3
+dbBulkSize=50000
 
 packetThreads=2
 magicMode=basic

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -317,7 +317,7 @@ my ($cmd) = @_;
         if (!$main::debug) {
             $mcmd .= " 2>&1 1>/dev/null";
         } else {
-            $mcmd .= " --debug 2>&1 1>/tmp/moloch.capture";
+            $mcmd .= " --debug 1>/tmp/moloch.capture 2>&1";
         }
 
 

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -831,6 +831,7 @@ app.post(['/MULTIPREFIX_fields/field/_search', '/MULTIPREFIX_fields/_search'], f
 
       if (result.error) {
         console.log('ERROR - GET /fields/field/_search', result.error);
+        return res.send(obj);
       }
 
       for (let h = 0; h < result.hits.hits.length; h++) {


### PR DESCRIPTION
* change test to use less conenctions and smaller db buffer
* change curl to only use curl_multi_socket_action
* increase curl timeout
* allow min of 3 for maxESConns
* pause file reading when ES Q > 30
* encodings test run 2 captures in parallel
* multies crash fix when index is missing