### PR TITLE
Preventing too many data being returned while creating clusters

### DIFF
--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1725,7 +1725,6 @@ router.post('/groups/:id/clusters', isAdmin, (req, res, next) => {
   const successObj = {
     success: true,
     cluster: newCluster,
-    parliament,
     text: 'Successfully added the requested cluster.'
   };
   const errorText = 'Unable to add that cluster to the parliament.';


### PR DESCRIPTION
Preventing too much data about the parliament instance being returned while creating a new cluster in a group.

Currently the complete parliament object is returned which contains a lot of information about the instance and also the passwordSecret which should be hidden.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
