### PR TITLE
no raw view for result link group

### DIFF
--- a/cont3xt/vueapp/src/components/links/LinkGroupCard.vue
+++ b/cont3xt/vueapp/src/components/links/LinkGroupCard.vue
@@ -16,8 +16,8 @@
           v-b-tooltip.hover="`Shared with you by ${linkGroup.creator}`"
         />
         {{ linkGroup.name }}
-        <div class="pull-right">
-          <small v-if="!itype && getUser && linkGroup.creator !== getUser.userId">
+        <div v-if="!itype && getUser && linkGroup.creator !== getUser.userId" class="pull-right">
+          <small>
             You can only view this Link Group
           </small>
           <b-button


### PR DESCRIPTION
* the raw view button was (unintentionally) being displayed for link groups on the cont3xt search page as well