### PR TITLE
tests.pl: add --skipgeo option

### DIFF
--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -23,20 +23,22 @@ my $INSECURE = "";
 
 ################################################################################
 sub doGeo {
-    if (! -f "ipv4-address-space.csv") {
-        system("wget https://s3.amazonaws.com/files.molo.ch/testing/ipv4-address-space.csv");
-    }
+    if(!$main::skipgeo) {
+        if (! -f "ipv4-address-space.csv") {
+            system("wget https://s3.amazonaws.com/files.molo.ch/testing/ipv4-address-space.csv");
+        }
 
-    if (! -f "oui.txt") {
-        system("wget https://s3.amazonaws.com/files.molo.ch/testing/oui.txt");
-    }
+        if (! -f "oui.txt") {
+            system("wget https://s3.amazonaws.com/files.molo.ch/testing/oui.txt");
+        }
 
-    if (! -f "GeoLite2-Country.mmdb") {
-        system("wget https://s3.amazonaws.com/files.molo.ch/testing/GeoLite2-Country.mmdb");
-    }
+        if (! -f "GeoLite2-Country.mmdb") {
+            system("wget https://s3.amazonaws.com/files.molo.ch/testing/GeoLite2-Country.mmdb");
+        }
 
-    if (! -f "GeoLite2-ASN.mmdb") {
-        system("wget https://s3.amazonaws.com/files.molo.ch/testing/GeoLite2-ASN.mmdb");
+        if (! -f "GeoLite2-ASN.mmdb") {
+            system("wget https://s3.amazonaws.com/files.molo.ch/testing/GeoLite2-ASN.mmdb");
+        }
     }
 
     if (! -f "plugins/test.so" || (stat('../capture/moloch.h'))[9] > (stat('plugins/test.so'))[9]) {
@@ -406,6 +408,7 @@ $main::debug = 0;
 $main::c8 = 0;
 $main::valgrind = 0;
 $main::copy = "";
+$main::skipgeo = 0;
 $main::cmd = "--capture";
 
 while (scalar (@ARGV) > 0) {
@@ -436,6 +439,9 @@ while (scalar (@ARGV) > 0) {
         shift @ARGV;
     } elsif ($ARGV[0] eq "--copy") {
         $main::copy = "--copy";
+        shift @ARGV;
+    } elsif ($ARGV[0] eq "--skipgeo") {
+        $main::skipgeo = 1;
         shift @ARGV;
     } elsif ($ARGV[0] =~ /^--(viewer|fix|make|capture|viewernostart|viewerstart|viewerhang|viewerload|help|reip|fuzz|fuzz2pcap)$/) {
         $main::cmd = $ARGV[0];
@@ -468,6 +474,7 @@ if ($main::cmd eq "--fix") {
     print "  --elasticsearch <url> Set elasticsearch URL\n";
     print "  --debug               Turn on debuggin\n";
     print "  --valgrind            Use valgrind on capture\n";
+    print "  --skipgeo             Skip downloading Geo files, assume already present (useful for offline)\n";
     print "\n";
     print "Commands:\n";
     print "  --help                This help\n";


### PR DESCRIPTION
This allows capture tests to be run offline.  It assumes that the usual
Geo files are already present in the directory.  Needed for packaging
that doesn't allow network access at build/test time.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
