### PR TITLE
Fix refanging

### DIFF
--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -559,7 +559,7 @@ class Integration {
       resultCount: 0 // sum of _cont3xt.count from results
     };
     res.write('[\n');
-    res.write(JSON.stringify({ success: true, itype, sent: shared.sent, total: integrations.length, text: 'more to follow' }));
+    res.write(JSON.stringify({ success: true, itype, query, sent: shared.sent, total: integrations.length, text: 'more to follow' }));
     res.write(',\n');
 
     const issuedAt = Date.now();

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -649,7 +649,7 @@ export default {
           if (data.itype && !this.searchItype) {
             // determine the search type and save the search term
             // based of the first itype seen
-            this.lastSearchedTerm = termSearched;
+            this.lastSearchedTerm = data.query;
             this.searchItype = data.itype;
             this.filterLinks(this.linkSearchTerm);
           }
@@ -779,7 +779,7 @@ export default {
               } else {
                 break;
               }
-              x = x - 2;
+              x -= 2;
             }
             if (leftHeight > rightHeight) {
               delta = Math.abs(leftHeight - rightHeight);
@@ -795,7 +795,7 @@ export default {
               } else {
                 break;
               }
-              x = x - 2;
+              x -= 2;
             }
             if (rightHeight > leftHeight) {
               delta = Math.abs(rightHeight - leftHeight);

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -642,9 +642,8 @@ export default {
           }
         });
       }
-      const termSearched = this.searchTerm;
       const viewId = this.getSelectedView?._id;
-      Cont3xtService.search({ searchTerm: termSearched, skipCache: this.skipCache, tags: this.tags, viewId }).subscribe({
+      Cont3xtService.search({ searchTerm: this.searchTerm, skipCache: this.skipCache, tags: this.tags, viewId }).subscribe({
         next: (data) => {
           if (data.itype && !this.searchItype) {
             // determine the search type and save the search term


### PR DESCRIPTION
refanging was not working, because the query stored (`lastSearchedTerm`) was using the directly inputted indicator, and not necessarily the one that the backend searched (i.e. that with refanging applied).

It now uses the `query` field from the first data returned (like `searchItype` does).