### PR TITLE
bulk search

### DIFF
--- a/cont3xt/vueapp/src/components/integrations/IntegrationBtns.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationBtns.vue
@@ -36,10 +36,9 @@
 <script>
 import { mapGetters } from 'vuex';
 import {
-  Cont3xtIndicatorProp,
   getIntegrationDataMap,
   shouldDisplayIntegrationBtn,
-  integrationCountSeverity, shouldDisplayCountedIntegrationBtn
+  integrationCountSeverity, shouldDisplayCountedIntegrationBtn, indicatorFromId
 } from '@/utils/cont3xtUtil';
 
 // Clicking an integration button commits to the store which integration, itype,
@@ -50,13 +49,14 @@ export default {
   name: 'IntegrationBtns',
   props: {
     /**
-     * object of { itype, query }
-     * * itype - the itype to display the integration data for (if clicked)
-     * * query - the value of the query to display the integration data for
-     * *     (there may be multiple IPs for instance, so the value
-     * *     indicates which IP to display information for)
+     * the global indicator id to display integration buttons for
+     *   we use the id instead of indicator itself to ensure that
+     *   the correct node is selected in the UI when a button is pressed
      */
-    indicator: Cont3xtIndicatorProp,
+    indicatorId: {
+      type: String,
+      required: true
+    },
     /**
      * undefined - show all integrations
      * 'success' | 'secondary' | 'danger' - show only integration buttons with that icon color/severity
@@ -68,6 +68,16 @@ export default {
   },
   computed: {
     ...mapGetters(['getIntegrationsArray', 'getLoading', 'getResults']),
+    /**
+     * object of { itype, query }
+     * * itype - the itype to display the integration data for (if clicked)
+     * * query - the value of the query to display the integration data for
+     * *     (there may be multiple IPs for instance, so the value
+     * *     indicates which IP to display information for)
+     */
+    indicator () {
+      return indicatorFromId(this.indicatorId);
+    },
     integrations () {
       return this.getIntegrationsArray.slice().sort((a, b) => {
         return a.order - b.order;
@@ -97,7 +107,7 @@ export default {
     shouldDisplayCountedIntegrationBtn,
     integrationCountSeverity,
     setAsActive (integration) {
-      this.$store.commit('SET_QUEUED_INTEGRATION', { indicator: this.indicator, source: integration.name });
+      this.$store.commit('SET_QUEUED_INTEGRATION', { indicatorId: this.indicatorId, source: integration.name });
     }
   }
 };

--- a/cont3xt/vueapp/src/components/integrations/IntegrationSeverityCounts.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationSeverityCounts.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="d-flex flex-row text-nowrap severity-badge-container">
     <span v-if="severityTypes.some(severity => severityCounts[severity])" class="mr-1">
-      <span :id="`severity-counts:${indicatorId(indicator)}`">
+      <span :id="`${indicatorId}-severity-counts`">
         <template v-for="severity in severityTypes">
           <b-badge v-if="severityCounts[severity]"
                    :key="severity"
@@ -11,7 +11,7 @@
           </b-badge>
         </template>
       </span>
-      <b-tooltip :target="`severity-counts:${indicatorId(indicator)}`" placement="top">
+      <b-tooltip :target="`${indicatorId}-severity-counts`" placement="top">
         <div class="d-flex flex-column gap-1">
           <template v-for="severity in severityTypes">
             <div v-if="severityCounts[severity]" :key="severity" class="d-flex flex-row">
@@ -19,7 +19,7 @@
                 {{ severityEmojiMap[severity] }}
               </span>
               <integration-btns
-                  :indicator="indicator"
+                  :indicator-id="indicatorId"
                   :count-severity-filter="severity"/>
             </div>
           </template>
@@ -31,19 +31,20 @@
 
 <script>
 import {
-  Cont3xtIndicatorProp,
   getIntegrationDataMap,
   shouldDisplayCountedIntegrationBtn,
-  integrationCountSeverity, indicatorId
+  integrationCountSeverity, indicatorFromId
 } from '@/utils/cont3xtUtil';
 import { mapGetters } from 'vuex';
 import IntegrationBtns from '@/components/integrations/IntegrationBtns.vue';
 export default {
   name: 'IntegrationSeverityCounts',
   components: { IntegrationBtns },
-  methods: { indicatorId },
   props: {
-    indicator: Cont3xtIndicatorProp
+    indicatorId: {
+      type: String,
+      required: true
+    }
   },
   data () {
     return {
@@ -58,7 +59,7 @@ export default {
   computed: {
     ...mapGetters(['getResults', 'getIntegrationsArray']),
     integrationDataMap () {
-      return getIntegrationDataMap(this.getResults, this.indicator);
+      return getIntegrationDataMap(this.getResults, indicatorFromId(this.indicatorId));
     },
     severityCounts () {
       const counts = { secondary: 0, success: 0, danger: 0 };

--- a/cont3xt/vueapp/src/components/integrations/IntegrationTidbit.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationTidbit.vue
@@ -31,7 +31,7 @@
       />
     </template>
     <template v-else-if="groupColorNames.includes(tidbit.display)">
-      <h5 :id="id" class="align-self-end mr-1 mw-100">
+      <h5 :id="id" class="align-self-end my-0 mr-1 mw-100">
         <b-badge variant="light" class="d-inline-flex flex-wrap group-container mw-100 overflow-auto"
           :class="groupClassMap(tidbit.display)"
         >

--- a/cont3xt/vueapp/src/components/itypes/BaseIType.vue
+++ b/cont3xt/vueapp/src/components/itypes/BaseIType.vue
@@ -1,7 +1,7 @@
 <template>
   <b-card v-if="indicator.query" class="cursor-pointer itype-card" :class="{ 'border-danger': isActiveIndicator }" @click.stop="setSelfAsActiveIndicator">
     <div class="d-xl-flex">
-      <div class="d-xl-flex flex-grow-1 flex-wrap mt-1 mw-100">
+      <div class="d-xl-flex flex-grow-1 flex-wrap mw-100">
         <h4 class="text-warning m-0">
           {{ indicator.itype.toUpperCase() }}
         </h4>
@@ -11,12 +11,12 @@
             :id="`${indicator.query}-${indicator.itype}`"
         />
 
-        <integration-severity-counts :indicator="indicator" />
+        <integration-severity-counts :indicator-id="indicatorId" />
 
         <!--    unlabeled tidbits    -->
         <template v-for="(tidbit, index) in unlabeledTidbits">
           <integration-tidbit :tidbit="tidbit" :key="index"
-                              :id="`${indicator.query}-tidbit-${index}`"/>
+                              :id="`${indicatorId}-tidbit-${index}`"/>
         </template><!--    /unlabeled tidbits    -->
       </div>
     </div>
@@ -25,7 +25,7 @@
     <div v-if="labeledTidbits.length > 0"  class="mt-1">
       <div v-for="(tidbit, index) in labeledTidbits" :key="index" class="row ml-3" :class="{ 'mt-1': index > 0 }">
         <div class="col">
-          <integration-tidbit :tidbit="tidbit" :id="`${indicator.query}-labeled-tidbit-${index}`"/>
+          <integration-tidbit :tidbit="tidbit" :id="`${indicatorId}-labeled-tidbit-${index}`"/>
         </div>
       </div>
     </div><!--  /labeled tidbits  -->
@@ -33,7 +33,7 @@
     <!--  children  -->
     <div v-if="children.length > 0" class="mt-2">
       <span v-for="(child, index) in children" :key="index">
-        <i-type-node :node="child" />
+        <i-type-node :node="child" :parent-indicator-id="indicatorId" />
       </span>
     </div> <!--  /children  -->
   </b-card>
@@ -66,10 +66,14 @@ export default {
     children: { // array of shape [{ indicator: { itype: string, query: string } }, ...]
       type: Array,
       default () { return []; }
+    },
+    indicatorId: {
+      type: String,
+      required: true
     }
   },
   computed: {
-    ...mapGetters(['getResults', 'getActiveIndicator']),
+    ...mapGetters(['getResults', 'getActiveIndicatorId']),
     labeledTidbits () {
       return this.tidbits.filter(tidbit => tidbit.label?.length);
     },
@@ -77,14 +81,14 @@ export default {
       return this.tidbits.filter(tidbit => !tidbit.label?.length);
     },
     isActiveIndicator () {
-      return this.indicator.query === this.getActiveIndicator.query && this.indicator.itype === this.getActiveIndicator.itype;
+      return this.indicatorId === this.getActiveIndicatorId;
     }
   },
   methods: {
     setSelfAsActiveIndicator () {
       if (this.isActiveIndicator) { return; }
 
-      this.$store.commit('SET_ACTIVE_INDICATOR', this.indicator);
+      this.$store.commit('SET_ACTIVE_INDICATOR_ID', this.indicatorId);
       this.$store.commit('SET_ACTIVE_SOURCE', undefined);
     }
   }

--- a/cont3xt/vueapp/src/components/itypes/Domain.vue
+++ b/cont3xt/vueapp/src/components/itypes/Domain.vue
@@ -1,5 +1,6 @@
 <template>
   <base-i-type
+      :indicator-id="indicatorId"
       :indicator="indicator"
       :tidbits="tidbits"
       :children="children"
@@ -19,6 +20,10 @@ export default {
     indicator: Cont3xtIndicatorProp,
     children: {
       type: Array,
+      required: true
+    },
+    indicatorId: {
+      type: String,
       required: true
     }
   }

--- a/cont3xt/vueapp/src/components/itypes/Email.vue
+++ b/cont3xt/vueapp/src/components/itypes/Email.vue
@@ -1,5 +1,6 @@
 <template>
   <base-i-type
+    :indicator-id="indicatorId"
     :indicator="indicator"
     :tidbits="tidbits"
     :children="children"
@@ -21,6 +22,10 @@ export default {
     indicator: Cont3xtIndicatorProp,
     children: {
       type: Array,
+      required: true
+    },
+    indicatorId: {
+      type: String,
       required: true
     }
   }

--- a/cont3xt/vueapp/src/components/itypes/Hash.vue
+++ b/cont3xt/vueapp/src/components/itypes/Hash.vue
@@ -1,5 +1,6 @@
 <template>
   <base-i-type
+      :indicator-id="indicatorId"
       :indicator="indicator"
       :tidbits="tidbits"
   />
@@ -20,6 +21,10 @@ export default {
     indicator: Cont3xtIndicatorProp,
     children: {
       type: Array,
+      required: true
+    },
+    indicatorId: {
+      type: String,
       required: true
     }
   }

--- a/cont3xt/vueapp/src/components/itypes/IP.vue
+++ b/cont3xt/vueapp/src/components/itypes/IP.vue
@@ -1,5 +1,6 @@
 <template>
   <base-i-type
+    :indicator-id="indicatorId"
     :indicator="indicator"
     :tidbits="tidbits"
   >
@@ -30,6 +31,10 @@ export default {
     },
     enhanceInfo: {
       type: Object,
+      required: true
+    },
+    indicatorId: {
+      type: String,
       required: true
     }
   }

--- a/cont3xt/vueapp/src/components/itypes/ITypeNode.vue
+++ b/cont3xt/vueapp/src/components/itypes/ITypeNode.vue
@@ -1,36 +1,43 @@
 <template>
   <cont3xt-domain
+      :indicator-id="indicatorId"
       :indicator="node.indicator"
       :children="node.children"
       v-if="node.indicator.itype === 'domain'"
   />
   <cont3xt-ip
+      :indicator-id="indicatorId"
       :indicator="node.indicator"
       :children="node.children"
       :enhance-info="node.enhanceInfo"
       v-else-if="node.indicator.itype === 'ip'"
   />
   <cont3xt-url
+      :indicator-id="indicatorId"
       :indicator="node.indicator"
       :children="node.children"
       v-else-if="node.indicator.itype === 'url'"
   />
   <cont3xt-email
+      :indicator-id="indicatorId"
       :indicator="node.indicator"
       :children="node.children"
       v-else-if="node.indicator.itype === 'email'"
   />
   <cont3xt-hash
+      :indicator-id="indicatorId"
       :indicator="node.indicator"
       :children="node.children"
       v-else-if="node.indicator.itype === 'hash'"
   />
   <cont3xt-phone
+      :indicator-id="indicatorId"
       :indicator="node.indicator"
       :children="node.children"
       v-else-if="node.indicator.itype === 'phone'"
   />
   <cont3xt-text
+      :indicator-id="indicatorId"
       :indicator="node.indicator"
       :children="node.children"
       v-else-if="node.indicator.itype === 'text'"
@@ -50,6 +57,7 @@ import Cont3xtEmail from '@/components/itypes/Email.vue';
 import Cont3xtHash from '@/components/itypes/Hash.vue';
 import Cont3xtPhone from '@/components/itypes/Phone.vue';
 import Cont3xtText from '@/components/itypes/Text.vue';
+import { localIndicatorId } from '@/utils/cont3xtUtil';
 
 export default {
   name: 'ITypeNode',
@@ -66,6 +74,15 @@ export default {
     node: {
       type: Object,
       required: true
+    },
+    parentIndicatorId: {
+      type: String,
+      required: false
+    }
+  },
+  computed: {
+    indicatorId () {
+      return `${(this.parentIndicatorId == null) ? '' : `${this.parentIndicatorId},`}${localIndicatorId(this.node.indicator)}`;
     }
   }
 };

--- a/cont3xt/vueapp/src/components/itypes/Phone.vue
+++ b/cont3xt/vueapp/src/components/itypes/Phone.vue
@@ -1,5 +1,6 @@
 <template>
   <base-i-type
+      :indicator-id="indicatorId"
       :indicator="indicator"
       :tidbits="tidbits"
   />
@@ -20,6 +21,10 @@ export default {
     indicator: Cont3xtIndicatorProp,
     children: {
       type: Array,
+      required: true
+    },
+    indicatorId: {
+      type: String,
       required: true
     }
   }

--- a/cont3xt/vueapp/src/components/itypes/Text.vue
+++ b/cont3xt/vueapp/src/components/itypes/Text.vue
@@ -1,5 +1,6 @@
 <template>
   <base-i-type
+      :indicator-id="indicatorId"
       :indicator="indicator"
       :tidbits="tidbits"
   />
@@ -20,6 +21,10 @@ export default {
     indicator: Cont3xtIndicatorProp,
     children: {
       type: Array,
+      required: true
+    },
+    indicatorId: {
+      type: String,
       required: true
     }
   }

--- a/cont3xt/vueapp/src/components/itypes/URL.vue
+++ b/cont3xt/vueapp/src/components/itypes/URL.vue
@@ -1,5 +1,6 @@
 <template>
   <base-i-type
+      :indicator-id="indicatorId"
       :indicator="indicator"
       :tidbits="tidbits"
       :children="children"
@@ -21,6 +22,10 @@ export default {
     indicator: Cont3xtIndicatorProp,
     children: {
       type: Array,
+      required: true
+    },
+    indicatorId: {
+      type: String,
       required: true
     }
   }

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -611,15 +611,6 @@ export default {
     indicatorTreeRoots () {
       return Object.values(this.getIndicatorGraph).filter(node => node.parentIds.has(undefined));
     },
-    // /** @returns {Cont3xtIndicatorNode | undefined} */
-    // indicatorTreeRoot () {
-    //   // since we don't yet have bulk, there can only be one root, so we grab it here
-    //   // TODO: this should be removed when bulk is added
-    //   return this.indicatorTreeRoots?.[0];
-    // },
-    // rootIndicator () {
-    //   return this.indicatorTreeRoot?.indicator;
-    // },
     showOverview () {
       return this.activeSource == null && !(this.getWaitRendering || this.getRendering);
     }

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -768,8 +768,14 @@ export default {
       switch (chunk.purpose) {
       case 'init':
         // determine the search type and save the search term
-        this.activeIndicatorId = localIndicatorId(chunk.indicator);
+        this.activeIndicatorId = localIndicatorId(chunk.indicators[0]);
         this.filterLinks(this.linkSearchTerm);
+
+        for (const indicator of chunk.indicators) {
+          this.$store.commit('UPDATE_INDICATOR_GRAPH', {
+            indicator, parentIndicator: undefined
+          });
+        }
         break;
       case 'error':
         this.error = `ERROR: ${chunk.text}`;

--- a/cont3xt/vueapp/src/cont3xt.css
+++ b/cont3xt/vueapp/src/cont3xt.css
@@ -41,3 +41,9 @@ td .integration-external-link-button {
 .gap-1 {
     gap: 0.25rem;
 }
+.gap-2 {
+    gap: 0.5rem;
+}
+.gap-3 {
+    gap: 1rem;
+}

--- a/cont3xt/vueapp/src/store.js
+++ b/cont3xt/vueapp/src/store.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import createPersistedState from 'vuex-persistedstate';
 import { iTypes, iTypeIndexMap } from '@/utils/iTypes';
-import { indicatorId } from '@/utils/cont3xtUtil';
+import { indicatorFromId, localIndicatorId } from '@/utils/cont3xtUtil';
 
 Vue.use(Vuex);
 
@@ -54,7 +54,7 @@ const store = new Vuex.Store({
     overviewsError: '',
     selectedOverviewIdMap: {},
     queuedIntegration: undefined,
-    activeIndicator: undefined,
+    activeIndicatorId: undefined,
     activeSource: undefined,
     /** @type {{ [itype: string]: { [query: string]: { [integrationName: string]: object } } }} */
     results: {}, // results[<itype>][<query>][<integration_name>] yields the data for an integration
@@ -283,8 +283,8 @@ const store = new Vuex.Store({
 
       Vue.set(state.results[itype][query], source, Object.freeze(result));
     },
-    SET_ACTIVE_INDICATOR (state, data) {
-      state.activeIndicator = data;
+    SET_ACTIVE_INDICATOR_ID (state, data) {
+      state.activeIndicatorId = data;
     },
     SET_QUEUED_INTEGRATION (state, data) {
       state.queuedIntegration = data;
@@ -293,7 +293,7 @@ const store = new Vuex.Store({
       state.activeSource = data;
     },
     ADD_ENHANCE_INFO (state, { indicator, enhanceInfo }) {
-      const id = indicatorId(indicator);
+      const id = localIndicatorId(indicator);
 
       if (!state.enhanceInfoTable[id]) {
         Vue.set(state.enhanceInfoTable, id, {});
@@ -303,10 +303,10 @@ const store = new Vuex.Store({
       }
     },
     UPDATE_INDICATOR_GRAPH (state, { indicator, parentIndicator }) {
-      const id = indicatorId(indicator);
+      const id = localIndicatorId(indicator);
 
       // a parentId of undefined means that the indicator is root-level
-      const parentId = parentIndicator ? indicatorId(parentIndicator) : undefined;
+      const parentId = parentIndicator ? localIndicatorId(parentIndicator) : undefined;
       if (!state.indicatorGraph[id]) {
         if (!state.enhanceInfoTable[id]) {
           Vue.set(state.enhanceInfoTable, id, {});
@@ -326,7 +326,7 @@ const store = new Vuex.Store({
 
       // handle case where parent already exists in the tree
       if (parentId && state.indicatorGraph[parentId]) {
-        const alreadyAChild = state.indicatorGraph[parentId].children.some(child => indicatorId(child.indicator) === id);
+        const alreadyAChild = state.indicatorGraph[parentId].children.some(child => localIndicatorId(child.indicator) === id);
         if (!alreadyAChild) {
           state.indicatorGraph[parentId].children.push(state.indicatorGraph[id]);
         }
@@ -528,8 +528,11 @@ const store = new Vuex.Store({
     getResults (state) {
       return state.results;
     },
+    getActiveIndicatorId (state) {
+      return state.activeIndicatorId;
+    },
     getActiveIndicator (state) {
-      return state.activeIndicator;
+      return (state.activeIndicatorId != null) ? indicatorFromId(state.activeIndicatorId) : undefined;
     },
     getQueuedIntegration (state) {
       return state.queuedIntegration;

--- a/cont3xt/vueapp/src/utils/cont3xtUtil.js
+++ b/cont3xt/vueapp/src/utils/cont3xtUtil.js
@@ -27,8 +27,25 @@ export function getIntegrationData (results, indicator, source) {
   return results?.[indicator.itype]?.[indicator.query]?.[source] ?? {};
 }
 
-export function indicatorId (indicator) {
+export function localIndicatorId (indicator) {
   return `${indicator.query}-${indicator.itype}`;
+}
+
+/**
+ * Extracts the indicator object from its global ID
+ *   (where a global ID is some number of local IDs separated by commas)
+ *
+ * @param globalId - the fully qualified indicator path-id
+ *           e.g. 'foo.com-domain,1.1.1.1-ip'
+ * @returns {Cont3xtIndicator}
+ */
+export function indicatorFromId (globalId) {
+  const localId = globalId.substring(globalId.lastIndexOf(',') + 1);
+  const splitAt = localId.lastIndexOf('-');
+  return {
+    query: localId.substring(0, splitAt),
+    itype: localId.substring(splitAt + 1)
+  };
 }
 
 export function shouldDisplayIntegrationBtn (integration, integrationData) {

--- a/cont3xt/vueapp/tests/integrations.btns.test.js
+++ b/cont3xt/vueapp/tests/integrations.btns.test.js
@@ -6,6 +6,7 @@ import BootstrapVue from 'bootstrap-vue';
 import { render, fireEvent } from '@testing-library/vue';
 import IntegrationBtns from '../src/components/integrations/IntegrationBtns.vue';
 import '../../../common/vueapp/vueFilters';
+import { localIndicatorId } from '@/utils/cont3xtUtil';
 
 Vue.use(BootstrapVue);
 
@@ -66,10 +67,10 @@ test('Integration Btns', async () => {
   } = render(IntegrationBtns, {
     store,
     props: {
-      indicator: {
+      indicatorId: localIndicatorId({
         query: 'threatbutt.com',
         itype: 'domain'
-      }
+      })
     }
   });
 
@@ -89,12 +90,12 @@ test('Integration Btns', async () => {
 
   // calls display integration mutation
   expect(store.mutations.SET_QUEUED_INTEGRATION).toHaveBeenCalledWith(store.state, {
-    source: 'Whois', indicator: { itype: 'domain', query: 'threatbutt.com' }
+    source: 'Whois', indicatorId: localIndicatorId({ itype: 'domain', query: 'threatbutt.com' })
   });
 
   // second button emits different values
   await fireEvent.click(btns[1]);
   expect(store.mutations.SET_QUEUED_INTEGRATION).toHaveBeenCalledWith(store.state, {
-    source: 'PT Whois', indicator: { itype: 'domain', query: 'threatbutt.com' }
+    source: 'PT Whois', indicatorId: localIndicatorId({ itype: 'domain', query: 'threatbutt.com' })
   });
 });

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -1,5 +1,5 @@
 # Test cont3xt.js
-use Test::More tests => 138;
+use Test::More tests => 143;
 use Test::Differences;
 use Data::Dumper;
 use MolochTest;
@@ -632,7 +632,7 @@ is($json->[2]->{resultCount}, 0);
 is (scalar @{$json}, 3);
 
 $json = cont3xtPost('/api/integration/search', to_json({
-  query => "example.com",
+  query => "example.com, 1.1.1.1",
   tags => ["goodtag"],
   doIntegrations => ["DNS"]
 }));
@@ -648,20 +648,25 @@ is($json->[1]->{indicator}->{query}, "example.com");
 is($json->[1]->{indicator}->{itype}, "domain");
 is($json->[1]->{parentIndicator}, undef);
 
-is($json->[2]->{purpose}, "enhance");
+is($json->[2]->{purpose}, "link");
+is($json->[2]->{indicator}->{query}, "1.1.1.1");
 is($json->[2]->{indicator}->{itype}, "ip");
-is($json->[3]->{purpose}, "link");
+is($json->[2]->{parentIndicator}, undef);
+
+is($json->[3]->{purpose}, "enhance");
 is($json->[3]->{indicator}->{itype}, "ip");
-is($json->[3]->{parentIndicator}->{query}, "example.com");
-is($json->[3]->{parentIndicator}->{itype}, "domain");
+is($json->[4]->{purpose}, "link");
+is($json->[4]->{indicator}->{itype}, "ip");
+is($json->[4]->{parentIndicator}->{query}, "example.com");
+is($json->[4]->{parentIndicator}->{itype}, "domain");
 
-is($json->[6]->{purpose}, "data");
-is($json->[6]->{indicator}->{query}, "example.com");
-is($json->[6]->{indicator}->{itype}, "domain");
+is($json->[7]->{purpose}, "data");
+is($json->[7]->{indicator}->{query}, "example.com");
+is($json->[7]->{indicator}->{itype}, "domain");
 
-is($json->[7]->{purpose}, "finish"); # last integration chunk
-is($json->[7]->{resultCount}, 0);
-is (scalar @{$json}, 8);
+is($json->[8]->{purpose}, "finish"); # last integration chunk
+is($json->[8]->{resultCount}, 0);
+is (scalar @{$json}, 9);
 
 $json = cont3xtPost('/api/integration/search', to_json({
   query => "example.com",
@@ -694,6 +699,11 @@ $json = cont3xtPost('/api/integration/search', to_json({
   viewId => 1
 }));
 eq_or_diff($json, from_json('{"purpose": "error", "text": "viewId must be a string when present"}'));
+
+$json = cont3xtPost('/api/integration/search', to_json({
+    query => ","
+}));
+eq_or_diff($json, from_json('{"purpose": "error", "text": "query must contain at least one non-whitespace indicator"}'));
 
 esGet("/_flush");
 esGet("/_refresh");

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -1,5 +1,5 @@
 # Test cont3xt.js
-use Test::More tests => 143;
+use Test::More tests => 136;
 use Test::Differences;
 use Data::Dumper;
 use MolochTest;
@@ -609,9 +609,10 @@ $json = cont3xtPost('/api/integration/search', to_json({
 is($json->[0]->{purpose}, "init");
 is($json->[0]->{sent}, 0);
 is($json->[0]->{text}, "more to follow");
-is($json->[0]->{indicator}->{itype}, "domain");
-is($json->[0]->{indicator}->{query}, "example.com");
-cmp_ok (scalar @{$json}, ">", 10);
+is(scalar @{$json->[0]->{indicators}}, 1);
+is($json->[0]->{indicators}->[0]->{itype}, "domain");
+is($json->[0]->{indicators}->[0]->{query}, "example.com");
+cmp_ok (scalar @{$json}, ">", 8);
 
 $json = cont3xtPost('/api/integration/search', to_json({
   query => "example.com",
@@ -621,15 +622,12 @@ $json = cont3xtPost('/api/integration/search', to_json({
 is($json->[0]->{purpose}, "init");
 is($json->[0]->{sent}, 0);
 is($json->[0]->{text}, "more to follow");
-is($json->[0]->{indicator}->{itype}, "domain");
-is($json->[0]->{indicator}->{query}, "example.com");
-is($json->[1]->{purpose}, "link");
-is($json->[1]->{parentIndicator}, undef);
-is($json->[1]->{indicator}->{itype}, "domain");
-is($json->[1]->{indicator}->{query}, "example.com");
-is($json->[2]->{purpose}, "finish");
-is($json->[2]->{resultCount}, 0);
-is (scalar @{$json}, 3);
+is(scalar @{$json->[0]->{indicators}}, 1);
+is($json->[0]->{indicators}->[0]->{itype}, "domain");
+is($json->[0]->{indicators}->[0]->{query}, "example.com");
+is($json->[1]->{purpose}, "finish");
+is($json->[1]->{resultCount}, 0);
+is (scalar @{$json}, 2);
 
 $json = cont3xtPost('/api/integration/search', to_json({
   query => "example.com, 1.1.1.1",
@@ -640,33 +638,26 @@ $json = cont3xtPost('/api/integration/search', to_json({
 is($json->[0]->{purpose}, "init"); # initial integration chunk
 is($json->[0]->{sent}, 0);
 is($json->[0]->{text}, "more to follow");
-is($json->[0]->{indicator}->{query}, "example.com");
-is($json->[0]->{indicator}->{itype}, "domain");
+is(scalar @{$json->[0]->{indicators}}, 2);
+is($json->[0]->{indicators}->[0]->{itype}, "domain");
+is($json->[0]->{indicators}->[0]->{query}, "example.com");
+is($json->[0]->{indicators}->[1]->{itype}, "ip");
+is($json->[0]->{indicators}->[1]->{query}, "1.1.1.1");
 
-is($json->[1]->{purpose}, "link");
-is($json->[1]->{indicator}->{query}, "example.com");
-is($json->[1]->{indicator}->{itype}, "domain");
-is($json->[1]->{parentIndicator}, undef);
-
+is($json->[1]->{purpose}, "enhance");
+is($json->[1]->{indicator}->{itype}, "ip");
 is($json->[2]->{purpose}, "link");
-is($json->[2]->{indicator}->{query}, "1.1.1.1");
 is($json->[2]->{indicator}->{itype}, "ip");
-is($json->[2]->{parentIndicator}, undef);
+is($json->[2]->{parentIndicator}->{query}, "example.com");
+is($json->[2]->{parentIndicator}->{itype}, "domain");
 
-is($json->[3]->{purpose}, "enhance");
-is($json->[3]->{indicator}->{itype}, "ip");
-is($json->[4]->{purpose}, "link");
-is($json->[4]->{indicator}->{itype}, "ip");
-is($json->[4]->{parentIndicator}->{query}, "example.com");
-is($json->[4]->{parentIndicator}->{itype}, "domain");
+is($json->[5]->{purpose}, "data");
+is($json->[5]->{indicator}->{query}, "example.com");
+is($json->[5]->{indicator}->{itype}, "domain");
 
-is($json->[7]->{purpose}, "data");
-is($json->[7]->{indicator}->{query}, "example.com");
-is($json->[7]->{indicator}->{itype}, "domain");
-
-is($json->[8]->{purpose}, "finish"); # last integration chunk
-is($json->[8]->{resultCount}, 0);
-is (scalar @{$json}, 9);
+is($json->[6]->{purpose}, "finish"); # last integration chunk
+is($json->[6]->{resultCount}, 0);
+is (scalar @{$json}, 7);
 
 $json = cont3xtPost('/api/integration/search', to_json({
   query => "example.com",


### PR DESCRIPTION
* api/integration/search now works for bulk as well
* comma separated queries
* use indicatorId to uniquely identify indicator nodes in the UI (since there can be multiple of the same indicator shown in a bulk search, eg. gmail.com for multiple emails)
* finishWrite moved into `shared` in `Integration.apiSearch`
* history log with itype 'bulk' and full query as indicator created for bulk searches
* fail requests with only commas and whitespace (eg ' ,   ,,,, ') since these don't resolve to any queries when split/trimmed
* update ui/backend tests