### PR TITLE
folding and bulk navigation

### DIFF
--- a/cont3xt/vueapp/src/App.vue
+++ b/cont3xt/vueapp/src/App.vue
@@ -37,6 +37,18 @@
           <br>
           <code>'>'</code> - toggle the link group panel
           <br>
+          <code>'-'</code> - collapse all top-level indicator result tree nodes
+          <br>
+          <code>'+'</code> - expand all top-level indicator result tree nodes
+          <br>
+          <code>'h'</code> - collapse active indicator result tree node, or navigate left
+          <br>
+          <code>'j'</code> - navigate down in indicator result tree
+          <br>
+          <code>'k'</code> - navigate up in indicator result tree
+          <br>
+          <code>'l'</code> - expand active indicator result tree node, or navigate right
+          <br>
           <code>'shift + enter'</code> - issue search/refresh
           <br>
           <code>'esc'</code> - remove focus from any input and close this dialog
@@ -113,80 +125,113 @@ export default {
         return;
       }
 
-      // quit if the user is in an input or not holding the shift key
-      if (!this.getShiftKeyHold || (activeElement && inputs.indexOf(activeElement.tagName.toLowerCase()) !== -1)) {
+      // quit if the user is in an input
+      if (activeElement && inputs.indexOf(activeElement.tagName.toLowerCase()) !== -1) {
         return;
       }
 
-      switch (e.keyCode) {
-      case 81: // q
+      // non-shift shortcuts
+      if (!this.getShiftKeyHold) {
+        switch (e.code) {
+        case 'KeyJ':
+          // navigate down the indicator result tree
+          this.$store.commit('SET_RESULT_TREE_NAVIGATION_DIRECTION', 'down');
+          break;
+        case 'KeyK':
+          // navigate up the indicator result tree
+          this.$store.commit('SET_RESULT_TREE_NAVIGATION_DIRECTION', 'up');
+          break;
+        case 'KeyH':
+          // navigate left in the indicator result tree
+          this.$store.commit('SET_RESULT_TREE_NAVIGATION_DIRECTION', 'left');
+          break;
+        case 'KeyL':
+          // navigate right in the indicator result tree
+          this.$store.commit('SET_RESULT_TREE_NAVIGATION_DIRECTION', 'right');
+          break;
+        }
+        return;
+      }
+
+      // shifted shortcuts
+      switch (e.code) {
+      case 'KeyQ':
         // focus on search expression input
         this.$store.commit('SET_FOCUS_SEARCH', true);
         break;
-      case 84: // t
+      case 'KeyT':
         // focus on start time input
         this.$store.commit('SET_FOCUS_START_DATE', true);
         break;
-      case 70: // f
+      case 'KeyF':
         // focus on time range selector
         this.$store.commit('SET_FOCUS_LINK_SEARCH', true);
         break;
-      case 86: // v
+      case 'KeyV':
         // focus on view dropdown selector
         this.$store.commit('SET_FOCUS_VIEW_SEARCH', true);
         break;
-      case 71: // g
+      case 'KeyG':
         // focus on tag input
         this.$store.commit('SET_FOCUS_TAG_INPUT', true);
         break;
-      case 69: // e
+      case 'KeyE':
         // toggle cache
         this.$store.commit('SET_TOGGLE_CACHE', true);
         break;
-      case 82: // r
+      case 'KeyR':
         // download report
         this.$store.commit('SET_DOWNLOAD_REPORT', true);
         break;
-      case 76: // l
+      case 'KeyL':
         // copy share link to clipboard
         this.$store.commit('SET_COPY_SHARE_LINK', true);
         break;
-      case 67: // c
+      case 'KeyC':
         // open cont3xt page if not on cont3xt page
         if (this.$route.name !== 'Cont3xt') {
           this.routeTo('/');
         }
         break;
-      case 65: // a
+      case 'KeyA':
         // open stats page if not on stats page
         if (this.$route.name !== 'Stats') {
           this.routeTo('/stats');
         }
         break;
-      case 89: // y
+      case 'KeyY':
         // open history page if not on history page
         if (this.$route.name !== 'History') {
           this.routeTo('/history');
         }
         break;
-      case 83: // s
+      case 'KeyS':
         // open settings page if not on settings page
         if (this.$route.name !== 'Settings') {
           this.routeTo('/settings');
         }
         break;
-      case 72: // h
+      case 'KeyH':
         // open help page if not on help page
         if (this.$route.name !== 'Help') {
           this.routeTo('/help');
         }
         break;
-      case 190: // . (seen as `>`, since shift is required)
+      case 'Period': // (seen as `>`, since shift is required)
+        // toggle link groups panel
         this.$store.commit('TOGGLE_LINK_GROUPS_PANEL');
         break;
-      case 13: // enter
+      case 'Enter':
         // trigger search/refresh
         this.$store.commit('SET_ISSUE_SEARCH', true);
+        break;
+      case 'Minus':
+        // collapse all indicator result tree nodes
+        this.$store.commit('SET_COLLAPSE_OR_EXPAND_INDICATOR_ROOTS', { setRootsOpen: false });
+        break;
+      case 'Equal': // (seen as `+`, since shift is required)
+        // expand all indicator result tree nodes
+        this.$store.commit('SET_COLLAPSE_OR_EXPAND_INDICATOR_ROOTS', { setRootsOpen: true });
         break;
       }
     });

