### PR TITLE
Improve usersAdmin permission checks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,10 +29,13 @@ NOTICE: Restart wiseService before capture when upgrading
 NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at once after upgrading
 
 4.3.3 2023/07/xx
+  - all - improved json verification
+  - all - fix password changing permission checks
   - capture - handle port reuse better
   - capture - fix kafka memory leak when produce fails
   - cont3xt - New overview cards
   - viewer - gtp decoding
+  - viewer - demo mode improvements, arkimeAdmin can use normally
 
 4.3.2 2023/06/13
   - release - cyberchef 10.4.0 libpcap 1.10.4
@@ -58,9 +61,9 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
   - all - passwordSecret log message now has the right [section]
   - capture - --tags option now works as well as --tag
   - viewer - new auto cronQueries setting
-  - viewer - change where primary viewer info is stored to not cause constant 
+  - viewer - change where primary viewer info is stored to not cause constant
              mapping change
-  - viewer - fixed ipv6 not working, now assumes zero filled with mask (if 
+  - viewer - fixed ipv6 not working, now assumes zero filled with mask (if
              not provided)
   - viewer - code refactor into javascript classes
 
@@ -77,14 +80,14 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
   - all - New authTrustProxy setting
   - capture - tcpClosingTimeout setting controls delay before saving tcp
               sessions after close
-  - capture - default dbBulkSize to 1M, min 500K, max 15M and removed 
+  - capture - default dbBulkSize to 1M, min 500K, max 15M and removed
               from sample config file
   - capture - s3 writer now writes multiple files based on packetThreads
   - capture - s3 writer supports zstd, s3Compression setting
   - capture - s3 writer compression level, s3CompressionBlockSize setting
   - capture - s3 writer block size, s3CompressionBlockSize setting
   - capture - s3 writer gap encoding, s3GapPacketPos setting
-  - capture - s3 writer when s3UseECSEnv is true use container env vars to find 
+  - capture - s3 writer when s3UseECSEnv is true use container env vars to find
               the id/key/token for s3 auth
   - capture - improve Gh0st parser (#2225)
   - capture - new dnp3 & finger classifier
@@ -148,7 +151,7 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
   - capture - add VNI field
   - capture - initial tzsp reader support
   - capture - y2038 fixes
-  - capture - Integer ops in rules now support a leading min or max which only 
+  - capture - Integer ops in rules now support a leading min or max which only
               sets the value if less than or greater than current value
   - wise - added usersElasticsearchBasicAuth setting and lmdb cache support
   - wise - add passivetotal value action if at least key is defined

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,4 +1,4 @@
-use Test::More tests => 140;
+use Test::More tests => 150;
 use Cwd;
 use URI::Escape;
 use MolochTest;
@@ -424,11 +424,47 @@ my $json;
 # Roles Tests - Some of these are repeats
 my $es = "-o 'elasticsearch=$MolochTest::elasticsearch' -o 'usersElasticsearch=$MolochTest::elasticsearch' $ENV{INSECURE}";
 system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testsuperadmin testsuperadmin testsuperadmin --roles superAdmin");
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testusersadmin testusersadmin testusersadmin --roles usersAdmin");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testusersadmin testusersadmin testusersadmin --roles usersAdmin,cont3xtAdmin");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testarkimeadmin testarkimeadmin testarkimeadmin --roles arkimeAdmin");
+system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testcont3xtadmin testcont3xtadmin testcont3xtadmin --roles cont3xtAdmin");
 system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testuser testuser testuser");
 
+my $tuToken = getTokenCookie('testuser');
 my $saToken = getTokenCookie('testsuperadmin');
 my $uaToken = getTokenCookie('testusersadmin');
+
+# Password changing - by user
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testuser', '{"newPassword": "wrong"}', $tuToken);
+    eq_or_diff($json, from_json('{"text": "Password mismatch", "success": false}'));
+
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testuser', '{"currentPassword": "wrong", "newPassword": "wrong"}', $tuToken);
+    eq_or_diff($json, from_json('{"text": "Password mismatch", "success": false}'));
+
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testuser', '{"currentPassword": "testuser"}', $tuToken);
+    eq_or_diff($json, from_json('{"text": "New password needs to be at least 3 characters", "success": false}'));
+
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testuser', '{"currentPassword": "testuser", "newPassword": "testuserpass"}', $tuToken);
+    eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
+
+# Password changing - by usersAdmin
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testusersadmin&userId=testuser', '{"newPassword": "test1"}', $uaToken);
+    eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
+
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testusersadmin&userId=testarkimeadmin', '{"newPassword": "test2"}', $uaToken);
+    eq_or_diff($json, from_json('{"text": "Not allowed to change arkimeAdmin password", "success": false}'));
+
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testusersadmin&userId=testcont3xtadmin', '{"newPassword": "test3"}', $uaToken);
+    eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
+
+# Password changing - by superAdmin
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testsuperadmin&userId=testuser', '{"newPassword": "test4"}', $saToken);
+    eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
+
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testsuperadmin&userId=testarkimeadmin', '{"newPassword": "test5"}', $saToken);
+    eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
+
+    $json = viewerPostToken('/api/user/password?molochRegressionUser=testsuperadmin&userId=testcont3xtadmin', '{"newPassword": "test6"}', $saToken);
+    eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
 
 # Make sure only superadmin can create superadmin
     $json = viewerPostToken("/user/create?molochRegressionUser=testsuperadmin", '{"userId": "testsuperadmin1", "userName": "testsuperadmin1", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $saToken);


### PR DESCRIPTION
Now a usersAdmin user can only change passwords on users it has the same Admin roles as.

userA is usersAdmin/cont3xtAdmin
userB is cont3xtAdmin
userC is cont3xtAdmin/arkimeAdmin

userA can change userB password but not userC because it doesn't have arkimeAdmin

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
