### PR TITLE
Add TLS Certificate Organisational Unit field parsing

### DIFF
--- a/capture/db.c
+++ b/capture/db.c
@@ -1228,8 +1228,10 @@ void moloch_db_save_session(MolochSession_t *session, int final)
 
                 SAVE_STRING_HEAD(certs->issuer.commonName, "issuerCN");
                 SAVE_STRING_HEAD(certs->issuer.orgName, "issuerON");
+                SAVE_STRING_HEAD(certs->issuer.orgUnitName, "issuerOUN");
                 SAVE_STRING_HEAD(certs->subject.commonName, "subjectCN");
                 SAVE_STRING_HEAD(certs->subject.orgName, "subjectON");
+                SAVE_STRING_HEAD(certs->subject.orgUnitName, "subjectOUN");
 
                 if (certs->serialNumber) {
                     int k;

--- a/capture/db.c
+++ b/capture/db.c
@@ -1228,10 +1228,10 @@ void moloch_db_save_session(MolochSession_t *session, int final)
 
                 SAVE_STRING_HEAD(certs->issuer.commonName, "issuerCN");
                 SAVE_STRING_HEAD(certs->issuer.orgName, "issuerON");
-                SAVE_STRING_HEAD(certs->issuer.orgUnitName, "issuerOUN");
+                SAVE_STRING_HEAD(certs->issuer.orgUnit, "issuerOU");
                 SAVE_STRING_HEAD(certs->subject.commonName, "subjectCN");
                 SAVE_STRING_HEAD(certs->subject.orgName, "subjectON");
-                SAVE_STRING_HEAD(certs->subject.orgUnitName, "subjectOUN");
+                SAVE_STRING_HEAD(certs->subject.orgUnit, "subjectOU");
 
                 if (certs->serialNumber) {
                     int k;

--- a/capture/field.c
+++ b/capture/field.c
@@ -1122,8 +1122,10 @@ int moloch_field_certsinfo_cmp(const void *keyv, const void *elementv)
            (memcmp(key->serialNumber, element->serialNumber, element->serialNumberLen) == 0) &&
            (key->issuer.commonName.s_count == element->issuer.commonName.s_count) &&
            (key->issuer.orgName.s_count == element->issuer.orgName.s_count) &&
+           (key->issuer.orgUnit.s_count == element->issuer.orgUnit.s_count) &&
            (key->subject.commonName.s_count == element->subject.commonName.s_count) &&
-           (key->subject.orgName.s_count == element->subject.orgName.s_count)
+           (key->subject.orgName.s_count == element->subject.orgName.s_count) &&
+           (key->subject.orgUnit.s_count == element->subject.orgUnit.s_count)
           )
        ) {
 
@@ -1149,6 +1151,14 @@ int moloch_field_certsinfo_cmp(const void *keyv, const void *elementv)
             return 0;
     }
 
