### PR TITLE
focus navigated indicator node and set to overview

### DIFF
--- a/cont3xt/vueapp/src/components/integrations/IntegrationBtns.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationBtns.vue
@@ -13,8 +13,8 @@
         tabindex="0"
         variant="outline-dark"
         class="mr-1 float-right no-wrap"
-        :id="`${indicator.itype}-${integration.name}-${indicator.query}`"
-        :key="integration.name"
+        :id="`${indicatorId}-${integration.name}-btn`"
+        :key="`${indicatorId}-${integration.name}`"
         @click="setAsActive(integration)">
         <img
           :alt="integration.name"

--- a/cont3xt/vueapp/src/components/itypes/BaseIType.vue
+++ b/cont3xt/vueapp/src/components/itypes/BaseIType.vue
@@ -111,6 +111,12 @@ export default {
     getIndicatorIdToFocus (val) {
       if (this.indicatorId === val) {
         this.$refs.nodeCardScrollMarker.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        // though the nodeCardScrollMarker element is not a focusable input
+        //   this moves the relative focus point to it (as if clicked),
+        //   so the next tab will go to the IntegrationBtns
+        this.$refs.nodeCardScrollMarker.focus({
+          preventScroll: true // don't double up on scrolling!
+        });
       }
     }
   }

--- a/cont3xt/vueapp/src/components/pages/Cont3xt.vue
+++ b/cont3xt/vueapp/src/components/pages/Cont3xt.vue
@@ -962,6 +962,7 @@ export default {
     navigateToResultNode (indicatorId) {
       // scroll and set active to the indicator node with this id
       this.activeIndicatorId = indicatorId;
+      this.activeSource = undefined;
       // handled in BaseIType component with the corresponding indicatorId
       this.$store.commit('SET_INDICATOR_ID_TO_FOCUS', indicatorId);
     },


### PR DESCRIPTION
* using hjkl moves focus point to node so a tab will bring you to the first integration button
* and set to overview when keyboard navigating (this wasn't being done, so we'd stay on whatever the last integration was when moving with the keyboard)
