### PR TITLE
Command Injection in moment-timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "jest": "^27.0.4",
     "jsdoc-to-markdown": "^7.0.1",
     "mini-css-extract-plugin": "^1.3.8",
-    "moment-timezone": "^0.5.32",
+    "moment-timezone": "^0.5.35",
     "node-notifier": "^8.0.1",
     "nodemon": "^2.0.19",
     "ora": "^5.1.0",


### PR DESCRIPTION
## Describe the bugs: 🐛
All versions of moment-timezone from 0.1.0 contain build tasks vulnerable to command injection.
  * if Alice uses tzdata pipeline to package moment-timezone on her own (for example via grunt data:2014d, where 2014d stands for the version of the tzdata to be used from IANA's website),
  * and Alice let's Mallory select the version (2014d in our example), then Mallory can execute arbitrary commands on the machine running the grunt task, with the same privilege as the grunt task

**Command Injection via grunt-zdownload.js and MITM on iana's ftp endpoint**
The `tasks/data-download.js` script takes in a parameter from grunt and uses it to form a command line which is then executed:
```
6  module.exports = function (grunt) {
7      grunt.registerTask('data-download', '1. Download data from iana.org/time-zones.', function (version) {
8          version = version || 'latest';

10          var done  = this.async(),
11              src   = 'ftp://ftp.iana.org/tz/tzdata-latest.tar.gz',
12              curl  = path.resolve('temp/curl', version, 'data.tar.gz'),
13              dest  = path.resolve('temp/download', version);
...
24          exec('curl ' + src + ' -o ' + curl + ' && cd ' + dest + ' && gzip -dc ' + curl + ' | tar -xf -', function (err) {
```
## Patches
The supplied patch on top of 0.5.34 is applicable with minor tweaks to all affected versions. It switches exec to execFile so arbitrary bash fragments won't be executed any more.