+    for (kstr = key->issuer.orgUnit.s_next, estr = element->issuer.orgUnit.s_next;
+         kstr != (void *)&(key->issuer.orgUnit);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
     for (kstr = key->subject.commonName.s_next, estr = element->subject.commonName.s_next;
          kstr != (void *)&(key->subject.commonName);
          kstr = kstr->s_next, estr = estr->s_next) {
@@ -1159,6 +1169,14 @@ int moloch_field_certsinfo_cmp(const void *keyv, const void *elementv)
 
     for (kstr = key->subject.orgName.s_next, estr = element->subject.orgName.s_next;
          kstr != (void *)&(key->subject.orgName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = key->subject.orgUnit.s_next, estr = element->subject.orgUnit.s_next;
+         kstr != (void *)&(key->subject.orgUnit);
          kstr = kstr->s_next, estr = estr->s_next) {
 
         if (strcmp(kstr->str, estr->str) != 0)

--- a/capture/field.c
+++ b/capture/field.c
@@ -1310,7 +1310,7 @@ void moloch_field_certsinfo_free (MolochCertsInfo_t *certs)
         MOLOCH_TYPE_FREE(MolochString_t, string);
     }
 
-    while (DLL_POP_HEAD(s_, &certs->issuer.orgUnitName, string)) {
+    while (DLL_POP_HEAD(s_, &certs->issuer.orgUnit, string)) {
         g_free(string->str);
         MOLOCH_TYPE_FREE(MolochString_t, string);
     }
@@ -1325,7 +1325,7 @@ void moloch_field_certsinfo_free (MolochCertsInfo_t *certs)
         MOLOCH_TYPE_FREE(MolochString_t, string);
     }
 
-    while (DLL_POP_HEAD(s_, &certs->subject.orgUnitName, string)) {
+    while (DLL_POP_HEAD(s_, &certs->subject.orgUnit, string)) {
         g_free(string->str);
         MOLOCH_TYPE_FREE(MolochString_t, string);
     }

--- a/capture/field.c
+++ b/capture/field.c
@@ -1310,12 +1310,22 @@ void moloch_field_certsinfo_free (MolochCertsInfo_t *certs)
         MOLOCH_TYPE_FREE(MolochString_t, string);
     }
 
+    while (DLL_POP_HEAD(s_, &certs->issuer.orgUnitName, string)) {
+        g_free(string->str);
+        MOLOCH_TYPE_FREE(MolochString_t, string);
+    }
+
     while (DLL_POP_HEAD(s_, &certs->subject.commonName, string)) {
         g_free(string->str);
         MOLOCH_TYPE_FREE(MolochString_t, string);
     }
 
     while (DLL_POP_HEAD(s_, &certs->subject.orgName, string)) {
+        g_free(string->str);
+        MOLOCH_TYPE_FREE(MolochString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &certs->subject.orgUnitName, string)) {
         g_free(string->str);
         MOLOCH_TYPE_FREE(MolochString_t, string);
     }

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -141,8 +141,9 @@ typedef struct moloch_trie {
  */
 
 typedef struct {
-    MolochStringHead_t  commonName; // 2.5.4.3
-    MolochStringHead_t  orgName;    // 2.5.4.10
+    MolochStringHead_t  commonName;  // 2.5.4.3
+    MolochStringHead_t  orgName;     // 2.5.4.10
+    MolochStringHead_t  orgUnitName; // 2.5.4.11
     char                orgUtf8;
 } MolochCertInfo_t;
 

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -141,9 +141,9 @@ typedef struct moloch_trie {
  */
 
 typedef struct {
-    MolochStringHead_t  commonName;  // 2.5.4.3
-    MolochStringHead_t  orgName;     // 2.5.4.10
-    MolochStringHead_t  orgUnitName; // 2.5.4.11
+    MolochStringHead_t  commonName; // 2.5.4.3
+    MolochStringHead_t  orgName;    // 2.5.4.10
+    MolochStringHead_t  orgUnit;    // 2.5.4.11
     char                orgUtf8;
 } MolochCertInfo_t;
 

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -59,7 +59,7 @@ LOCAL void dtls_certinfo_process(MolochCertInfo_t *ci, BSB *bsb)
                 MolochString_t *element = MOLOCH_TYPE_ALLOC0(MolochString_t);
                 element->utf8 = atag == 12;
                 element->str = g_strndup((char*)value, alen);
-                DLL_PUSH_TAIL(s_, &ci->orgUnitName, element);
+                DLL_PUSH_TAIL(s_, &ci->orgUnit, element);
             }
         }
     }
@@ -139,10 +139,10 @@ LOCAL void dtls_process_server_certificate(MolochSession_t *session, const unsig
         DLL_INIT(s_, &certs->alt);
         DLL_INIT(s_, &certs->subject.commonName);
         DLL_INIT(s_, &certs->subject.orgName);
-        DLL_INIT(s_, &certs->subject.orgUnitName);
+        DLL_INIT(s_, &certs->subject.orgUnit);
         DLL_INIT(s_, &certs->issuer.commonName);
         DLL_INIT(s_, &certs->issuer.orgName);
-        DLL_INIT(s_, &certs->issuer.orgUnitName);
+        DLL_INIT(s_, &certs->issuer.orgUnit);
 
         uint32_t       atag, alen, apc;
         unsigned char *value;

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -55,6 +55,11 @@ LOCAL void dtls_certinfo_process(MolochCertInfo_t *ci, BSB *bsb)
                 element->utf8 = atag == 12;
                 element->str = g_strndup((char*)value, alen);
                 DLL_PUSH_TAIL(s_, &ci->orgName, element);
+            } else if (strcmp(lastOid, "2.5.4.11") == 0) {
+                MolochString_t *element = MOLOCH_TYPE_ALLOC0(MolochString_t);
+                element->utf8 = atag == 12;
+                element->str = g_strndup((char*)value, alen);
+                DLL_PUSH_TAIL(s_, &ci->orgUnitName, element);
             }
         }
     }
@@ -134,8 +139,10 @@ LOCAL void dtls_process_server_certificate(MolochSession_t *session, const unsig
         DLL_INIT(s_, &certs->alt);
         DLL_INIT(s_, &certs->subject.commonName);
         DLL_INIT(s_, &certs->subject.orgName);
+        DLL_INIT(s_, &certs->subject.orgUnitName);
         DLL_INIT(s_, &certs->issuer.commonName);
         DLL_INIT(s_, &certs->issuer.orgName);
+        DLL_INIT(s_, &certs->issuer.orgUnitName);
 
         uint32_t       atag, alen, apc;
         unsigned char *value;

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -74,6 +74,11 @@ LOCAL void tls_certinfo_process(MolochCertInfo_t *ci, BSB *bsb)
                 element->utf8 = atag == 12;
                 element->str = g_strndup((char*)value, alen);
                 DLL_PUSH_TAIL(s_, &ci->orgName, element);
+            } else if (strcmp(lastOid, "2.5.4.11") == 0) {
+                MolochString_t *element = MOLOCH_TYPE_ALLOC0(MolochString_t);
+                element->utf8 = atag == 12;
+                element->str = g_strndup((char*)value, alen);
+                DLL_PUSH_TAIL(s_, &ci->orgUnitName, element);
             }
         }
     }
