### PR TITLE
fix clean start not letting auth be set up

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,9 +32,11 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
   - release - cyberchef 10.5.2
   - all - improved json verification
   - all - fix password changing permission checks
+  - all - better logging when requiredAuthHeader fails
   - capture - handle port reuse better
   - capture - fix kafka memory leak when produce fails
   - cont3xt - New overview cards
+  - parliament - fix parliament clean start not letting auth be set up
   - viewer - gtp decoding
   - viewer - demo mode improvements, arkimeAdmin can use normally
 

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1221,7 +1221,7 @@ router.post('/logout', (req, res, next) => {
 
 // Get whether authentication or dashboardOnly mode is set
 router.get('/auth', (req, res, next) => {
-  const hasAuth = !!app.get('password') || !!parliament.settings.commonAuth;
+  const hasAuth = !!app.get('password') || Object.keys(parliament?.settings?.commonAuth).length > 0;
   const dashboardOnly = !!app.get('dashboardOnly');
   return res.json({
     hasAuth,

--- a/parliament/vueapp/src/components/Settings.vue
+++ b/parliament/vueapp/src/components/Settings.vue
@@ -317,8 +317,7 @@
                   </span>
                 </span>
                 <input class="form-control"
-                  @keyup.enter="updatePassword"
-                  name="currentPassword"
+                  name="authSetupCode"
                   @input="passwordChanged = true"
                   v-model="authSetupCode"
                   autocomplete="current-password"


### PR DESCRIPTION
Fix parliament not actually letting you set up auth when starting from scratch without a pass

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
