### PR TITLE
TLS Cert validity with negative values

### DIFF
--- a/capture/db.c
+++ b/capture/db.c
@@ -1277,9 +1277,15 @@ void moloch_db_save_session(MolochSession_t *session, int final)
                 BSB_EXPORT_sprintf(jbsb, "\"notBefore\":%" PRId64 ",", certs->notBefore*1000);
                 BSB_EXPORT_sprintf(jbsb, "\"notAfter\":%" PRId64 ",", certs->notAfter*1000);
                 if (certs->notAfter >= certs->notBefore) {
-                    BSB_EXPORT_sprintf(jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)certs->notAfter - certs->notBefore)/(60*60*24));
                     BSB_EXPORT_sprintf(jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)certs->notAfter - currentTime.tv_sec)/(60*60*24));
                 }
+                if (certs->notAfter < session->firstPacket.tv_sec) {
+                    BSB_EXPORT_sprintf(jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)0));
+                } else {
+                    BSB_EXPORT_sprintf(jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)certs->notAfter - session->firstPacket.tv_sec));
+                }
+                BSB_EXPORT_sprintf(jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)certs->notAfter - certs->notBefore)/(60*60*24));
+                BSB_EXPORT_sprintf(jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)certs->notAfter - certs->notBefore));
 
                 BSB_EXPORT_rewind(jbsb, 1); // Remove last comma
 

--- a/capture/db.c
+++ b/capture/db.c
@@ -1276,13 +1276,12 @@ void moloch_db_save_session(MolochSession_t *session, int final)
 
                 BSB_EXPORT_sprintf(jbsb, "\"notBefore\":%" PRId64 ",", certs->notBefore*1000);
                 BSB_EXPORT_sprintf(jbsb, "\"notAfter\":%" PRId64 ",", certs->notAfter*1000);
-                if (certs->notAfter >= certs->notBefore) {
-                    BSB_EXPORT_sprintf(jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)certs->notAfter - currentTime.tv_sec)/(60*60*24));
-                }
-                if (certs->notAfter < session->firstPacket.tv_sec) {
+                if (certs->notAfter < ((uint64_t)session->firstPacket.tv_sec)) {
+                    BSB_EXPORT_sprintf(jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)0));
                     BSB_EXPORT_sprintf(jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)0));
                 } else {
-                    BSB_EXPORT_sprintf(jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)certs->notAfter - session->firstPacket.tv_sec));
+                    BSB_EXPORT_sprintf(jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)certs->notAfter - ((uint64_t)session->firstPacket.tv_sec))/(60*60*24));
+                    BSB_EXPORT_sprintf(jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)certs->notAfter - ((uint64_t)session->firstPacket.tv_sec)));
                 }
                 BSB_EXPORT_sprintf(jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)certs->notAfter - certs->notBefore)/(60*60*24));
                 BSB_EXPORT_sprintf(jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)certs->notAfter - certs->notBefore));

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -887,6 +887,18 @@ void moloch_parser_init()
         0, MOLOCH_FIELD_FLAG_FAKE,
         (char *)NULL);
 
