### PR TITLE
Build curl without zstd, pip install meson without sudo

### DIFF
--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -190,7 +190,7 @@ else
     fi
 
     if [ ! -f "glib-$GLIB/_build/gio/libgio-2.0.a" ] || [ ! -f "glib-$GLIB/_build/glib/libglib-2.0.a" ]; then
-      sudo pip3 install meson
+      pip3 install --user meson
       git clone https://github.com/ninja-build/ninja.git
       (echo $PATH; cd ninja; git checkout release; python3 configure.py --bootstrap)
       xzcat glib-$GLIB.tar.xz | tar xf -
@@ -263,7 +263,7 @@ else
 
   if [ ! -f "curl-$CURL/lib/.libs/libcurl.a" ]; then
     tar zxf curl-$CURL.tar.gz
-    ( cd curl-$CURL; ./configure --disable-ldap --disable-ldaps --without-libidn2 --without-librtmp --without-libpsl --without-nghttp2 --without-nghttp2 --without-nss --with-openssl; $MAKE)
+    ( cd curl-$CURL; ./configure --disable-ldap --disable-ldaps --without-libidn2 --without-librtmp --without-libpsl --without-nghttp2 --without-nghttp2 --without-nss --with-openssl --without-zstd; $MAKE)
     if [ $? -ne 0 ]; then
       echo "ARKIME: $MAKE failed"
       exit 1


### PR DESCRIPTION
PR contains two minor changes for the build:

1.  modifies curl config line adding `--without-zstd` to avoid errors like below
```
 In function `zstd_unencode_write':
content_encoding.c:(.text+0x55e): undefined reference to `ZSTD_decompressStream'
content_encoding.c:(.text+0x566): undefined reference to `ZSTD_isError
```
2. changes the pip3 install of meson from `sudo` to `pip3 install --user` to follow the conventions and security recommendations of avoiding pip installs with sudo.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
