### PR TITLE
move different bulk generation to db.c from kafka.c

### DIFF
--- a/capture/Makefile.in
+++ b/capture/Makefile.in
@@ -94,4 +94,4 @@ distclean realclean clean:
 	rm -f *.o moloch-capture capture */*.o */*.so
 
 cppcheck:
-	cppcheck -q --enable=all --std=c99 -I. -Ithirdparty *.c plugins/*.c parsers/*.c
+	cppcheck -q --enable=all --std=c99 -I. -Ithirdparty *.c plugins/*.c plugins/*/*.c parsers/*.c

--- a/capture/moloch.h
+++ b/capture/moloch.h
@@ -897,6 +897,10 @@ gchar   *moloch_db_community_id(MolochSession_t *session);
 // Replace how SPI data is sent to ES.
 // The implementation must either call a moloch_http_free_buffer or another moloch_http routine that frees the buffer
 typedef void (* MolochDbSendBulkFunc) (char *json, int len);
+// bulkHeader - include the bulk header
+// indexInDoc - add sessionIndex field to doc where arkime would index doc
+// maxDocs - max docs per call
+void     moloch_db_set_send_bulk2(MolochDbSendBulkFunc func, gboolean bulkHeader, gboolean indexInDoc, uint16_t maxDocs);
 void     moloch_db_set_send_bulk(MolochDbSendBulkFunc func);
 
 /******************************************************************************/


### PR DESCRIPTION
New moloch_db_set_send_bulk2 that can control options around bulk generation when using another callback. Can now add session index into the spi doc