### PR TITLE
yara autodetection recognize >yara-1.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,7 +270,7 @@ esac ], [
   else
     TMP=$LIBS
     LIBS="-lyara $LIBS"
-    AC_TRY_LINK([#include <yara.h>], yr_init(), LIBYARA_FOUND=1,LIBYARA_FOUND=0)
+    AC_TRY_LINK([#include <yara.h>], yr_initialize(), LIBYARA_FOUND=1,LIBYARA_FOUND=0)
     LIBS=$TMP
     if test $LIBYARA_FOUND = 1 ; then
       YARA_LIBS="-lyara"


### PR DESCRIPTION
yara-1.x uses `yr_init()`, later versions use `yr_initialize()`.  Arkime dropped support for yara-1.x in 1.0 anyway: https://github.com/arkime/arkime/commit/3b0b0e87d062636b2189c359cb89f90b4b2b2de2#diff-db0f18e9368fcfe79f5773890743f087d8a866738535d59b035c784a9e56ce2cL371

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.