### PR TITLE
Add Content-Type: application/json to /api/fields endpoint

### DIFF
--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -72,7 +72,8 @@ module.exports = (Config, Db, internals, sessionAPIs, userAPIs, ViewerUtils) => 
       res.status(404);
       res.send('Cannot locate fields');
     }
-
+    
+    res.header('Content-Type', 'application/json');
     if (req.query && req.query.array) {
       res.send(internals.fieldsArr);
     } else {


### PR DESCRIPTION
Add Content-Type: application/json to /api/fields endpoint

The /api/fields endpoint responded with a Content-Type: text/html. This would enable potential XSS attacks. By setting the correct content type for the presented data (application/json), this issue is mitigated.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