@@ -362,8 +367,10 @@ LOCAL void tls_process_server_certificate(MolochSession_t *session, const unsign
         DLL_INIT(s_, &certs->alt);
         DLL_INIT(s_, &certs->subject.commonName);
         DLL_INIT(s_, &certs->subject.orgName);
+        DLL_INIT(s_, &certs->subject.orgUnitName);
         DLL_INIT(s_, &certs->issuer.commonName);
         DLL_INIT(s_, &certs->issuer.orgName);
+        DLL_INIT(s_, &certs->issuer.orgUnitName);
 
         uint32_t       atag, alen, apc;
         unsigned char *value;
@@ -831,6 +838,18 @@ void moloch_parser_init()
     moloch_field_define("cert", "termfield",
         "cert.subject.on", "Subject ON", "cert.subjectON",
         "Subject's organization name",
+        0, MOLOCH_FIELD_FLAG_FAKE,
+        (char *)NULL);
+
+    moloch_field_define("cert", "termfield",
+        "cert.issuer.oun", "Issuer Org Unit", "cert.issuerOUN",
+        "Issuer's organizational unit name",
+        0, MOLOCH_FIELD_FLAG_FAKE,
+        (char *)NULL);
+
+    moloch_field_define("cert", "termfield",
+        "cert.subject.oun", "Subject Org Unit", "cert.subjectOUN",
+        "Subject's organizational unit name",
         0, MOLOCH_FIELD_FLAG_FAKE,
         (char *)NULL);
 

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -843,13 +843,13 @@ void moloch_parser_init()
 
     moloch_field_define("cert", "termfield",
         "cert.issuer.ou", "Issuer Org Unit", "cert.issuerOU",
-        "Issuer's organizational unit name",
+        "Issuer's organizational unit",
         0, MOLOCH_FIELD_FLAG_FAKE,
         (char *)NULL);
 
     moloch_field_define("cert", "termfield",
         "cert.subject.ou", "Subject Org Unit", "cert.subjectOU",
-        "Subject's organizational unit name",
+        "Subject's organizational unit",
         0, MOLOCH_FIELD_FLAG_FAKE,
         (char *)NULL);
 

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -78,7 +78,7 @@ LOCAL void tls_certinfo_process(MolochCertInfo_t *ci, BSB *bsb)
                 MolochString_t *element = MOLOCH_TYPE_ALLOC0(MolochString_t);
                 element->utf8 = atag == 12;
                 element->str = g_strndup((char*)value, alen);
-                DLL_PUSH_TAIL(s_, &ci->orgUnitName, element);
+                DLL_PUSH_TAIL(s_, &ci->orgUnit, element);
             }
         }
     }
@@ -367,10 +367,10 @@ LOCAL void tls_process_server_certificate(MolochSession_t *session, const unsign
         DLL_INIT(s_, &certs->alt);
         DLL_INIT(s_, &certs->subject.commonName);
         DLL_INIT(s_, &certs->subject.orgName);
-        DLL_INIT(s_, &certs->subject.orgUnitName);
+        DLL_INIT(s_, &certs->subject.orgUnit);
         DLL_INIT(s_, &certs->issuer.commonName);
         DLL_INIT(s_, &certs->issuer.orgName);
-        DLL_INIT(s_, &certs->issuer.orgUnitName);
+        DLL_INIT(s_, &certs->issuer.orgUnit);
 
         uint32_t       atag, alen, apc;
         unsigned char *value;
@@ -842,13 +842,13 @@ void moloch_parser_init()
         (char *)NULL);
 
     moloch_field_define("cert", "termfield",
-        "cert.issuer.oun", "Issuer Org Unit", "cert.issuerOUN",
+        "cert.issuer.ou", "Issuer Org Unit", "cert.issuerOU",
         "Issuer's organizational unit name",
         0, MOLOCH_FIELD_FLAG_FAKE,
         (char *)NULL);
 
     moloch_field_define("cert", "termfield",
-        "cert.subject.oun", "Subject Org Unit", "cert.subjectOUN",
+        "cert.subject.ou", "Subject Org Unit", "cert.subjectOU",
         "Subject's organizational unit name",
         0, MOLOCH_FIELD_FLAG_FAKE,
         (char *)NULL);

--- a/capture/parsers/tls.detail.jade
+++ b/capture/parsers/tls.detail.jade
@@ -46,6 +46,15 @@ if (session.cert)
       - else if (cert.issuerON)
         strong.medium.ml-1 Issuer Org
         moloch-session-field.detail-field(:expr="'cert.issuer.on'", :value='"'+cert.issuerON+'"', :field="fields['cert.issuer.on']", :pull-left="true")
+      - if (cert.issuerOUN && Array.isArray(cert.issuerOUN))
+        strong.medium.ml-1 Issuer Org Unit
+        each oun,i in cert.issuerOUN
+          if (i > 0)
+            |,
+          moloch-session-field.detail-field(:expr="'cert.issuer.oun'", :value='"'+oun+'"', :field="fields['cert.issuer.oun']", :pull-left="true")
+      - else if (cert.issuerOUN)
+        strong.medium.ml-1 Issuer Org unit
+        moloch-session-field.detail-field(:expr="'cert.issuer.oun'", :value='"'+cert.issuerOUN+'"', :field="fields['cert.issuer.oun']", :pull-left="true")
       - if (cert.subjectCN && Array.isArray(cert.subjectCN))
         strong.medium.ml-1 Subject Common
         each cn,i in cert.subjectCN
@@ -64,6 +73,15 @@ if (session.cert)
       - else if (cert.subjectON)
         strong.medium.ml-1 Subject Org
         moloch-session-field.detail-field(:expr="'cert.subject.on'", :value='"'+cert.subjectON+'"', :field="fields['cert.subject.on']", :pull-left="true")
