### PR TITLE
Widen the CSS for field names in session view (.session-detail dt and dd)

### DIFF
--- a/viewer/vueapp/src/components/sessions/SessionDetail.vue
+++ b/viewer/vueapp/src/components/sessions/SessionDetail.vue
@@ -848,7 +848,7 @@ export default {
 .session-detail dt {
   float: left;
   clear: left;
-  width: 160px;
+  width: 320px;
   text-align: right;
   margin-right: 6px;
   line-height: 1.7;
@@ -856,7 +856,7 @@ export default {
 }
 
 .session-detail dd {
-  margin-left: 165px;
+  margin-left: 325px;
 }
 
 /* more items link */


### PR DESCRIPTION
Widen the CSS for field names in the session details (.session-detail dt and dd) from 160px/165px to 320px/325px, respectively. A number of my custom fields' names were being truncated. This gives field names in the session view more 'breathing room.'

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.