### PR TITLE
address arkime/arkime#1952, in which export PCAP fails if there are any sessions without packets

### DIFF
--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -1140,7 +1140,11 @@ module.exports = (Config, Db, internals, ViewerUtils) => {
 
       const fields = session.fields;
 
-      if (maxPackets && fields.packetPos && fields.packetPos.length > maxPackets) {
+      if (!fields.packetPos) {
+        return endCb(null);
+      }
+
+      if (maxPackets && fields.packetPos.length > maxPackets) {
         fields.packetPos.length = maxPackets;
       }
 
@@ -1160,16 +1164,11 @@ module.exports = (Config, Db, internals, ViewerUtils) => {
         }
       }
 
-      if (fields.packetPos) {
-        for (i = 0, ilen = fields.packetPos.length; i < ilen; i++) {
-          if (fields.packetPos[i] < 0) {
-            outstanding++;
-            Db.fileIdToFile(fields.node, -1 * fields.packetPos[i], fileReadyCb);
-          }
+      for (i = 0, ilen = fields.packetPos.length; i < ilen; i++) {
+        if (fields.packetPos[i] < 0) {
+          outstanding++;
+          Db.fileIdToFile(fields.node, -1 * fields.packetPos[i], fileReadyCb);
         }
-      } else {
-        // no PCAP backing the session
-        readyToProcess();
       }
 
       function readyToProcess () {

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -1140,7 +1140,7 @@ module.exports = (Config, Db, internals, ViewerUtils) => {
 
       const fields = session.fields;
 
-      if (maxPackets && fields.packetPos.length > maxPackets) {
+      if (maxPackets && fields.packetPos && fields.packetPos.length > maxPackets) {
         fields.packetPos.length = maxPackets;
       }
 
@@ -1160,11 +1160,16 @@ module.exports = (Config, Db, internals, ViewerUtils) => {
         }
       }
 
-      for (i = 0, ilen = fields.packetPos.length; i < ilen; i++) {
-        if (fields.packetPos[i] < 0) {
-          outstanding++;
-          Db.fileIdToFile(fields.node, -1 * fields.packetPos[i], fileReadyCb);
+      if (fields.packetPos) {
+        for (i = 0, ilen = fields.packetPos.length; i < ilen; i++) {
+          if (fields.packetPos[i] < 0) {
+            outstanding++;
+            Db.fileIdToFile(fields.node, -1 * fields.packetPos[i], fileReadyCb);
+          }
         }
+      } else {
+        // no PCAP backing the session
+        readyToProcess();
       }
 
       function readyToProcess () {


### PR DESCRIPTION
See #1952. There needs to be a check to make sure `fields.packetPos` is not null when getting the list for PCAP export, in `sessionAPIs.processSessionId` in `apiSessions.js.

arkime/arkime#1952

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.