### PR TITLE
tests.pl takes optional --elasticsearch that is used everywhere

### DIFF
--- a/tests/addUser.t
+++ b/tests/addUser.t
@@ -8,19 +8,20 @@ use strict;
 
 viewerGet("/regressionTests/deleteAllUsers");
 my $token = getTokenCookie();
+my $es = "-o 'elasticsearch=$MolochTest::elasticsearch' -o 'usersElasticsearch=$MolochTest::elasticsearch'";
 
 # script exits successfully
-my $result = system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser admin admin admin --admin");
+my $result = system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser admin admin admin --admin");
 eq_or_diff($result, "0", "script exited successfully");
 
 # create a user with each flag
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test1 test1 test1");
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test2 test2 test2 --apionly");
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test3 test3 test3 --email");
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test4 test4 test4 --expression 'ip.src == 10.0.0.1'");
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test5 test5 test5 --remove");
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test6 test6 test6 --webauth");
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test7 test7 test7 --packetSearch");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test1 test1 test1");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test2 test2 test2 --apionly");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test3 test3 test3 --email");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test4 test4 test4 --expression 'ip.src == 10.0.0.1'");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test5 test5 test5 --remove");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test6 test6 test6 --webauth");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test7 test7 test7 --packetSearch");
 
 # fetch the users
 my $users = viewerPost("/api/users", "");
@@ -42,13 +43,13 @@ ok(exists $response->{passStore}, "Users has password");
 
 # --createOnly flag should not overwrite the user if it already exists
 my $user7 = $users->{data}->[7];
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test7 test7 test7 --createOnly --email --remove --expression 'ip.src == 10.0.0.2'");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test7 test7 test7 --createOnly --email --remove --expression 'ip.src == 10.0.0.2'");
 $users = viewerPost("/api/users", "");
 eq_or_diff($users->{data}->[7], $user7, "Create only doesn't overwrite user");
 
 # can update a user
 my $user1 = $users->{data}->[1];
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n testuser test1 test1 test1 --email");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser test1 test1 test1 --email");
 $users = viewerPost("/api/users", "");
 ok($users->{data}->[1]->{emailSearch}, "Can update exiting user");
 
@@ -76,7 +77,7 @@ eq_or_diff($response, $mresponse);
 delete $response->{passStore};
 eq_or_diff($response, from_json('{"headerAuthEnabled":true,"enabled":true,"userId":"authtest1","webEnabled":true,"removeEnabled":false,"userName":"authtest1","packetSearch":true,"emailSearch":true,"createEnabled":false,"expression":"","settings":{}}'));
 
-system("cd ../viewer ; node addUser.js -c ../tests/config.test.ini -n test3 authtest2 authtest2 authtest2");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n test3 authtest2 authtest2 authtest2");
 $response = viewerGet("/regressionTests/getUser/authtest2");
 
 $response = $MolochTest::userAgent->get("http://$MolochTest::host:8126/", ':arkime_user' => 'authtest2');

--- a/tests/api-encodings.t
+++ b/tests/api-encodings.t
@@ -10,6 +10,7 @@ my $json;
 
 my $prefix = int(rand()*100000);
 my $token = getTokenCookie();
