### PR TITLE
shorten link groups start stop

### DIFF
--- a/cont3xt/vueapp/src/components/links/LinkGroupCard.vue
+++ b/cont3xt/vueapp/src/components/links/LinkGroupCard.vue
@@ -424,13 +424,13 @@ export default {
         .replace(/\${type}/g, this.itype)
         .replace(/\${numDays}/g, this.numDays)
         .replace(/\${numHours}/g, this.numHours)
-        .replace(/\${stopTS}/g, this.stopDate)
+        .replace(/\${(stop|end)Ts}/g, this.stopDate)
         .replace(/\${startTS}/g, this.startDate)
-        .replace(/\${stopDate}/g, this.stopDate.split('T')[0])
+        .replace(/\${(stop|end)Date}/g, this.stopDate.split('T')[0])
         .replace(/\${startDate}/g, this.startDate.split('T')[0])
-        .replace(/\${stopEpoch}/g, new Date(this.stopDate).getTime() / 1000)
+        .replace(/\${(stop|end)Epoch}/g, new Date(this.stopDate).getTime() / 1000)
         .replace(/\${startEpoch}/g, new Date(this.startDate).getTime() / 1000)
-        .replace(/\${stopSplunk}/g, moment(this.stopDate).format('MM/DD/YYYY:HH:mm:ss'))
+        .replace(/\${(stop|end)Splunk}/g, moment(this.stopDate).format('MM/DD/YYYY:HH:mm:ss'))
         .replace(/\${startSplunk}/g, moment(this.startDate).format('MM/DD/YYYY:HH:mm:ss'));
     },
     openAllLinks (linkGroup) {

--- a/cont3xt/vueapp/src/components/links/LinkGroupCard.vue
+++ b/cont3xt/vueapp/src/components/links/LinkGroupCard.vue
@@ -424,13 +424,13 @@ export default {
         .replace(/\${type}/g, this.itype)
         .replace(/\${numDays}/g, this.numDays)
         .replace(/\${numHours}/g, this.numHours)
-        .replace(/\${(stop|end)Ts}/g, this.stopDate)
+        .replace(/\${(stopTs|endTs)}/g, this.stopDate)
         .replace(/\${startTS}/g, this.startDate)
-        .replace(/\${(stop|end)Date}/g, this.stopDate.split('T')[0])
+        .replace(/\${(stopDate|endDate)}/g, this.stopDate.split('T')[0])
         .replace(/\${startDate}/g, this.startDate.split('T')[0])
-        .replace(/\${(stop|end)Epoch}/g, new Date(this.stopDate).getTime() / 1000)
+        .replace(/\${(stopEpoch|endEpoch)}/g, new Date(this.stopDate).getTime() / 1000)
         .replace(/\${startEpoch}/g, new Date(this.startDate).getTime() / 1000)
-        .replace(/\${(stop|end)Splunk}/g, moment(this.stopDate).format('MM/DD/YYYY:HH:mm:ss'))
+        .replace(/\${(stopSplunk|endSplunk)}/g, moment(this.stopDate).format('MM/DD/YYYY:HH:mm:ss'))
         .replace(/\${startSplunk}/g, moment(this.startDate).format('MM/DD/YYYY:HH:mm:ss'));
     },
     openAllLinks (linkGroup) {

--- a/cont3xt/vueapp/src/components/links/LinkGroupForm.vue
+++ b/cont3xt/vueapp/src/components/links/LinkGroupForm.vue
@@ -309,7 +309,7 @@ export default {
       draggedOver: undefined,
       linkTip: {
         /* eslint-disable no-template-curly-in-string */
-        title: 'These values within links will be filled in <code>${indicator}</code>, <code>${startDate}</code>, <code>${stopDate}</code>, <code>${startTS}</code>, <code>${stopTS}</code>, <code>${numDays}</code>, <code>${numHours}</code>, <code>${type}</code><br><a target="_blank" href="help#linkgroups">more info</a>'
+        title: 'These values within links will be filled in <code>${indicator}</code>, <code>${type}</code>, <code>${numDays}</code>, <code>${numHours}</code>, <code>${startDate}</code>, <code>${endDate}</code>, <code>${startTS}</code>, <code>${endTS}</code>, <code>${startEpoch}</code>, <code>${endEpoch}</code>, <code>${startSplunk}</code>, <code>${endSplunk}</code><br><a target="_blank" href="help#linkgroups">more info</a>'
       },
       linkInfoTip: {
         title: 'Use this field to provide guidance about this link. It will be shown as an <span class="fa fa-info-circle cursor-help"></span> tooltip.'

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -291,7 +291,7 @@
                           variant="dark"
                           class="text-center">
                         There is no overview configured for the <strong>{{ this.activeIndicator.itype }}</strong> iType.
-                        <a class="no-decoration" href="settings#overviews">Create one here!</a>
+                        <a class="no-decoration" href="settings#overviews">Create one!</a>
                       </b-alert>
                     </template>
                     <integration-card
@@ -433,8 +433,8 @@
                     There are no Link Groups that match your search.
                   </span>
                   <span v-else class="p-1">
-                    There are no Link Groups for the <strong>{{ this.rootIndicator.itype }}</strong> iType.
-                    <a class="no-decoration" href="settings#linkgroups">Create one here!</a>
+                    There are no Link Groups for the <strong>{{ activeIndicator.itype }}</strong> iType.
+                    <a class="no-decoration" href="settings#linkgroups">Create one!</a>
                   </span> <!-- /no link groups message -->
                 </div> <!-- /link groups -->
               </div>

--- a/cont3xt/vueapp/src/components/pages/Help.vue
+++ b/cont3xt/vueapp/src/components/pages/Help.vue
@@ -148,20 +148,20 @@
           <dd>The number of days defined in the "Days" input</dd>
           <dt>${numHours}</dt>
           <dd>The number of hours defined in the "Hours" input</dd>
-          <dt>${stopTS}</dt>
-          <dd>The stop date timestamp defined in the "Stop Date" input (YYYY-mm-ddTHH.mm.ssZ)</dd>
+          <dt>${endTS}</dt>
+          <dd>The end date timestamp defined in the "End Date" input (YYYY-mm-ddTHH.mm.ssZ)</dd>
           <dt>${startTS}</dt>
           <dd>The start date timestamp defined in the "Start Date" input (YYYY-mm-ddTHH.mm.ssZ)</dd>
-          <dt>${stopDate}</dt>
-          <dd>The stop date defined in the "Stop Date" input (YYYY-mm-dd)</dd>
+          <dt>${endDate}</dt>
+          <dd>The end date defined in the "End Date" input (YYYY-mm-dd)</dd>
           <dt>${startDate}</dt>
           <dd>The start date defined in the "Start Date" input (YYYY-mm-dd)</dd>
-          <dt>${stopEpoch}</dt>
-          <dd>The stop date timestamp since epoch (in seconds) in the "Stop Date" input</dd>
+          <dt>${endEpoch}</dt>
+          <dd>The end date timestamp since epoch (in seconds) in the "End Date" input</dd>
           <dt>${startEpoch}</dt>
           <dd>The start date timestamp since epoch (in seconds) defined in the "Start Date" input</dd>
-          <dt>${stopSplunk}</dt>
-          <dd>The stop date timestamp defined in the "Stop Date" input (MM/DD/YYYY:HH:mm:ss)</dd>
+          <dt>${endSplunk}</dt>
+          <dd>The end date timestamp defined in the "End Date" input (MM/DD/YYYY:HH:mm:ss)</dd>
           <dt>${startSplunk}</dt>
           <dd>The start date timestamp defined in the "Start Date" input (MM/DD/YYYY:HH:mm:ss)</dd>
         </dl>

--- a/cont3xt/vueapp/src/utils/TimeRangeInput.vue
+++ b/cont3xt/vueapp/src/utils/TimeRangeInput.vue
@@ -32,7 +32,7 @@
         class="mr-2">
       <template #prepend>
         <b-input-group-text>
-          Stop
+          End
         </b-input-group-text>
       </template>
       <b-form-input
@@ -83,7 +83,7 @@ export default {
     },
     inputWidth: {
       type: String,
-      default: '152px'
+      default: '146px'
     }
   },
   data () {


### PR DESCRIPTION
* Change Stop to End
* Reduce default fixed size for time inputs
* remove web 1.0 terminology ("here" in links)
* Also fix `No Link Groups for ${itype}` to match active indicator instead of root indicator