### PR TITLE
improve demo mode, admin role can do more, turn off history

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1094,15 +1094,19 @@ function expireCheckAll () {
 // APIs disabled in demoMode, needs to be before real callbacks
 if (Config.get('demoMode', false)) {
   console.log('WARNING - Starting in demo mode, some APIs disabled');
-  app.all(['/settings', '/users', '/history/list'], (req, res) => {
-    return res.send('Disabled in demo mode.');
-  });
-
-  app.get(['/user/cron', '/api/cron', '/api/user/cron', '/history/list'], (req, res) => {
-    return res.serverError(403, 'Disabled in demo mode.');
-  });
-
-  app.post(['/user/password/change', '/changePassword', '/api/user/password', '/tableState/:tablename'], (req, res) => {
+  app.all([
+    '/history/*',
+    '/api/histories',
+    '/api/history/*',
+    '/api/cron*',
+    '/api/user/cron*',
+    '/user/cron*',
+    '/user/password*',
+    '/api/user/password*'
+  ], (req, res, next) => {
+    if (req.user.hasRole('arkimeAdmin')) {
+      return next();
+    }
     return res.serverError(403, 'Disabled in demo mode.');
   });
 }
@@ -1942,7 +1946,7 @@ app.use(cspHeader, setCookie, (req, res) => {
     return res.status(403).send('Permission denied');
   }
 
-  if (req.path === '/settings' && Config.get('demoMode', false)) {
+  if (req.path === '/settings' && Config.get('demoMode', false) && !req.user.hasRole('usersAdmin')) {
     return res.status(403).send('Permission denied');
   }
 


### PR DESCRIPTION
* arkimeAdmin users will still have most functionality in demoMode
* history apis now denied
* cron apis now denied
* just use app.all instead of tracking get vs post

Follow up to #2320


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
