### PR TITLE
Fix incorrect WISE auth method for OIDC

### DIFF
--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -228,7 +228,7 @@ process.on('SIGINT', function () {
 function setupAuth () {
   let userNameHeader = getConfig('wiseService', 'userNameHeader', 'anonymous');
   let mode;
-  if (userNameHeader === 'anonymous' || userNameHeader === 'digest' || userNameHeader === 'digest') {
+  if (userNameHeader === 'anonymous' || userNameHeader === 'digest' || userNameHeader === 'oidc') {
     mode = userNameHeader;
     userNameHeader = undefined;
   } else {


### PR DESCRIPTION
wiseService.js had an error in it's `userNameHeader` check which made OIDC authentication impossible. "digest" was referenced twice.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
