### PR TITLE
Updated tags endpoints to use `checkCookieToken`

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -493,15 +493,6 @@ function checkCookieToken (req, res, next) {
   return next();
 }
 
-// use for APIs that can be used from places other than just the UI
-function checkHeaderToken (req, res, next) {
-  if (req.headers.cookie) { // if there's a cookie, check header
-    return checkCookieToken(req, res, next);
-  } else { // if there's no cookie, just continue so the API still works
-    return next();
-  }
-}
-
 // used to disable endpoints in multi es mode
 function disableInMultiES (req, res, next) {
   if (Config.get('multiES', false)) {
@@ -1673,13 +1664,13 @@ app.get( // session packets endpoint
 
 app.post( // add tags endpoint
   ['/api/sessions/addtags', '/addTags'],
-  [ArkimeUtil.noCacheJson, checkHeaderToken, logAction('addTags')],
+  [ArkimeUtil.noCacheJson, checkCookieToken, logAction('addTags')],
   sessionAPIs.addTags
 );
 
 app.post( // remove tags endpoint
   ['/api/sessions/removetags', '/removeTags'],
-  [ArkimeUtil.noCacheJson, checkHeaderToken, logAction('removeTags'), User.checkPermissions(['removeEnabled'])],
+  [ArkimeUtil.noCacheJson, checkCookieToken, logAction('removeTags'), User.checkPermissions(['removeEnabled'])],
   sessionAPIs.removeTags
 );
 


### PR DESCRIPTION
The paths `/api/sessions/addtags` and `/api/sessions/removetags` uses the `checkHeaderToken` middelware instead of `checkCookieToken` which most state changing endpoints uses. `checkCookieToken` requires that the `x-arkime-cookie` header is present, which makes it secure from CSRF attacks, but `checkHeaderToken` does not.

This PR removes the `checkHeaderToken` function and updates the tags endpoints to use `checkCookieToken` instead.

**Note:** This will break the the API from "being used from places other than just the UI" as specified in the in-line comment as the reason for this functions existence. I'm not sure if there's still a use-case for this, but if this still needs to be supported, we need to come up with another soltuion.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
