### PR TITLE
Fix issue with arkimecapture.service starting before elasticsearch.service

### DIFF
--- a/release/arkimecapture.systemd.service
+++ b/release/arkimecapture.systemd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Arkime Capture
-After=network.target opensearch elasticsearch
+After=network.target opensearch elasticsearch.service
 
 [Service]
 Type=simple

--- a/release/arkimecapture.systemd.service
+++ b/release/arkimecapture.systemd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Arkime Capture
-After=network.target opensearch elasticsearch.service
+After=network.target opensearch.service elasticsearch.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
correct issue with failing to start after elasticsearch on Rocky Linux 8

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
arkimecapture.service has been failing to start on our Rocky Linux 8 instance after a reboot. I checked logs and found the following error:
`Failed to add dependency on elasticsearch, ignoring: Invalid argument`. I was able to manually start `arkimecapture.service` once elasticsearch was running, but it would fail on reboot or a clean boot. This error combined with the behavior lead me to believe that arkimecapture was trying to start before elasticsearch. Going based off the error provided, it told me that elasticsearch was not a valid dependency so I checked & found it should actually be `elasticsearch.service`. I updated the source of arkimecapture.systemd.service to correct this issue upstream.

**Relevant issue number(s) if applicable**
https://github.com/arkime/arkime/issues/2306

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
I did

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
