### PR TITLE
Send CSP-headers for cyberchef.html

### DIFF
--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1343,7 +1343,7 @@ router.put('/settings', isAdmin, (req, res, next) => {
 // Update an existing notifier
 router.put('/notifiers/:name', isAdmin, (req, res, next) => {
   if (!parliament.settings.notifiers[req.params.name]) {
-    const error = new Error(`${req.params.name} not fount.`);
+    const error = new Error(`${req.params.name} not found.`);
     error.httpStatusCode = 404;
     return next(error);
   }

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -948,7 +948,7 @@ function updateParliament () {
         return resolve();
       })
       .catch((error) => {
-        console.log('Parliament update error:', error.messge || error);
+        console.log('Parliament update error:', error.message || error);
         return resolve();
       });
   });

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1968,10 +1968,10 @@ app.get(
 );
 
 // cyberchef apis -------------------------------------------------------------
-app.get('/cyberchef.html', express.static( // cyberchef client file endpoint
+app.get('/cyberchef.html', [ArkimeUtil.missingResource, cyberchefCspHeader], express.static( // cyberchef client file endpoint
   path.join(__dirname, '/public'),
   { maxAge: dayMs, fallthrough: false }
-), ArkimeUtil.missingResource, cyberchefCspHeader);
+));
 
 app.get( // cyberchef endpoint
   '/cyberchef/:nodeName/session/:id',

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1968,10 +1968,10 @@ app.get(
 );
 
 // cyberchef apis -------------------------------------------------------------
-app.get('/cyberchef.html', [ArkimeUtil.missingResource, cyberchefCspHeader], express.static( // cyberchef client file endpoint
+app.get('/cyberchef.html', [cyberchefCspHeader], express.static( // cyberchef client file endpoint
   path.join(__dirname, '/public'),
   { maxAge: dayMs, fallthrough: false }
-));
+), ArkimeUtil.missingResource);
 
 app.get( // cyberchef endpoint
   '/cyberchef/:nodeName/session/:id',


### PR DESCRIPTION
The file viewer/viewer.js has a defintion for serving the static file cyberchef.html.
The code does not work like intended as no CSP-headers are sent out with the response:

```
HTTP/1.1 200 OK
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
Accept-Ranges: bytes
Cache-Control: public, max-age=86400
Last-Modified: Wed, 17 Aug 2022 17:07:47 GMT
ETag: W/"fdec-182acc682fb"
Content-Type: text/html; charset=UTF-8
Vary: Accept-Encoding
Date: Wed, 17 Aug 2022 18:01:03 GMT
Connection: close
Content-Length: 65004
```

This PR fixes the problem and results in the defined CSP-header being sent:

```
HTTP/1.1 200 OK
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
Content-Security-Policy: default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; object-src 'self' data:
Accept-Ranges: bytes
Cache-Control: public, max-age=86400
Last-Modified: Wed, 17 Aug 2022 17:07:47 GMT
ETag: W/"fdec-182acc682fb"
Content-Type: text/html; charset=UTF-8
Vary: Accept-Encoding
Date: Wed, 17 Aug 2022 18:01:12 GMT
Connection: close
Content-Length: 65004
```

## Checks
* npm run lint: YES
* ./tests.pl --viewer: YES

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
