### PR TITLE
add config option for httpRealm and note that it must match viewer

### DIFF
--- a/release/cont3xt.ini.sample
+++ b/release/cont3xt.ini.sample
@@ -22,6 +22,11 @@ userNameHeader=digest
 # Make this RANDOM, you never need to type in
 passwordSecret=ARKIME_PASSWORD
 
+# HTTP Digest Realm - Must be in default section. Changing the value
+# will make all previously stored passwords no longer work
+# This must be the same setting as Arkime uses, specified in config.ini
+httpRealm=Moloch
+
 # Port Cont3xt listens on
 #port=3218
 #


### PR DESCRIPTION
**Clearly describe the problem and solution**
Digest authentication requires the "Realm" value to be identical across both the Arkime Viewer and Cont3xt applications but there is currently no mention of this in the `cont3xt.ini.sample` file.

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
n/a - just added stub to config file

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
n/a - just added stub to config file

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
