### PR TITLE
Kafka plugin to send SPIs

### DIFF
--- a/capture/plugins/kafka/Makefile.in
+++ b/capture/plugins/kafka/Makefile.in
@@ -1,0 +1,21 @@
+INCLUDE_KAFKA  = @KAFKA_CFLAGS@ \
+                 @KAFKA_LIBS@
+
+INCLUDE_OTHER = -I../.. -I../../thirdparty \
+                @GLIB2_CFLAGS@
+
+install_sh = @install_sh@
+mkdir_p = @mkdir_p@
+INSTALL = @INSTALL@
+PLUGINDIR = @prefix@/plugins
+
+SRCS=$(wildcard *.c)
+SOS=$(patsubst %.c,../%.so,$(SRCS))
+
+../%.so : %.c ../../moloch.h ../../hash.h ../../dll.h
+	$(CC) -pthread @SHARED_FLAGS@ -o $@ @CFLAGS@ -Wall -Wextra -D_GNU_SOURCE -fPIC $(INCLUDE_OTHER) $(INCLUDE_KAFKA) $< -lrdkafka
+
+all:$(SOS)
+
+distclean realclean clean:
+	rm -f *.o *.so

--- a/capture/plugins/kafka/README.md
+++ b/capture/plugins/kafka/README.md
@@ -1,0 +1,26 @@
+Kafka Write Plugin
+====
+
+The kafka writer plugin sends the SPI to Kafka instead of Elasticsearch.
+
+Please note that communication to Elasticsearch is still needed, for the stats and other housekeeping tasks.
+
+# Build
+
+```
+./easybutton-build.sh --kafka
+```
+
+# Configure
+
+The table below list all the possible configuration option of the kafka plugin.
+
+| Property | Details | Example |
+|----------|---------|---------|
+| kafkaBootstrapServers | bootstrap servers, comma separated, to connet to | 1.2.3.4:9020,5.6.7.8:9020 |
+| kafkaTopic | topic to send the SPI to | arkime-spi |
+| kafkaSSL | whether to enable SSL security protocol | `true` |
+| kafkaSSLCALocation | path where the SSL CA is located  | `/path/to/ca.crt` |
+| kafkaSSLCertificateLocation | path where the SSL client certificate is located | `/path/to/client.crt` |
+| kafkaSSLKeyLocation | path where the SSL cilent key is located | `/path/to/client.key` |
+| kafkaSSLKeyPassword | optional password for the client key |  |

