### PR TITLE
Can now specify viewerOnly:true in [custom-fields]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,10 @@ NOTICE: Restart wiseService before capture when upgrading
 NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at once after upgrading
 
 4.4.1 2023/08/xx
+  - release - node 16.20.2
+  - capture - dns answers were double parsed
+  - capture - custom-fields honors viewerOnly:true
+  - cont3xt - remove raw view button for link groups on the cont3xt search page
 
 4.4.0 2023/08/02
   - release - cyberchef 10.5.2

--- a/capture/field.c
+++ b/capture/field.c
@@ -246,7 +246,7 @@ int moloch_field_define_text_full(char *field, char *text, int *shortcut)
         flags |= MOLOCH_FIELD_FLAG_FORCE_UTF8;
 
     if (fake)
-        flags |= ARKIME_FIELD_FLAG_FAKE;
+        flags |= MOLOCH_FIELD_FLAG_FAKE;
 
     int pos =  moloch_field_define(group, kind, field, friendly, db, help, type, flags, "category", category, "transform", transform, "aliases", aliases, (char *)NULL);
     g_strfreev(elements);

--- a/capture/field.c
+++ b/capture/field.c
@@ -122,6 +122,7 @@ int moloch_field_define_text_full(char *field, char *text, int *shortcut)
     int count = 0;
     int nolinked = 0;
     int noutf8 = 0;
+    int fake = 0;
     char *kind = 0;
     char *help = 0;
     char *db = 0;
@@ -153,6 +154,8 @@ int moloch_field_define_text_full(char *field, char *text, int *shortcut)
             nolinked = strcmp(colon, "true") == 0;
         else if (strcmp(elements[e], "noutf8") == 0)
             noutf8 = strcmp(colon, "true") == 0;
+        else if (strcmp(elements[e], "fake") == 0 || strcmp(elements[e], "viewerOnly") == 0)
+            fake = strcmp(colon, "true") == 0;
         else if (strcmp(elements[e], "friendly") == 0)
             friendly = colon;
         else if (strcmp(elements[e], "db") == 0)
@@ -241,6 +244,9 @@ int moloch_field_define_text_full(char *field, char *text, int *shortcut)
 
     if (!noutf8 && type == MOLOCH_FIELD_TYPE_STR_HASH)
         flags |= MOLOCH_FIELD_FLAG_FORCE_UTF8;
+
+    if (fake)
+        flags |= ARKIME_FIELD_FLAG_FAKE;
 
     int pos =  moloch_field_define(group, kind, field, friendly, db, help, type, flags, "category", category, "transform", transform, "aliases", aliases, (char *)NULL);
     g_strfreev(elements);

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -875,11 +875,22 @@ char *moloch_sprint_hex_string(char *buf, const unsigned char* data, unsigned in
 /******************************************************************************/
 void  moloch_parsers_register2(MolochSession_t *session, MolochParserFunc func, void *uw, MolochParserFreeFunc ffunc, MolochParserSaveFunc sfunc)
 {
+#ifdef DEBUG_PARSERS
+    LOG("session: %p func: %p uw: %p", session, func, uw);
+#endif
+
     if (session->parserNum > 30) {
         char ipStr[200];
         moloch_session_pretty_string(session, ipStr, sizeof(ipStr));
         LOG("WARNING - Too many parsers registered: %d %s", session->parserNum, ipStr);
         return;
+    }
+
+    // Check if this is a duplicate
+    for (int i = 0; i < session->parserNum; i++) {
+        if (session->parserInfo[i].parserFunc == func && session->parserInfo[i].uw == uw) {
+            return;
+        }
     }
 
     if (session->parserNum >= session->parserLen) {

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -295,7 +295,7 @@ ASDF=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&
 ALLTEST=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%;name:All Field Action %FIELDNAME%!;all:true
 
 [custom-fields]
-iscool=kind:termfield;count:true;friendly:Is cool;db:iscool;help:Is Cool String
+iscool=kind:termfield;count:true;friendly:Is cool;db:iscool;help:Is Cool String;viewerOnly:true
 sample.md5=db:sample.md5;kind:lotermfield;friendly:Sample MD5;count:true;help:MD5 of the sample
 
 [custom-views]


### PR DESCRIPTION
Can now specify viewerOnly:true in [custom-fields] which will define the field for viewer and not capture. This will save memory in capture. Fixes part of #2374