### PR TITLE
New auto cronQueries setting, move primary-viewer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,7 +29,12 @@ NOTICE: Restart wiseService before capture when upgrading
 NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at once after upgrading
 
 4.3.1 2023/05/xx
+  - BREAKING - If running mixed versions of Arkime, broken cron queries error
+               might show on OLD version
   - release - fix ubuntu22 kafka dep
+  - viewer - new auto cronQueries setting
+  - viewer - change where primary viewer info is stored to not cause constant 
+             mapping change
 
 4.3.0 2023/04/27
   - BREAKING - Only SuperAdmin can assign *Admin roles now

--- a/tests/api-cron.t
+++ b/tests/api-cron.t
@@ -1,4 +1,4 @@
-use Test::More tests => 24;
+use Test::More tests => 26;
 use Cwd;
 use MolochTest;
 use JSON;
@@ -81,6 +81,14 @@ ok(!$json->{success}, "shared user cannot delete query");
 # can delete periodic queries
 $json = viewerDeleteToken("/api/cron/$key", $token);
 ok($json->{success}, "query can be deleted");
+
+# can not update primary-viewer periodic query
+$json = viewerPostToken("/api/cron/primary-viewer", '{"name":"test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3"}', $token);
+eq_or_diff($json, from_json('{"text": "Bad query key", "success": false}'));
+
+# can not delete primary-viewer periodic queries
+$json = viewerDeleteToken("/api/cron/primary-viewer", $token);
+eq_or_diff($json, from_json('{"text": "Bad query key", "success": false}'));
 
 # cleanup
 $json = viewerDeleteToken("/api/cron/$key2?molochRegressionUser=test1", $test1Token);

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -49,8 +49,6 @@ class CronAPIs {
       setInterval(CronAPIs.#updatePrimaryViewer, 45 * 1000, false);
       setInterval(CronAPIs.#runPrimaryViewer, 60 * 1000);
     } else if (Config.get('cronQueries') === true) {
-      CronAPIs.#primaryViewer = true;
-      console.log('This node will process Periodic Queries (CRON), delayed by', internals.cronTimeout, 'seconds');
       setTimeout(CronAPIs.#updatePrimaryViewer, 1000, true);
       setInterval(CronAPIs.#updatePrimaryViewer, 120 * 1000, true);
       setInterval(CronAPIs.#runPrimaryViewer, 60 * 1000);

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -12,6 +12,7 @@ const User = require('../common/user');
 const internals = require('./internals');
 const ViewerUtils = require('./viewerUtils');
 const SessionAPIs = require('./apiSessions');
+const CronAPIs = require('./apiCrons');
 
 class HuntAPIs {
   // --------------------------------------------------------------------------
@@ -616,7 +617,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
   // Kick off the process of running a hunt job
   // cb is optional and is called either when a job has been started or end of function
   static async processHuntJobs (cb) {
-    if (!Config.get('cronQueries', false)) {
+    if (!CronAPIs.isPrimaryViewer()) {
       return;
     }
 
@@ -927,7 +928,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
         }
 
         // don't add the running job to the queue
-        if (hunt.status === 'running' && (!Config.get('cronQueries', false) || internals.runningHuntJob)) {
+        if (hunt.status === 'running' && (!CronAPIs.isPrimaryViewer() || internals.runningHuntJob)) {
           runningJob = hunt;
           if (req.query.all !== undefined) {
             continue;

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -140,6 +140,9 @@ exports.getFull = function (node, key, defaultValue) {
   if (value === 'false') {
     return false;
   }
+  if (value === 'true') {
+    return true;
+  }
   return value;
 };
 

--- a/viewer/db.js
+++ b/viewer/db.js
@@ -38,7 +38,6 @@ const internals = {
   masterCache: {},
   qInProgress: 0,
   q: [],
-  doShortcutsUpdates: false,
   remoteShortcutsIndex: undefined,
   localShortcutsIndex: undefined,
   localShortcutsVersion: -1 // always start with -1 so there's an initial sync of shortcuts from user's es db
@@ -189,20 +188,9 @@ exports.initialize = async (info, cb) => {
     setInterval(() => { exports.getAliasesCache(['sessions2-*', 'sessions3-*']); }, 2 * 60 * 1000);
   }
 
-  // if there's a user's db and cronQueries is set, sync shortcuts from user's
-  // to local db so they can be used for sessions search
-  // (can't use remote db for searching via shortcuts)
   internals.localShortcutsIndex = fixIndex('lookups');
-  if (internals.info.usersHost && internals.info.cronQueries) {
-    internals.remoteShortcutsIndex = `${internals.usersPrefix}lookups`;
-    // make sure the remote es is not the same as local es
-    if (info.host !== info.usersHost && info.prefix !== info.usersPrefix) {
-      // only need to sync and update if the es' are different
-      internals.doShortcutsUpdates = true; // for updating if editing shortcuts locally
-      exports.updateLocalShortcuts(); // immediately update shortcuts
-      setInterval(() => { exports.updateLocalShortcuts(); }, 60000); // and every minute
-    }
-  } else if (internals.info.usersHost && internals.usersPrefix !== undefined) {
+
+  if (internals.info.usersHost && internals.usersPrefix !== undefined) {
     internals.remoteShortcutsIndex = `${internals.usersPrefix}lookups`;
   } else { // there is no remote shorcuts index, just set it to local
     internals.remoteShortcutsIndex = internals.localShortcutsIndex;
@@ -1206,6 +1194,11 @@ async function setShortcutsVersion () {
 // if there's a users es set, then the shortcuts are saved in the remote db
 // so they need to be periodically updated in the local db for searching by shortcuts to work
 exports.updateLocalShortcuts = async () => {
+  if (!internals.info.usersHost || !internals.info.isPrimaryViewer || !internals.info.isPrimaryViewer() ||
+    !(internals.info.host !== internals.info.usersHost && internals.info.prefix !== internals.info.usersPrefix)) {
+    return;
+  }
+
   if (internals.multiES) { return; } // don't sync shortcuts for multies
 
   const msg = `updating local shortcuts (${internals.info.host}/${internals.localShortcutsIndex}) from remote (${internals.info.usersHost}/${internals.remoteShortcutsIndex})`;
@@ -1313,7 +1306,7 @@ exports.createShortcut = async (doc) => {
   const response = await internals.usersClient7.index({
     index: internals.remoteShortcutsIndex, body: doc, refresh: 'wait_for', timeout: '10m'
   });
-  if (internals.doShortcutsUpdates) { exports.updateLocalShortcuts(); }
+  exports.updateLocalShortcuts();
   return response;
 };
 exports.deleteShortcut = async (id) => {
@@ -1322,7 +1315,7 @@ exports.deleteShortcut = async (id) => {
   const response = await internals.usersClient7.delete({
     index: internals.remoteShortcutsIndex, id, refresh: true
   });
-  if (internals.doShortcutsUpdates) { exports.updateLocalShortcuts(); }
+  exports.updateLocalShortcuts();
   return response;
 };
 exports.setShortcut = async (id, doc) => {
@@ -1331,7 +1324,7 @@ exports.setShortcut = async (id, doc) => {
   const response = await internals.usersClient7.index({
     index: internals.remoteShortcutsIndex, body: doc, id, refresh: true, timeout: '10m'
   });
-  if (internals.doShortcutsUpdates) { exports.updateLocalShortcuts(); }
+  exports.updateLocalShortcuts();
   return response;
 };
 exports.getShortcut = async (id) => {
@@ -1897,23 +1890,86 @@ exports.putTemplate = async (templateName, body) => {
   return internals.client7.indices.putTemplate({ name: fixIndex(templateName), body });
 };
 
-exports.setQueriesNode = async (node) => {
-  internals.client7.indices.putMapping({
-    index: fixIndex('queries'),
-    body: { _meta: { node, updateTime: Date.now() } }
-  });
+exports.setQueriesNode = async (node, force) => {
+  const namePid = `node-${process.pid}`;
+
+  // force is true we just rewrite the primary-viewer entry everytime
+  if (force) {
+    internals.client7.index({
+      id: 'primary-viewer',
+      index: fixIndex('queries'),
+      body: { name: namePid, lastRun: Date.now(), enabled: false }
+    });
+    return true;
+  }
+
+  // force is false. Try and update the previous record. If our record
+  // just update the time stamp. If not our record then take the record if
+  // timestamp is 1 min old. Otherwise noop.
+
+  const script = `
+    if (ctx._source.name == params.name) {
+      ctx._source.lastRun = ctx['_now'];
+    } else if (ctx['_now'] - ctx._source.lastRun >= 60000) {
+      ctx._source.lastRun = ctx['_now'];
+      ctx._source.name = params.name;
+    } else {
+      ctx.op = "none";
+    }
+  `;
+
+  const body = {
+    script: {
+      source: script,
+      lang: 'painless',
+      params: {
+        name: namePid
+      }
+    }
+  };
+  try {
+    const result = await internals.client7.update({
+      id: 'primary-viewer',
+      index: fixIndex('queries'),
+      body
+    });
+    return result.body.result === 'updated';
+  } catch (e) {
+    // There was no entry to update, just try and create a new record as ourself
+    try {
+      const result = await internals.client7.index({
+        id: 'primary-viewer',
+        index: fixIndex('queries'),
+        body: { name: namePid, lastRun: Date.now(), enabled: false },
+        op_type: 'create'
+      });
+      return result.body.result === 'created';
+    } catch (e2) {
+      return false;
+    }
+  }
 };
 
 exports.getQueriesNode = async () => {
-  const { body: doc } = await internals.client7.indices.getMapping({
-    index: fixIndex('queries')
-  });
+  try {
+    const { body: doc } = await internals.client7.get({
+      id: 'primary-viewer',
+      index: fixIndex('queries')
+    });
+    return {
+      node: doc._source?.name,
+      updateTime: doc._source?.lastRun
+    };
+  } catch (e) {
+    const { body: doc } = await internals.client7.indices.getMapping({
+      index: fixIndex('queries')
+    });
+    // Since queries is an alias we dont't know the real index name here
+    const meta = doc[Object.keys(doc)[0]].mappings._meta;
 
-  // Since queries is an alias we dont't know the real index name here
-  const meta = doc[Object.keys(doc)[0]].mappings._meta;
-
-  return {
-    node: meta?.node,
-    updateTime: meta?.updateTime
-  };
+    return {
+      node: meta?.node,
+      updateTime: meta?.updateTime
+    };
+  }
 };

--- a/viewer/db.js
+++ b/viewer/db.js
@@ -189,7 +189,6 @@ exports.initialize = async (info, cb) => {
   }
 
   internals.localShortcutsIndex = fixIndex('lookups');
-
   if (internals.info.usersHost && internals.usersPrefix !== undefined) {
     internals.remoteShortcutsIndex = `${internals.usersPrefix}lookups`;
   } else { // there is no remote shorcuts index, just set it to local
@@ -1194,8 +1193,10 @@ async function setShortcutsVersion () {
 // if there's a users es set, then the shortcuts are saved in the remote db
 // so they need to be periodically updated in the local db for searching by shortcuts to work
 exports.updateLocalShortcuts = async () => {
-  if (!internals.info.usersHost || !internals.info.isPrimaryViewer || !internals.info.isPrimaryViewer() ||
-    !(internals.info.host !== internals.info.usersHost && internals.info.prefix !== internals.info.usersPrefix)) {
+  if (!internals.info.usersHost ||
+     !internals.info.isPrimaryViewer || // If no isPrimaryViewer then we aren't actually viewer, dont do this
+    !internals.info.isPrimaryViewer() ||
+    internals.info.host === internals.info.usersHost) {
     return;
   }
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2039,20 +2039,6 @@ async function main () {
   createActions('field-actions', 'makeFieldActions', 'fieldActions');
   setInterval(() => createActions('field-actions', 'makeFieldActions', 'fieldActions'), 150 * 1000); // Check every 2.5 minutes
 
-  if (Config.get('cronQueries', false)) { // this viewer will process the cron queries
-    console.log('This node will process Periodic Queries (CRON), delayed by', internals.cronTimeout, 'seconds');
-    setInterval(CronAPIs.processCronQueries, 60 * 1000);
-    setTimeout(CronAPIs.processCronQueries, 1000);
-    setInterval(HuntAPIs.processHuntJobs, 10000);
-  } else if (!Config.get('multiES', false)) {
-    const info = await Db.getQueriesNode();
-    if (info.node === undefined) {
-      console.log(`WARNING - No cronQueries=true found in ${Config.getConfigFile()}, one and only one node MUST have cronQueries=true set for cron/hunts to work`);
-    } else if (Date.now() - info.updateTime > 2 * 60 * 1000) {
-      console.log(`WARNING - cronQueries=true node '${info.node}' hasn't checked in lately, cron/hunts might be broken`);
-    }
-  }
-
   let server;
   if (Config.isHTTPS()) {
     const cryptoOption = require('crypto').constants.SSL_OP_NO_TLSv1;
@@ -2134,7 +2120,7 @@ Db.initialize({
   usersEsApiKey: Config.get('usersElasticsearchAPIKey', null),
   esBasicAuth: Config.get('elasticsearchBasicAuth', null),
   usersEsBasicAuth: Config.get('usersElasticsearchBasicAuth', null),
-  cronQueries: Config.get('cronQueries', false),
+  isPrimaryViewer: CronAPIs.isPrimaryViewer,
   getCurrentUserCB: UserAPIs.getCurrentUserCB,
   maxConcurrentShardRequests: Config.get('esMaxConcurrentShardRequests')
 }, main);


### PR DESCRIPTION
primary-viewer is now a doc in the queries index instead of a _meta mapping change that was causing constant index mapping refreshes