### PR TITLE
remove results between pages

### DIFF
--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -501,6 +501,11 @@ export default {
 
     // needs to be unfocused to focus again later with hotkey (subsequent focuses are unfocused in store)
     this.$store.commit('SET_FOCUS_SEARCH', false);
+
+    // clear existing results from the store (in case the user made a search and then came back to this page from another)
+    this.$store.commit('CLEAR_CONT3XT_RESULTS');
+    this.activeSource = undefined;
+    this.activeIndicator = undefined;
   },
   computed: {
     ...mapGetters([


### PR DESCRIPTION
* there was a bug where:
> * If the user makes a search, goes to a different page, then comes back to Cont3xt page, they could see the tip of the search results at the bottom of the page.

* this is fixed by clearing results in the store via the Cont3xt page's `mounted()`
