### PR TITLE
move DnsRecords into IntegrationValue

### DIFF
--- a/cont3xt/descriptions.txt
+++ b/cont3xt/descriptions.txt
@@ -13,6 +13,7 @@ Card Description - an object of the following
     * otherwise it can be an object with
       * label - the field label to show the user
       * field - the path (it can have dots) to the data for field, if not set the field is the same as name. For table type this will be the path to the array.
+      * path - alternative to field, this is the field path pre-separated into a string array (eg. field: 'foo.bar' is equivalent to path: ['foo', 'bar'])
       * fields - for tables, the list of fields, same format as this
       * type - if not set it is string
         * string - obvious
@@ -24,10 +25,12 @@ Card Description - an object of the following
         * ms - a ms time value
         * seconds - a second time value
         * json - just display raw json, call in JSON.stringify(blah, false, 2)
+        * dnsRecords - display of non-A/AAAA dns records (for use with DNS integration and `path: []`)
       * defang - when true defang the string, change http to hXXp and change . to [.]
       * pivot - when set this field should be added to action menu for table entry that you can replace query with
       * join - with array, display with value as the separator on one line (example single: ', ')
       * fieldRoot - for arrays/tables, the path (it can have dots) from each object in the array to its desired field. Effectively maps the root array of objects to an array of values/sub-objects.
+      * fieldRootPath - alternative to fieldRoot, this is the fieldRoot path pre-separated into a string array (eg. fieldRoot: 'foo.bar' is equivalent to fieldRootPath: ['foo', 'bar'])
       * filterEmpty - for arrays/tables, removes empty (nullish & empty string/array) rows/elements when true (default is true)
       * defaultSortField - with array, sorts the table by this field
       * defaultSortDirection - with array and defaultSortField, sorts the table in this direction ('asc' or 'desc')

--- a/cont3xt/vueapp/src/components/integrations/IntegrationValue.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationValue.vue
@@ -125,6 +125,10 @@
             :content="value.value"
             :highlights="highlights"/></code></pre>
       </template> <!-- /json field -->
+      <!-- DnsRecords field -->
+      <template v-else-if="field.type === 'dnsRecords'">
+        <DnsRecords :data="value.value" />
+      </template> <!-- /DnsRecords field -->
       <!-- /default string, ms, seconds, & date field -->
       <template v-else>
         <template v-if="field.pivot">
@@ -151,10 +155,12 @@ import IntegrationArray from '@/components/integrations/IntegrationArray';
 import IntegrationTable from '@/components/integrations/IntegrationTable';
 import HighlightableText from '@/utils/HighlightableText';
 import { formatPostProcessedValue } from '@/utils/formatValue';
