### PR TITLE
fixed write after end for urls on view=none

### DIFF
--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -377,7 +377,8 @@ class Integration {
     const checkWriteDone = () => {
       // setImmediate to ensure that any pending integration lists have a chance to start (and contribute to total)
       setImmediate(() => {
-        if (shared.sent === shared.total) {
+        if (shared.sent === shared.total && shared.finished !== true) {
+          shared.finished = true;
           onFinish();
         }
       });


### PR DESCRIPTION
urls and emails no longer cause write after read error (possible since their runIntegrationsList, when on view=none, was fast enough to finish before the sub-indicator's runIntegrationList began). Now, the number of pending integrations is added to the shared object (before each is run), and checkWriteDone will fail if that number is non-zero (meaning there still exists another runIntegrationList that should do the finishing).