+    moloch_field_define("cert", "integer",
+        "cert.validforSeconds", "Seconds Valid For", "cert.validSeconds",
+        "Certificate is valid for this many seconds total",
+        0, MOLOCH_FIELD_FLAG_FAKE,
+        (char *)NULL);
+
+    moloch_field_define("cert", "integer",
+        "cert.remainingSeconds", "Seconds remaining", "cert.remainingSeconds",
+        "Certificate is still valid for this many seconds",
+        0, MOLOCH_FIELD_FLAG_FAKE,
+        (char *)NULL);
+
     moloch_field_define("cert", "termfield",
         "cert.curve", "Curve", "cert.curve",
         "Curve Algorithm",

--- a/capture/parsers/tls.detail.jade
+++ b/capture/parsers/tls.detail.jade
@@ -28,6 +28,18 @@ if (session.cert)
       - if (cert.notAfter)
         strong.medium.ml-1 Not After
         moloch-session-field.detail-field(:expr="'cert.notafter'", :value='"'+cert.notAfter+'"', :field="fields['cert.notafter']", :pull-left="true")
+      - if (cert.validDays)
+        strong.medium.ml-1 Days Valid For
+        moloch-session-field.detail-field(:expr="'cert.validfor'", :value='"'+cert.validDays+'"', :field="fields['cert.validfor']", :pull-left="true")
+      - if (cert.validSeconds)
+        strong.medium.ml-1 Seconds Valid For
+        moloch-session-field.detail-field(:expr="'cert.validforSeconds'", :value='"'+cert.validSeconds+'"', :field="fields['cert.validforSeconds']", :pull-left="true")
+      - if (cert.remainingDays)
+        strong.medium.ml-1 Days Remaining
+        moloch-session-field.detail-field(:expr="'cert.remainingDays'", :value='"'+cert.remainingDays+'"', :field="fields['cert.remainingDays']", :pull-left="true")
+      - if (cert.remainingSeconds)
+        strong.medium.ml-1 Seconds Remaining
+        moloch-session-field.detail-field(:expr="'cert.remainingSeconds'", :value='"'+cert.remainingSeconds+'"', :field="fields['cert.remainingSeconds']", :pull-left="true")
       - if (cert.issueCN && Array.isArray(cert.issueCN))
         strong.medium.ml-1 Issuer Common
         each cn,i in cert.issueCN

--- a/tests/pcap/badcurveball.test
+++ b/tests/pcap/badcurveball.test
@@ -17,6 +17,7 @@
                   "notBefore" : 1579183250000,
                   "publicAlgorithm" : "id-ecPublicKey",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 2481434,
                   "serial" : "62344031f7ab03e6f9327cde33419cf7fb09df94",
                   "subjectCN" : [
                      "infigo"
@@ -24,7 +25,8 @@
                   "subjectON" : [
                      "INFIGO IS"
                   ],
-                  "validDays" : 30
+                  "validDays" : 30,
+                  "validSeconds" : 2592000
                },
                {
                   "alt" : [
@@ -43,6 +45,7 @@
                   "notBefore" : 1521875742000,
                   "publicAlgorithm" : "id-ecPublicKey",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 5653926,
                   "serial" : "5ecb7cee8ca206bf9ec00728889ad99f4362cfd9",
                   "subjectCN" : [
                      "sans isc dshield test"
@@ -50,7 +53,8 @@
                   "subjectON" : [
                      "SANS Internet Storm Center"
                   ],
-                  "validDays" : 730
+                  "validDays" : 730,
+                  "validSeconds" : 63072000
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/badcurveball.test
+++ b/tests/pcap/badcurveball.test
@@ -16,7 +16,7 @@
                   "notAfter" : 1581775250000,
                   "notBefore" : 1579183250000,
                   "publicAlgorithm" : "id-ecPublicKey",
-                  "remainingDays" : -1,
+                  "remainingDays" : 28,
                   "remainingSeconds" : 2481434,
                   "serial" : "62344031f7ab03e6f9327cde33419cf7fb09df94",
                   "subjectCN" : [
@@ -44,7 +44,7 @@
                   "notAfter" : 1584947742000,
                   "notBefore" : 1521875742000,
                   "publicAlgorithm" : "id-ecPublicKey",
-                  "remainingDays" : -1,
+                  "remainingDays" : 65,
                   "remainingSeconds" : 5653926,
                   "serial" : "5ecb7cee8ca206bf9ec00728889ad99f4362cfd9",
                   "subjectCN" : [

--- a/tests/pcap/cloudshark-dtls1.test
+++ b/tests/pcap/cloudshark-dtls1.test
@@ -11,7 +11,7 @@
                   ],
                   "notAfter" : 1720007767000,
                   "notBefore" : 1404647767000,
-                  "remainingDays" : 1,
+                  "remainingDays" : 3649,
                   "remainingSeconds" : 315359665,
                   "serial" : "00f1965d11e3ff07ee",
                   "subjectON" : [

--- a/tests/pcap/cloudshark-dtls1.test
+++ b/tests/pcap/cloudshark-dtls1.test
@@ -12,11 +12,13 @@
                   "notAfter" : 1720007767000,
                   "notBefore" : 1404647767000,
                   "remainingDays" : 1,
+                  "remainingSeconds" : 315359665,
                   "serial" : "00f1965d11e3ff07ee",
                   "subjectON" : [
                      "Internet Widgits Pty Ltd"
                   ],
-                  "validDays" : 3650
+                  "validDays" : 3650,
+                  "validSeconds" : 315360000
                }
             ],
             "certCnt" : 1,

--- a/tests/pcap/https-connect.test
+++ b/tests/pcap/https-connect.test
@@ -26,6 +26,7 @@
                   "notBefore" : 1495670400000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 23302987,
                   "serial" : "048d398cbd9d68c87e1ba3ec99c2b07d",
                   "subjectCN" : [
                      "lfoup01-b.cloudsink.net"
@@ -33,7 +34,8 @@
                   "subjectON" : [
                      "CrowdStrike, Inc."
                   ],
-                  "validDays" : 1100
+                  "validDays" : 1100,
+                  "validSeconds" : 95083200
                },
                {
                   "hash" : "a0:31:c4:67:82:e6:e6:c6:62:c2:c8:7c:76:da:9a:a6:2c:ca:bd:8e",
@@ -50,6 +52,7 @@
                   "notBefore" : 1382443200000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : 1,
+                  "remainingSeconds" : 288378187,
                   "serial" : "04e1e7a4dc5cf2f36dc02b42b85d159f",
                   "subjectCN" : [
                      "digicert sha2 high assurance server ca"
@@ -60,7 +63,8 @@
                   "subjectOU" : [
                      "www.digicert.com"
                   ],
-                  "validDays" : 5479
+                  "validDays" : 5479,
+                  "validSeconds" : 473385600
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/https-connect.test
+++ b/tests/pcap/https-connect.test
@@ -25,7 +25,7 @@
                   "notAfter" : 1590753600000,
                   "notBefore" : 1495670400000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 269,
                   "remainingSeconds" : 23302987,
                   "serial" : "048d398cbd9d68c87e1ba3ec99c2b07d",
                   "subjectCN" : [
@@ -51,7 +51,7 @@
                   "notAfter" : 1855828800000,
                   "notBefore" : 1382443200000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 1,
+                  "remainingDays" : 3337,
                   "remainingSeconds" : 288378187,
                   "serial" : "04e1e7a4dc5cf2f36dc02b42b85d159f",
                   "subjectCN" : [

--- a/tests/pcap/https-generalizedtime.test
+++ b/tests/pcap/https-generalizedtime.test
@@ -34,6 +34,7 @@
                   "notBefore" : 1415717263000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 29801713,
                   "serial" : "2e8f3b9cbc17eacb6459a3b8c0b598fb",
                   "subjectCN" : [
                      "mail.yandex.ru"
@@ -44,7 +45,8 @@
                   "subjectOU" : [
                      "ITO"
                   ],
-                  "validDays" : 415
+                  "validDays" : 415,
+                  "validSeconds" : 35856000
                },
                {
                   "hash" : "12:e1:89:f7:dc:2f:a2:82:38:0b:48:77:31:9f:5f:1d:fe:af:6d:69",
@@ -58,6 +60,7 @@
                   "notBefore" : 1236084865000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : 1,
+                  "remainingSeconds" : 287698915,
                   "serial" : "4ca5fec6617c48b056382a8280e0508c",
                   "subjectCN" : [
                      "certum level iv ca"
@@ -68,7 +71,8 @@
                   "subjectOU" : [
                      "Certum Certification Authority"
                   ],
-                  "validDays" : 5479
+                  "validDays" : 5479,
+                  "validSeconds" : 473385600
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/https-generalizedtime.test
+++ b/tests/pcap/https-generalizedtime.test
@@ -33,7 +33,7 @@
                   "notAfter" : 1451573263000,
                   "notBefore" : 1415717263000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 344,
                   "remainingSeconds" : 29801713,
                   "serial" : "2e8f3b9cbc17eacb6459a3b8c0b598fb",
                   "subjectCN" : [
@@ -59,7 +59,7 @@
                   "notAfter" : 1709470465000,
                   "notBefore" : 1236084865000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 1,
+                  "remainingDays" : 3329,
                   "remainingSeconds" : 287698915,
                   "serial" : "4ca5fec6617c48b056382a8280e0508c",
                   "subjectCN" : [

--- a/tests/pcap/https2-301-get.test
+++ b/tests/pcap/https2-301-get.test
@@ -19,6 +19,7 @@
                   "notBefore" : 1194609600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 251092127,
                   "serial" : "0337b928347c60a6aec5adb1217f3860",
                   "subjectCN" : [
                      "digicert high assurance ev ca-1"
@@ -29,7 +30,8 @@
                   "subjectOU" : [
                      "www.digicert.com"
                   ],
-                  "validDays" : 5114
+                  "validDays" : 5114,
+                  "validSeconds" : 441892800
                },
                {
                   "alt" : [
@@ -51,6 +53,7 @@
                   "notBefore" : 1370822400000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 55784927,
                   "serial" : "047fbe2e4bde0084d2caf8e3ecfe7058",
                   "subjectCN" : [
                      "github.com"
@@ -58,7 +61,8 @@
                   "subjectON" : [
                      "GitHub, Inc."
                   ],
-                  "validDays" : 814
+                  "validDays" : 814,
+                  "validSeconds" : 70372800
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/https2-301-get.test
+++ b/tests/pcap/https2-301-get.test
@@ -18,7 +18,7 @@
                   "notAfter" : 1636502400000,
                   "notBefore" : 1194609600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 2906,
                   "remainingSeconds" : 251092127,
                   "serial" : "0337b928347c60a6aec5adb1217f3860",
                   "subjectCN" : [
@@ -52,7 +52,7 @@
                   "notAfter" : 1441195200000,
                   "notBefore" : 1370822400000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 645,
                   "remainingSeconds" : 55784927,
                   "serial" : "047fbe2e4bde0084d2caf8e3ecfe7058",
                   "subjectCN" : [
@@ -232,3 +232,4 @@
       }
    ]
 }
+

--- a/tests/pcap/https3-301-get.test
+++ b/tests/pcap/https3-301-get.test
@@ -19,6 +19,7 @@
                   "notBefore" : 1194609600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 251105579,
                   "serial" : "0337b928347c60a6aec5adb1217f3860",
                   "subjectCN" : [
                      "digicert high assurance ev ca-1"
@@ -29,7 +30,8 @@
                   "subjectOU" : [
                      "www.digicert.com"
                   ],
-                  "validDays" : 5114
+                  "validDays" : 5114,
+                  "validSeconds" : 441892800
                },
                {
                   "alt" : [
@@ -51,6 +53,7 @@
                   "notBefore" : 1370822400000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 55798379,
                   "serial" : "047fbe2e4bde0084d2caf8e3ecfe7058",
                   "subjectCN" : [
                      "github.com"
@@ -58,7 +61,8 @@
                   "subjectON" : [
                      "GitHub, Inc."
                   ],
-                  "validDays" : 814
+                  "validDays" : 814,
+                  "validSeconds" : 70372800
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/https3-301-get.test
+++ b/tests/pcap/https3-301-get.test
@@ -18,7 +18,7 @@
                   "notAfter" : 1636502400000,
                   "notBefore" : 1194609600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 2906,
                   "remainingSeconds" : 251105579,
                   "serial" : "0337b928347c60a6aec5adb1217f3860",
                   "subjectCN" : [
@@ -52,7 +52,7 @@
                   "notAfter" : 1441195200000,
                   "notBefore" : 1370822400000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 645,
                   "remainingSeconds" : 55798379,
                   "serial" : "047fbe2e4bde0084d2caf8e3ecfe7058",
                   "subjectCN" : [
@@ -246,3 +246,4 @@
       }
    ]
 }
+

--- a/tests/pcap/ldap-ssl.test
+++ b/tests/pcap/ldap-ssl.test
@@ -13,11 +13,13 @@
                   "notBefore" : 1422670709000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : 1,
+                  "remainingSeconds" : 315357177,
                   "serial" : "008a07e08d4ab50a7b",
                   "subjectCN" : [
                      "ldap ssl test"
                   ],
-                  "validDays" : 3650
+                  "validDays" : 3650,
+                  "validSeconds" : 315360000
                }
             ],
             "certCnt" : 1,

--- a/tests/pcap/ldap-ssl.test
+++ b/tests/pcap/ldap-ssl.test
@@ -12,7 +12,7 @@
                   "notAfter" : 1738030709000,
                   "notBefore" : 1422670709000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 1,
+                  "remainingDays" : 3649,
                   "remainingSeconds" : 315357177,
                   "serial" : "008a07e08d4ab50a7b",
                   "subjectCN" : [

--- a/tests/pcap/mysql-tls.test
+++ b/tests/pcap/mysql-tls.test
@@ -12,7 +12,7 @@
                   "notAfter" : 1779463436000,
                   "notBefore" : 1464103436000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 1,
+                  "remainingDays" : 3436,
                   "remainingSeconds" : 296911218,
                   "serial" : "02",
                   "subjectCN" : [

--- a/tests/pcap/mysql-tls.test
+++ b/tests/pcap/mysql-tls.test
@@ -13,11 +13,13 @@
                   "notBefore" : 1464103436000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : 1,
+                  "remainingSeconds" : 296911218,
                   "serial" : "02",
                   "subjectCN" : [
                      "mysql_server_5.7.12_auto_generated_server_certificate"
                   ],
-                  "validDays" : 3650
+                  "validDays" : 3650,
+                  "validSeconds" : 315360000
                }
             ],
             "certCnt" : 1,

--- a/tests/pcap/openssl-ssl3.test
+++ b/tests/pcap/openssl-ssl3.test
@@ -15,7 +15,7 @@
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 1406,
                   "remainingSeconds" : 121486231,
                   "serial" : "12bbe6",
                   "subjectCN" : [
@@ -90,7 +90,7 @@
                   "notAfter" : 1419292800000,
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 68,
                   "remainingSeconds" : 5955031,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
@@ -113,7 +113,7 @@
                   "notAfter" : 1483228799000,
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 808,
                   "remainingSeconds" : 69891030,
                   "serial" : "023a76",
                   "subjectCN" : [

--- a/tests/pcap/openssl-ssl3.test
+++ b/tests/pcap/openssl-ssl3.test
@@ -16,6 +16,7 @@
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 121486231,
                   "serial" : "12bbe6",
                   "subjectCN" : [
                      "geotrust global ca"
@@ -23,7 +24,8 @@
                   "subjectON" : [
                      "GeoTrust Inc."
                   ],
-                  "validDays" : 5936
+                  "validDays" : 5936,
+                  "validSeconds" : 512870400
                },
                {
                   "alt" : [
@@ -89,6 +91,7 @@
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 5955031,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
                      "*.google.com"
@@ -96,7 +99,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 89
+                  "validDays" : 89,
+                  "validSeconds" : 7739515
                },
                {
                   "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
@@ -110,6 +114,7 @@
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 69891030,
                   "serial" : "023a76",
                   "subjectCN" : [
                      "google internet authority g2"
@@ -117,7 +122,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 1366
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/openssl-tls1-tls1_2.test
+++ b/tests/pcap/openssl-tls1-tls1_2.test
@@ -16,6 +16,7 @@
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 121485793,
                   "serial" : "12bbe6",
                   "subjectCN" : [
                      "geotrust global ca"
@@ -23,7 +24,8 @@
                   "subjectON" : [
                      "GeoTrust Inc."
                   ],
-                  "validDays" : 5936
+                  "validDays" : 5936,
+                  "validSeconds" : 512870400
                },
                {
                   "alt" : [
@@ -89,6 +91,7 @@
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 5954593,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
                      "*.google.com"
@@ -96,7 +99,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 89
+                  "validDays" : 89,
+                  "validSeconds" : 7739515
                },
                {
                   "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
@@ -110,6 +114,7 @@
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 69890592,
                   "serial" : "023a76",
                   "subjectCN" : [
                      "google internet authority g2"
@@ -117,7 +122,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 1366
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/openssl-tls1-tls1_2.test
+++ b/tests/pcap/openssl-tls1-tls1_2.test
@@ -15,7 +15,7 @@
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 1406,
                   "remainingSeconds" : 121485793,
                   "serial" : "12bbe6",
                   "subjectCN" : [
@@ -90,7 +90,7 @@
                   "notAfter" : 1419292800000,
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 68,
                   "remainingSeconds" : 5954593,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
@@ -113,7 +113,7 @@
                   "notAfter" : 1483228799000,
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 808,
                   "remainingSeconds" : 69890592,
                   "serial" : "023a76",
                   "subjectCN" : [

--- a/tests/pcap/openssl-tls1.test
+++ b/tests/pcap/openssl-tls1.test
@@ -15,7 +15,7 @@
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 1406,
                   "remainingSeconds" : 121486179,
                   "serial" : "12bbe6",
                   "subjectCN" : [
@@ -90,7 +90,7 @@
                   "notAfter" : 1419292800000,
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 68,
                   "remainingSeconds" : 5954979,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
@@ -113,7 +113,7 @@
                   "notAfter" : 1483228799000,
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 808,
                   "remainingSeconds" : 69890978,
                   "serial" : "023a76",
                   "subjectCN" : [

--- a/tests/pcap/openssl-tls1.test
+++ b/tests/pcap/openssl-tls1.test
@@ -16,6 +16,7 @@
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 121486179,
                   "serial" : "12bbe6",
                   "subjectCN" : [
                      "geotrust global ca"
@@ -23,7 +24,8 @@
                   "subjectON" : [
                      "GeoTrust Inc."
                   ],
-                  "validDays" : 5936
+                  "validDays" : 5936,
+                  "validSeconds" : 512870400
                },
                {
                   "alt" : [
@@ -89,6 +91,7 @@
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 5954979,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
                      "*.google.com"
@@ -96,7 +99,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 89
+                  "validDays" : 89,
+                  "validSeconds" : 7739515
                },
                {
                   "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
@@ -110,6 +114,7 @@
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 69890978,
                   "serial" : "023a76",
                   "subjectCN" : [
                      "google internet authority g2"
@@ -117,7 +122,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 1366
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/openssl-tls1_1.test
+++ b/tests/pcap/openssl-tls1_1.test
@@ -16,6 +16,7 @@
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 121486163,
                   "serial" : "12bbe6",
                   "subjectCN" : [
                      "geotrust global ca"
@@ -23,7 +24,8 @@
                   "subjectON" : [
                      "GeoTrust Inc."
                   ],
-                  "validDays" : 5936
+                  "validDays" : 5936,
+                  "validSeconds" : 512870400
                },
                {
                   "alt" : [
@@ -89,6 +91,7 @@
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 5954963,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
                      "*.google.com"
@@ -96,7 +99,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 89
+                  "validDays" : 89,
+                  "validSeconds" : 7739515
                },
                {
                   "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
@@ -110,6 +114,7 @@
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 69890962,
                   "serial" : "023a76",
                   "subjectCN" : [
                      "google internet authority g2"
@@ -117,7 +122,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 1366
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/openssl-tls1_1.test
+++ b/tests/pcap/openssl-tls1_1.test
@@ -15,7 +15,7 @@
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 1406,
                   "remainingSeconds" : 121486163,
                   "serial" : "12bbe6",
                   "subjectCN" : [
@@ -90,7 +90,7 @@
                   "notAfter" : 1419292800000,
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 68,
                   "remainingSeconds" : 5954963,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
@@ -113,7 +113,7 @@
                   "notAfter" : 1483228799000,
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 808,
                   "remainingSeconds" : 69890962,
                   "serial" : "023a76",
                   "subjectCN" : [

--- a/tests/pcap/openssl-tls1_2-tls1.test
+++ b/tests/pcap/openssl-tls1_2-tls1.test
@@ -84,7 +84,7 @@
                   "notAfter" : 1497242632000,
                   "notBefore" : 1402510723000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 971,
                   "remainingSeconds" : 83904558,
                   "serial" : "4c235548",
                   "subjectCN" : [
@@ -114,7 +114,7 @@
                   "notAfter" : 1636685477000,
                   "notBefore" : 1321026040000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 2585,
                   "remainingSeconds" : 223347403,
                   "serial" : "4c0e8c39",
                   "subjectCN" : [

--- a/tests/pcap/openssl-tls1_2-tls1.test
+++ b/tests/pcap/openssl-tls1_2-tls1.test
@@ -85,6 +85,7 @@
                   "notBefore" : 1402510723000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 83904558,
                   "serial" : "4c235548",
                   "subjectCN" : [
                      "www.aol.com"
@@ -95,7 +96,8 @@
                   "subjectOU" : [
                      "Homepages"
                   ],
-                  "validDays" : 1096
+                  "validDays" : 1096,
+                  "validSeconds" : 94731909
                },
                {
                   "hash" : "c5:3e:73:07:3f:93:ce:78:95:de:74:84:12:6b:c3:03:da:b9:e6:57",
@@ -113,6 +115,7 @@
                   "notBefore" : 1321026040000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 223347403,
                   "serial" : "4c0e8c39",
                   "subjectCN" : [
                      "entrust certification authority - l1c"
@@ -124,7 +127,8 @@
                      "www.entrust.net/rpa is incorporated by reference",
                      "(c) 2009 Entrust, Inc."
                   ],
-                  "validDays" : 3653
+                  "validDays" : 3653,
+                  "validSeconds" : 315659437
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/openssl-tls1_2.test
+++ b/tests/pcap/openssl-tls1_2.test
@@ -15,7 +15,7 @@
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 1406,
                   "remainingSeconds" : 121486104,
                   "serial" : "12bbe6",
                   "subjectCN" : [
@@ -90,7 +90,7 @@
                   "notAfter" : 1419292800000,
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 68,
                   "remainingSeconds" : 5954904,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
@@ -113,7 +113,7 @@
                   "notAfter" : 1483228799000,
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 808,
                   "remainingSeconds" : 69890903,
                   "serial" : "023a76",
                   "subjectCN" : [

--- a/tests/pcap/openssl-tls1_2.test
+++ b/tests/pcap/openssl-tls1_2.test
@@ -16,6 +16,7 @@
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 121486104,
                   "serial" : "12bbe6",
                   "subjectCN" : [
                      "geotrust global ca"
@@ -23,7 +24,8 @@
                   "subjectON" : [
                      "GeoTrust Inc."
                   ],
-                  "validDays" : 5936
+                  "validDays" : 5936,
+                  "validSeconds" : 512870400
                },
                {
                   "alt" : [
@@ -89,6 +91,7 @@
                   "notBefore" : 1411553285000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 5954904,
                   "serial" : "7a5b0bd895632f87",
                   "subjectCN" : [
                      "*.google.com"
@@ -96,7 +99,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 89
+                  "validDays" : 89,
+                  "validSeconds" : 7739515
                },
                {
                   "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
@@ -110,6 +114,7 @@
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 69890903,
                   "serial" : "023a76",
                   "subjectCN" : [
                      "google internet authority g2"
@@ -117,7 +122,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 1366
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/pppoe.test
+++ b/tests/pcap/pppoe.test
@@ -15,7 +15,7 @@
                   "notAfter" : 1231995540000,
                   "notBefore" : 1168837200000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 443,
                   "remainingSeconds" : 38319485,
                   "serial" : "0119",
                   "subjectCN" : [
@@ -41,7 +41,7 @@
                   "notAfter" : 2142276180000,
                   "notBefore" : 1022565600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 1,
+                  "remainingDays" : 10979,
                   "remainingSeconds" : 948600125,
                   "serial" : "01",
                   "subjectCN" : [
@@ -64,7 +64,7 @@
                   "notAfter" : 1875288399000,
                   "notBefore" : 1086369999000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 1,
+                  "remainingDays" : 7889,
                   "remainingSeconds" : 681612344,
                   "serial" : "07",
                   "subjectCN" : [

--- a/tests/pcap/pppoe.test
+++ b/tests/pcap/pppoe.test
@@ -16,6 +16,7 @@
                   "notBefore" : 1168837200000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 38319485,
                   "serial" : "0119",
                   "subjectCN" : [
                      "kdc.uas.aol.com"
@@ -26,7 +27,8 @@
                   "subjectOU" : [
                      "Core Services"
                   ],
-                  "validDays" : 730
+                  "validDays" : 730,
+                  "validSeconds" : 63158340
                },
                {
                   "hash" : "39:21:c1:15:c1:5d:0e:ca:5c:cb:5b:c4:f0:7d:21:d8:05:0b:56:6a",
@@ -40,6 +42,7 @@
                   "notBefore" : 1022565600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : 1,
+                  "remainingSeconds" : 948600125,
                   "serial" : "01",
                   "subjectCN" : [
                      "america online root certification authority 1"
@@ -47,7 +50,8 @@
                   "subjectON" : [
                      "America Online Inc."
                   ],
-                  "validDays" : 12959
+                  "validDays" : 12959,
+                  "validSeconds" : 1119710580
                },
                {
                   "hash" : "a1:44:6b:ce:0c:87:4d:f0:f2:c3:f6:1d:a5:c9:a2:bc:f9:da:b2:04",
@@ -61,6 +65,7 @@
                   "notBefore" : 1086369999000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : 1,
+                  "remainingSeconds" : 681612344,
                   "serial" : "07",
                   "subjectCN" : [
                      "aol member ca"
@@ -68,7 +73,8 @@
                   "subjectON" : [
                      "America Online Inc."
                   ],
-                  "validDays" : 9131
+                  "validDays" : 9131,
+                  "validSeconds" : 788918400
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/smtp-starttls.test
+++ b/tests/pcap/smtp-starttls.test
@@ -15,7 +15,7 @@
                   "notAfter" : 1428160555000,
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 464,
                   "remainingSeconds" : 40143431,
                   "serial" : "023a69",
                   "subjectCN" : [
@@ -38,7 +38,7 @@
                   "notAfter" : 1534824000000,
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 1699,
                   "remainingSeconds" : 146806876,
                   "serial" : "12bbe6",
                   "subjectCN" : [
@@ -84,7 +84,7 @@
                   "notAfter" : 1410262355000,
                   "notBefore" : 1378726355000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 257,
                   "remainingSeconds" : 22245231,
                   "serial" : "325d8297987d50b0",
                   "subjectCN" : [

--- a/tests/pcap/smtp-starttls.test
+++ b/tests/pcap/smtp-starttls.test
@@ -16,6 +16,7 @@
                   "notBefore" : 1365174955000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 40143431,
                   "serial" : "023a69",
                   "subjectCN" : [
                      "google internet authority g2"
@@ -23,7 +24,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 729
+                  "validDays" : 729,
+                  "validSeconds" : 62985600
                },
                {
                   "hash" : "73:59:75:5c:6d:f9:a0:ab:c3:06:0b:ce:36:95:64:c8:ec:45:42:a3",
@@ -37,6 +39,7 @@
                   "notBefore" : 1021953600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 146806876,
                   "serial" : "12bbe6",
                   "subjectCN" : [
                      "geotrust global ca"
@@ -44,7 +47,8 @@
                   "subjectON" : [
                      "GeoTrust Inc."
                   ],
-                  "validDays" : 5936
+                  "validDays" : 5936,
+                  "validSeconds" : 512870400
                },
                {
                   "alt" : [
@@ -81,6 +85,7 @@
                   "notBefore" : 1378726355000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 22245231,
                   "serial" : "325d8297987d50b0",
                   "subjectCN" : [
                      "mx.google.com"
@@ -88,7 +93,8 @@
                   "subjectON" : [
                      "Google Inc"
                   ],
-                  "validDays" : 365
+                  "validDays" : 365,
+                  "validSeconds" : 31536000
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/socks-https-example.test
+++ b/tests/pcap/socks-https-example.test
@@ -171,6 +171,7 @@
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 32208328,
                   "serial" : "062d488986c9a6d7f94901c2b5906882",
                   "subjectCN" : [
                      "gp1.wac.edgecastcdn.net"
@@ -178,7 +179,8 @@
                   "subjectON" : [
                      "EdgeCast Networks, Inc."
                   ],
-                  "validDays" : 1164
+                  "validDays" : 1164,
+                  "validSeconds" : 100612800
                },
                {
                   "hash" : "42:85:78:55:fb:0e:a4:3f:54:c9:91:1e:30:e7:79:1d:8c:e8:27:05",
@@ -195,6 +197,7 @@
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 262939528,
                   "serial" : "0a5f114d035b179117d2efd4038c3f3b",
                   "subjectCN" : [
                      "digicert high assurance ca-3"
@@ -205,7 +208,8 @@
                   "subjectOU" : [
                      "www.digicert.com"
                   ],
-                  "validDays" : 5113
+                  "validDays" : 5113,
+                  "validSeconds" : 441806400
                }
             ],
             "certCnt" : 2,
@@ -571,6 +575,7 @@
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 32208325,
                   "serial" : "062d488986c9a6d7f94901c2b5906882",
                   "subjectCN" : [
                      "gp1.wac.edgecastcdn.net"
@@ -578,7 +583,8 @@
                   "subjectON" : [
                      "EdgeCast Networks, Inc."
                   ],
-                  "validDays" : 1164
+                  "validDays" : 1164,
+                  "validSeconds" : 100612800
                },
                {
                   "hash" : "42:85:78:55:fb:0e:a4:3f:54:c9:91:1e:30:e7:79:1d:8c:e8:27:05",
@@ -595,6 +601,7 @@
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 262939525,
                   "serial" : "0a5f114d035b179117d2efd4038c3f3b",
                   "subjectCN" : [
                      "digicert high assurance ca-3"
@@ -605,7 +612,8 @@
                   "subjectOU" : [
                      "www.digicert.com"
                   ],
-                  "validDays" : 5113
+                  "validDays" : 5113,
+                  "validSeconds" : 441806400
                }
             ],
             "certCnt" : 2,
@@ -968,6 +976,7 @@
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 32208320,
                   "serial" : "062d488986c9a6d7f94901c2b5906882",
                   "subjectCN" : [
                      "gp1.wac.edgecastcdn.net"
@@ -975,7 +984,8 @@
                   "subjectON" : [
                      "EdgeCast Networks, Inc."
                   ],
-                  "validDays" : 1164
+                  "validDays" : 1164,
+                  "validSeconds" : 100612800
                },
                {
                   "hash" : "42:85:78:55:fb:0e:a4:3f:54:c9:91:1e:30:e7:79:1d:8c:e8:27:05",
@@ -992,6 +1002,7 @@
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 262939520,
                   "serial" : "0a5f114d035b179117d2efd4038c3f3b",
                   "subjectCN" : [
                      "digicert high assurance ca-3"
@@ -1002,7 +1013,8 @@
                   "subjectOU" : [
                      "www.digicert.com"
                   ],
-                  "validDays" : 5113
+                  "validDays" : 5113,
+                  "validSeconds" : 441806400
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/socks-https-example.test
+++ b/tests/pcap/socks-https-example.test
@@ -170,7 +170,7 @@
                   "notAfter" : 1418212800000,
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 372,
                   "remainingSeconds" : 32208328,
                   "serial" : "062d488986c9a6d7f94901c2b5906882",
                   "subjectCN" : [
@@ -196,7 +196,7 @@
                   "notAfter" : 1648944000000,
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 3043,
                   "remainingSeconds" : 262939528,
                   "serial" : "0a5f114d035b179117d2efd4038c3f3b",
                   "subjectCN" : [
@@ -574,7 +574,7 @@
                   "notAfter" : 1418212800000,
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 372,
                   "remainingSeconds" : 32208325,
                   "serial" : "062d488986c9a6d7f94901c2b5906882",
                   "subjectCN" : [
@@ -600,7 +600,7 @@
                   "notAfter" : 1648944000000,
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 3043,
                   "remainingSeconds" : 262939525,
                   "serial" : "0a5f114d035b179117d2efd4038c3f3b",
                   "subjectCN" : [
@@ -975,7 +975,7 @@
                   "notAfter" : 1418212800000,
                   "notBefore" : 1317600000000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 372,
                   "remainingSeconds" : 32208320,
                   "serial" : "062d488986c9a6d7f94901c2b5906882",
                   "subjectCN" : [
@@ -1001,7 +1001,7 @@
                   "notAfter" : 1648944000000,
                   "notBefore" : 1207137600000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 3043,
                   "remainingSeconds" : 262939520,
                   "serial" : "0a5f114d035b179117d2efd4038c3f3b",
                   "subjectCN" : [

--- a/tests/pcap/socks4-https.test
+++ b/tests/pcap/socks4-https.test
@@ -32,7 +32,7 @@
                   "notAfter" : 1448927999000,
                   "notBefore" : 1413504000000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 392,
                   "remainingSeconds" : 33874359,
                   "serial" : "0dc04875701d090d9f3645da26f51fe7",
                   "subjectCN" : [
@@ -58,7 +58,7 @@
                   "notAfter" : 1636329599000,
                   "notBefore" : 1162944000000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 2561,
                   "remainingSeconds" : 221275959,
                   "serial" : "35973187f3873a07327ece580c9b7eda",
                   "subjectCN" : [
@@ -89,7 +89,7 @@
                   "notAfter" : 1478563199000,
                   "notBefore" : 1162944000000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 735,
                   "remainingSeconds" : 63509559,
                   "serial" : "112a006d37e5106fd6ca7cc3efbacc18",
                   "subjectCN" : [

--- a/tests/pcap/socks4-https.test
+++ b/tests/pcap/socks4-https.test
@@ -33,6 +33,7 @@
                   "notBefore" : 1413504000000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 33874359,
                   "serial" : "0dc04875701d090d9f3645da26f51fe7",
                   "subjectCN" : [
                      "login.live.com"
@@ -43,7 +44,8 @@
                   "subjectOU" : [
                      "Passport"
                   ],
-                  "validDays" : 409
+                  "validDays" : 409,
+                  "validSeconds" : 35423999
                },
                {
                   "hash" : "f4:a8:0a:0c:d1:e6:cf:19:0b:8c:bc:6f:bc:99:17:11:d4:82:c9:d0",
@@ -57,6 +59,7 @@
                   "notBefore" : 1162944000000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 221275959,
                   "serial" : "35973187f3873a07327ece580c9b7eda",
                   "subjectCN" : [
                      "verisign class 3 public primary certification authority - g5"
@@ -68,7 +71,8 @@
                      "VeriSign Trust Network",
                      "(c) 2006 VeriSign, Inc. - For authorized use only"
                   ],
-                  "validDays" : 5478
+                  "validDays" : 5478,
+                  "validSeconds" : 473385599
                },
                {
                   "hash" : "4a:8a:2a:0e:27:6f:f3:3b:5d:d8:8a:36:21:46:01:0f:2a:8b:6a:ee",
@@ -86,6 +90,7 @@
                   "notBefore" : 1162944000000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 63509559,
                   "serial" : "112a006d37e5106fd6ca7cc3efbacc18",
                   "subjectCN" : [
                      "verisign class 3 extended validation ssl sgc ca"
@@ -97,7 +102,8 @@
                      "VeriSign Trust Network",
                      "Terms of use at https://www.verisign.com/rpa (c)06"
                   ],
-                  "validDays" : 3652
+                  "validDays" : 3652,
+                  "validSeconds" : 315619199
                }
             ],
             "certCnt" : 3,
@@ -290,3 +296,4 @@
       }
    ]
 }
+

--- a/tests/pcap/ssl-selfsign.test
+++ b/tests/pcap/ssl-selfsign.test
@@ -13,11 +13,13 @@
                   "notBefore" : 1519399598000,
                   "publicAlgorithm" : "rsaEncryption",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 2591473,
                   "serial" : "00b27e45d092b4dddf",
                   "subjectCN" : [
                      "molochftw"
                   ],
-                  "validDays" : 30
+                  "validDays" : 30,
+                  "validSeconds" : 2592000
                }
             ],
             "certCnt" : 1,

--- a/tests/pcap/ssl-selfsign.test
+++ b/tests/pcap/ssl-selfsign.test
@@ -12,7 +12,7 @@
                   "notAfter" : 1521991598000,
                   "notBefore" : 1519399598000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : -1,
+                  "remainingDays" : 29,
                   "remainingSeconds" : 2591473,
                   "serial" : "00b27e45d092b4dddf",
                   "subjectCN" : [

--- a/tests/pcap/tls-alpn-h2.test
+++ b/tests/pcap/tls-alpn-h2.test
@@ -25,6 +25,7 @@
                   "notBefore" : 1540857600000,
                   "publicAlgorithm" : "id-ecPublicKey",
                   "remainingDays" : -1,
+                  "remainingSeconds" : 10424192,
                   "serial" : "0a68bb984a507399f4716e809a44a7b0",
                   "subjectCN" : [
                      "cloudflare.com"
@@ -32,7 +33,8 @@
                   "subjectON" : [
                      "Cloudflare, Inc."
                   ],
-                  "validDays" : 735
+                  "validDays" : 735,
+                  "validSeconds" : 63547200
                },
                {
                   "curve" : "secp384r1",
@@ -50,6 +52,7 @@
                   "notBefore" : 1466513667000,
                   "publicAlgorithm" : "id-ecPublicKey",
                   "remainingDays" : 1,
+                  "remainingSeconds" : 345832259,
                   "serial" : "029707560cd4a9ebbfe272f1e096d882",
                   "subjectCN" : [
                      "digicert ecc extended validation server ca"
@@ -60,7 +63,8 @@
                   "subjectOU" : [
                      "www.digicert.com"
                   ],
-                  "validDays" : 5478
+                  "validDays" : 5478,
+                  "validSeconds" : 473299200
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/tls-alpn-h2.test
+++ b/tests/pcap/tls-alpn-h2.test
@@ -24,7 +24,7 @@
                   "notAfter" : 1604404800000,
                   "notBefore" : 1540857600000,
                   "publicAlgorithm" : "id-ecPublicKey",
-                  "remainingDays" : -1,
+                  "remainingDays" : 120,
                   "remainingSeconds" : 10424192,
                   "serial" : "0a68bb984a507399f4716e809a44a7b0",
                   "subjectCN" : [
@@ -51,7 +51,7 @@
                   "notAfter" : 1939812867000,
                   "notBefore" : 1466513667000,
                   "publicAlgorithm" : "id-ecPublicKey",
-                  "remainingDays" : 1,
+                  "remainingDays" : 4002,
                   "remainingSeconds" : 345832259,
                   "serial" : "029707560cd4a9ebbfe272f1e096d882",
                   "subjectCN" : [

--- a/tests/pcap/wireshark-dtls0.test
+++ b/tests/pcap/wireshark-dtls0.test
@@ -17,7 +17,7 @@
                   ],
                   "notAfter" : 1204562865000,
                   "notBefore" : 1046882865000,
-                  "remainingDays" : -1,
+                  "remainingDays" : 630,
                   "remainingSeconds" : 54441796,
                   "serial" : "01",
                   "subjectCN" : [

--- a/tests/pcap/wireshark-dtls0.test
+++ b/tests/pcap/wireshark-dtls0.test
@@ -18,6 +18,7 @@
                   "notAfter" : 1204562865000,
                   "notBefore" : 1046882865000,
                   "remainingDays" : -1,
+                  "remainingSeconds" : 54441796,
                   "serial" : "01",
                   "subjectCN" : [
                      "www.snakeoil.dom"
@@ -28,7 +29,8 @@
                   "subjectOU" : [
                      "Webserver Team"
                   ],
-                  "validDays" : 1825
+                  "validDays" : 1825,
+                  "validSeconds" : 157680000
                }
             ],
             "certCnt" : 1,

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -212,15 +212,6 @@ my ($json) = @_;
                 }
             }
         }
-        if (exists $body->{cert}) {
-            for (my $i = 0; $i < @{$body->{cert}}; $i++) {
-                if ($body->{cert}->[$i]->{remainingDays} < 0) {
-                    $body->{cert}->[$i]->{remainingDays} = -1;
-                } elsif ($body->{cert}->[$i]->{remainingDays} > 0) {
-                    $body->{cert}->[$i]->{remainingDays} = 1;
-                }
-            }
-        }
     }
 
     @{$json->{sessions3}} = sort {


### PR DESCRIPTION
**Clearly describe the problem and solution**

Currently if TLS certificate expiry date is before the start validity date the `cert.validDays` and `cert.remainingDays` are not being saved in the SPI. This information though can be very useful in identifying forged TLS certs, so this PR removes the check for `cert.validDays` and `cert.remainingDays`.

We also added a greater granularity for these values with a granularity of seconds, this allows to identify certs that are generated with extremely short validity periods.

The `cert.remaining*` values are no longer calculated based on the current time of parsing, but rather the `firstPacket` timestamp, which IMO is a better choice since it is more consistent when potentially re-analysing a captured PCAP. If the value would be negative we set a value of `0`. This entailed also modifying the tests `--fix` script.

**Relevant issue number(s) if applicable**

N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

N/A

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
