### PR TITLE
prevent userid from containing a backslash

### DIFF
--- a/common/user.js
+++ b/common/user.js
@@ -675,6 +675,10 @@ class User {
       return res.serverError(403, 'Missing userId');
     }
 
+    if (userId.contains("\\")) {
+      return res.serverError(403, "Malformed UserID")
+    }
+
     const isRole = userId.startsWith('role:');
 
     if (userId === '_moloch_shared') {


### PR DESCRIPTION
Terminal Command injection vulnerability

POST method for /api/user/user fails to sanitize the userid parameter which leads to a terminal command injection vulnerability. A carefully crafted requests with Escape codes can cause shell escape sequences to be written to the terminal via the applications log functionality. These escape sequences can be leveraged to manipulate the content of the stdout / logs or execute commands in the operators terminal.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
