### PR TITLE
Custom overview fields

### DIFF
--- a/common/vueapp/RoleDropdown.vue
+++ b/common/vueapp/RoleDropdown.vue
@@ -3,7 +3,8 @@
     size="sm"
     @shown="setFocus"
     class="roles-dropdown"
-    :text="displayText || getRolesStr(localSelectedRoles)">
+    :text="displayText || getRolesStr(localSelectedRoles)"
+    :disabled="disabled">
     <!-- roles search -->
     <b-dropdown-header class="w-100 sticky-top">
       <b-input-group size="sm">
@@ -75,7 +76,8 @@ export default {
     id: { type: String },
     displayText: { type: String },
     selectedRoles: { type: Array },
-    roles: { type: Array, required: true }
+    roles: { type: Array, required: true },
+    disabled: { type: Boolean, default: false }
   },
   data () {
     return {

--- a/cont3xt/descriptions.txt
+++ b/cont3xt/descriptions.txt
@@ -8,7 +8,7 @@ Card Description - an object of the following
   * title - title of the card
   * fields - an array of fields.
     * If the element is just a string that means
-      * both "name" and "field" are that string
+      * both "label" and "field" are that string
       * type is string
     * otherwise it can be an object with
       * label - the field label to show the user

--- a/cont3xt/vueapp/src/components/overviews/OverviewForm.vue
+++ b/cont3xt/vueapp/src/components/overviews/OverviewForm.vue
@@ -404,7 +404,10 @@ export default {
     fieldOptionsFor (fieldRef) {
       if (!this.validateFieldRefFrom(fieldRef)) { return []; }
 
-      return (this.getIntegrations[fieldRef.from]?.card?.fields?.map(field => field.label) ?? []).concat(['Custom']);
+      const integrationFields = this.getIntegrations[fieldRef.from]?.card?.fields?.map(field => field.label) ?? [];
+      integrationFields.sort();
+
+      return integrationFields.concat(['Custom']);
     },
     isCustom (fieldRef) {
       return fieldRef.type === 'custom';

--- a/cont3xt/vueapp/src/components/overviews/OverviewForm.vue
+++ b/cont3xt/vueapp/src/components/overviews/OverviewForm.vue
@@ -87,6 +87,7 @@
         display-text="Who Can View"
         :selected-roles="localOverview.viewRoles"
         @selected-roles-updated="updateViewRoles"
+        :disabled="isDefaultOverview"
     />
     <RoleDropdown
         :roles="getRoles"
@@ -127,16 +128,25 @@
             class="d-flex"
         >
           <b-form inline>
+            <ToggleBtn
+                class="overview-toggle-btn mr-2"
+                @toggle="toggleExpanded(fieldRef)"
+                :opened="fieldRef.expanded"
+                :class="{expanded: fieldRef.expanded, invisible: !isCustom(fieldRef)}"
+            />
+
             <b-input-group
                 size="sm">
               <template #prepend>
                 <b-input-group-text>
-                  Integration Name
+                  Source
                 </b-input-group-text>
               </template>
-              <b-form-input
+              <b-form-select
                   trim
-                  v-model="fieldRef.from"
+                  :value="fieldRef.from"
+                  @change="e => setFrom(fieldRef, e)"
+                  :options="sourceOptions"
                   :state="validateFieldRefFrom(fieldRef)"
                   @input="updateOverview"
               />
@@ -153,12 +163,14 @@
                 class="ml-2 flex-grow-1">
               <template #prepend>
                 <b-input-group-text>
-                  Field Label
+                  Field
                 </b-input-group-text>
               </template>
-              <b-form-input
+              <b-form-select
                   trim
-                  v-model="fieldRef.field"
+                  :value="getField(fieldRef)"
+                  @change="e => setField(fieldRef, e)"
+                  :options="fieldOptionsFor(fieldRef)"
                   :state="validateFieldRef(fieldRef)"
                   @input="updateOverview"
               />
@@ -171,11 +183,12 @@
               </template>
             </b-input-group>
             <b-input-group
+                v-if="!isCustom(fieldRef)"
                 size="sm"
                 class="ml-2">
               <template #prepend>
                 <b-input-group-text>
-                  Alias
+                  Label
                 </b-input-group-text>
               </template>
               <b-form-input
@@ -224,6 +237,22 @@
               </b-dropdown-item>
             </b-dropdown>
           </b-form>
+          <template v-if="fieldRef.expanded">
+            <textarea
+                rows="5"
+                size="sm"
+                :value="getOrInitCustomText(fieldRef)"
+                @input="e => debounceCustomRawEdit(fieldRef, e)"
+                class="form-control form-control-sm mt-2"
+            />
+            <b-alert
+                variant="warning"
+                :show="!!fieldRef._error"
+                class="alert-sm mt-2 mb-0">
+              <span class="fa fa-exclamation-triangle fa-fw pr-2" />
+              {{ fieldRef._error }}
+            </b-alert>
+          </template>
         </b-card>
       </template>
     </reorder-list>
@@ -242,12 +271,14 @@ import ReorderList from '@/utils/ReorderList.vue';
 import { mapGetters } from 'vuex';
 import RoleDropdown from '@../../../common/vueapp/RoleDropdown';
 import { iTypes } from '@/utils/iTypes';
+import ToggleBtn from '../../../../../common/vueapp/ToggleBtn.vue';
 
 let timeout;
 
 export default {
   name: 'OverviewForm',
   components: {
+    ToggleBtn,
     ReorderList,
     RoleDropdown
   },
@@ -280,10 +311,10 @@ export default {
         title: 'The indicator type to display this overview for... Can be either: <code>domain</code>, <code>ip</code>, <code>url</code>, <code>email</code>, <code>phone</code>, <code>hash</code>, or <code>text</code>.'
       },
       fieldRefFromTip: {
-        title: 'Enter the <code>name</code> of the Integration you would like to show a field from.'
+        title: 'Select the <code>name</code> of the Integration you would like to show a field from.'
       },
       fieldRefFieldTip: {
-        title: 'Enter the <code>label</code> of the field you would like to show from the given Integration.'
+        title: 'Select the <code>label</code> of the field you would like to show from the given Integration, or <code>Custom</code> to make your own.'
       },
       fieldRefAliasTip: {
         title: 'Optionally, change the label that will be displayed with this field.'
@@ -292,7 +323,12 @@ export default {
     };
   },
   computed: {
-    ...mapGetters(['getIntegrations', 'getRoles', 'getUser'])
+    ...mapGetters(['getIntegrations', 'getRoles', 'getUser']),
+    sourceOptions () {
+      const sources = Object.keys(this.getIntegrations);
+      sources.sort();
+      return sources;
+    }
   },
   watch: {
     modifiedOverview () {
@@ -313,6 +349,18 @@ export default {
       delete clone._editable;
       delete clone._viewable;
 
+      clone.fields ??= [];
+      for (const fieldRef of clone.fields) {
+        if (!this.isCustom(fieldRef) || !fieldRef.expanded) {
+          // expanded is only necessary to keep open currently expanded custom fields
+          delete fieldRef.expanded;
+        }
+        delete fieldRef._customRawEdit;
+        // type can be inferred from other fields (field vs custom existence)
+        //     so we don't need it for raw edit to avoid verbosity
+        delete fieldRef.type;
+      }
+
       this.rawEditText = JSON.stringify(clone, null, 2);
     }
   },
@@ -330,7 +378,7 @@ export default {
     },
     insertFieldRef (index) {
       this.localOverview.fields.splice(index, 0, {
-        from: '', field: ''
+        type: 'linked', from: '', field: ''
       });
       this.updateOverview();
     },
@@ -353,16 +401,70 @@ export default {
     sendToBottom (fromIndex) {
       this.moveFieldRef(fromIndex, this.localOverview.fields.length - 1);
     },
+    fieldOptionsFor (fieldRef) {
+      if (!this.validateFieldRefFrom(fieldRef)) { return []; }
+
+      return (this.getIntegrations[fieldRef.from]?.card?.fields?.map(field => field.label) ?? []).concat(['Custom']);
+    },
+    isCustom (fieldRef) {
+      return fieldRef.type === 'custom';
+    },
+    getOrInitCustomText (fieldRef) {
+      if (fieldRef._customRawEdit == null) {
+        this.$set(fieldRef, '_customRawEdit', JSON.stringify(fieldRef.custom ?? {}, null, 2));
+      }
+      return fieldRef._customRawEdit;
+    },
+    debounceCustomRawEdit (fieldRef, e) {
+      fieldRef._customRawEdit = e.target.value;
+      if (timeout) { clearTimeout(timeout); }
+      // debounce the textarea so that it only updates the overview after keyups cease for 400ms
+      timeout = setTimeout(() => {
+        timeout = null;
+        this.updateCustomRawEdit(fieldRef);
+      }, 400);
+    },
+    updateCustomRawEdit (fieldRef) {
+      try {
+        fieldRef.custom = JSON.parse(fieldRef._customRawEdit);
+        delete fieldRef._error;
+      } catch (err) {
+        this.$set(fieldRef, '_error', 'ERROR: Invalid JSON');
+      }
+      this.updateOverview();
+    },
     validateFieldRefFrom (fieldRef) {
-      return Object.keys(this.getIntegrations)?.includes(fieldRef.from);
+      return this.sourceOptions.includes(fieldRef.from);
     },
     validateFieldRef (fieldRef) {
-      if (!this.validateFieldRefFrom(fieldRef)) { return false; }
-
-      const integrationFields = this.getIntegrations[fieldRef.from]?.card?.fields;
-      const matchingField = integrationFields?.find(field => field.label === fieldRef.field);
-
-      return matchingField != null;
+      return this.validateFieldRefFrom(fieldRef) &&
+          (this.fieldOptionsFor(fieldRef)?.includes(fieldRef.field) || this.isCustom(fieldRef));
+    },
+    setFrom (fieldRef, from) {
+      fieldRef.from = from;
+      this.updateOverview();
+    },
+    getField (fieldRef) {
+      return this.isCustom(fieldRef) ? 'Custom' : fieldRef.field;
+    },
+    setField (fieldRef, field) {
+      if (field === 'Custom') {
+        fieldRef.type = 'custom';
+        this.$set(fieldRef, 'custom', { field: '', label: fieldRef.alias ?? '' });
+        this.$set(fieldRef, 'expanded', true);
+        delete fieldRef.field;
+      } else {
+        fieldRef.type = 'linked';
+        this.$set(fieldRef, 'field', field);
+        delete fieldRef.custom;
+        delete fieldRef._customRawEdit;
+        delete fieldRef.expanded;
+      }
+      this.updateOverview();
+    },
+    toggleExpanded (fieldRef) {
+      this.$set(fieldRef, 'expanded', !fieldRef.expanded);
+      this.updateOverview();
     },
     updateOverviewFieldsList ({ list }) {
       this.localOverview.fields = list;
@@ -380,6 +482,10 @@ export default {
     updateRawOverview () {
       try {
         const overviewFromRaw = JSON.parse(this.rawEditText);
+        overviewFromRaw.fields ??= [];
+        for (const fieldRef of overviewFromRaw.fields) {
+          fieldRef.type = (fieldRef.custom == null) ? 'linked' : 'custom';
+        }
 
         this.localOverview = {
           ...this.localOverview,
@@ -399,3 +505,10 @@ export default {
   }
 };
 </script>
+
+<style scoped>
+.overview-toggle-btn {
+  font-size: 1rem;
+  padding: 0.1rem 0.5rem;
+}
+</style>

--- a/cont3xt/vueapp/src/components/overviews/OverviewFormCard.vue
+++ b/cont3xt/vueapp/src/components/overviews/OverviewFormCard.vue
@@ -198,12 +198,18 @@ export default {
       normalizedOverview.viewRoles.sort();
       normalizedOverview.editRoles.sort();
 
+      normalizedOverview.fields ??= [];
+      for (const field of normalizedOverview.fields) { // delete temporary field properties
+        delete field.expanded;
+        delete field._customRawEdit;
+      }
+
       return normalizedOverview;
     },
     updateOverview (updatedOverview) {
-      this.localOverview = this.normalizeOverview(updatedOverview);
+      this.localOverview = JSON.parse(JSON.stringify(updatedOverview));
 
-      this.$emit('update-modified-overview', JSON.parse(JSON.stringify(this.localOverview)));
+      this.$emit('update-modified-overview', this.normalizeOverview(updatedOverview));
     },
     saveOverview () {
       OverviewService.updateOverview(this.localOverview);

--- a/cont3xt/vueapp/src/normalizeCardField.js
+++ b/cont3xt/vueapp/src/normalizeCardField.js
@@ -1,0 +1,36 @@
+const normalizeCardField = (inField) => {
+  const f = JSON.parse(JSON.stringify(inField));
+
+  if (typeof f === 'string') {
+    return {
+      label: f,
+      path: f.split('.'),
+      type: 'string'
+    };
+  }
+  if (f.field === undefined) { f.field = f.label; }
+  if (typeof f.field === 'string') { f.path = f.field.split('.'); }
+  delete f.field;
+
+  if (f.type === undefined) { f.type = 'string'; }
+
+  if (f.type === 'table') {
+    f.fields = f.fields.map(subField => normalizeCardField(subField));
+  }
+
+  if (f.type === 'array' || f.type === 'table') { // array-like types
+    if (f.filterEmpty === undefined) { f.filterEmpty = true; }
+
+    if (f.fieldRoot !== undefined) {
+      f.fieldRootPath = f.fieldRoot.split('.');
+      delete f.fieldRoot;
+    }
+  }
+
+  // disable filtering if not searchable
+  f.noSearch ??= f.type === 'externalLink';
+
+  return f;
+};
+
+module.exports = normalizeCardField;

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -1,5 +1,5 @@
 # Test cont3xt.js
-use Test::More tests => 133;
+use Test::More tests => 138;
 use Test::Differences;
 use Data::Dumper;
 use MolochTest;
@@ -263,6 +263,7 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field"
     }]
@@ -275,6 +276,7 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field"
     }]
@@ -287,6 +289,7 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field"
     }]
@@ -300,6 +303,7 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field"
     }]
@@ -342,6 +346,20 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        from => "Foo",
+        field => "foo_field"
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Field type must be either \"linked\" or \"custom\""}'));
+
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "Overview1",
+    title => "Overview of %{query}",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type => "linked",
         field => "foo_field"
     }]
 }), $token);
