### PR TITLE
have to have both usersAdmin and *Admin to change setting

### DIFF
--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -26,6 +26,8 @@ const sjson = require('secure-json-parse');
 
 class ArkimeUtil {
   static debug = 0;
+  static adminRole;
+
   // ----------------------------------------------------------------------------
   /**
    * A json body parser that doesn't allow anything that looks like "__proto__": or "constructor":
@@ -335,7 +337,7 @@ class ArkimeUtil {
       }
 
       userId = req.user.userId;
-    } else if (!req.user.hasRole('usersAdmin')) {
+    } else if (!req.user.hasRole('usersAdmin') || (ArkimeUtil.adminRole && !req.user.hasRole(ArkimeUtil.adminRole))) {
       // user is trying to get another user's settings without admin privilege
       return res.serverError(403, 'Need admin privileges');
     } else {

--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -337,7 +337,7 @@ class ArkimeUtil {
       }
 
       userId = req.user.userId;
-    } else if (!req.user.hasRole('usersAdmin') || (ArkimeUtil.adminRole && !req.user.hasRole(ArkimeUtil.adminRole))) {
+    } else if (!req.user.hasRole('usersAdmin') || (!req.url.startsWith('/api/user/password') && ArkimeUtil.adminRole && !req.user.hasRole(ArkimeUtil.adminRole))) {
       // user is trying to get another user's settings without admin privilege
       return res.serverError(403, 'Need admin privileges');
     } else {

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -527,6 +527,10 @@ async function setupAuth () {
   const usersUrl = getConfig('cont3xt', 'usersUrl');
   let usersEs = getConfig('cont3xt', 'usersElasticsearch');
 
+  // ALW - 5.0 Fix
+  ArkimeUtil.debug = internals.debug;
+  ArkimeUtil.adminRole = 'cont3xtAdmin';
+
   await Db.initialize({
     insecure: internals.insecure,
     debug: internals.debug,

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -717,7 +717,7 @@ function getSettingUserCache (req, res, next) {
   }
 
   // user is trying to get another user's settings without admin privilege
-  if (!req.user.hasRole('usersAdmin')) { return res.serverError(403, 'Need admin privileges'); }
+  if (!req.user.hasRole('usersAdmin') || !req.user.hasRole('arkimeAdmin')) { return res.serverError(403, 'Need admin privileges'); }
 
   User.getUserCache(req.query.userId, (err, user) => {
     if (err || !user) {
@@ -2115,6 +2115,10 @@ process.on('unhandledRejection', (reason, p) => {
   console.trace('Unhandled Rejection at: Promise', p, 'reason:', reason, JSON.stringify(reason, false, 2));
   // application specific logging, throwing an error, or other logic here
 });
+
+// ALW - 5.0 Fix
+ArkimeUtil.debug = Config.debug;
+ArkimeUtil.adminRole = 'arkimeAdmin';
 
 Db.initialize({
   host: internals.elasticBase,


### PR DESCRIPTION
I'm not in love with this solution. If a password change require usersAdmin. If a settings change then viewer - usersAdmin && arkimeAdmin or cont3xt - usersAdmin && cont3xtAdmin. I wonder if for settings it should just be the Admin setting and usersAdmin isn't required. I think thats what the doc says. 