+      - if (cert.subjectOUN && Array.isArray(cert.subjectOUN))
+        strong.medium.ml-1 Subject Org Unit
+        each oun,i in cert.subjectOUN
+          if (i > 0)
+            |,
+          moloch-session-field.detail-field(:expr="'cert.subject.oun'", :value='"'+oun+'"', :field="fields['cert.subject.oun']", :pull-left="true")
+      - else if (cert.subjectOUN)
+        strong.medium.ml-1 Subject Org Unit
+        moloch-session-field.detail-field(:expr="'cert.subject.oun'", :value='"'+cert.subjectOUN+'"', :field="fields['cert.subject.oun']", :pull-left="true")
       - if (cert.alt)
         | [
         each alt,i in cert.alt

--- a/capture/parsers/tls.detail.jade
+++ b/capture/parsers/tls.detail.jade
@@ -46,15 +46,15 @@ if (session.cert)
       - else if (cert.issuerON)
         strong.medium.ml-1 Issuer Org
         moloch-session-field.detail-field(:expr="'cert.issuer.on'", :value='"'+cert.issuerON+'"', :field="fields['cert.issuer.on']", :pull-left="true")
-      - if (cert.issuerOUN && Array.isArray(cert.issuerOUN))
+      - if (cert.issuerOU && Array.isArray(cert.issuerOU))
         strong.medium.ml-1 Issuer Org Unit
-        each oun,i in cert.issuerOUN
+        each ou,i in cert.issuerOU
           if (i > 0)
             |,
-          moloch-session-field.detail-field(:expr="'cert.issuer.oun'", :value='"'+oun+'"', :field="fields['cert.issuer.oun']", :pull-left="true")
-      - else if (cert.issuerOUN)
+          moloch-session-field.detail-field(:expr="'cert.issuer.ou'", :value='"'+ou+'"', :field="fields['cert.issuer.ou']", :pull-left="true")
+      - else if (cert.issuerOU)
         strong.medium.ml-1 Issuer Org unit
-        moloch-session-field.detail-field(:expr="'cert.issuer.oun'", :value='"'+cert.issuerOUN+'"', :field="fields['cert.issuer.oun']", :pull-left="true")
+        moloch-session-field.detail-field(:expr="'cert.issuer.ou'", :value='"'+cert.issuerOU+'"', :field="fields['cert.issuer.ou']", :pull-left="true")
       - if (cert.subjectCN && Array.isArray(cert.subjectCN))
         strong.medium.ml-1 Subject Common
         each cn,i in cert.subjectCN
@@ -73,15 +73,15 @@ if (session.cert)
       - else if (cert.subjectON)
         strong.medium.ml-1 Subject Org
         moloch-session-field.detail-field(:expr="'cert.subject.on'", :value='"'+cert.subjectON+'"', :field="fields['cert.subject.on']", :pull-left="true")
-      - if (cert.subjectOUN && Array.isArray(cert.subjectOUN))
+      - if (cert.subjectOU && Array.isArray(cert.subjectOU))
         strong.medium.ml-1 Subject Org Unit
-        each oun,i in cert.subjectOUN
+        each ou,i in cert.subjectOU
           if (i > 0)
             |,
-          moloch-session-field.detail-field(:expr="'cert.subject.oun'", :value='"'+oun+'"', :field="fields['cert.subject.oun']", :pull-left="true")
-      - else if (cert.subjectOUN)
+          moloch-session-field.detail-field(:expr="'cert.subject.ou'", :value='"'+ou+'"', :field="fields['cert.subject.ou']", :pull-left="true")
+      - else if (cert.subjectOU)
         strong.medium.ml-1 Subject Org Unit
-        moloch-session-field.detail-field(:expr="'cert.subject.oun'", :value='"'+cert.subjectOUN+'"', :field="fields['cert.subject.oun']", :pull-left="true")
+        moloch-session-field.detail-field(:expr="'cert.subject.ou'", :value='"'+cert.subjectOU+'"', :field="fields['cert.subject.ou']", :pull-left="true")
       - if (cert.alt)
         | [
         each alt,i in cert.alt

--- a/tests/cert.t
+++ b/tests/cert.t
@@ -1,4 +1,4 @@
-use Test::More tests => 72;
+use Test::More tests => 82;
 use Cwd;
 use URI::Escape;
 use MolochTest;
@@ -24,11 +24,16 @@ my $files = "(file=$pwd/openssl-ssl3.pcap||file=$pwd/openssl-tls1.pcap||file=$pw
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.issuer.cn==\"google internet authority g2\""));
     countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.cn==\"google internet authority g3\""));
 
-# cert.issuer.cn
+# cert.issuer.on
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.issuer.on==\"*Google Inc*\""));
     countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.on==\"*Foo Inc*\""));
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.issuer.on==\"*Google*\""));
     countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.on==\"*Foo*\""));
+
+# cert.issuer.oun
+    countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*Equifax Secure Certificate Authority*\""));
+    countTest(1, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*www.digicert.com*\""));
+    countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*www.foo.com*\""));
 
 # cert.notafter
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.notafter==\"2018/08/21 00:00:00\""));
@@ -48,11 +53,15 @@ my $files = "(file=$pwd/openssl-ssl3.pcap||file=$pwd/openssl-tls1.pcap||file=$pw
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.subject.cn==\"google internet authority g2\""));
     countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.subject.cn==\"google internet authority g3\""));
 
-# cert.subject.cn
+# cert.subject.on
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.subject.on==\"Google Inc\""));
     countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.subject.on==\"Foo Inc\""));
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.subject.on==\"*Google*\""));
     countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.subject.on==\"Foo\""));
