### PR TITLE
Added autorization checks to ensure only the creator and admins can delete a view

### DIFF
--- a/tests/api-views.t
+++ b/tests/api-views.t
@@ -1,4 +1,4 @@
-use Test::More tests => 30;
+use Test::More tests => 31;
 use MolochTest;
 use JSON;
 use Test::Differences;
@@ -68,6 +68,10 @@ eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal for test2 user");
 delete $info->{data}->[0]->{id};
 # and it doesn't show users and roles field because test2 is not the creator
 eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 4.3.2.1","user":"test1","name":"view1update"}'), "can't see roles and users fields");
+
+# can not delete view from other user
+$info = viewerDeleteToken("/api/view/${id1}?molochRegressionUser=test2", $token2);
+ok(!$info->{success}, "can't delete view created by an other user");
 
 # can delete view with id
 $info = viewerDeleteToken("/api/view/${id1}?molochRegressionUser=test1", $token);

--- a/tests/api-views.t
+++ b/tests/api-views.t
@@ -101,7 +101,7 @@ $info = viewerGet("/api/views?molochRegressionUser=anonymous&all=true");
 eq_or_diff($info->{recordsTotal}, 2, "returns 2 recordsTotal with all flag");
 
 # cleanup views
-viewerDeleteToken("/api/view/${id2}?molochRegressionUser=test1", $token);
+viewerDeleteToken("/api/view/${id2}?molochRegressionUser=test2", $token2);
 viewerDeleteToken("/api/view/${id3}?molochRegressionUser=test1", $token);
 
 # views are empty

--- a/viewer/apiViews.js
+++ b/viewer/apiViews.js
@@ -155,6 +155,13 @@ class View {
    */
   static async apiDeleteView (req, res) {
     try {
+      const { body: dbView } = await Db.getView(req.params.id);
+
+      // only allow admins or view creator to delete view
+      if (!req.user.hasRole('arkimeAdmin') && req.settingUser.userId !== dbView._source.user) {
+        return res.serverError(403, 'Permission denied');
+      }
+
       await Db.deleteView(req.params.id);
       res.send(JSON.stringify({
         success: true,


### PR DESCRIPTION
Currently, `apiDeleteView` in `viewer/apiViews.js` lacks authorization checks to ensure a user can delete a view. Checks are performed correctly in `apiUpdateView` and should also be implemented in `apiDeleteView`.

This PR adds the autorization check from `apiUpdateView` to `apiDeleteView` to ensure only the creator and admins can delete a view.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
