### PR TITLE
all itype components now support tidbits

### DIFF
--- a/cont3xt/vueapp/src/components/itypes/Domain.vue
+++ b/cont3xt/vueapp/src/components/itypes/Domain.vue
@@ -54,7 +54,7 @@ import { ITypeMixin } from './ITypeMixin';
 
 export default {
   name: 'Cont3xtDomain',
-  mixins: [ITypeMixin],
+  mixins: [ITypeMixin], // for tidbits
   components: {
     Cont3xtField,
     TtlTooltip,

--- a/cont3xt/vueapp/src/components/itypes/Email.vue
+++ b/cont3xt/vueapp/src/components/itypes/Email.vue
@@ -3,15 +3,18 @@
     :value="query"
     :itype="itype"
     :data="data"
+    :tidbits="tidbits"
     :children="domainChildren"
   />
 </template>
 
 <script>
 import BaseIType from '@/components/itypes/BaseIType';
+import { ITypeMixin } from './ITypeMixin';
 
 export default {
   name: 'Cont3xtEmail',
+  mixins: [ITypeMixin], // for tidbits
   components: {
     BaseIType
   },

--- a/cont3xt/vueapp/src/components/itypes/Hash.vue
+++ b/cont3xt/vueapp/src/components/itypes/Hash.vue
@@ -3,14 +3,17 @@
       :value="query"
       :itype="itype"
       :data="data"
+      :tidbits="tidbits"
   />
 </template>
 
 <script>
 import BaseIType from '@/components/itypes/BaseIType';
+import { ITypeMixin } from './ITypeMixin';
 
 export default {
   name: 'Cont3xtHash',
+  mixins: [ITypeMixin], // for tidbits
   components: {
     BaseIType
   },

--- a/cont3xt/vueapp/src/components/itypes/IP.vue
+++ b/cont3xt/vueapp/src/components/itypes/IP.vue
@@ -20,7 +20,7 @@ import { ITypeMixin } from './ITypeMixin';
 
 export default {
   name: 'Cont3xtIp',
-  mixins: [ITypeMixin], // gives enhancements
+  mixins: [ITypeMixin], // for tidbits
   components: {
     BaseIType,
     TtlTooltip

--- a/cont3xt/vueapp/src/components/itypes/Phone.vue
+++ b/cont3xt/vueapp/src/components/itypes/Phone.vue
@@ -13,7 +13,7 @@ import { ITypeMixin } from './ITypeMixin';
 
 export default {
   name: 'Cont3xtPhone',
-  mixins: [ITypeMixin],
+  mixins: [ITypeMixin], // for tidbits
   components: {
     BaseIType
   },

--- a/cont3xt/vueapp/src/components/itypes/Text.vue
+++ b/cont3xt/vueapp/src/components/itypes/Text.vue
@@ -3,14 +3,17 @@
       :value="query"
       :itype="itype"
       :data="data"
+      :tidbits="tidbits"
   />
 </template>
 
 <script>
 import BaseIType from '@/components/itypes/BaseIType';
+import { ITypeMixin } from './ITypeMixin';
 
 export default {
   name: 'Cont3xtText',
+  mixins: [ITypeMixin], // for tidbits
   components: {
     BaseIType
   },

--- a/cont3xt/vueapp/src/components/itypes/URL.vue
+++ b/cont3xt/vueapp/src/components/itypes/URL.vue
@@ -3,15 +3,18 @@
       :value="query"
       :itype="itype"
       :data="data"
+      :tidbits="tidbits"
       :children="sliceChildren"
   />
 </template>
 
 <script>
 import BaseIType from '@/components/itypes/BaseIType';
+import { ITypeMixin } from './ITypeMixin';
 
 export default {
   name: 'Cont3xtUrl',
+  mixins: [ITypeMixin], // for tidbits
   components: {
     BaseIType
   },


### PR DESCRIPTION
all itype components now use ITypeMixin for consistency and ability to add tidbits

eg. URL `https://artem1994buffonshiola.com/aollfss/aollfss/aolfs/login.php` will now present ThreatStream tags, whereas they were not rendered before