### PR TITLE
Type and range of bucket

### DIFF
--- a/capture/pq.c
+++ b/capture/pq.c
@@ -122,7 +122,7 @@ void moloch_pq_upsert(MolochPQ_t *pq, MolochSession_t *session, int timeout, voi
     MolochPQItem_t *item;
     HASH_FIND(pqh_, (pq->keys[session->thread]), session->sessionId, item);
     if (item) {
-        long int bucket = item->expire - pq->bucket0[session->thread];
+        int bucket = item->expire - pq->bucket0[session->thread];
         if (bucket < 0) bucket = 0;
         if (bucket > pq->maxSeconds) bucket = pq->maxSeconds;
 
@@ -156,7 +156,7 @@ void moloch_pq_remove(MolochPQ_t *pq, MolochSession_t *session)
     if (!item)
         return;
 
-    long int bucket = item->expire - pq->bucket0[session->thread];
+    int bucket = item->expire - pq->bucket0[session->thread];
     if (bucket < 0) bucket = 0;
     if (bucket > pq->maxSeconds) bucket = pq->maxSeconds;
     DLL_REMOVE(pql_, &pq->buckets[session->thread][bucket], item);

--- a/capture/pq.c
+++ b/capture/pq.c
@@ -122,8 +122,9 @@ void moloch_pq_upsert(MolochPQ_t *pq, MolochSession_t *session, int timeout, voi
     MolochPQItem_t *item;
     HASH_FIND(pqh_, (pq->keys[session->thread]), session->sessionId, item);
     if (item) {
-        int bucket = item->expire - pq->bucket0[session->thread];
+        long int bucket = item->expire - pq->bucket0[session->thread];
         if (bucket < 0) bucket = 0;
+        if (bucket > pq->maxSeconds) bucket = pq->maxSeconds;
 
         // Same bucket
         if (bucket == timeout) {
@@ -155,8 +156,9 @@ void moloch_pq_remove(MolochPQ_t *pq, MolochSession_t *session)
     if (!item)
         return;
 
-    int bucket = item->expire - pq->bucket0[session->thread];
+    long int bucket = item->expire - pq->bucket0[session->thread];
     if (bucket < 0) bucket = 0;
+    if (bucket > pq->maxSeconds) bucket = pq->maxSeconds;
     DLL_REMOVE(pql_, &pq->buckets[session->thread][bucket], item);
     HASH_REMOVE(pqh_, pq->keys[session->thread], item);
     MOLOCH_TYPE_FREE(MolochPQItem_t, item);


### PR DESCRIPTION
An integer underflow was triggered when the arkime capture module was processing a pcap file. The crafted pcap file manipulates the value of  `long int lastPacketSecs`, and causes the underflow of `int bucket` in the following processing. Also, the range of `bucket` ought to be limitted to avoid the out of bound reference.