### PR TITLE
fix alt name memory leak and compiler warning

### DIFF
--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -189,7 +189,7 @@ LOCAL void dtls_process_server_certificate(MolochSession_t *session, const unsig
         memcpy(certs->serialNumber, value, alen);
 
         /* signature */
-        if (!(value = moloch_parsers_asn_get_tlv(&bsb, &apc, &atag, &alen)))
+        if (!moloch_parsers_asn_get_tlv(&bsb, &apc, &atag, &alen))
             {badreason = 5; goto bad_cert;}
 
         /* issuer */
@@ -219,7 +219,7 @@ LOCAL void dtls_process_server_certificate(MolochSession_t *session, const unsig
         dtls_certinfo_process(&certs->subject, &tbsb);
 
         /* subjectPublicKeyInfo */
-        if (!(value = moloch_parsers_asn_get_tlv(&bsb, &apc, &atag, &alen)))
+        if (!moloch_parsers_asn_get_tlv(&bsb, &apc, &atag, &alen))
             {badreason = 9; goto bad_cert;}
 
         /* extensions */

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -166,9 +166,8 @@ LOCAL void tls_alt_names(MolochSession_t *session, MolochCertsInfo_t *certs, BSB
             tls_alt_names(session, certs, &tbsb, lastOid);
             return;
         } else if (lastOid[0] && atag == 2) {
-            MolochString_t *element = MOLOCH_TYPE_ALLOC0(MolochString_t);
-
             if (g_utf8_validate((char *)value, alen, NULL)) {
+                MolochString_t *element = MOLOCH_TYPE_ALLOC0(MolochString_t);
                 element->str = g_ascii_strdown((char *)value, alen);
                 element->len = alen;
                 element->utf8 = 1;
@@ -418,7 +417,7 @@ LOCAL void tls_process_server_certificate(MolochSession_t *session, const unsign
         memcpy(certs->serialNumber, value, alen);
 
         /* signature */
-        if (!(value = moloch_parsers_asn_get_tlv(&bsb, &apc, &atag, &alen)))
+        if (!moloch_parsers_asn_get_tlv(&bsb, &apc, &atag, &alen))
             {badreason = 5; goto bad_cert;}
 
         /* issuer */


### PR DESCRIPTION
was leaking memory when bad alt name