### PR TITLE
Do not allow usersAdmin to delete superAdmin

### DIFF
--- a/common/user.js
+++ b/common/user.js
@@ -700,6 +700,16 @@ class User {
       return res.serverError(403, 'Can not delete yourself');
     }
 
+    User.getUser(userId, (err, user) => {
+      if (err || !user) {
+        console.log(`ERROR - ${req.method} /api/user/%s`, userId, util.inspect(err, false, 50), user);
+        return res.serverError(404, 'User not found');
+      }
+      if (user.hasRole('superAdmin') && !req.user.hasRole('superAdmin')) {
+        return res.serverError(403, 'Can not delete superAdmin unless you are superAdmin');
+      }
+    });
+
     try {
       await User.deleteUser(userId);
       res.send({ success: true, text: 'User deleted successfully' });

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1165,7 +1165,7 @@ if (Config.get('demoMode', false)) {
     return res.serverError(403, 'Disabled in demo mode.');
   });
 
-  app.post(['/user/password/change', '/changePassword', '/tableState/:tablename'], (req, res) => {
+  app.post(['/user/password/change', '/changePassword', '/api/user/password', '/tableState/:tablename'], (req, res) => {
     return res.serverError(403, 'Disabled in demo mode.');
   });
 }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1165,7 +1165,7 @@ if (Config.get('demoMode', false)) {
     return res.serverError(403, 'Disabled in demo mode.');
   });
 
-  app.post(['/user/password/change', '/changePassword', '/api/user/password', '/tableState/:tablename'], (req, res) => {
+  app.post(['/user/password/change', '/changePassword', '/tableState/:tablename'], (req, res) => {
     return res.serverError(403, 'Disabled in demo mode.');
   });
 }


### PR DESCRIPTION

**Clearly describe the problem and solution**

The application does not allow a usersAdmin to create and update a superAdmin but is allowing to delete them. This means an escalated privilege for usersAdmin. Only a superAdmin should be allowed to delete another superAdmin as per the permission hierarchy.

**Relevant issue number(s) if applicable**
HackerOne report: 1909898

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
