### PR TITLE
Enforce extension of configuration-file to ensure it is parsed as JSO…

### DIFF
--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -152,6 +152,11 @@ const invalidTokens = {};
     }
   }
 
+  if (file && !file.endsWith('.json')) {
+    console.log('ERROR: Parliament config filename must end with \'.json\'');
+    process.exit(1);
+  }
+
   if (!appArgs.length) {
     console.log('WARNING: No config options were set, starting Parliament in view only mode with defaults.\n');
   }


### PR DESCRIPTION
In order for the parliament configuration-file to be correctly parsed, the filename must end with `.json`. This pull-request enforces this requirement.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
