### PR TITLE
Don't crash on adding fake field after real

### DIFF
--- a/capture/field.c
+++ b/capture/field.c
@@ -298,6 +298,11 @@ int moloch_field_define(char *group, char *kind, char *expression, char *friendl
     } else {
         flags |= (minfo->flags & MOLOCH_FIELD_FLAG_DISABLED);
 
+        // If we already have a pos can't be a fake field later
+        if (minfo->pos != -1 && (flags & MOLOCH_FIELD_FLAG_FAKE)) {
+            return minfo->pos;
+        }
+
         char *category = NULL;
         char *transform = NULL;
         char *aliases = NULL;


### PR DESCRIPTION
If adding a fake field after the real has already been defined just ignore the fake field.