@@ -354,10 +372,11 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from => "Foo"
     }]
 }), $token);
-eq_or_diff($json, from_json('{"success": false, "text": "Field missing field"}'));
+eq_or_diff($json, from_json('{"success": false, "text": "Linked field missing field"}'));
 
 $json = cont3xtPutToken("/api/overview", to_json({
     name => "Overview1",
@@ -366,12 +385,76 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field",
         alias => 1
     }]
 }), $token);
-eq_or_diff($json, from_json('{"success": false, "text": "Field alias must be a string or undefined"}'));
+eq_or_diff($json, from_json('{"success": false, "text": "Linked field alias must be a string or undefined"}'));
+
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "Overview1",
+    title => "Overview of %{query}",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type => "custom",
+        from => "Foo"
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Custom field must be a string or object"}'));
+
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "Overview1",
+    title => "Overview of %{query}",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type   => "custom",
+        from => "Foo",
+        custom => 1
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Custom field must be a string or object"}'));
+
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "Overview1",
+    title => "Overview of %{query}",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type   => "custom",
+        from => "Foo",
+        custom => {
+            label => "foo name",
+            field => "foo.bar"
+        },
+        field  => "baz"
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Custom field must not have field"}'));
+
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "Overview1",
+    title => "Overview of %{query}",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type   => "custom",
+        from => "Foo",
+        custom => {
+            label => "foo name",
+            field => "foo.bar"
+        },
+        alias  => "foo-ier name"
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Custom field must not have alias"}'));
 
 $json = cont3xtPutToken("/api/overview", to_json({
     name => "Overview1",
@@ -380,6 +463,7 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => 1,
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field"
     }]
@@ -393,6 +477,7 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => [1],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field"
     }]