--- a/capture/plugins/kafka/kafka.c
+++ b/capture/plugins/kafka/kafka.c
@@ -1,0 +1,270 @@
+/* kafka.c  -- Simple plugin that sends json encoded data to Kafka
+ *
+ * Copyright 2020 Sqooba AG. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this Software except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <netdb.h>
+#include <uuid/uuid.h>
+#include <ctype.h>
+#include <errno.h>
+#include "moloch.h"
+#include "bsb.h"
+#include "rdkafka.h"
+
+LOCAL rd_kafka_t *rk = NULL; /* Producer instance handle */
+LOCAL rd_kafka_conf_t *conf; /* Temporary configuration object */
+LOCAL char errstr[512];      /* librdkafka API error reporting buffer */
+LOCAL const char *brokers;   /* Argument: broker list */
+LOCAL const char *topic;     /* Argument: topic to produce to */
+LOCAL char kafkaSSL;
+LOCAL const char *kafkaSSLCALocation;
+LOCAL const char *kafkaSSLCertificateLocation;
+LOCAL const char *kafkaSSLKeyLocation;
+LOCAL const char *kafkaSSLKeyPassword;
+
+extern MolochConfig_t config;
+
+/******************************************************************************
+ * Message delivery report callback using the richer rd_kafka_message_t object.
+ */
+LOCAL void kafka_msg_delivered_cb(rd_kafka_t *rk,
+                           const rd_kafka_message_t *rkmessage, void *opaque) {
+
+    if (rkmessage->err) {
+        LOG(
+            "%% Message delivery failed (broker %"PRId32"): %s\n",
+            rd_kafka_message_broker_id(rkmessage),
+            rd_kafka_err2str(rkmessage->err));
+    } else if (config.debug) {
+        LOG(
+            "%% Message delivered in %.2fms (%zd bytes, offset %"PRId64", "
+            "partition %"PRId32", broker %"PRId32")\n",
+            (float)rd_kafka_message_latency(rkmessage) / 1000.0,
+            rkmessage->len, rkmessage->offset,
+            rkmessage->partition,
+            rd_kafka_message_broker_id(rkmessage),
+            (int)rkmessage->len);
+        if (config.debug > 6) {
+            LOG(
+            "%% Payload: %.*s\n", (const char *)rkmessage->payload);
+        }
+    }
+
+    char *json = (char *)rkmessage->_private; /* V_OPAQUE */
+    if (config.debug > 2)
+        LOG("%% opaque=%p\n", json);
+    MOLOCH_SIZE_FREE(buffer, json);
+}
+
+/******************************************************************************/
+LOCAL void kafka_send_session(char *json, int len)
+{
+
+    rd_kafka_resp_err_t err;
+
+    if (config.debug)
+        LOG("About to send %d bytes in kafka %s, opaque=%p\n", len, topic, json);
+
+retry:
+    err = rd_kafka_producev(
+        /* Producer handle */
+        rk,
+        /* Topic name */
+        RD_KAFKA_V_TOPIC(topic),
+        /* Message value and length */
+        RD_KAFKA_V_VALUE(json, len),
+        /* Per-Message opaque, provided in
+                    * delivery report callback as
+                    * msg_opaque. */
+        RD_KAFKA_V_OPAQUE(json),
+        /* End sentinel */
+        RD_KAFKA_V_END);
+
+    if (err)
+    {
+        /*
+                * Failed to *enqueue* message for producing.
+                */
+        LOG("%% Failed to produce to topic %s: %s\n",
+            topic, rd_kafka_err2str(err));
+
+        if (err == RD_KAFKA_RESP_ERR__QUEUE_FULL)
+        {
+            /* If the internal queue is full, wait for
+                    * messages to be delivered and then retry.
+                    * The internal queue represents both
+                    * messages to be sent and messages that have
+                    * been sent or failed, awaiting their
+                    * delivery report callback to be called.
+                    *
+                    * The internal queue is limited by the
+                    * configuration property
+                    * queue.buffering.max.messages */
+            rd_kafka_poll(rk, 1000 /*block for max 1000ms*/);
+            goto retry;
+        }
+    }
+    else
+    {
+        if (config.debug)
+            LOG("%% Enqueued message (%d bytes) "
+                "for topic %s\n",
+                len, topic);
+    }
+
+    /* A producer application should continually serve
+        * the delivery report queue by calling rd_kafka_poll()
+        * at frequent intervals.
+        * Either put the poll call in your main loop, or in a
+        * dedicated thread, or call it after every
+        * rd_kafka_produce() call.
+        * Just make sure that rd_kafka_poll() is still called
+        * during periods where you are not producing any messages
+        * to make sure previously produced messages have their
+        * delivery report callback served (and any other callbacks
+        * you register). */
+    rd_kafka_poll(rk, 0 /*non-blocking*/);
+}
+
+LOCAL MolochDbSendBulkFunc send_to_kafka = kafka_send_session;
+
+/******************************************************************************/
+/*
+ * Called by moloch when moloch is quiting
+ */
+LOCAL void kafka_plugin_exit()
+{
+    if (rk != NULL)
+    {
+        if (config.debug)
+            LOG("%% Flushing final messages..\n");
+        rd_kafka_flush(rk, 10 * 1000 /* wait for max 10 seconds */);
+
+        /* If the output queue is still not empty there is an issue
+            * with producing messages to the clusters. */
+        if (rd_kafka_outq_len(rk) > 0)
+            LOG("%% %d message(s) were not delivered\n",
+                rd_kafka_outq_len(rk));
+
+        /* Destroy the producer instance */
+        rd_kafka_destroy(rk);
+    }
+}
+
+/******************************************************************************/
+/*
+ * Called by moloch when the plugin is loaded
+ */
+void moloch_plugin_init()
+{
+    moloch_plugins_register("kafka", TRUE);
+
+    LOG("%% Loading Kafka plugin");
+
+    moloch_plugins_set_cb("kafka",
+                          NULL,
+                          NULL,
+                          NULL,
+                          NULL,
+                          NULL,
+                          NULL,
+                          kafka_plugin_exit,
+                          NULL);
+
+    conf = rd_kafka_conf_new();
+    brokers = *moloch_config_str_list(NULL, "kafkaBootstrapServers", "");
+    topic = moloch_config_str(NULL, "kafkaTopic", "arkime-json");
+
+    // See more config on https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+
+    if (rd_kafka_conf_set(conf, "metadata.broker.list", brokers,
+                          errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+    {
+        LOGEXIT("Error configuring kafka:metadata.broker.list, error = %s\n", errstr);
+    }
+
+    if (config.debug)
+        LOG("%% kafka broker %s", brokers);
+
+    kafkaSSL = moloch_config_boolean(NULL, "kafkaSSL", FALSE);
+    if (kafkaSSL)
+    {
+        if (config.debug)
+            LOG("%% kafka SSL is turned on");
+
+        if (rd_kafka_conf_set(conf, "security.protocol", "SSL",
+                              errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+        {
+            LOGEXIT("Error configuring kafka:security.protocol, error = %s\n", errstr);
+        }
+
+        kafkaSSLCALocation = moloch_config_str(NULL, "kafkaSSLCALocation", NULL);
+        if (kafkaSSLCALocation)
+        {
+            if (rd_kafka_conf_set(conf, "ssl.ca.location", kafkaSSLCALocation,
+                                  errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+            {
+                LOGEXIT("Error configuring kafka:ssl.ca.location, error = %s\n", errstr);
+            }
+        }
+
+        kafkaSSLCertificateLocation = moloch_config_str(NULL, "kafkaSSLCertificateLocation", NULL);
+	    if (kafkaSSLCertificateLocation)
+	    {
+	        if (rd_kafka_conf_set(conf, "ssl.certificate.location", kafkaSSLCertificateLocation,
+                                  errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+            {
+                LOGEXIT("Error configuring kafka:ssl.certificate.location, error = %s\n", errstr);
+            }
+	    }
+
+        kafkaSSLKeyLocation = moloch_config_str(NULL, "kafkaSSLKeyLocation", NULL);
+        if (kafkaSSLKeyLocation) {
+            if (rd_kafka_conf_set(conf, "ssl.key.location", kafkaSSLKeyLocation,
+                                  errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+            {
+                LOGEXIT("Error configuring kafka:ssl.key.location, error = %s\n", errstr);
+            }
+        }
+
+        kafkaSSLKeyPassword = moloch_config_str(NULL, "kafkaSSLKeyPassword", NULL);
+        if (kafkaSSLKeyPassword) {
+             if (rd_kafka_conf_set(conf, "ssl.key.password", kafkaSSLKeyPassword,
+                                  errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK)
+            {
+                LOGEXIT("Error configuring kafka:ss.key.password, error = %s\n", errstr);
+            }
+        }
+    }
+
+    rd_kafka_conf_set_dr_msg_cb(conf, kafka_msg_delivered_cb);
+
+    rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr, sizeof(errstr));
+    if (!rk)
+    {
+        LOGEXIT("%% Failed to create new producer: %s\n", errstr);
+    }
+
+    moloch_db_set_send_bulk(send_to_kafka);
+
+    LOG("%% Kafka plugin loaded");
+}

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_CONFIG_FILES([
   capture/plugins/pfring/Makefile
   capture/plugins/snf/Makefile
   capture/plugins/lua/Makefile
+  capture/plugins/kafka/Makefile
   capture/parsers/Makefile
   db/Makefile
   tests/plugins/Makefile
@@ -541,6 +542,40 @@ esac ], [
 AC_MSG_RESULT(yes) ])
 AC_SUBST(ZSTD_CFLAGS)
 AC_SUBST(ZSTD_LIBS)
+
+dnl Checks for kafka
+AC_MSG_CHECKING(for kafka)
+AC_ARG_WITH(kafka,
+[ --with-kafka=DIR use kafka (librdkafka) build directory],
+[ case "$withval" in
+  no)
+     AC_MSG_RESULT(no)
+     ;;
+  *)
+
+  if test "x$withval" = xyes; then
+    withval=/usr/local/include/librdkafka/
+  fi
+
+  AC_MSG_RESULT($withval)
+    if test -f $withval/src/rdkafka.h -a -f $withval/src/librdkafka.a; then
+      KAFKA_CFLAGS="-I$withval/src"
+      #KAFKA_LIBS=$withval/src/librdkafka.a
+      KAFKA_LIBS=""
+      #cp $withval/src/librdkafka.so capture/plugins/
+    elif test -f $withval/rdkafka.h; then
+      KAFKA_CFLAGS="-I$withval"
+      KAFKA_LIBS="-lrdkafka"
+    else
+      AC_ERROR(rdkafka.h or librdkafka.a not found in $withval)
+    fi
+    ;;
+esac ], [
+  KAFKA_CFLAGS=
+  KAFKA_LIBS=
+AC_MSG_RESULT(no) ])
+AC_SUBST(KAFKA_CFLAGS)
+AC_SUBST(KAFKA_LIBS)
 
 AS_IF([test "$prefix" == "NONE"],
     [AC_DEFINE_UNQUOTED(CONFIG_PREFIX,"$ac_default_prefix", [config prefix directory])],


### PR DESCRIPTION
Arkime is sending SPI data directly to Elastic, using the `/_bulk` API. While this is proven to do the job and rather well, having Kafka in between might be useful in some use case, for instance (near) real-time processing on SPI pattern, or flattening traffic peaks in buffering SPIs before indexing in KAfka. In short, once the SPI data is in Kafka, it can be re-read multiple time at a rather low effort and cost.

The diagram below show this write once - read many pattern Kafka (or similar technology) can help implementing:

```
                                                ┌         ┐
                 ┌       ┐  ┌─> _ES indexer_ >──┤ elastic ├──< arkime-viewer
arkime-capture >─┤ kafka ├──┤                   └         ┘
                 └       ┘  ├─> (near) real time alerting on some patterns
                            │
                            └─> ... some other stream processing ... 
```

In order to have the Arkime setup working the same way than before, two components would be required:
1. Kafka plugin running in Arkime-capture and sending the SPI to Kafka instead of Elastic
2. An _ES indexer_, consuming from Kafka and indexing to Elastic in the same collections that Arkime itself would do to ensure feature parity.

# Kafka plugin

Arkime has a powerful built-in plugin mechanism which could be leveraged to:
- load the plugin
- initialize the connection to Kafka
- hook into SPI data sending mechanism using `moloch_db_set_send_bulk` setter.

This approach means that instead of calling the default `moloch_db_send_bulk` function which is post'ing the SPI data to the `/_bulk` endpoint of Elastic, this exact same payload, when ready, would be send to Kafka instead.
This keeps the design easy and to not add any overhead (or very little) to Arkime-capture.

The disadvantage of this approach is that the data post'ed to Elastic in a [json lines format](http://jsonlines.org/) *with* some metadata json in between, mostly the name of the collection to insert into. I.e. a consumer of the SPI data might do some (easy, but still) parsing of the message before decoding a single SPI.

A watch item in this approach is Kafka limitation in the message payload (1MB by default).

# ES Indexer

The second part in the proposed approach is a component reading from Kafka and indexing the SPI in Elastic (i.e. what Arkime-capture is doing by default). This component can be standalone, outside of Arkime. If the messages sent to Kafka
remain untouched as it was proposed, they can be directly post'ed to Elastic.

There are already numerous of tools doing that (reading from Kafka and indexing to Elastic):
- [Kafka Connect for Elastic search](https://github.com/confluentinc/kafka-connect-elasticsearch),
- [Logstash](https://www.elastic.co/guide/en/logstash/current/plugins-inputs-kafka.html)
- [Fluentd](https://github.com/fluent/fluent-plugin-kafka)
- ...

but very few of them are using the `/_bulk` API. And in the proposed design, the payload pushed to Kafka can literally be post'ed as is to `/_bulk`.

Writing this in [Akka streams](https://doc.akka.io/docs/akka/current/stream/index.html) would fit in less than 20 lines of code:

```scala
  val elasticBulkEndpoint = "http://elastic/_bulk"
  val httpPool =
    Http().superPool[ConsumerRecord[Integer, String]]()

  Consumer
    .plainSource[Integer, String](kafkaConsumerSettings, Subscriptions.topics(topic))
    .map { msg =>
      (HttpRequest(
         method = HttpMethods.POST,
         uri = elasticBulkEndpoint,
         entity = HttpEntity(ContentTypes.`application/json`, msg.value())
       ),
       msg)
    }
    .via(httpPool)
    .run
```

# Pros and cons

This approach does *not* completely remove Arkime interactions with Elastic, since stats and new file calls are still done directly from Arkime.

But having Kafka in between Arkime and Elastic for the SPI data might be useful to amortize the pressure on Elastic by providing a buffer, and allows multiple processing/indexing streams consuming the SPI data

The downside of the approach is the additional complexity of running a Kafka cluster and a _ES indexer_ component.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
