### PR TITLE
add color counts for indicator nodes

### DIFF
--- a/cont3xt/vueapp/src/components/integrations/IntegrationSeverityCounts.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationSeverityCounts.vue
@@ -1,0 +1,95 @@
+<template>
+  <div class="d-flex flex-row text-nowrap severity-badge-container">
+    <span v-if="severityTypes.some(severity => severityCounts[severity])" class="mr-1">
+      <span :id="`severity-counts:${indicatorId(indicator)}`">
+        <template v-for="severity in severityTypes">
+          <b-badge v-if="severityCounts[severity]"
+                   :key="severity"
+                   class="severity-badge"
+                   :variant="severity">
+            {{ severityCounts[severity] }}
+          </b-badge>
+        </template>
+      </span>
+      <b-tooltip :target="`severity-counts:${indicatorId(indicator)}`" placement="top">
+        <div class="d-flex flex-column gap-1">
+          <template v-for="severity in severityTypes">
+            <div v-if="severityCounts[severity]" :key="severity" class="d-flex flex-row">
+              <span class="severity-emoji align-self-center mr-2">
+                {{ severityEmojiMap[severity] }}
+              </span>
+              <integration-btns
+                  :indicator="indicator"
+                  :count-severity-filter="severity"/>
+            </div>
+          </template>
+        </div>
+      </b-tooltip>
+    </span>
+  </div>
+</template>
+
+<script>
+import {
+  Cont3xtIndicatorProp,
+  getIntegrationDataMap,
+  shouldDisplayCountedIntegrationBtn,
+  integrationCountSeverity, indicatorId
+} from '@/utils/cont3xtUtil';
+import { mapGetters } from 'vuex';
+import IntegrationBtns from '@/components/integrations/IntegrationBtns.vue';
+export default {
+  name: 'IntegrationSeverityCounts',
+  components: { IntegrationBtns },
+  methods: { indicatorId },
+  props: {
+    indicator: Cont3xtIndicatorProp
+  },
+  data () {
+    return {
+      severityTypes: ['success', 'secondary', 'danger'],
+      severityEmojiMap: {
+        success: '😀',
+        secondary: '😐',
+        danger: '😡'
+      }
+    };
+  },
+  computed: {
+    ...mapGetters(['getResults', 'getIntegrationsArray']),
+    integrationDataMap () {
+      return getIntegrationDataMap(this.getResults, this.indicator);
+    },
+    severityCounts () {
+      const counts = { secondary: 0, success: 0, danger: 0 };
+      for (const integration of this.getIntegrationsArray) {
+        const integrationData = this.integrationDataMap[integration.name];
+        if (shouldDisplayCountedIntegrationBtn(integration, integrationData)) {
+          counts[integrationCountSeverity(integrationData)]++;
+        }
+      }
+      return counts;
+    }
+  }
+};
+</script>
+
+<style scoped>
+.severity-badge-container {
+  height: min-content;
+  align-self: center;
+}
+/* first and/or middle */
+.severity-badge:not(:last-child) {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+/* middle and/or last */
+.severity-badge:not(:first-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.severity-emoji {
+  font-size: 1.5rem;
+}
+</style>

--- a/cont3xt/vueapp/src/components/itypes/BaseIType.vue
+++ b/cont3xt/vueapp/src/components/itypes/BaseIType.vue
@@ -10,6 +10,9 @@
             class="align-self-center mr-1"
             :id="`${indicator.query}-${indicator.itype}`"
         />
+
+        <integration-severity-counts :indicator="indicator" />
+
         <!--    unlabeled tidbits    -->
         <template v-for="(tidbit, index) in unlabeledTidbits">
           <integration-tidbit :tidbit="tidbit" :key="index"
@@ -41,6 +44,7 @@ import Cont3xtField from '@/utils/Field';
 import IntegrationTidbit from '@/components/integrations/IntegrationTidbit';
 import { mapGetters } from 'vuex';
 import { Cont3xtIndicatorProp } from '@/utils/cont3xtUtil';
+import IntegrationSeverityCounts from '@/components/integrations/IntegrationSeverityCounts.vue';
 
 export default {
   name: 'BaseIType',
@@ -50,7 +54,8 @@ export default {
     // see: vuejs.org/v2/guide/components.html#Circular-References-Between-Components
     ITypeNode: () => import('@/components/itypes/ITypeNode'),
     Cont3xtField,
-    IntegrationTidbit
+    IntegrationTidbit,
+    IntegrationSeverityCounts
   },
   props: {
     indicator: Cont3xtIndicatorProp,

--- a/cont3xt/vueapp/src/cont3xt.css
+++ b/cont3xt/vueapp/src/cont3xt.css
@@ -37,3 +37,7 @@ td .integration-external-link-button {
     border-radius: 14px;
     background: var(--secondary);
 }
+
+.gap-1 {
+    gap: 0.25rem;
+}

--- a/cont3xt/vueapp/src/utils/cont3xtUtil.js
+++ b/cont3xt/vueapp/src/utils/cont3xtUtil.js
@@ -30,3 +30,21 @@ export function getIntegrationData (results, indicator, source) {
 export function indicatorId (indicator) {
   return `${indicator.query}-${indicator.itype}`;
 }
+
+export function shouldDisplayIntegrationBtn (integration, integrationData) {
+  return integrationData != null && integration?.icon != null;
+}
+
+export function shouldDisplayCountedIntegrationBtn (integration, integrationData) {
+  return shouldDisplayIntegrationBtn(integration, integrationData) && integrationData?._cont3xt?.count != null;
+}
+
+export function integrationCountSeverity (integrationData) {
+  if (integrationData._cont3xt.count === 0) {
+    return 'secondary';
+  } else if (integrationData._cont3xt.severity === 'high') {
+    return 'danger';
+  } else {
+    return 'success';
+  }
+}


### PR DESCRIPTION
* add severity counts to indicator result nodes
* hover tooltip displays clickable Integrations Buttons per category (green counts, grey counts, red counts)
* counts of zero are not shown, so if all are zero, nothing will appear
* IntegrationBtns minor refactors + severity filter added (for use in color-counter tooltip)