@@ -406,6 +491,7 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => 1,
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field"
     }]
@@ -419,6 +505,7 @@ $json = cont3xtPutToken("/api/overview", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => [1],
     fields => [{
+        type => "linked",
         from => "Foo",
         field => "foo_field"
     }]
@@ -433,6 +520,7 @@ $json = cont3xtPut('/api/overview', to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from  => "Foo",
         field => "foo_field"
     }]
@@ -446,8 +534,17 @@ $json = cont3xtPutToken('/api/overview', to_json({
     viewRoles => ["superAdmin"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from  => "Foo",
         field => "foo_field"
+    }, {
+        type => "custom",
+        from => "Foo",
+        custom => {
+            field  => "foo.bar",
+            label  => "Foo Bar",
+            type   => "array"
+        }
     }]
 }), $token);
 eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
@@ -455,7 +552,7 @@ eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 $json = cont3xtGet('/api/overview');
 my $id = $json->{overviews}->[0]->{_id};
 delete $json->{overviews}->[0]->{_id};
-eq_or_diff($json, from_json('{"overviews":[{"creator":"anonymous","_editable":true,"_viewable": true, "viewRoles":["superAdmin"],"fields":[{"from":"Foo","field":"foo_field"}],"name":"Overview1","title":"Overview of %{query}","iType":"domain","editRoles":["superAdmin"]}],"success":true}'));
+eq_or_diff($json, from_json('{"overviews":[{"creator":"anonymous","_editable":true,"_viewable": true, "viewRoles":["superAdmin"],"fields":[{"type":"linked","from":"Foo","field":"foo_field"},{"type":"custom","from":"Foo","custom":{"field":"foo.bar","label":"Foo Bar","type":"array"}}],"name":"Overview1","title":"Overview of %{query}","iType":"domain","editRoles":["superAdmin"]}],"success":true}'));
 
 $json = cont3xtPutToken("/api/overview/$id", to_json({
     name => "Overview1 v2",
@@ -464,8 +561,13 @@ $json = cont3xtPutToken("/api/overview/$id", to_json({
     viewRoles => ["cont3xtUser"],
     editRoles => ["superAdmin"],
     fields => [{
+        type => "linked",
         from  => "Foo",
         field => "bar_field"
+    }, {
+        type   => "custom",
+        from  => "Foo",
+        custom => "foo.bar"
     }]
 }), $token);
 eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
@@ -473,7 +575,7 @@ eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 $json = cont3xtGet('/api/overview');
 my $id = $json->{overviews}->[0]->{_id};
 delete $json->{overviews}->[0]->{_id};
-eq_or_diff($json, from_json('{"overviews":[{"creator":"anonymous","_editable":true,"_viewable": true, "viewRoles":["cont3xtUser"],"fields":[{"from":"Foo","field":"bar_field"}],"name":"Overview1 v2","title":"Overview v2 of %{query}","iType":"ip","editRoles":["superAdmin"]}],"success":true}'));
+eq_or_diff($json, from_json('{"overviews":[{"creator":"anonymous","_editable":true,"_viewable": true, "viewRoles":["cont3xtUser"],"fields":[{"type":"linked","from":"Foo","field":"bar_field"},{"type":"custom","from":"Foo","custom":"foo.bar"}],"name":"Overview1 v2","title":"Overview v2 of %{query}","iType":"ip","editRoles":["superAdmin"]}],"success":true}'));
 
 # delete overview requires token
 $json = cont3xtDelete("/api/overview/$id", "{}");


### PR DESCRIPTION
* custom fields can be created by selecting Custom at the bottom of the options for field in an Overview config.
* the custom object (which is the same format as index.js card fields) can be edited in the local raw edit box by expanding or in the full json raw edit page
* type:linked and type:custom to differentiate field types
* verify custom object on backend and store as a json string
* updated cont3xt overview tests
* improve warnings on OverviewCard for certain bad field configs (linked: typo in from/field name; custom: missing path)
* normalizeCardField shared between frontend/backend