### PR TITLE
Bugfix for SLL layers

### DIFF
--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -860,7 +860,8 @@ Pcap.prototype.pcap = function (buffer, obj) {
     this.framerelay(buffer.slice(16, obj.pcap.incl_len + 16), obj, 16);
     break;
   case 113: // SLL
-    this.ip4(buffer.slice(32, obj.pcap.incl_len + 16), obj, 32);
+    obj.ether = {};
+    this.ethertype(buffer.slice(30, obj.pcap.incl_len + 16), obj, 30);
     break;
   case 127: // radiotap
     this.radiotap(buffer.slice(16, obj.pcap.incl_len + 16), obj, 16);


### PR DESCRIPTION
Other layers than IPv4 can be within the encapsulation of SLL. This can crash the front-end viewer of Arkime. The commit in this merge request fixes this by making sure more encapsulation is correctly interpreted.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
