### PR TITLE
Can now set up ops with override-ip

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -514,13 +514,14 @@ typedef struct arkime_config {
 } ArkimeConfig_t;
 
 typedef struct {
-    char     *tagsStr[10];
-    char     *country;
-    char     *asStr;
-    char     *rir;
-    uint32_t  asNum;
-    int       asLen;
-    int       numtags;
+    ArkimeFieldOps_t *ops;
+    char             *tagsStr[10];
+    char             *country;
+    char             *asStr;
+    char             *rir;
+    uint32_t          asNum;
+    char              asLen;
+    char              numtags;
 } ArkimeIpInfo_t;
 
 /******************************************************************************/

--- a/capture/config.c
+++ b/capture/config.c
@@ -658,11 +658,22 @@ void arkime_config_load_local_ips()
                 ii->rir = g_strdup(values[v]+4);
             } else if (strncmp(values[v], "tag:", 4) == 0) {
                 if (ii->numtags < 10) {
-                    ii->tagsStr[ii->numtags] = strdup(values[v]+4);
+                    ii->tagsStr[(int)ii->numtags] = strdup(values[v]+4);
                     ii->numtags++;
                 }
             } else if (strncmp(values[v], "country:", 8) == 0) {
                 ii->country = g_strdup(values[v]+8);
+            } else {
+                char *colon = strchr(values[v], ':');
+                *colon = 0; // remove :
+                int pos = arkime_field_by_exp(values[v]);
+                if (pos != -1) {
+                    if (!ii->ops) {
+                        ii->ops = ARKIME_TYPE_ALLOC0(ArkimeFieldOps_t);
+                        arkime_field_ops_init(ii->ops, 1, ARKIME_FIELD_OPS_FLAGS_COPY);
+                    }
+                    arkime_field_ops_add(ii->ops, pos, colon + 1, strlen(colon + 1));
+                }
             }
         }
         arkime_db_add_local_ip(keys[k], ii);

--- a/capture/db.c
+++ b/capture/db.c
@@ -129,6 +129,10 @@ LOCAL ArkimeIpInfo_t *arkime_db_get_local_ip6(ArkimeSession_t *session, struct i
         arkime_field_string_add(config.tagsStringField, session, ii->tagsStr[t], -1, TRUE);
     }
 
+    if (ii->ops) {
+        arkime_field_ops_run(session, ii->ops);
+    }
+
     return ii;
 }
 

--- a/capture/field.c
+++ b/capture/field.c
@@ -18,6 +18,7 @@
 #include "arkime.h"
 #include <stdarg.h>
 #include <arpa/inet.h>
+#include <math.h>
 #include "patricia.h"
 
 extern ArkimeConfig_t        config;
@@ -1595,7 +1596,12 @@ void arkime_field_ops_int_parse(ArkimeFieldOp_t *op, char *value)
 /******************************************************************************/
 void arkime_field_ops_add(ArkimeFieldOps_t *ops, int fieldPos, char *value, int valuelen)
 {
-    if (ops->num >= ops->size || fieldPos == -1 || fieldPos > config.maxField) {
+    if (ops->num >= ops->size) {
+        ops->size = ceil (ops->size * 1.6);
+        ops->ops = realloc(ops->ops, ops->size * sizeof(ArkimeFieldOp_t));
+    }
+
+    if (fieldPos == -1 || fieldPos > config.maxField) {
         LOG("WARNING - Not adding %d %s %d", fieldPos, value, valuelen);
         return;
     }

--- a/capture/main.c
+++ b/capture/main.c
@@ -795,10 +795,10 @@ LLVMFuzzerInitialize(int *UNUSED(argc), char ***UNUSED(argv))
     arkime_http_init();
     arkime_db_init();
     arkime_packet_init();
-    arkime_config_load_local_ips();
     arkime_config_load_packet_ips();
     arkime_yara_init();
     arkime_parsers_init();
+    arkime_config_load_local_ips();
     arkime_session_init();
     arkime_plugins_load(config.plugins);
     arkime_rules_init();
@@ -891,10 +891,10 @@ int main(int argc, char **argv)
     arkime_http_init();
     arkime_db_init();
     arkime_packet_init();
-    arkime_config_load_local_ips();
     arkime_config_load_packet_ips();
     arkime_yara_init();
     arkime_parsers_init();
+    arkime_config_load_local_ips();
     arkime_session_init();
     arkime_plugins_load(config.plugins);
     arkime_rules_init();

--- a/capture/main.c
+++ b/capture/main.c
@@ -798,9 +798,9 @@ LLVMFuzzerInitialize(int *UNUSED(argc), char ***UNUSED(argv))
     arkime_config_load_packet_ips();
     arkime_yara_init();
     arkime_parsers_init();
-    arkime_config_load_local_ips();
     arkime_session_init();
     arkime_plugins_load(config.plugins);
+    arkime_config_load_local_ips();
     arkime_rules_init();
     arkime_packet_batch_init(&batch);
     return 0;
@@ -894,9 +894,9 @@ int main(int argc, char **argv)
     arkime_config_load_packet_ips();
     arkime_yara_init();
     arkime_parsers_init();
-    arkime_config_load_local_ips();
     arkime_session_init();
     arkime_plugins_load(config.plugins);
+    arkime_config_load_local_ips();
     arkime_rules_init();
     g_timeout_add(1, arkime_ready_gfunc, 0);
 


### PR DESCRIPTION
With override-ip can now setup field ops to run

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