+
+# cert.subject.oun
+    countTest(1, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*www.digicert.com*\""));
+    countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*www.foo.com*\""));
 
 # cert.validfor
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.validfor==5936"));

--- a/tests/cert.t
+++ b/tests/cert.t
@@ -30,10 +30,10 @@ my $files = "(file=$pwd/openssl-ssl3.pcap||file=$pwd/openssl-tls1.pcap||file=$pw
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.issuer.on==\"*Google*\""));
     countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.on==\"*Foo*\""));
 
-# cert.issuer.oun
-    countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*Equifax Secure Certificate Authority*\""));
-    countTest(1, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*www.digicert.com*\""));
-    countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*www.foo.com*\""));
+# cert.issuer.ou
+    countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.issuer.ou==\"*Equifax Secure Certificate Authority*\""));
+    countTest(1, "date=-1&expression=" . uri_escape("$files&&cert.issuer.ou==\"*www.digicert.com*\""));
+    countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.ou==\"*www.foo.com*\""));
 
 # cert.notafter
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.notafter==\"2018/08/21 00:00:00\""));
@@ -59,9 +59,9 @@ my $files = "(file=$pwd/openssl-ssl3.pcap||file=$pwd/openssl-tls1.pcap||file=$pw
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.subject.on==\"*Google*\""));
     countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.subject.on==\"Foo\""));
 
-# cert.subject.oun
-    countTest(1, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*www.digicert.com*\""));
-    countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.oun==\"*www.foo.com*\""));
+# cert.subject.ou
+    countTest(1, "date=-1&expression=" . uri_escape("$files&&cert.issuer.ou==\"*www.digicert.com*\""));
+    countTest(0, "date=-1&expression=" . uri_escape("$files&&cert.issuer.ou==\"*www.foo.com*\""));
 
 # cert.validfor
     countTest(2, "date=-1&expression=" . uri_escape("$files&&cert.validfor==5936"));

--- a/tests/pcap/https-connect.test
+++ b/tests/pcap/https-connect.test
@@ -19,7 +19,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1590753600000,
@@ -43,7 +43,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1855828800000,
@@ -57,7 +57,7 @@
                   "subjectON" : [
                      "DigiCert Inc"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "www.digicert.com"
                   ],
                   "validDays" : 5479

--- a/tests/pcap/https-connect.test
+++ b/tests/pcap/https-connect.test
@@ -19,6 +19,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1590753600000,
                   "notBefore" : 1495670400000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -40,6 +43,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1855828800000,
                   "notBefore" : 1382443200000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -50,6 +56,9 @@
                   ],
                   "subjectON" : [
                      "DigiCert Inc"
+                  ],
+                  "subjectOUN" : [
+                     "www.digicert.com"
                   ],
                   "validDays" : 5479
                }

--- a/tests/pcap/https-generalizedtime.test
+++ b/tests/pcap/https-generalizedtime.test
@@ -27,7 +27,7 @@
                   "issuerON" : [
                      "Unizeto Technologies S.A."
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Certum Certification Authority"
                   ],
                   "notAfter" : 1451573263000,
@@ -41,7 +41,7 @@
                   "subjectON" : [
                      "Yandex LLC"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "ITO"
                   ],
                   "validDays" : 415
@@ -65,7 +65,7 @@
                   "subjectON" : [
                      "Unizeto Technologies S.A."
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "Certum Certification Authority"
                   ],
                   "validDays" : 5479

--- a/tests/pcap/https-generalizedtime.test
+++ b/tests/pcap/https-generalizedtime.test
@@ -27,6 +27,9 @@
                   "issuerON" : [
                      "Unizeto Technologies S.A."
                   ],
+                  "issuerOUN" : [
+                     "Certum Certification Authority"
+                  ],
                   "notAfter" : 1451573263000,
                   "notBefore" : 1415717263000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -37,6 +40,9 @@
                   ],
                   "subjectON" : [
                      "Yandex LLC"
+                  ],
+                  "subjectOUN" : [
+                     "ITO"
                   ],
                   "validDays" : 415
                },
@@ -58,6 +64,9 @@
                   ],
                   "subjectON" : [
                      "Unizeto Technologies S.A."
+                  ],
+                  "subjectOUN" : [
+                     "Certum Certification Authority"
                   ],
                   "validDays" : 5479
                }

--- a/tests/pcap/https2-301-get.test
+++ b/tests/pcap/https2-301-get.test
@@ -12,6 +12,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1636502400000,
                   "notBefore" : 1194609600000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -22,6 +25,9 @@
                   ],
                   "subjectON" : [
                      "DigiCert Inc"
+                  ],
+                  "subjectOUN" : [
+                     "www.digicert.com"
                   ],
                   "validDays" : 5114
                },
@@ -37,6 +43,9 @@
                   ],
                   "issuerON" : [
                      "DigiCert Inc"
+                  ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
                   ],
                   "notAfter" : 1441195200000,
                   "notBefore" : 1370822400000,

--- a/tests/pcap/https2-301-get.test
+++ b/tests/pcap/https2-301-get.test
@@ -12,7 +12,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1636502400000,
@@ -26,7 +26,7 @@
                   "subjectON" : [
                      "DigiCert Inc"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "www.digicert.com"
                   ],
                   "validDays" : 5114
@@ -44,7 +44,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1441195200000,