+my $es = "-o 'elasticsearch=$MolochTest::elasticsearch'";
 
 sub doTest {
     my ($encryption, $gzip, $shortheader) = @_;
@@ -19,7 +20,7 @@ sub doTest {
     my $btag = "bdat-$prefix-$encryption-$gzip-$shortheader";
 
   ###### wireshark-bdat.pcap - run
-    $cmd = "../capture/capture -c config.test.ini -n test --copy -r pcap/wireshark-bdat.pcap --tag $btag";
+    $cmd = "../capture/capture $es -c config.test.ini -n test --copy -r pcap/wireshark-bdat.pcap --tag $btag";
     if (defined $encryption) {
         $cmd .= " -o simpleEncoding=$encryption -o simpleKEKId=test";
     }
@@ -33,7 +34,7 @@ sub doTest {
     system("$cmd");
 
   ###### socks-http-pass.pcap - run
-    $cmd = "../capture/capture -c config.test.ini -n test --copy -r pcap/socks-http-pass.pcap --tag $stag";
+    $cmd = "../capture/capture $es -c config.test.ini -n test --copy -r pcap/socks-http-pass.pcap --tag $stag";
     if (defined $encryption) {
         $cmd .= " -o simpleEncoding=$encryption -o simpleKEKId=test";
     }

--- a/tests/api-scrub.t
+++ b/tests/api-scrub.t
@@ -9,13 +9,14 @@ use strict;
 
 my $copytest = getcwd() . "/copytest.pcap";
 my $token = getTokenCookie();
+my $es = "-o 'elasticsearch=$MolochTest::elasticsearch'";
 
 countTest(0, "date=-1&expression=" . uri_escape("file=$copytest"));
 
 system("../db/db.pl --prefix tests $MolochTest::elasticsearch rm $copytest 2>&1 1>/dev/null");
 viewerPost("/regressionTests/flushCache");
 system("/bin/cp pcap/socks-http-example.pcap copytest.pcap");
-system("../capture/capture -c config.test.ini -n test -r copytest.pcap");
+system("../capture/capture $es -c config.test.ini -n test -r copytest.pcap");
 esGet("/_flush");
 esGet("/_refresh");
 

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -16,7 +16,6 @@ use Socket6 qw(AF_INET6 inet_pton);
 $main::userAgent = LWP::UserAgent->new(timeout => 20);
 
 my $ELASTICSEARCH = $ENV{ELASTICSEARCH} = "http://127.0.0.1:9200";
-#my $ELASTICSEARCH = $ENV{ELASTICSEARCH} = "http://elastic:changeme\@127.0.0.1:9200";
 
 $ENV{'PERL5LIB'} = getcwd();
 $ENV{'TZ'} = 'US/Eastern';
@@ -307,13 +306,17 @@ my ($cmd) = @_;
         waitFor($MolochTest::host, 8081, 1);
     }
 
+    my $es = "-o 'elasticsearch=$ELASTICSEARCH'";
+    my $ues = "-o 'usersElasticsearch=$ELASTICSEARCH'";
+    my $mes = "-o 'multiESNodes=$ELASTICSEARCH,prefix:tests,name:test;$ELASTICSEARCH,prefix:tests2_,name:test2'";
+
     if ($cmd ne "--viewernostart" && $cmd ne "--viewerstart" && $cmd ne "--viewerhang") {
         $main::userAgent->get("$ELASTICSEARCH/_flush");
         $main::userAgent->get("$ELASTICSEARCH/_refresh");
 
         print ("Loading PCAP\n");
 
-        my $mcmd = "../capture/capture $INSECURE $main::copy -c config.test.ini -n test -R pcap --flush";
+        my $mcmd = "../capture/capture $es $INSECURE $main::copy -c config.test.ini -n test -R pcap --flush";
         if (!$main::debug) {
             $mcmd .= " 2>&1 1>/dev/null";
         } else {
@@ -336,20 +339,20 @@ my ($cmd) = @_;
     if ($cmd ne "--viewernostart") {
         print ("Starting viewer\n");
         if ($main::debug) {
-            system("cd ../viewer ; $node --trace-warnings multies.js -c ../tests/config.test.ini -n all --debug $INSECURE > /tmp/multies.all &");
+            system("cd ../viewer ; $node --trace-warnings multies.js $mes -c ../tests/config.test.ini -n all --debug $INSECURE > /tmp/multies.all &");
             waitFor($MolochTest::host, 8200, 1);
-            system("cd ../viewer ; $node --trace-warnings viewer.js -c ../tests/config.test.ini -n test --debug $INSECURE > /tmp/moloch.test &");
-            system("cd ../viewer ; $node --trace-warnings viewer.js -c ../tests/config.test.ini -n test2 --debug $INSECURE > /tmp/moloch.test2 &");
-            system("cd ../viewer ; $node --trace-warnings viewer.js -c ../tests/config.test.ini -n test3 --debug $INSECURE > /tmp/moloch.test3 &");
-            system("cd ../viewer ; $node --trace-warnings viewer.js -c ../tests/config.test.ini -n all --debug $INSECURE > /tmp/moloch.all &");
+            system("cd ../viewer ; $node --trace-warnings viewer.js $es $ues -c ../tests/config.test.ini -n test --debug $INSECURE > /tmp/moloch.test &");
+            system("cd ../viewer ; $node --trace-warnings viewer.js $es $ues -c ../tests/config.test.ini -n test2 --debug $INSECURE > /tmp/moloch.test2 &");
+            system("cd ../viewer ; $node --trace-warnings viewer.js $es $ues -c ../tests/config.test.ini -n test3 --debug $INSECURE > /tmp/moloch.test3 &");
+            system("cd ../viewer ; $node --trace-warnings viewer.js $ues -c ../tests/config.test.ini -n all --debug $INSECURE > /tmp/moloch.all &");
             system("cd ../parliament ; $node --trace-warnings parliament.js --regressionTests -c /dev/null --debug > /tmp/moloch.parliament 2>&1 &");
         } else {
-            system("cd ../viewer ; $node multies.js -c ../tests/config.test.ini -n all $INSECURE > /dev/null &");
+            system("cd ../viewer ; $node multies.js $mes -c ../tests/config.test.ini -n all $INSECURE > /dev/null &");
             waitFor($MolochTest::host, 8200, 1);
-            system("cd ../viewer ; $node viewer.js -c ../tests/config.test.ini -n test $INSECURE > /dev/null &");
-            system("cd ../viewer ; $node viewer.js -c ../tests/config.test.ini -n test2 $INSECURE > /dev/null &");
-            system("cd ../viewer ; $node viewer.js -c ../tests/config.test.ini -n test3 $INSECURE > /dev/null &");
-            system("cd ../viewer ; $node viewer.js -c ../tests/config.test.ini -n all $INSECURE > /dev/null &");
+            system("cd ../viewer ; $node viewer.js $es $ues -c ../tests/config.test.ini -n test $INSECURE > /dev/null &");
+            system("cd ../viewer ; $node viewer.js $es $ues -c ../tests/config.test.ini -n test2 $INSECURE > /dev/null &");
+            system("cd ../viewer ; $node viewer.js $es $ues -c ../tests/config.test.ini -n test3 $INSECURE > /dev/null &");
+            system("cd ../viewer ; $node viewer.js $ues -c ../tests/config.test.ini -n all $INSECURE > /dev/null &");
             system("cd ../parliament ; $node parliament.js --regressionTests -c /dev/null > /dev/null 2>&1 &");
         }
         sleep (10000) if ($cmd eq "--viewerhang");
@@ -402,6 +405,10 @@ while (scalar (@ARGV) > 0) {
     if ($ARGV[0] eq "--debug") {
         $main::debug = 1;
         shift @ARGV;
+    } elsif ($ARGV[0] eq "--elasticsearch") {
+        shift @ARGV;
+        $ELASTICSEARCH = $ENV{ELASTICSEARCH} = $ARGV[0];
+        shift @ARGV;
     } elsif ($ARGV[0] eq "--c8") {
         $main::c8 = 1;
         $main::debug = 1;
@@ -446,8 +453,9 @@ if ($main::cmd eq "--fix") {
 } elsif ($main::cmd eq "--help") {
     print "$ARGV[0] [OPTIONS] [COMMAND] <pcap> files\n";
     print "Options:\n";
-    print "  --debug       Turn on debuggin\n";
-    print "  --valgrind    Use valgrind on capture\n";
+    print "  --elasticsearch <url> Set elasticsearch URL\n";
+    print "  --debug               Turn on debuggin\n";
+    print "  --valgrind            Use valgrind on capture\n";
     print "\n";
     print "Commands:\n";
     print "  --help                This help\n";


### PR DESCRIPTION
elasticsearch now comes from tests.pl (including --elasticsearch) and ignores config file. (those are still used for npm run stuff)