### PR TITLE
Prevent crash when receiving bad data in wise

### DIFF
--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -1089,6 +1089,9 @@ app.post('/get', function (req, res) {
         } else {
           typeName = internals.type2Name[type];
         }
+        if (!typeName) {
+          throw new Error('Could not make out typeName from query');
+        }
 
         const len = buf.readUInt16BE(offset);
         offset += 2;


### PR DESCRIPTION
Wise will crash when receiving bad data in a HTTP POST-request to the endpoint `http://<HOST>:8081/get`


If  `body[0] & 0x80 === false` and `body[0] > 7` then `typeName == undefined` and the process will crash.

Stacktrace:

```
[[11:42:41.104]] [LOG]   Express server listening on port 8081 in development mode
/opt/arkime/wiseService/wiseService.js:844
      excludeName: 'exclude' + type[0].toUpperCase() + type.slice(1) + 's',
                                   ^

TypeError: Cannot read properties of undefined (reading '0')
    at addType (/opt/arkime/wiseService/wiseService.js:844:36)
    at processQuery (/opt/arkime/wiseService/wiseService.js:902:16)
    at /opt/arkime/wiseService/wiseService.js:1108:7
    at /opt/arkime/node_modules/async/dist/async.js:246:13
    at eachOfArrayLike (/opt/arkime/node_modules/async/dist/async.js:506:13)
    at eachOf (/opt/arkime/node_modules/async/dist/async.js:626:16)
    at awaitable (/opt/arkime/node_modules/async/dist/async.js:211:32)
    at _asyncMap (/opt/arkime/node_modules/async/dist/async.js:244:16)
    at Object.map (/opt/arkime/node_modules/async/dist/async.js:749:16)
    at Object.awaitable [as map] (/opt/arkime/node_modules/async/dist/async.js:211:32)
    at IncomingMessage.<anonymous> (/opt/arkime/wiseService/wiseService.js:1107:11)
    at Object.onceWrapper (node:events:641:28)
    at IncomingMessage.emit (node:events:539:35)
    at endReadableNT (node:internal/streams/readable:1345:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```

This pull request throws an exception if typeName is not found and will make the server respond with the `Received malformed packet` response

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