--- a/tests/pcap/https3-301-get.test
+++ b/tests/pcap/https3-301-get.test
@@ -12,6 +12,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1636502400000,
                   "notBefore" : 1194609600000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -22,6 +25,9 @@
                   ],
                   "subjectON" : [
                      "DigiCert Inc"
+                  ],
+                  "subjectOUN" : [
+                     "www.digicert.com"
                   ],
                   "validDays" : 5114
                },
@@ -37,6 +43,9 @@
                   ],
                   "issuerON" : [
                      "DigiCert Inc"
+                  ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
                   ],
                   "notAfter" : 1441195200000,
                   "notBefore" : 1370822400000,

--- a/tests/pcap/https3-301-get.test
+++ b/tests/pcap/https3-301-get.test
@@ -12,7 +12,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1636502400000,
@@ -26,7 +26,7 @@
                   "subjectON" : [
                      "DigiCert Inc"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "www.digicert.com"
                   ],
                   "validDays" : 5114
@@ -44,7 +44,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1441195200000,

--- a/tests/pcap/openssl-ssl3.test
+++ b/tests/pcap/openssl-ssl3.test
@@ -9,6 +9,9 @@
                   "issuerON" : [
                      "Equifax"
                   ],
+                  "issuerOUN" : [
+                     "Equifax Secure Certificate Authority"
+                  ],
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",

--- a/tests/pcap/openssl-ssl3.test
+++ b/tests/pcap/openssl-ssl3.test
@@ -9,7 +9,7 @@
                   "issuerON" : [
                      "Equifax"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Equifax Secure Certificate Authority"
                   ],
                   "notAfter" : 1534824000000,

--- a/tests/pcap/openssl-tls1-tls1_2.test
+++ b/tests/pcap/openssl-tls1-tls1_2.test
@@ -9,6 +9,9 @@
                   "issuerON" : [
                      "Equifax"
                   ],
+                  "issuerOUN" : [
+                     "Equifax Secure Certificate Authority"
+                  ],
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",

--- a/tests/pcap/openssl-tls1-tls1_2.test
+++ b/tests/pcap/openssl-tls1-tls1_2.test
@@ -9,7 +9,7 @@
                   "issuerON" : [
                      "Equifax"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Equifax Secure Certificate Authority"
                   ],
                   "notAfter" : 1534824000000,

--- a/tests/pcap/openssl-tls1.test
+++ b/tests/pcap/openssl-tls1.test
@@ -9,6 +9,9 @@
                   "issuerON" : [
                      "Equifax"
                   ],
+                  "issuerOUN" : [
+                     "Equifax Secure Certificate Authority"
+                  ],
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",

--- a/tests/pcap/openssl-tls1.test
+++ b/tests/pcap/openssl-tls1.test
@@ -9,7 +9,7 @@
                   "issuerON" : [
                      "Equifax"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Equifax Secure Certificate Authority"
                   ],
                   "notAfter" : 1534824000000,

--- a/tests/pcap/openssl-tls1_1.test
+++ b/tests/pcap/openssl-tls1_1.test
@@ -9,6 +9,9 @@
                   "issuerON" : [
                      "Equifax"
                   ],
+                  "issuerOUN" : [
+                     "Equifax Secure Certificate Authority"
+                  ],
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",

--- a/tests/pcap/openssl-tls1_1.test
+++ b/tests/pcap/openssl-tls1_1.test
@@ -9,7 +9,7 @@
                   "issuerON" : [
                      "Equifax"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Equifax Secure Certificate Authority"
                   ],
                   "notAfter" : 1534824000000,

--- a/tests/pcap/openssl-tls1_2-tls1.test
+++ b/tests/pcap/openssl-tls1_2-tls1.test
@@ -77,7 +77,7 @@
                   "issuerON" : [
                      "Entrust, Inc."
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.entrust.net/rpa is incorporated by reference",
                      "(c) 2009 Entrust, Inc."
                   ],
@@ -92,7 +92,7 @@
                   "subjectON" : [
                      "AOL Inc."
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "Homepages"
                   ],
                   "validDays" : 1096
@@ -105,7 +105,7 @@
                   "issuerON" : [
                      "Entrust.net"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.entrust.net/CPS_2048 incorp. by ref. (limits liab.)",
                      "(c) 1999 Entrust.net Limited"
                   ],
@@ -120,7 +120,7 @@
                   "subjectON" : [
                      "Entrust, Inc."
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "www.entrust.net/rpa is incorporated by reference",
                      "(c) 2009 Entrust, Inc."
                   ],

--- a/tests/pcap/openssl-tls1_2-tls1.test
+++ b/tests/pcap/openssl-tls1_2-tls1.test
@@ -77,6 +77,10 @@
                   "issuerON" : [
                      "Entrust, Inc."
                   ],
+                  "issuerOUN" : [
+                     "www.entrust.net/rpa is incorporated by reference",
+                     "(c) 2009 Entrust, Inc."
+                  ],
                   "notAfter" : 1497242632000,
                   "notBefore" : 1402510723000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -88,6 +92,9 @@
                   "subjectON" : [
                      "AOL Inc."
                   ],
