### PR TITLE
Stopsaving

### DIFF
--- a/capture/field.c
+++ b/capture/field.c
@@ -1370,7 +1370,7 @@ void moloch_field_ops_run(MolochSession_t *session, MolochFieldOps_t *ops)
         if (op->fieldPos < 0) {
             switch (op->fieldPos) {
             case MOLOCH_FIELD_SPECIAL_STOP_SPI:
-                session->stopSPI = op->strLenOrInt;
+                moloch_session_set_stop_spi(session, op->strLenOrInt);
                 break;
             case MOLOCH_FIELD_SPECIAL_STOP_PCAP:
                 session->stopSaving = op->strLenOrInt;

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -1057,6 +1057,9 @@ typedef void (*MolochCmd_func)(MolochSession_t *session, gpointer uw1, gpointer 
 void moloch_session_add_cmd(MolochSession_t *session, MolochSesCmd sesCmd, gpointer uw1, gpointer uw2, MolochCmd_func func);
 void moloch_session_add_cmd_thread(int thread, gpointer uw1, gpointer uw2, MolochCmd_func func);
 
+void moloch_session_set_stop_saving(MolochSession_t *session);
+void moloch_session_set_stop_spi(MolochSession_t *session, int value);
+
 /******************************************************************************/
 /*
  * packet.c

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -702,6 +702,7 @@ typedef struct moloch_session {
     uint16_t               diskOverload:1;
     uint16_t               pq:1;
     uint16_t               synSet:2;
+    uint16_t               inStoppedSave:1;
 } MolochSession_t;
 
 typedef struct moloch_session_head {

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -312,7 +312,7 @@ LOCAL void moloch_packet_process(MolochPacket_t *packet, int thread)
         // If we hit stopSaving for this session and try and save 1 more packet then
         // add truncated-pcap tag to the session
         if (packets - 1 == session->stopSaving) {
-            moloch_session_add_tag(session, "truncated-pcap");
+            moloch_session_set_stop_saving(session);
         }
         MOLOCH_THREAD_INCR_NUM(unwrittenBytes, packet->pktlen);
     }

--- a/capture/session.c
+++ b/capture/session.c
@@ -527,14 +527,16 @@ LOCAL void moloch_session_load_stopped()
         return;
     }
 
-    int cnt;
+    uint32_t cnt;
     if (!fread(&cnt, 4, 1, fp)) {
         fclose(fp);
         LOG("ERROR - `%s` corrupt", stoppedFilename);
         return;
     }
 
-    for (int i = 0; i < cnt; i++) {
+    if (config.debug)
+        LOG("Load %u", cnt);
+    for (uint32_t i = 0; i < cnt; i++) {
         int read = 0;
         uint8_t  key[MOLOCH_SESSIONID_LEN];
         uint32_t value;
@@ -590,7 +592,7 @@ LOCAL gboolean moloch_session_save_stopped(gpointer UNUSED(user_data))
         g_hash_table_iter_init(&iter, stoppedSessions[t].new);
         unsigned char *ikey;
         gpointer ivalue;
-        while (g_hash_table_iter_next (&iter, &ikey, &ivalue)) {
+        while (g_hash_table_iter_next (&iter, (gpointer *)&ikey, &ivalue)) {
             cnt++;
             fwrite(ikey, ikey[0], 1, fp);
             uint32_t val = (long)ivalue;
@@ -602,6 +604,9 @@ LOCAL gboolean moloch_session_save_stopped(gpointer UNUSED(user_data))
     // Now write the count
     fseek(fp, 4, SEEK_SET);
     fwrite(&cnt, 4, 1, fp);
+
+    if (config.debug)
+        LOG("Saved %u", cnt);
 
     fclose(fp);
     return TRUE;


### PR DESCRIPTION
Save sessionIds for sessions that have stopSPI or aren't saving packets to disk to a tmp file every 10 seconds so on restart we can't restore state and continue to not save the sessions/packets.