### PR TITLE
fix access control in remote hunt endpoint

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1786,7 +1786,7 @@ app.delete( // remove users from hunt endpoint
 
 app.get( // remote hunt endpoint
   ['/api/hunt/:nodeName/:huntId/remote/:sessionId', '/:nodeName/hunt/:huntId/remote/:sessionId'],
-  [ArkimeUtil.noCacheJson],
+  [ArkimeUtil.noCacheJson], User.checkPermissions(['packetSearch'],
   HuntAPIs.remoteHunt
 );
 


### PR DESCRIPTION
User should have packetSearch permission in order to do anything related to hunts but `/api/hunt/:nodeName/:huntId/remote/:sessionId` does not have any protection.

This is a fix for that security issue.