### PR TITLE
fix prototype pollution

### DIFF
--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -315,7 +315,11 @@ function apiPutSettings (req, res, next) {
     }
 
     if (user.cont3xt === undefined) { user.cont3xt = {}; }
-
+    
+    if (req.body.hasOwnProperty('__proto__')) {
+      return res.send({ success: false, text: '__proto__ not allowed' });
+    }
+    
     if (req.body?.settings) {
       user.cont3xt.settings = req.body.settings;
       save = true;


### PR DESCRIPTION
There is a prototype pollution vulnerability that will DOS users if a request is sent to `POST /api/user/settings`.

Blacklisting` __proto__` will fix the issue.

HackerOne report: #2053341