### PR TITLE
Speed up column chooser

### DIFF
--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -1101,7 +1101,7 @@ export default {
      * @return {number} number  The index of the visible header
      */
     isColVisible: function (id) {
-      return this.isVisible(id, this.tableState.visibleHeaders);
+      return this.tableState.visibleHeaders.indexOf(id);
     },
     /**
      * Toggles the visibility of a column given its id


### PR DESCRIPTION
Speed up the column chooser. Tiny change for your consideration. =)

We have an Arkime instance running, and have added more than one hundred fields due to various in-house enrichments on the data. This makes the column chooser in Arkime viewer very slow and laggy. This commit speeds it up quite a bit. 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors** Yes

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`** Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
