### PR TITLE
prevent stats disabled users to make changes in stats api

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1460,7 +1460,7 @@ app.post( // cancel OpenSearch/Elasticsearch task endpoint
 app.post( // cancel OpenSearch/Elasticsearch task by opaque id endpoint
   ['/api/estasks/:id/cancelwith', '/estask/cancelById'],
   // should not have admin check so users can use, each user is name spaced
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkPermissions(['hideStats'])],
   StatsAPIs.cancelUserESTask
 );
 


### PR DESCRIPTION
The endpoints `/api/estasks/:id/cancelwith` and `/estask/cancelById` are not protected from the users who have their Arkime Stats disabled.

HackerOne report: #2065883