### PR TITLE
new ecsEventDataset setting for capture, corresponding to ECS event.dataset

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,7 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
   - BREAKING - new defaults maxFileSizeG=12, compressES=true
   - BREAKING - pcap compression is turned on by default with simpleGzipBlockSize=32000
   - addUser.js - new --roles option, --admin creates superAdmin user
+  - capture - New ecsEventDatset setting
   - cont3xt - new Cont3xt application, see https://arkime.com/cont3xt
   - cont3xt/viewer - share new user UI
   - parliament/wise - can be configured to use shared user DB

--- a/capture/db.c
+++ b/capture/db.c
@@ -71,6 +71,7 @@ LOCAL int               dbExit;
 LOCAL char             *esBulkQuery;
 LOCAL int               esBulkQueryLen;
 LOCAL char             *ecsEventProvider;
+LOCAL char             *ecsEventDataset;
 
 extern uint64_t         packetStats[MOLOCH_PACKET_MAX];
 
@@ -906,8 +907,12 @@ void moloch_db_save_session(MolochSession_t *session, int final)
     }
     BSB_EXPORT_cstr(jbsb, "],");
 
-    if (ecsEventProvider) {
+    if (ecsEventProvider && ecsEventDataset) {
+        BSB_EXPORT_sprintf(jbsb, "\"event\":{\"provider\":\"%s\", \"dataset\":\"%s\"},", ecsEventProvider, ecsEventDataset);
+    } else if (ecsEventProvider) {
         BSB_EXPORT_sprintf(jbsb, "\"event\":{\"provider\":\"%s\"},", ecsEventProvider);
+    } else if (ecsEventDataset) {
+        BSB_EXPORT_sprintf(jbsb, "\"event\":{\"dataset\":\"%s\"},", ecsEventDataset);
     }
 
     int inGroupNum = 0;
@@ -2661,6 +2666,7 @@ void moloch_db_init()
     }
 
     ecsEventProvider = moloch_config_str(NULL, "ecsEventProvider", NULL);
+    ecsEventDataset = moloch_config_str(NULL, "ecsEventDataset", NULL);
 
     int thread;
     for (thread = 0; thread < config.packetThreads; thread++) {


### PR DESCRIPTION
new `ecsEventDataset` setting for `capture`, corresponding to `event.dataset` [as specified in the Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/ecs-event.html#field-event-dataset).

Implemented the same way as arkime/arkime@99c4e0f74df68a64fa100e01599fdc56b0f6dbc1 for `ecsEventProvider` (`event.provider`)

event.provider and event.dataset can help categorize network event traffic. Recently event.provider was added as an option to capture (by default it isn't included, though a value such as `arkime` may be specified in the .ini file or on the command line). Similarly, event.dataset isn't included in the session record by default, but a value (such as `session`) can now be included in the same way.

Signed-off-by: Seth Grover <mero.mero.guero@gmail.com>

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