+import DnsRecords from '@/utils/DnsRecords.vue';
 
 export default {
   name: 'IntegrationValue',
   components: {
+    DnsRecords,
     Cont3xtField,
     IntegrationArray,
     IntegrationTable,
@@ -197,7 +203,7 @@ export default {
       let value = this.findValue(this.data, this.field);
 
       // truncate long values
-      if (this.truncate && value && value.length > (this.field.len || 100)) {
+      if (this.truncate && value && typeof value === 'string' && value.length > (this.field.len || 100)) {
         full = value;
         value = `${value.substring(0, this.field.len || 100)}...`;
       }

--- a/cont3xt/vueapp/src/components/itypes/Domain.vue
+++ b/cont3xt/vueapp/src/components/itypes/Domain.vue
@@ -3,50 +3,10 @@
       :indicator="indicator"
       :tidbits="tidbits"
       :children="children"
-  >
-    <!--  non-ip dns records  -->
-    <template #after-children>
-      <template v-if="integrationDataMap.DNS">
-        <div
-            :key="key"
-            class="row medium"
-            v-for="(value, key) in integrationDataMap.DNS">
-          <div class="col"
-               v-if="value.Answer && value.Answer.length">
-            <dl v-if="key !== 'A' && key !== 'AAAA'"
-                class="dl-horizontal">
-              <dt>
-                {{ key }}
-                ({{ value.Answer.length }})
-              </dt>
-              <dd>
-                <div v-for="(group, groupIndex) in answerGroups(key, value.Answer)" :key="`${key}-${groupIndex}`">
-                  <hr v-if="groupIndex > 0" class="m-0 bg-secondary">
-                  <template v-for="(item, index) in group">
-                    <cont3xt-field
-                        :id="`${key}-${groupIndex}-${index}`"
-                        :key="`${key}-${groupIndex}-${index}`"
-                        :value="item.data"
-                    />
-                    <ttl-tooltip
-                      :ttl="item.TTL"
-                      :key="`${key}-${groupIndex}-${index}-ttl`"
-                      :target="`${key}-${groupIndex}-${index}`"
-                    />
-                  </template>
-                </div>
-              </dd>
-            </dl>
-          </div>
-        </div>
-      </template>
-    </template><!--  /non-ip dns records  -->
-  </base-i-type>
+  />
 </template>
 
 <script>
-import Cont3xtField from '@/utils/Field';
-import TtlTooltip from '@/utils/TtlTooltip';
 import BaseIType from '@/components/itypes/BaseIType';
 import { ITypeMixin } from './ITypeMixin';
 import { Cont3xtIndicatorProp } from '@/utils/cont3xtUtil';
@@ -54,43 +14,12 @@ import { Cont3xtIndicatorProp } from '@/utils/cont3xtUtil';
 export default {
   name: 'Cont3xtDomain',
   mixins: [ITypeMixin], // for tidbits
-  components: {
-    Cont3xtField,
-    TtlTooltip,
-    BaseIType
-  },
+  components: { BaseIType },
   props: {
     indicator: Cont3xtIndicatorProp,
     children: {
       type: Array,
       required: true
-    }
-  },
-  methods: {
-    // splits the elements of an Answer into groups to have horizontal rules in between
-    answerGroups (recordType, answer) {
-      // split txt records into domain-verification, site-verification, other
-      if (recordType === 'TXT') {
-        return this.txtGroups(answer);
-      }
-      // most record types only have 1 group, so make an array of size one
-      return [answer];
-    },
-    // grouping for TXT records
-    txtGroups (answer) {
-      const txtGroups = [[], [], []]; // initialize for all 3 possible groups
-      for (const txtEntry of answer) {
-        txtGroups[this.txtGroupIndex(txtEntry.data)].push(txtEntry);
-      }
-      // filter out empty groups, then sort alphabetically within groups
-      const filteredTxtGroups = txtGroups.filter(group => group.length > 0);
-      filteredTxtGroups.forEach(group => group.sort((a, b) => a.data.localeCompare(b.data)));
-      return filteredTxtGroups;
-    },
-    txtGroupIndex (txtData) {
-      if (txtData.includes('domain-verification')) { return 0; }
-      if (txtData.includes('site-verification')) { return 1; }
-      return 2;
     }
   }
 };

--- a/cont3xt/vueapp/src/components/overviews/OverviewFormCard.vue
+++ b/cont3xt/vueapp/src/components/overviews/OverviewFormCard.vue
@@ -43,8 +43,14 @@
         <b-card v-for="(field, i) in localOverview.fields" :key="i"
                 class="mb-1"
         >
-          <span class="text-warning bold">{{ field.from }}</span> <span class="text-primary">{{ field.field }}</span>
-          <span v-if="field.alias">as <span class="text-info">"{{ field.alias }}"</span></span>
+          <span class="text-warning bold">{{ field.from }}</span>
+          <template v-if="field.type === 'custom'">
+            <span class="text-primary">Custom</span>:<span class="text-info">"{{ normalizeCardField(field.custom).label }}"</span>
+          </template>
+          <template v-else>
+            <span class="text-primary">{{ field.field }}</span>
+            <span v-if="field.alias">as <span class="text-info">"{{ field.alias }}"</span></span>
+          </template>
         </b-card>
       </div>
     </b-card-body>
@@ -153,6 +159,7 @@ import { mapGetters } from 'vuex';
 import OverviewService from '@/components/services/OverviewService';
 import UserService from '@/components/services/UserService';
 import OverviewForm from '@/components/overviews/OverviewForm';
+import normalizeCardField from '../../normalizeCardField';
 
 export default {
   name: 'OverviewFormCard',
@@ -192,6 +199,7 @@ export default {
     }
   },
   methods: {
+    normalizeCardField,
     normalizeOverview (unNormalizedOverview) {
       const normalizedOverview = JSON.parse(JSON.stringify(unNormalizedOverview));
       // sort roles, as their order should not matter

--- a/cont3xt/vueapp/src/normalizeCardField.js
+++ b/cont3xt/vueapp/src/normalizeCardField.js
@@ -9,7 +9,7 @@ const normalizeCardField = (inField) => {
     };
   }
   if (f.field === undefined) { f.field = f.label; }
-  if (typeof f.field === 'string') { f.path = f.field.split('.'); }
+  if (typeof f.field === 'string') { f.path ??= f.field.split('.'); }
   delete f.field;
 
   if (f.type === undefined) { f.type = 'string'; }
@@ -22,7 +22,7 @@ const normalizeCardField = (inField) => {
     if (f.filterEmpty === undefined) { f.filterEmpty = true; }
 
     if (f.fieldRoot !== undefined) {
-      f.fieldRootPath = f.fieldRoot.split('.');
+      f.fieldRootPath ??= f.fieldRoot.split('.');
       delete f.fieldRoot;
     }
   }

--- a/cont3xt/vueapp/src/utils/DnsRecords.vue
+++ b/cont3xt/vueapp/src/utils/DnsRecords.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="d-flex flex-column">
+    <div
+        :key="key"
+        class="row medium"
+        v-for="(value, key) in data">
+      <div class="col"
+           v-if="value.Answer && value.Answer.length">
+        <dl v-if="key !== 'A' && key !== 'AAAA'"
+            class="dl-horizontal">
+          <dt>
+            {{ key }}
+            ({{ value.Answer.length }})
+          </dt>
+          <dd>
+            <div v-for="(group, groupIndex) in answerGroups(key, value.Answer)" :key="`${key}-${groupIndex}`">
+              <hr v-if="groupIndex > 0" class="m-0 bg-secondary">
+              <template v-for="(item, index) in group">
+                <cont3xt-field
+                    :id="`${key}-${groupIndex}-${index}`"
+                    :key="`${key}-${groupIndex}-${index}`"
+                    :value="item.data"
+                />
+                <ttl-tooltip
+                    :ttl="item.TTL"
+                    :key="`${key}-${groupIndex}-${index}-ttl`"
+                    :target="`${key}-${groupIndex}-${index}`"
+                />
+              </template>
+            </div>
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Cont3xtField from '@/utils/Field.vue';
+import TtlTooltip from '@/utils/TtlTooltip.vue';
+
+export default {
+  name: 'DnsRecords',
+  components: { TtlTooltip, Cont3xtField },
+  props: {
+    data: {
+      type: Object,
+      required: true
+    }
+  },
+  methods: {
+    // splits the elements of an Answer into groups to have horizontal rules in between
+    answerGroups (recordType, answer) {
+      // split txt records into domain-verification, site-verification, other
+      if (recordType === 'TXT') {
+        return this.txtGroups(answer);
+      }
+      // most record types only have 1 group, so make an array of size one
+      return [answer];
+    },
+    // grouping for TXT records
+    txtGroups (answer) {
+      const txtGroups = [[], [], []]; // initialize for all 3 possible groups
+      for (const txtEntry of answer) {
+        txtGroups[this.txtGroupIndex(txtEntry.data)].push(txtEntry);
+      }
+      // filter out empty groups, then sort alphabetically within groups
+      const filteredTxtGroups = txtGroups.filter(group => group.length > 0);
+      filteredTxtGroups.forEach(group => group.sort((a, b) => a.data.localeCompare(b.data)));
+      return filteredTxtGroups;
+    },
+    txtGroupIndex (txtData) {
+      if (txtData.includes('domain-verification')) { return 0; }
+      if (txtData.includes('site-verification')) { return 1; }
+      return 2;
+    }
+  }
+};
+</script>


### PR DESCRIPTION
* removed DNS records from under domain
* add DNS > Custom with config `{"label":"some label","type":"dnsRecords", "path":[]}` in a domain overview to display records as an overview field
* type check to fix IntegrationValue bug --> only truncate string values
* updated descriptions.txt with `dnsRecords`, `path`, and `fieldRootPath`
* normalizeCardField uses original `path` and `fieldRootPath` if they already exist