### PR TITLE
Add Content-Type: text/plain to the /api/title endpoint

### DIFF
--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -174,6 +174,7 @@ module.exports = (Config, Db, internals, sessionAPIs, userAPIs, ViewerUtils) => 
    * @returns {string} title - The title of the app based on the configured setting.
    */
   miscAPIs.getPageTitle = (req, res) => {
+    ViewerUtils.noCache(req, res, 'text/plain; charset=utf-8');
     let titleConfig = Config.get('titleTemplate', '_cluster_ - _page_ _-view_ _-expression_');
 
     titleConfig = titleConfig.replace(/_cluster_/g, internals.clusterName)


### PR DESCRIPTION
Add Content-Type: text/plain to the /api/title endpoint

The /api/title endpoint responded with a `Content-Type: text/html`. 
This would enable potential XSS attacks. By setting the correct content type for the presented data (text/html), this issue is mitigated.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
