### PR TITLE
Add proper encoding to prevent HTML injection

### DIFF
--- a/viewer/decode.js
+++ b/viewer/decode.js
@@ -788,12 +788,12 @@ exports.register('ITEM-LINKBODY', through.ctor({ objectMode: true }, function (i
     return callback(null, item);
   }
 
-  const url = `api/session/${this.options.nodeName}/${this.options.id}/body/${item.bodyType}/${item.bodyNum}/${item.bodyName}.pellet`;
+  const url = `api/session/${encodeURIComponent(this.options.nodeName)}/${encodeURIComponent(this.options.id)}/body/${encodeURIComponent(item.bodyType)}/${encodeURIComponent(item.bodyNum)}/${encodeURIComponent(item.bodyName)}.pellet`;
 
   if (item.bodyType === 'image') {
     item.html = '<img src="' + url + '">';
   } else {
-    item.html = "<a target='_blank' class='imagetag file' href=\"" + url + '">' + item.bodyName + '</a>';
+    item.html = "<a target='_blank' class='imagetag file' href=\"" + url + '">' + ArkimeUtil.safeStr(item.bodyName) + '</a>';
   }
   callback(null, item);
 }));


### PR DESCRIPTION
Add proper encoding to prevent HTML injection

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
