### PR TITLE
Allow role forced expression without user forced expression

### DIFF
--- a/common/user.js
+++ b/common/user.js
@@ -980,8 +980,11 @@ class User {
       allRoles.add(r);
 
       if (role.expression && role.expression.trim().length > 0) {
-        if (!this.#allExpression) { this.#allExpression = ''; }
-        this.#allExpression += ' && (' + role.expression.trim() + ')';
+        if (!this.#allExpression) {
+          this.#allExpression = '(' + role.expression.trim() + ')';
+        } else {
+          this.#allExpression += ' && (' + role.expression.trim() + ')';
+        }
       }
 
       if (role.timeLimit !== undefined) {


### PR DESCRIPTION
Assigning a Forced Expression via role results in an error when there is no Forced Expression already set on the user.

The current code begins the first Forced Expression with "&&".

Fixes #2212 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
