### PR TITLE
Avoid crash when searching cont3xt with invalid URL

### DIFF
--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -169,7 +169,14 @@ class Integration {
     // https://urlregex.com/
     // eslint-disable-next-line no-useless-escape
     if (str.match(/https?:\/\//) && str.match(/((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/)) {
-      return 'url';
+      try {
+        // Make sure we can construct a proper URL-object using this string
+        // eslint-disable-next-line no-unused-vars
+        const url = new URL(str);
+        return 'url';
+      } catch (e) {
+        // This looked like a URL but could not be parsed as such. Continue testing below.
+      }
     }
 
     if (str.match(/^[A-Fa-f0-9]{32}$/) || str.match(/^[A-Fa-f0-9]{40}$/) || str.match(/^[A-Fa-f0-9]{64}$/)) {


### PR DESCRIPTION
Cont3xt will crash if you search for an invalid URL such as `http://www%`.

This pull request makes sure that only correct URLs will get identified as `URL`. Invalid URLs will now be identified as `TEXT` instead of crashing the process.

Stacktrace from crash below:

```
node:internal/errors:465
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_INVALID_URL]: Invalid URL
    at new NodeError (node:internal/errors:372:5)
    at URL.onParseError (node:internal/url:553:9)
    at new URL (node:internal/url:629:5)
    at apiSearch (/opt/arkime/cont3xt/integration.js:590:19)
    at Layer.handle [as handle_request] (/opt/arkime/node_modules/express/lib/router/layer.js:95:5)
    at next (/opt/arkime/node_modules/express/lib/router/route.js:137:13)
    at /opt/arkime/node_modules/body-parser/lib/read.js:130:5
    at invokeCallback (/opt/arkime/node_modules/raw-body/index.js:224:16)
    at done (/opt/arkime/node_modules/raw-body/index.js:213:7)
    at IncomingMessage.onEnd (/opt/arkime/node_modules/raw-body/index.js:273:7) {
  input: 'http://www%',
  code: 'ERR_INVALID_URL'
}

```

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
