### PR TITLE
Update misc.c Gh0st parser identification to reduce false positives

### DIFF
--- a/capture/parsers/misc.c
+++ b/capture/parsers/misc.c
@@ -44,7 +44,7 @@ LOCAL void gh0st_classify(MolochSession_t *session, const unsigned char *data, i
     if (len < 15)
         return;
 
-    if (data[13] == 0x78 &&
+    if (data[13] == 0x78 && data[14] == 0x9c &&
         (((data[8] == 0) && (data[7] == 0) && (((data[6]&0xff) << (uint32_t)8 | (data[5]&0xff)) == len)) ||  // Windows
          ((data[5] == 0) && (data[6] == 0) && (((data[7]&0xff) << (uint32_t)8 | (data[8]&0xff)) == len)))) { // Mac
         moloch_session_add_protocol(session, "gh0st");


### PR DESCRIPTION
Gh0st parser has false positives by not looking at both bytes of the zlib header x789c at offsets 13 and 14

Problem:
gh0st RAT traffic is currently not identifying the whole zlib header. This has resulted in hundreds of false identifications of NTLM  sessions as gh0st sessions.  later in this same code block (line 53) an alternate detection is made that includes the full zlib header. This update is to make sure both methods check data[14].

Issue #867 was closed dismissing a similar issue with false identification of DCE/RPC traffic as gh0st
Sources for understanding gh0st use of zlib header:
    https://chopshop.readthedocs.io/en/latest/modules/gh0st_decode.html

Proposed fix is not tested because I can not set that up in my current environment. 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
