### PR TITLE
Fix for spelling-mistake when using message from exception in parliament

### DIFF
--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -948,7 +948,7 @@ function updateParliament () {
         return resolve();
       })
       .catch((error) => {
-        console.log('Parliament update error:', error.messge || error);
+        console.log('Parliament update error:', error.message || error);
         return resolve();
       });
   });


### PR DESCRIPTION
Quick fix for a minor issue for logging update-errors. The attribute for message was mis-spelled.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
