### PR TITLE
Support ipv6 expansion like 1:2:3 => 1:2:3::, fixes #2238

### DIFF
--- a/tests/api-buildquery.t
+++ b/tests/api-buildquery.t
@@ -1,4 +1,4 @@
-use Test::More tests => 163;
+use Test::More tests => 168;
 use Cwd;
 use URI::Escape;
 use MolochTest;
@@ -120,6 +120,13 @@ doTest('ip.src != [1.2.3.4,$ipshortcut1,2.3.4.5:80]', qq({"bool":{"must_not":[{"
 doTest('ip.src != [$ipshortcut1,1.2.3.4,$ipshortcut2]', qq({"bool":{"must_not":[{"term":{"source.ip":"1.2.3.4"}},{"terms":{"source.ip":{"index":"tests_lookups","path":"ip","id":"$ipshortcut1"}}},{"terms":{"source.ip":{"index":"tests_lookups","path":"ip","id":"$ipshortcut2"}}}]}}));
 
 doTest('ip.src == ]$ipshortcut1[', q(]$ipshortcut1[ - AND array not supported with shortcuts));
+
+doTest('ip.src == 1::2', qq({"term":{"source.ip":"1::2"}}));
+doTest('ip.src == 1::2.80', qq({"bool":{"filter":[{"term":{"source.ip":"1::2"}},{"term":{"source.port":"80"}}]}}));
+doTest('ip.src == 1::2/8.80', qq({"bool":{"filter":[{"term":{"source.ip":"1::2/8"}},{"term":{"source.port":"80"}}]}}));
+doTest('ip.src == 1:2:3', qq({"term":{"source.ip":"1:2:3::/48"}}));
+doTest('ip.src == 1:2:3.80', qq({"bool":{"filter":[{"term":{"source.ip":"1:2:3::/48"}},{"term":{"source.port":"80"}}]}}));
+
 
 #### IP
 

--- a/viewer/molochparser.jison
+++ b/viewer/molochparser.jison
@@ -256,8 +256,7 @@ function parseIpPort (yy, field, ipPortStr) {
   let port = -1;
   const colons = ipPortStr.split(':');
 
-  // More then 1 colon is ip 6
-  if (colons.length > 2) {
+  if (ipPortStr.includes('::')) { // Double colon is ip6 with 0 filled
     // Everything after . is port
     const dots = ipPortStr.split('.');
     if (dots.length > 1 && dots[1] !== '') {
@@ -265,6 +264,37 @@ function parseIpPort (yy, field, ipPortStr) {
     }
     // Everything before . is ip and slash
     ip = dots[0];
+  } else if (colons.length > 2) { // More than 1 colon is ip6 
+    // Everything after . is port
+    const dots = ipPortStr.split('.');
+    if (dots.length > 1 && dots[1] !== '') {
+      port = dots[1];
+    }
+
+    const slash = dots[0].split('/');
+    const colons2 = slash[0].split(':');
+
+    // If the last one is empty just pretend : isn't there, for auto complete
+    if (colons2[colons2.length - 1] === '') {
+      colons2.length--;
+    }
+
+    if (slash[1] === undefined) {
+      console.log(colons2.length, colons2, colons2.length, 16*colons2.length);
+      slash[1] = `${16*colons2.length}`;
+    }
+
+    if (colons2.length < 8) {
+      ip = colons2.join(':') + '::';
+    } else {
+      ip = colons2.join(':');
+    }
+
+
+    // Add the slash back to the ip
+    if (slash[1] && slash[1] !== '128') {
+      ip = `${ip}/${slash[1]}`;
+    }
   } else {
     // everything after : is port
     if (colons.length > 1 && colons[1] !== '') {

--- a/viewer/molochparser.js
+++ b/viewer/molochparser.js
@@ -454,8 +454,7 @@ function parseIpPort (yy, field, ipPortStr) {
   let port = -1;
   const colons = ipPortStr.split(':');
 
-  // More then 1 colon is ip 6
-  if (colons.length > 2) {
+  if (ipPortStr.includes('::')) { // Double colon is ip6 with 0 filled
     // Everything after . is port
     const dots = ipPortStr.split('.');
     if (dots.length > 1 && dots[1] !== '') {
@@ -463,6 +462,37 @@ function parseIpPort (yy, field, ipPortStr) {
     }
     // Everything before . is ip and slash
     ip = dots[0];
+  } else if (colons.length > 2) { // More than 1 colon is ip6 
+    // Everything after . is port
+    const dots = ipPortStr.split('.');
+    if (dots.length > 1 && dots[1] !== '') {
+      port = dots[1];
+    }
+
+    const slash = dots[0].split('/');
+    const colons2 = slash[0].split(':');
+
+    // If the last one is empty just pretend : isn't there, for auto complete
+    if (colons2[colons2.length - 1] === '') {
+      colons2.length--;
+    }
+
+    if (slash[1] === undefined) {
+      console.log(colons2.length, colons2, colons2.length, 16*colons2.length);
+      slash[1] = `${16*colons2.length}`;
+    }
+
+    if (colons2.length < 8) {
+      ip = colons2.join(':') + '::';
+    } else {
+      ip = colons2.join(':');
+    }
+
+
+    // Add the slash back to the ip
+    if (slash[1] && slash[1] !== '128') {
+      ip = `${ip}/${slash[1]}`;
+    }
   } else {
     // everything after : is port
     if (colons.length > 1 && colons[1] !== '') {


### PR DESCRIPTION
Previously we would just pass 1:2:3 to ES which isn't a valid ipv6, now we add the :: at the end to zero fill and also calculate the correct mask