+                  "subjectOUN" : [
+                     "Homepages"
+                  ],
                   "validDays" : 1096
                },
                {
@@ -97,6 +104,10 @@
                   ],
                   "issuerON" : [
                      "Entrust.net"
+                  ],
+                  "issuerOUN" : [
+                     "www.entrust.net/CPS_2048 incorp. by ref. (limits liab.)",
+                     "(c) 1999 Entrust.net Limited"
                   ],
                   "notAfter" : 1636685477000,
                   "notBefore" : 1321026040000,
@@ -108,6 +119,10 @@
                   ],
                   "subjectON" : [
                      "Entrust, Inc."
+                  ],
+                  "subjectOUN" : [
+                     "www.entrust.net/rpa is incorporated by reference",
+                     "(c) 2009 Entrust, Inc."
                   ],
                   "validDays" : 3653
                }

--- a/tests/pcap/openssl-tls1_2.test
+++ b/tests/pcap/openssl-tls1_2.test
@@ -9,6 +9,9 @@
                   "issuerON" : [
                      "Equifax"
                   ],
+                  "issuerOUN" : [
+                     "Equifax Secure Certificate Authority"
+                  ],
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",

--- a/tests/pcap/openssl-tls1_2.test
+++ b/tests/pcap/openssl-tls1_2.test
@@ -9,7 +9,7 @@
                   "issuerON" : [
                      "Equifax"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Equifax Secure Certificate Authority"
                   ],
                   "notAfter" : 1534824000000,

--- a/tests/pcap/pppoe.test
+++ b/tests/pcap/pppoe.test
@@ -23,7 +23,7 @@
                   "subjectON" : [
                      "AOL LLC"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "Core Services"
                   ],
                   "validDays" : 730

--- a/tests/pcap/pppoe.test
+++ b/tests/pcap/pppoe.test
@@ -23,6 +23,9 @@
                   "subjectON" : [
                      "AOL LLC"
                   ],
+                  "subjectOUN" : [
+                     "Core Services"
+                  ],
                   "validDays" : 730
                },
                {

--- a/tests/pcap/smtp-starttls.test
+++ b/tests/pcap/smtp-starttls.test
@@ -30,6 +30,9 @@
                   "issuerON" : [
                      "Equifax"
                   ],
+                  "issuerOUN" : [
+                     "Equifax Secure Certificate Authority"
+                  ],
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",

--- a/tests/pcap/smtp-starttls.test
+++ b/tests/pcap/smtp-starttls.test
@@ -30,7 +30,7 @@
                   "issuerON" : [
                      "Equifax"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Equifax Secure Certificate Authority"
                   ],
                   "notAfter" : 1534824000000,

--- a/tests/pcap/socks-https-example.test
+++ b/tests/pcap/socks-https-example.test
@@ -164,6 +164,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1418212800000,
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -185,6 +188,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1648944000000,
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -195,6 +201,9 @@
                   ],
                   "subjectON" : [
                      "DigiCert Inc"
+                  ],
+                  "subjectOUN" : [
+                     "www.digicert.com"
                   ],
                   "validDays" : 5113
                }
@@ -551,6 +560,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1418212800000,
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -572,6 +584,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1648944000000,
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -582,6 +597,9 @@
                   ],
                   "subjectON" : [
                      "DigiCert Inc"
+                  ],
+                  "subjectOUN" : [
+                     "www.digicert.com"
                   ],
                   "validDays" : 5113
                }
@@ -935,6 +953,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1418212800000,
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -956,6 +977,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1648944000000,
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -966,6 +990,9 @@
                   ],
                   "subjectON" : [
                      "DigiCert Inc"
+                  ],
+                  "subjectOUN" : [
+                     "www.digicert.com"
                   ],
                   "validDays" : 5113
                }

--- a/tests/pcap/socks-https-example.test
+++ b/tests/pcap/socks-https-example.test
@@ -164,7 +164,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1418212800000,
@@ -188,7 +188,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1648944000000,
@@ -202,7 +202,7 @@
                   "subjectON" : [
                      "DigiCert Inc"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "www.digicert.com"
                   ],
                   "validDays" : 5113
@@ -560,7 +560,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1418212800000,
@@ -584,7 +584,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1648944000000,
@@ -598,7 +598,7 @@
                   "subjectON" : [
                      "DigiCert Inc"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "www.digicert.com"
                   ],
                   "validDays" : 5113
@@ -953,7 +953,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1418212800000,
@@ -977,7 +977,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1648944000000,
@@ -991,7 +991,7 @@
                   "subjectON" : [
                      "DigiCert Inc"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "www.digicert.com"
                   ],
                   "validDays" : 5113

--- a/tests/pcap/socks4-https.test
+++ b/tests/pcap/socks4-https.test
@@ -25,7 +25,7 @@
                   "issuerON" : [
                      "VeriSign, Inc."
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "VeriSign Trust Network",
                      "Terms of use at https://www.verisign.com/rpa (c)06"
                   ],
@@ -40,7 +40,7 @@
                   "subjectON" : [
                      "Microsoft Corporation"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "Passport"
                   ],
                   "validDays" : 409
@@ -50,7 +50,7 @@
                   "issuerON" : [
                      "VeriSign, Inc."
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Class 3 Public Primary Certification Authority"
                   ],
                   "notAfter" : 1636329599000,
@@ -64,7 +64,7 @@
                   "subjectON" : [
                      "VeriSign, Inc."
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "VeriSign Trust Network",
                      "(c) 2006 VeriSign, Inc. - For authorized use only"
                   ],