--- a/cont3xt/vueapp/src/App.vue
+++ b/cont3xt/vueapp/src/App.vue
@@ -35,11 +35,13 @@
           <br>
           <code>'H'</code> - jump to the Help page
           <br>
-          <code>'>'</code> - toggle the link group panel
+          <code>'&lt;'</code> - toggle the integration panel
           <br>
-          <code>'-'</code> - collapse all top-level indicator result tree nodes
+          <code>'&gt;'</code> - toggle the link group panel
           <br>
-          <code>'+'</code> - expand all top-level indicator result tree nodes
+          <code>'shift -'</code> - collapse all top-level indicator result tree nodes
+          <br>
+          <code>'shift +'</code> - expand all top-level indicator result tree nodes
           <br>
           <code>'h'</code> - collapse active indicator result tree node, or navigate left
           <br>
@@ -216,6 +218,10 @@ export default {
         if (this.$route.name !== 'Help') {
           this.routeTo('/help');
         }
+        break;
+      case 'Comma': // (seen as `<`, since shift is required)
+        // toggle integration panel
+        this.$store.commit('SET_TOGGLE_INTEGRATION_PANEL', true);
         break;
       case 'Period': // (seen as `>`, since shift is required)
         // toggle link groups panel

--- a/cont3xt/vueapp/src/components/integrations/IntegrationPanel.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationPanel.vue
@@ -123,7 +123,7 @@ export default {
   computed: {
     ...mapGetters([
       'getDoableIntegrations', 'getRoles', 'getUser', 'getSortedIntegrations',
-      'getAllViews', 'getImmediateSubmissionReady', 'getSelectedView'
+      'getAllViews', 'getImmediateSubmissionReady', 'getSelectedView', 'getToggleIntegrationPanel'
     ]),
     sidebarKeepOpen: {
       get () {
@@ -146,6 +146,9 @@ export default {
     }
   },
   watch: {
+    getToggleIntegrationPanel (val) {
+      if (val) { this.toggleSidebar(); }
+    },
     getDoableIntegrations (newVal) {
       // forces initialization of selectedIntegrations when without persisted storage (ex. new browser/incognito)
       if (this.selectedIntegrations == null) {

--- a/cont3xt/vueapp/src/components/itypes/BaseIType.vue
+++ b/cont3xt/vueapp/src/components/itypes/BaseIType.vue
@@ -1,6 +1,8 @@
 <template>
-  <b-card v-if="indicator.query" class="cursor-pointer itype-card" :class="{ 'border-danger': isActiveIndicator }" @click.stop="setSelfAsActiveIndicator">
-    <div class="d-xl-flex">
+  <b-card v-if="indicator.query"
+          class="cursor-pointer itype-card" :class="{ 'border-danger': isActiveIndicator }"
+          @click.stop="setSelfAsActiveIndicator">
+    <div class="d-xl-flex" ref="nodeCardScrollMarker">
       <div class="d-xl-flex flex-grow-1 flex-wrap mw-100">
         <h4 class="text-warning m-0">
           {{ indicator.itype.toUpperCase() }}
@@ -32,9 +34,16 @@
 
     <!--  children  -->
     <div v-if="children.length > 0" class="mt-2">
-      <span v-for="(child, index) in children" :key="index">
-        <i-type-node :node="child" :parent-indicator-id="indicatorId" />
-      </span>
+      <template v-if="isCollapsed">
+        <b-card class="itype-card" @click.stop="toggleCollapse">
+          <span class="fa fa-plus fa-lg"/> {{ children.length }} hidden
+        </b-card>
+      </template>
+      <template v-else>
+        <span v-for="(child, index) in children" :key="index">
+          <i-type-node :node="child" :parent-indicator-id="indicatorId" />
+        </span>
+      </template>
     </div> <!--  /children  -->
   </b-card>
 </template>
@@ -73,7 +82,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['getResults', 'getActiveIndicatorId']),
+    ...mapGetters(['getResults', 'getActiveIndicatorId', 'getIndicatorIdToFocus', 'getCollapsedIndicatorNodeMap']),
     labeledTidbits () {
       return this.tidbits.filter(tidbit => tidbit.label?.length);
     },
@@ -82,6 +91,9 @@ export default {
     },
     isActiveIndicator () {
       return this.indicatorId === this.getActiveIndicatorId;
+    },
+    isCollapsed () {
+      return this.getCollapsedIndicatorNodeMap[this.indicatorId];
     }
   },
   methods: {
@@ -90,6 +102,16 @@ export default {
 
       this.$store.commit('SET_ACTIVE_INDICATOR_ID', this.indicatorId);
       this.$store.commit('SET_ACTIVE_SOURCE', undefined);
+    },
+    toggleCollapse () {
+      this.$store.commit('TOGGLE_INDICATOR_NODE_COLLAPSE', this.indicatorId);
+    }
+  },
+  watch: {
+    getIndicatorIdToFocus (val) {
+      if (this.indicatorId === val) {
+        this.$refs.nodeCardScrollMarker.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
     }
   }
 };

--- a/cont3xt/vueapp/src/store.js
+++ b/cont3xt/vueapp/src/store.js
@@ -62,7 +62,14 @@ const store = new Vuex.Store({
     indicatorGraph: {}, // maps every `${query}-${itype}` to its corresponding indicator node
     /** @type {{ [indicatorId: string]: object }} */
     enhanceInfoTable: {}, // maps every `${query}-${itype}` to any enhancement info it may have
-    linkGroupsPanelOpen: true
+    linkGroupsPanelOpen: true,
+    indicatorIdToFocus: undefined,
+    /** @type {'down' | 'up' | 'left' | 'right' | undefined} */
+    resultTreeNavigationDirection: undefined,
+    /** @type {{ [indicatorId: string]: boolean }} */
+    collapsedIndicatorNodeMap: {},
+    /** @type {{ setRootsOpen: boolean } | undefined} */
+    collapseOrExpandIndicatorRoots: undefined
   },
   mutations: {
     SET_USER (state, data) {
@@ -336,9 +343,25 @@ const store = new Vuex.Store({
       state.results = {};
       state.indicatorGraph = {};
       state.enhanceInfoTable = {};
+      state.collapsedIndicatorNodeMap = {};
     },
     TOGGLE_LINK_GROUPS_PANEL (state) {
       state.linkGroupsPanelOpen = !state.linkGroupsPanelOpen;
+    },
+    TOGGLE_INDICATOR_NODE_COLLAPSE (state, data) {
+      Vue.set(state.collapsedIndicatorNodeMap, data, !state.collapsedIndicatorNodeMap[data]);
+    },
+    SET_INDICATOR_ID_TO_FOCUS (state, data) {
+      state.indicatorIdToFocus = data;
+      setTimeout(() => { state.indicatorIdToFocus = undefined; });
+    },
+    SET_RESULT_TREE_NAVIGATION_DIRECTION (state, data) {
+      state.resultTreeNavigationDirection = data;
+      setTimeout(() => { state.resultTreeNavigationDirection = undefined; });
+    },
+    SET_COLLAPSE_OR_EXPAND_INDICATOR_ROOTS (state, data) {
+      state.collapseOrExpandIndicatorRoots = data;
+      setTimeout(() => { state.collapseOrExpandIndicatorRoots = undefined; });
     }
   },
   getters: {
@@ -545,6 +568,18 @@ const store = new Vuex.Store({
     },
     getLinkGroupsPanelOpen (state) {
       return state.linkGroupsPanelOpen;
+    },
+    getIndicatorIdToFocus (state) {
+      return state.indicatorIdToFocus;
+    },
+    getResultTreeNavigationDirection (state) {
+      return state.resultTreeNavigationDirection;
+    },
+    getCollapsedIndicatorNodeMap (state) {
+      return state.collapsedIndicatorNodeMap;
+    },
+    getCollapseOrExpandIndicatorRoots (state) {
+      return state.collapseOrExpandIndicatorRoots;
     }
   },
   plugins: [createPersistedState({

--- a/cont3xt/vueapp/src/store.js
+++ b/cont3xt/vueapp/src/store.js
@@ -43,6 +43,7 @@ const store = new Vuex.Store({
     toggleCache: false,
     downloadReport: false,
     copyShareLink: false,
+    toggleIntegrationPanel: false,
     immediateSubmissionReady: false,
     theme: undefined,
     tags: [],
@@ -232,6 +233,10 @@ const store = new Vuex.Store({
     SET_COPY_SHARE_LINK (state, value) {
       state.copyShareLink = value;
       setTimeout(() => { state.copyShareLink = false; });
+    },
+    SET_TOGGLE_INTEGRATION_PANEL (state, value) {
+      state.toggleIntegrationPanel = value;
+      setTimeout(() => { state.toggleIntegrationPanel = false; });
     },
     SET_IMMEDIATE_SUBMISSION_READY (state, value) {
       state.immediateSubmissionReady = value;
@@ -462,6 +467,9 @@ const store = new Vuex.Store({
     },
     getCopyShareLink (state) {
       return state.copyShareLink;
+    },
+    getToggleIntegrationPanel (state) {
+      return state.toggleIntegrationPanel;
     },
     getImmediateSubmissionReady (state) {
       return state.immediateSubmissionReady;

--- a/cont3xt/vueapp/src/utils/cont3xtUtil.js
+++ b/cont3xt/vueapp/src/utils/cont3xtUtil.js
@@ -48,6 +48,16 @@ export function indicatorFromId (globalId) {
   };
 }
 
+/**
+ * @param indicatorId - the id of the indicator to get the parent id for
+ * @returns {string|undefined} - the parent id, or undefined if there is no parent
+ */
+export function indicatorParentId (indicatorId) {
+  return (indicatorId.includes(','))
+    ? indicatorId.substring(0, indicatorId.lastIndexOf(','))
+    : undefined;
+}
+
 export function shouldDisplayIntegrationBtn (integration, integrationData) {
   return integrationData != null && integration?.icon != null;
 }


### PR DESCRIPTION
* hjkl to navigate indicator result tree
* scroll node to middle when navigating
* click '+ {n} hidden' to expand children
* shift - and shift + to collapse/expand all root nodes
* updated shortcut reminder tab
* updated shortcuts to use e.code instead of e.keyCode