### PR TITLE
Avoid SSRF through sid/token parameters

### DIFF
--- a/cont3xt/integrations/twilio/index.js
+++ b/cont3xt/integrations/twilio/index.js
@@ -94,9 +94,13 @@ class TwilioIntegration extends Integration {
         return undefined;
       }
 
-      const result = await axios.get(`https://${sid}:${token}@lookups.twilio.com/v1/PhoneNumbers/+1${query}?Type=carrier&Type=caller-name`, {
+      const result = await axios.get(`https://lookups.twilio.com/v1/PhoneNumbers/+1${query}?Type=carrier&Type=caller-name`, {
         headers: {
           'User-Agent': this.userAgent()
+        },
+        auth: {
+          username: sid,
+          password: token
         }
       });
 


### PR DESCRIPTION
The SID and Token parameters can be used to issue arbitrary requests to internal hosts, or whatever host an attacker that are able to change it want. Moving both to an `auth` block that is doing the parsing correctly.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
