### PR TITLE
addition of view and submit query params for cont3xt

### DIFF
--- a/cont3xt/db.js
+++ b/cont3xt/db.js
@@ -90,7 +90,7 @@ class Db {
   }
 
   /**
-   * Get a single linkGroup
+   * Get a single view
    */
   static async getView (id) {
     return Db.implementation.getView(id);

--- a/cont3xt/vueapp/src/App.vue
+++ b/cont3xt/vueapp/src/App.vue
@@ -77,11 +77,16 @@ export default {
     }
 
     // NOTE: don't need to do anything with the data (the store does it)
-    Cont3xtService.getIntegrations();
+    Promise.allSettled([
+      Cont3xtService.getIntegrations(),
+      UserService.getIntegrationViews()
+    ]).then(() => {
+      // raise flag to process on-load query parameters like 'submit' once the necessary data is loaded
+      this.$store.commit('SET_IMMEDIATE_SUBMISSION_READY', true);
+    });
     LinkService.getLinkGroups();
     UserService.getUser();
     UserService.getRoles();
-    UserService.getIntegrationViews();
 
     // watch for keyup/down events for the entire app
     // the rest of the app should compute necessary values with:

--- a/cont3xt/vueapp/src/components/integrations/IntegrationPanel.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationPanel.vue
@@ -120,7 +120,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters(['getDoableIntegrations', 'getRoles', 'getUser', 'getSortedIntegrations']),
+    ...mapGetters(['getDoableIntegrations', 'getRoles', 'getUser', 'getSortedIntegrations', 'getAllViews']),
     sidebarKeepOpen: {
       get () {
         return this.$store.state.sidebarKeepOpen;
@@ -164,11 +164,21 @@ export default {
     changeView (newSelectedIntegrations) {
       // optionalUpdatedSelectedIntegrations only exists when called from @change in UI
       const selectedIntegrationsStr = JSON.stringify(newSelectedIntegrations);
+      // set the selected view to none/all if that is the case, otherwise, clear the selected view
+      const getViewByIdOrUndefined = (viewID) => {
+        return this.getAllViews.find(view => view._id === viewID);
+      };
       const selectView = (() => {
-        if (selectedIntegrationsStr === JSON.stringify([])) { return 'None'; }
-        if (selectedIntegrationsStr === JSON.stringify(Object.keys(this.getDoableIntegrations))) { return 'All'; }
-        return '';
+        switch (selectedIntegrationsStr) {
+        case JSON.stringify([]):
+          return getViewByIdOrUndefined('none');
+        case JSON.stringify(Object.keys(this.getDoableIntegrations)):
+          return getViewByIdOrUndefined('all');
+        default:
+          return undefined;
+        }
       })();
+
       this.$store.commit('SET_SELECTED_VIEW', selectView);
     },
     /* helpers ------------------------------------------------------------- */

--- a/cont3xt/vueapp/src/components/integrations/IntegrationPanel.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationPanel.vue
@@ -67,7 +67,7 @@
               <template
                 v-for="integration in getSortedIntegrations">
                 <b-form-checkbox
-                  @change="unsetView"
+                  @change="changeView"
                   :key="integration.key"
                   :value="integration.key"
                   v-if="integration.doable">
@@ -159,10 +159,17 @@ export default {
     },
     toggleAll (checked) {
       this.selectedIntegrations = checked ? Object.keys(this.getDoableIntegrations) : [];
-      this.unsetView();
+      this.changeView(this.selectedIntegrations);
     },
-    unsetView () {
-      this.$store.commit('SET_SELECTED_VIEW', '');
+    changeView (newSelectedIntegrations) {
+      // optionalUpdatedSelectedIntegrations only exists when called from @change in UI
+      const selectedIntegrationsStr = JSON.stringify(newSelectedIntegrations);
+      const selectView = (() => {
+        if (selectedIntegrationsStr === JSON.stringify([])) { return 'None'; }
+        if (selectedIntegrationsStr === JSON.stringify(Object.keys(this.getDoableIntegrations))) { return 'All'; }
+        return '';
+      })();
+      this.$store.commit('SET_SELECTED_VIEW', selectView);
     },
     /* helpers ------------------------------------------------------------- */
     calculateSelectAll (list) {

--- a/cont3xt/vueapp/src/components/itypes/Text.vue
+++ b/cont3xt/vueapp/src/components/itypes/Text.vue
@@ -18,12 +18,12 @@
 import Cont3xtField from '@/utils/Field';
 
 export default {
-  name: 'Cont3xtPhone',
+  name: 'Cont3xtText',
   components: {
     Cont3xtField
   },
   props: {
-    query: { // the query string to display (needed because phones don't get
+    query: { // the query string to display (needed because text doesn't get
       // searched so there is no data.phone)
       type: String,
       required: true

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -509,7 +509,6 @@ export default {
 
       // apply 'view' query param
       if (this.$route.query.view !== undefined) {
-        console.log(this.$route.query);
         this.setViewByQueryParam(this.$route.query.view);
       }
 

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -418,7 +418,7 @@ export default {
       'getSidebarKeepOpen', 'getShiftKeyHold', 'getFocusSearch',
       'getIssueSearch', 'getFocusStartDate', 'getFocusLinkSearch',
       'getToggleCache', 'getDownloadReport', 'getCopyShareLink',
-      'getViews', 'getImmediateSubmissionReady', 'getDoableIntegrations'
+      'getAllViews', 'getImmediateSubmissionReady'
     ]),
     loading: {
       get () { return this.$store.state.loading; },
@@ -508,7 +508,7 @@ export default {
       }
 
       // apply 'view' query param
-      if (this.$route.query.view != null) {
+      if (this.$route.query.view !== undefined) {
         this.setViewByQueryParamName(this.$route.query.view);
       }
 
@@ -778,28 +778,21 @@ export default {
         this.$router.push({ query: { ...this.$route.query, view: undefined } });
       };
 
-      if (typeof viewName !== 'string' || viewName === '') {
+      if (typeof viewName !== 'string' || viewName === '' || viewName === null) {
         console.log(`WARNING -- Invalid view '${viewName}' from query parameter... defaulting to current integrations.`);
         removeViewParam();
         return;
       }
       const lowercaseViewName = viewName.toLowerCase();
-      for (const view of this.getViews) {
+      for (const view of this.getAllViews) {
         if (view.name.toLowerCase() === lowercaseViewName) {
           this.$store.commit('SET_SELECTED_VIEW', view.name);
           this.$store.commit('SET_SELECTED_INTEGRATIONS', view.integrations);
           return;
         }
       }
+      console.log(`WARNING -- View '${viewName}' specified by query parameter was not found... defaulting to current integrations.`);
       removeViewParam();
-
-      if (lowercaseViewName === 'none') {
-        this.$store.commit('SET_SELECTED_INTEGRATIONS', []);
-      } else if (lowercaseViewName === 'all') {
-        this.$store.commit('SET_SELECTED_INTEGRATIONS', Object.keys(this.getDoableIntegrations));
-      } else {
-        console.log(`WARNING -- View '${viewName}' specified by query parameter was not found... defaulting to current integrations.`);
-      }
     },
     shouldSubmitImmediately () {
       const submitParam = this.$route.query.submit;

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -509,7 +509,8 @@ export default {
 
       // apply 'view' query param
       if (this.$route.query.view !== undefined) {
-        this.setViewByQueryParamName(this.$route.query.view);
+        console.log(this.$route.query);
+        this.setViewByQueryParam(this.$route.query.view);
       }
 
       // search now depending on 'submit' query parameter
@@ -773,25 +774,33 @@ export default {
         }
       });
     },
-    setViewByQueryParamName (viewName) {
+    setViewByQueryParam (viewParam) {
       const removeViewParam = () => {
         this.$router.push({ query: { ...this.$route.query, view: undefined } });
       };
 
-      if (typeof viewName !== 'string' || viewName === '' || viewName === null) {
-        console.log(`WARNING -- Invalid view '${viewName}' from query parameter... defaulting to current integrations.`);
+      if (typeof viewParam !== 'string' || viewParam === '' || viewParam === null) {
+        console.log(`WARNING -- Invalid view '${viewParam}' from query parameter... defaulting to current integrations.`);
         removeViewParam();
         return;
       }
-      const lowercaseViewName = viewName.toLowerCase();
+      // first check if the parameter is an existing view id
       for (const view of this.getAllViews) {
-        if (view.name.toLowerCase() === lowercaseViewName) {
-          this.$store.commit('SET_SELECTED_VIEW', view.name);
+        if (viewParam === view._id) {
+          this.$store.commit('SET_SELECTED_VIEW', view);
           this.$store.commit('SET_SELECTED_INTEGRATIONS', view.integrations);
           return;
         }
       }
-      console.log(`WARNING -- View '${viewName}' specified by query parameter was not found... defaulting to current integrations.`);
+      // if not an id, check if the parameter is an exact match for an existing view name
+      for (const view of this.getAllViews) {
+        if (viewParam === view.name) {
+          this.$store.commit('SET_SELECTED_VIEW', view);
+          this.$store.commit('SET_SELECTED_INTEGRATIONS', view.integrations);
+          return;
+        }
+      }
+      console.log(`WARNING -- View '${viewParam}' specified by query parameter was not found... defaulting to current integrations.`);
       removeViewParam();
     },
     shouldSubmitImmediately () {

--- a/cont3xt/vueapp/src/components/views/ViewSelector.vue
+++ b/cont3xt/vueapp/src/components/views/ViewSelector.vue
@@ -12,7 +12,7 @@
         {{ getSelectedView }}
       </span>
     </template>
-    <div class="ml-1 mr-1 mb-2" v-if="getViews.length">
+    <div class="ml-1 mr-1 mb-2">
       <b-input-group size="sm">
         <template #prepend>
           <b-input-group-text>
@@ -25,14 +25,6 @@
         />
       </b-input-group>
     </div>
-    <b-dropdown-text
-      v-if="error"
-      variant="danger">
-      <span
-        class="fa fa-exclamation-triangle"
-      />
-      {{ error }}
-    </b-dropdown-text>
     <template v-for="(view, index) in filteredViews">
       <b-tooltip
         noninteractive
@@ -69,7 +61,8 @@
           </template>
         </div>
       </b-dropdown-item>
-      <hr :key="view._id + '-separator'" v-if="view._systemDefault && (filteredViews[index + 1] == null || !filteredViews[index + 1]._systemDefault)"
+      <hr :key="view._id + '-separator'"
+          v-if="view._systemDefault && ((filteredViews[index + 1] && !filteredViews[index + 1]._systemDefault) || (!filteredViews[index + 1] && getViews.length === 0))"
           class="border-secondary my-0"/>
     </template>
     <b-dropdown-item
@@ -85,6 +78,14 @@
       <br>
       Click to create one.
     </b-dropdown-item>
+    <b-dropdown-text
+        v-if="error"
+        variant="danger">
+      <span
+          class="fa fa-exclamation-triangle"
+      />
+      {{ error }}
+    </b-dropdown-text>
   </b-dropdown>
 </template>
 

--- a/cont3xt/vueapp/src/components/views/ViewSelector.vue
+++ b/cont3xt/vueapp/src/components/views/ViewSelector.vue
@@ -25,19 +25,6 @@
         />
       </b-input-group>
     </div>
-    <b-dropdown-item
-      class="small"
-      v-b-modal.view-form
-      v-if="!getViews.length || !filteredViews.length">
-      <template v-if="!getViews.length">
-        No saved views.
-      </template>
-      <template v-else>
-        No views match your search.
-      </template>
-      <br>
-      Click to create one.
-    </b-dropdown-item>
     <b-dropdown-text
       v-if="error"
       variant="danger">
@@ -46,7 +33,7 @@
       />
       {{ error }}
     </b-dropdown-text>
-    <template v-for="view in filteredViews">
+    <template v-for="(view, index) in filteredViews">
       <b-tooltip
         noninteractive
         :target="view._id"
@@ -65,7 +52,7 @@
           <div class="d-inline no-wrap no-overflow ellipsis flex-grow-1">
             <span
               class="fa fa-share-alt mr-1 cursor-help"
-              v-if="getUser && view.creator !== getUser.userId"
+              v-if="getUser && view.creator !== getUser.userId && !view._systemDefault"
               v-b-tooltip.hover="`Shared with you by ${view.creator}`"
             />
             {{ view.name }}
@@ -82,7 +69,22 @@
           </template>
         </div>
       </b-dropdown-item>
+      <hr :key="view._id + '-separator'" v-if="view._systemDefault && (filteredViews[index + 1] == null || !filteredViews[index + 1]._systemDefault)"
+          class="border-secondary my-0"/>
     </template>
+    <b-dropdown-item
+        class="small"
+        v-b-modal.view-form
+        v-if="!getViews.length || !filteredViews.length">
+      <template v-if="!getViews.length">
+        No saved views.
+      </template>
+      <template v-else>
+        No views match your search.
+      </template>
+      <br>
+      Click to create one.
+    </b-dropdown-item>
   </b-dropdown>
 </template>
 
@@ -115,7 +117,7 @@ export default {
   },
   computed: {
     ...mapGetters([
-      'getViews', 'getUser', 'getSelectedIntegrations', 'getSelectedView'
+      'getViews', 'getUser', 'getSelectedView', 'getDoableIntegrations', 'getAllViews'
     ])
   },
   watch: {
@@ -151,13 +153,12 @@ export default {
     },
     filterViews (searchTerm) {
       if (!searchTerm) {
-        this.filteredViews = JSON.parse(JSON.stringify(this.getViews));
+        this.filteredViews = JSON.parse(JSON.stringify(this.getAllViews));
         return;
       }
 
       const query = searchTerm.toLowerCase();
-
-      this.filteredViews = this.getViews.filter((view) => {
+      this.filteredViews = this.getAllViews.filter((view) => {
         return view.name.toString().toLowerCase().match(query)?.length > 0;
       });
     }

--- a/cont3xt/vueapp/src/components/views/ViewSelector.vue
+++ b/cont3xt/vueapp/src/components/views/ViewSelector.vue
@@ -8,8 +8,8 @@
       <slot name="title">
         Integration Views
       </slot>
-      <span v-if="showSelectedView">
-        {{ getSelectedView }}
+      <span v-if="showSelectedView && getSelectedView">
+        {{ getSelectedView.name }}
       </span>
     </template>
     <div class="ml-1 mr-1 mb-2">
@@ -129,15 +129,15 @@ export default {
       this.filterViews(this.viewSearch);
     },
     getSelectedView (newView) {
-      const newViewName = newView === '' ? undefined : newView?.toLowerCase();
-      if (this.$route.query.view !== newViewName) {
-        this.$router.push({ query: { ...this.$route.query, view: newViewName } });
+      const newViewIDParam = newView?._id;
+      if (this.$route.query.view !== newViewIDParam) {
+        this.$router.push({ query: { ...this.$route.query, view: newViewIDParam } });
       }
     }
   },
   methods: {
     selectView (view) {
-      this.$store.commit('SET_SELECTED_VIEW', view.name);
+      this.$store.commit('SET_SELECTED_VIEW', view);
       this.$store.commit('SET_SELECTED_INTEGRATIONS', view.integrations);
     },
     deleteView (view) {
@@ -145,7 +145,7 @@ export default {
       UserService.deleteIntegrationsView(view._id).then(() => {
         if (view.name === this.getSelectedView) {
           this.$refs.integrationViewsDropdown.hide(true);
-          this.$store.commit('SET_SELECTED_VIEW', '');
+          this.$store.commit('SET_SELECTED_VIEW', undefined);
         }
       }).catch((error) => {
         this.error = error.text || error;

--- a/cont3xt/vueapp/src/components/views/ViewSelector.vue
+++ b/cont3xt/vueapp/src/components/views/ViewSelector.vue
@@ -124,6 +124,12 @@ export default {
     },
     getViews () {
       this.filterViews(this.viewSearch);
+    },
+    getSelectedView (newView) {
+      const newViewName = newView === '' ? undefined : newView?.toLowerCase();
+      if (this.$route.query.view !== newViewName) {
+        this.$router.push({ query: { ...this.$route.query, view: newViewName } });
+      }
     }
   },
   methods: {

--- a/cont3xt/vueapp/src/store.js
+++ b/cont3xt/vueapp/src/store.js
@@ -40,7 +40,8 @@ const store = new Vuex.Store({
     focusLinkSearch: false,
     toggleCache: false,
     downloadReport: false,
-    copyShareLink: false
+    copyShareLink: false,
+    immediateSubmissionReady: false
   },
   mutations: {
     SET_USER (state, data) {
@@ -198,6 +199,9 @@ const store = new Vuex.Store({
     SET_COPY_SHARE_LINK (state, value) {
       state.copyShareLink = value;
       setTimeout(() => { state.copyShareLink = false; });
+    },
+    SET_IMMEDIATE_SUBMISSION_READY (state, value) {
+      state.immediateSubmissionReady = value;
     }
   },
   getters: {
@@ -295,6 +299,9 @@ const store = new Vuex.Store({
     },
     getCopyShareLink (state) {
       return state.copyShareLink;
+    },
+    getImmediateSubmissionReady (state) {
+      return state.immediateSubmissionReady;
     }
   },
   plugins: [createPersistedState({

--- a/cont3xt/vueapp/src/store.js
+++ b/cont3xt/vueapp/src/store.js
@@ -302,6 +302,26 @@ const store = new Vuex.Store({
     },
     getImmediateSubmissionReady (state) {
       return state.immediateSubmissionReady;
+    },
+    getAllViews (state, getters) {
+      const makeSystemDefault = (viewName, integrationList, _id) => {
+        return {
+          creator: 'THE_SYSTEM',
+          name: viewName,
+          integrations: integrationList,
+          viewRoles: [],
+          editRoles: [],
+          _id,
+          _editable: false,
+          _viewable: false,
+          _systemDefault: true
+        };
+      };
+      const systemDefaultViews = [
+        makeSystemDefault('All', Object.keys(getters.getDoableIntegrations), 'DEFAULT_VIEW_ALL'),
+        makeSystemDefault('None', [], 'DEFAULT_VIEW_NONE')
+      ];
+      return [...systemDefaultViews, ...state.views];
     }
   },
   plugins: [createPersistedState({

--- a/cont3xt/vueapp/src/store.js
+++ b/cont3xt/vueapp/src/store.js
@@ -32,7 +32,7 @@ const store = new Vuex.Store({
     sidebarKeepOpen: false,
     views: [],
     integrationsPanelHoverDelay: 400,
-    selectedView: '',
+    selectedView: undefined,
     shiftKeyHold: false,
     focusSearch: true,
     issueSearch: false,
@@ -318,8 +318,8 @@ const store = new Vuex.Store({
         };
       };
       const systemDefaultViews = [
-        makeSystemDefault('All', Object.keys(getters.getDoableIntegrations), 'DEFAULT_VIEW_ALL'),
-        makeSystemDefault('None', [], 'DEFAULT_VIEW_NONE')
+        makeSystemDefault('All', Object.keys(getters.getDoableIntegrations), 'all'),
+        makeSystemDefault('None', [], 'none')
       ];
       return [...systemDefaultViews, ...state.views];
     }


### PR DESCRIPTION
* view and submit query parameters that are used after views/integrations have been loaded following page load (signaled by immediateSubmissionReady on the store)
* view is synced with the users currently selected view
* view is a case-insensitive string that selects a view by name (with special cases to ensure 'none' and 'all' work as intended)
* submit=y is tacked onto shareable links generated using Shift+L to make shared links automatically issue a search (one time only)