### PR TITLE
config file can now have viewRoles per integration

### DIFF
--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -539,8 +539,7 @@ async function setupAuth () {
 
   Integration.initialize({
     debug: ArkimeConfig.debug,
-    cache,
-    getConfig
+    cache
   });
 }
 

--- a/cont3xt/integrations/abuseipdb/index.js
+++ b/cont3xt/integrations/abuseipdb/index.js
@@ -96,7 +96,7 @@ class AbuseIPDBIntegration extends Integration {
 
   async fetchIp (user, ip) {
     try {
-      const key = this.getUserConfig(user, this.name, 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }

--- a/cont3xt/integrations/alienvaultotx/index.js
+++ b/cont3xt/integrations/alienvaultotx/index.js
@@ -134,7 +134,7 @@ class AlienVaultOTXIntegration extends Integration {
 
   async fetch (user, type, query) {
     try {
-      const key = this.getUserConfig(user, this.name, 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }

--- a/cont3xt/integrations/builtwith/index.js
+++ b/cont3xt/integrations/builtwith/index.js
@@ -78,7 +78,7 @@ class BuiltWithIntegration extends Integration {
 
   async fetchDomain (user, query) {
     try {
-      const key = this.getUserConfig(user, this.name, 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }

--- a/cont3xt/integrations/censys/index.js
+++ b/cont3xt/integrations/censys/index.js
@@ -120,8 +120,8 @@ class CensysIntegration extends Integration {
   }
 
   async fetchIp (user, ip) {
-    const id = this.getUserConfig(user, this.name, 'id');
-    const secret = this.getUserConfig(user, this.name, 'secret');
+    const id = this.getUserConfig(user, 'id');
+    const secret = this.getUserConfig(user, 'secret');
     if (!id || !secret) {
       return undefined;
     }

--- a/cont3xt/integrations/elasticsearch/index.js
+++ b/cont3xt/integrations/elasticsearch/index.js
@@ -50,6 +50,7 @@ class ElasticsearchIntegration extends Integration {
   constructor (section) {
     super();
 
+    this.section = section;
     this.name = ArkimeConfig.get(section, 'name', section);
     this.icon = ArkimeConfig.get(section, 'icon',
       section.startsWith('elasticsearch') ? 'integrations/elasticsearch/elasticsearch.png' : 'integrations/elasticsearch/opensearch.png');

--- a/cont3xt/integrations/greynoise/index.js
+++ b/cont3xt/integrations/greynoise/index.js
@@ -87,7 +87,7 @@ class GreyNoiseIntegration extends Integration {
 
   async fetchIp (user, ip) {
     try {
-      const key = this.getUserConfig(user, 'GreyNoise', 'key');
+      const key = this.getUserConfig(user, 'key');
 
       const headers = { 'User-Agent': this.userAgent() };
       // use key if provided (optional, allows one to get around the daily rate limit)

--- a/cont3xt/integrations/maxmind/index.js
+++ b/cont3xt/integrations/maxmind/index.js
@@ -16,6 +16,7 @@
 const Integration = require('../../integration.js');
 const maxmind = require('maxmind');
 const fs = require('fs');
+const ArkimeConfig = require('../../../common/arkimeConfig');
 
 class MaxmindIntegration extends Integration {
   name = 'Maxmind';
@@ -50,8 +51,8 @@ class MaxmindIntegration extends Integration {
   constructor () {
     super();
 
-    const asnPaths = Integration.getConfig('cont3xt', 'geoLite2ASN', '/var/lib/GeoIP/GeoLite2-ASN.mmdb;/usr/share/GeoIP/GeoLite2-ASN.mmdb').split(';');
-    const countryPaths = Integration.getConfig('cont3xt', 'geoLite2Country', '/var/lib/GeoIP/GeoLite2-Country.mmdb;/usr/share/GeoIP/GeoLite2-Country.mmdb').split(';');
+    const asnPaths = ArkimeConfig.get('cont3xt', 'geoLite2ASN', '/var/lib/GeoIP/GeoLite2-ASN.mmdb;/usr/share/GeoIP/GeoLite2-ASN.mmdb').split(';');
+    const countryPaths = ArkimeConfig.get('cont3xt', 'geoLite2Country', '/var/lib/GeoIP/GeoLite2-Country.mmdb;/usr/share/GeoIP/GeoLite2-Country.mmdb').split(';');
 
     if (asnPaths.length === 0 && countryPaths.length === 0) {
       return;

--- a/cont3xt/integrations/passivetotal/index.js
+++ b/cont3xt/integrations/passivetotal/index.js
@@ -131,8 +131,8 @@ class PassiveTotalWhoisIntegration extends Integration {
 
   async fetchDomain (user, domain) {
     try {
-      const puser = this.getUserConfig(user, 'PassiveTotal', 'user');
-      const pkey = this.getUserConfig(user, 'PassiveTotal', 'key');
+      const puser = this.getUserConfig(user, 'user');
+      const pkey = this.getUserConfig(user, 'key');
       if (!puser || !pkey) {
         return undefined;
       }
@@ -199,8 +199,8 @@ class PassiveTotalSubdomainsIntegration extends Integration {
 
   async fetchDomain (user, domain) {
     try {
-      const puser = this.getUserConfig(user, 'PassiveTotal', 'user');
-      const pkey = this.getUserConfig(user, 'PassiveTotal', 'key');
+      const puser = this.getUserConfig(user, 'user');
+      const pkey = this.getUserConfig(user, 'key');
       if (!puser || !pkey) {
         return undefined;
       }
@@ -299,8 +299,8 @@ class PassiveTotalDNSIntegration extends Integration {
 
   async fetch (user, query) {
     try {
-      const puser = this.getUserConfig(user, 'PassiveTotal', 'user');
-      const pkey = this.getUserConfig(user, 'PassiveTotal', 'key');
+      const puser = this.getUserConfig(user, 'user');
+      const pkey = this.getUserConfig(user, 'key');
       if (!puser || !pkey) {
         return undefined;
       }

--- a/cont3xt/integrations/shodan/index.js
+++ b/cont3xt/integrations/shodan/index.js
@@ -140,7 +140,7 @@ class ShodanIntegration extends Integration {
 
   async fetchIp (user, ip) {
     try {
-      const key = this.getUserConfig(user, 'Shodan', 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }

--- a/cont3xt/integrations/spur/index.js
+++ b/cont3xt/integrations/spur/index.js
@@ -144,7 +144,7 @@ class SpurIntegration extends Integration {
 
   async fetchIp (user, ip) {
     try {
-      const key = this.getUserConfig(user, 'Spur', 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }

--- a/cont3xt/integrations/threatstream/index.js
+++ b/cont3xt/integrations/threatstream/index.js
@@ -120,7 +120,7 @@ class ThreatstreamIntegration extends Integration {
 
   async fetch (user, query) {
     try {
-      const host = this.getUserConfig(user, 'Threatstream', 'host', 'api.threatstream.com');
+      const host = this.getUserConfig(user, 'host', 'api.threatstream.com');
 
       // https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch08s15.html + uppercase
       if (!host.match(/^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,}$/)) {
@@ -128,8 +128,8 @@ class ThreatstreamIntegration extends Integration {
         return undefined;
       }
 
-      const tuser = this.getUserConfig(user, 'Threatstream', 'user');
-      const tkey = this.getUserConfig(user, 'Threatstream', 'key');
+      const tuser = this.getUserConfig(user, 'user');
+      const tkey = this.getUserConfig(user, 'key');
       if (!tkey || !tuser) {
         return undefined;
       }

--- a/cont3xt/integrations/twilio/index.js
+++ b/cont3xt/integrations/twilio/index.js
@@ -91,12 +91,12 @@ class TwilioIntegration extends Integration {
 
   async fetch (user, query) {
     try {
-      const sid = this.getUserConfig(user, 'Twilio', 'sid');
+      const sid = this.getUserConfig(user, 'sid');
       if (!sid) {
         return undefined;
       }
 
-      const token = this.getUserConfig(user, 'Twilio', 'token');
+      const token = this.getUserConfig(user, 'token');
       if (!token) {
         return undefined;
       }

--- a/cont3xt/integrations/urlscan/index.js
+++ b/cont3xt/integrations/urlscan/index.js
@@ -133,7 +133,7 @@ class URLScanIntegration extends Integration {
 
   async fetch (user, query) {
     try {
-      const key = this.getUserConfig(user, 'URLScan', 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }

--- a/cont3xt/integrations/virustotal/index.js
+++ b/cont3xt/integrations/virustotal/index.js
@@ -155,7 +155,7 @@ class VirusTotalDomainIntegration extends Integration {
 
   async fetchDomain (user, domain) {
     try {
-      const key = this.getUserConfig(user, 'VirusTotal', 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }
@@ -287,7 +287,7 @@ class VirusTotalIPIntegration extends Integration {
 
   async fetchIp (user, ip) {
     try {
-      const key = this.getUserConfig(user, 'VirusTotal', 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }
@@ -386,7 +386,7 @@ class VirusTotalHashIntegration extends Integration {
 
   async fetchHash (user, hash) {
     try {
-      const key = this.getUserConfig(user, 'VirusTotal', 'key');
+      const key = this.getUserConfig(user, 'key');
       if (!key) {
         return undefined;
       }


### PR DESCRIPTION
* Cleaned up how config is done
- switch to ArkimeConfig if you just want to get things from config file for integrations
- if configName is set use that for config file and user config
- if section is set use that for config file and name for user config

* When viewRoles in config file is set for integration check that for both list and run operations

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