@@ -78,7 +78,7 @@
                   "issuerON" : [
                      "VeriSign, Inc."
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "VeriSign Trust Network",
                      "(c) 2006 VeriSign, Inc. - For authorized use only"
                   ],
@@ -93,7 +93,7 @@
                   "subjectON" : [
                      "VeriSign, Inc."
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "VeriSign Trust Network",
                      "Terms of use at https://www.verisign.com/rpa (c)06"
                   ],

--- a/tests/pcap/socks4-https.test
+++ b/tests/pcap/socks4-https.test
@@ -25,6 +25,10 @@
                   "issuerON" : [
                      "VeriSign, Inc."
                   ],
+                  "issuerOUN" : [
+                     "VeriSign Trust Network",
+                     "Terms of use at https://www.verisign.com/rpa (c)06"
+                  ],
                   "notAfter" : 1448927999000,
                   "notBefore" : 1413504000000,
                   "publicAlgorithm" : "rsaEncryption",
@@ -36,12 +40,18 @@
                   "subjectON" : [
                      "Microsoft Corporation"
                   ],
+                  "subjectOUN" : [
+                     "Passport"
+                  ],
                   "validDays" : 409
                },
                {
                   "hash" : "f4:a8:0a:0c:d1:e6:cf:19:0b:8c:bc:6f:bc:99:17:11:d4:82:c9:d0",
                   "issuerON" : [
                      "VeriSign, Inc."
+                  ],
+                  "issuerOUN" : [
+                     "Class 3 Public Primary Certification Authority"
                   ],
                   "notAfter" : 1636329599000,
                   "notBefore" : 1162944000000,
@@ -54,6 +64,10 @@
                   "subjectON" : [
                      "VeriSign, Inc."
                   ],
+                  "subjectOUN" : [
+                     "VeriSign Trust Network",
+                     "(c) 2006 VeriSign, Inc. - For authorized use only"
+                  ],
                   "validDays" : 5478
                },
                {
@@ -63,6 +77,10 @@
                   ],
                   "issuerON" : [
                      "VeriSign, Inc."
+                  ],
+                  "issuerOUN" : [
+                     "VeriSign Trust Network",
+                     "(c) 2006 VeriSign, Inc. - For authorized use only"
                   ],
                   "notAfter" : 1478563199000,
                   "notBefore" : 1162944000000,
@@ -74,6 +92,10 @@
                   ],
                   "subjectON" : [
                      "VeriSign, Inc."
+                  ],
+                  "subjectOUN" : [
+                     "VeriSign Trust Network",
+                     "Terms of use at https://www.verisign.com/rpa (c)06"
                   ],
                   "validDays" : 3652
                }

--- a/tests/pcap/tls-alpn-h2.test
+++ b/tests/pcap/tls-alpn-h2.test
@@ -18,6 +18,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1604404800000,
                   "notBefore" : 1540857600000,
                   "publicAlgorithm" : "id-ecPublicKey",
@@ -40,6 +43,9 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
+                  "issuerOUN" : [
+                     "www.digicert.com"
+                  ],
                   "notAfter" : 1939812867000,
                   "notBefore" : 1466513667000,
                   "publicAlgorithm" : "id-ecPublicKey",
@@ -50,6 +56,9 @@
                   ],
                   "subjectON" : [
                      "DigiCert Inc"
+                  ],
+                  "subjectOUN" : [
+                     "www.digicert.com"
                   ],
                   "validDays" : 5478
                }

--- a/tests/pcap/tls-alpn-h2.test
+++ b/tests/pcap/tls-alpn-h2.test
@@ -18,7 +18,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1604404800000,
@@ -43,7 +43,7 @@
                   "issuerON" : [
                      "DigiCert Inc"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "www.digicert.com"
                   ],
                   "notAfter" : 1939812867000,
@@ -57,7 +57,7 @@
                   "subjectON" : [
                      "DigiCert Inc"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "www.digicert.com"
                   ],
                   "validDays" : 5478

--- a/tests/pcap/wireshark-dtls0.test
+++ b/tests/pcap/wireshark-dtls0.test
@@ -12,6 +12,9 @@
                   "issuerON" : [
                      "Snake Oil, Ltd"
                   ],
+                  "issuerOUN" : [
+                     "Certificate Authority"
+                  ],
                   "notAfter" : 1204562865000,
                   "notBefore" : 1046882865000,
                   "remainingDays" : -1,
@@ -21,6 +24,9 @@
                   ],
                   "subjectON" : [
                      "Snake Oil, Ltd"
+                  ],
+                  "subjectOUN" : [
+                     "Webserver Team"
                   ],
                   "validDays" : 1825
                }

--- a/tests/pcap/wireshark-dtls0.test
+++ b/tests/pcap/wireshark-dtls0.test
@@ -12,7 +12,7 @@
                   "issuerON" : [
                      "Snake Oil, Ltd"
                   ],
-                  "issuerOUN" : [
+                  "issuerOU" : [
                      "Certificate Authority"
                   ],
                   "notAfter" : 1204562865000,
@@ -25,7 +25,7 @@
                   "subjectON" : [
                      "Snake Oil, Ltd"
                   ],
-                  "subjectOUN" : [
+                  "subjectOU" : [
                      "Webserver Team"
                   ],
                   "validDays" : 1825


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

Arkime does not currently parse the Organisational Unit (OU) field of TLS certificates, this PR adds the parsing and display of this field.

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
No changes to viewer or parliament

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
