### PR TITLE
Auth init refactor

### DIFF
--- a/common/auth.js
+++ b/common/auth.js
@@ -145,7 +145,7 @@ class Auth {
       Auth.#serverSecret = options.serverSecret;
       Auth.#serverSecret256 = crypto.createHash('sha256').update(options.serverSecret).digest();
     } else {
-      Auth.#serverSecret = options.passwordSecret;
+      Auth.#serverSecret = Auth.passwordSecret;
       Auth.#serverSecret256 = Auth.passwordSecret256;
     }
     Auth.#requiredAuthHeader = options.requiredAuthHeader;

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -82,7 +82,7 @@ const cspHeader = helmet.contentSecurityPolicy({
 
 function setCookie (req, res, next) {
   const cookieOptions = {
-    path: getConfig('cont3xt', 'webBasePath', '/'),
+    path: internals.webBasePath,
     sameSite: 'Strict',
     overwrite: true
   };
@@ -375,7 +375,7 @@ app.use(cspHeader, setCookie, (req, res, next) => {
   const appContext = {
     nonce: res.locals.nonce,
     version: version.version,
-    path: getConfig('cont3xt', 'webBasePath', '/'),
+    path: internals.webBasePath,
     disableUserPasswordUI: getConfig('cont3xt', 'disableUserPasswordUI', true)
   };
 
@@ -456,27 +456,9 @@ const getConfig = ArkimeConfig.get;
 // Initialize stuff
 // ----------------------------------------------------------------------------
 async function setupAuth () {
-  Auth.initialize({
-    debug: ArkimeConfig.debug,
-    mode: getConfig('cont3xt', 'authMode'),
-    userNameHeader: getConfig('cont3xt', 'userNameHeader'),
-    passwordSecret: getConfig('cont3xt', 'passwordSecret', 'password'),
+  Auth.initialize('cont3xt', {
     passwordSecretSection: 'cont3xt',
-    basePath: internals.webBasePath,
-    requiredAuthHeader: getConfig('cont3xt', 'requiredAuthHeader'),
-    requiredAuthHeaderVal: getConfig('cont3xt', 'requiredAuthHeaderVal'),
-    userAutoCreateTmpl: getConfig('cont3xt', 'userAutoCreateTmpl'),
-    userAuthIps: getConfig('cont3xt', 'userAuthIps'),
-    caTrustFile: getConfig('cont3xt', 'caTrustFile'),
-    authConfig: {
-      httpRealm: getConfig('cont3xt', 'httpRealm', 'Moloch'),
-      userIdField: getConfig('cont3xt', 'authUserIdField'),
-      discoverURL: getConfig('cont3xt', 'authDiscoverURL'),
-      clientId: getConfig('cont3xt', 'authClientId'),
-      clientSecret: getConfig('cont3xt', 'authClientSecret'),
-      redirectURIs: getConfig('cont3xt', 'authRedirectURIs'),
-      trustProxy: getConfig('cont3xt', 'authTrustProxy')
-    }
+    basePath: internals.webBasePath
   });
 
   const dbUrl = getConfig('cont3xt', 'dbUrl');

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1861,27 +1861,8 @@ app.put('/parliament/api/removeSelectedAcknowledgedIssues', [isUser, checkCookie
 // INITIALIZE
 // ----------------------------------------------------------------------------
 async function setupAuth () {
-  Auth.initialize({
-    debug: ArkimeConfig.debug,
-    mode: getConfig('parliament', 'authMode'),
-    userNameHeader: getConfig('parliament', 'userNameHeader'),
-    passwordSecret: getConfig('parliament', 'passwordSecret', 'password'),
-    passwordSecretSection: 'parliament',
-    basePath: getConfig('parliament', 'webBasePath', '/'),
-    requiredAuthHeader: getConfig('parliament', 'requiredAuthHeader'),
-    requiredAuthHeaderVal: getConfig('parliament', 'requiredAuthHeaderVal'),
-    userAutoCreateTmpl: getConfig('parliament', 'userAutoCreateTmpl'),
-    userAuthIps: getConfig('parliament', 'userAuthIps'),
-    caTrustFile: getConfig('parliament', 'caTrustFile'),
-    authConfig: {
-      httpRealm: getConfig('parliament', 'httpRealm', 'Moloch'),
-      userIdField: getConfig('parliament', 'authUserIdField'),
-      discoverURL: getConfig('parliament', 'authDiscoverURL'),
-      clientId: getConfig('parliament', 'authClientId'),
-      clientSecret: getConfig('parliament', 'authClientSecret'),
-      redirectURIs: getConfig('parliament', 'authRedirectURIs'),
-      trustProxy: getConfig('parliament', 'authTrustProxy')
-    }
+  Auth.initialize('parliament', {
+    passwordSecretSection: 'parliament'
   });
 
   User.initialize({

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -370,30 +370,17 @@ class Config {
       }
     }
 
-    Auth.initialize({
-      mode: Config.get('authMode'),
-      userNameHeader: Config.get('userNameHeader'),
+    const section = [internals.nodeName];
+    if (internals.nodeName !== 'cont3xt') {
+      section.push('default');
+    }
+    Auth.initialize(section, {
       debug: Config.debug,
       basePath: Config.basePath(),
       passwordSecret: Config.getFull(internals.nodeName === 'cont3xt' ? 'cont3xt' : 'default', 'passwordSecret', 'password'),
       passwordSecretSection: internals.nodeName === 'cont3xt' ? 'cont3xt' : 'default',
-      serverSecret: Config.getFull('default', 'serverSecret'),
-      requiredAuthHeader: Config.get('requiredAuthHeader'),
-      requiredAuthHeaderVal: Config.get('requiredAuthHeaderVal'),
-      userAutoCreateTmpl: Config.get('userAutoCreateTmpl'),
-      userAuthIps: Config.get('userAuthIps'),
       s2s: true,
-      s2sRegressionTests: !!Config.get('s2sRegressionTests'),
-      caTrustFile: Config.getFull(internals.nodeName, 'caTrustFile'),
-      authConfig: {
-        httpRealm: Config.get('httpRealm', 'Moloch'),
-        userIdField: Config.get('authUserIdField'),
-        discoverURL: Config.get('authDiscoverURL'),
-        clientId: Config.get('authClientId'),
-        clientSecret: Config.get('authClientSecret'),
-        redirectURIs: Config.get('authRedirectURIs'),
-        trustProxy: Config.get('authTrustProxy')
-      }
+      s2sRegressionTests: !!Config.get('s2sRegressionTests')
     });
   }
 }

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -196,23 +196,8 @@ process.on('SIGINT', function () {
 
 // ----------------------------------------------------------------------------
 function setupAuth () {
-  Auth.initialize({
-    debug: ArkimeConfig.debug,
-    mode: getConfig('wiseService', 'authMode'),
-    userNameHeader: getConfig('wiseService', 'userNameHeader'),
-    passwordSecret: getConfig('wiseService', 'passwordSecret', 'password'),
-    passwordSecretSection: 'wiseService',
-    userAuthIps: getConfig('wiseService', 'userAuthIps'),
-    caTrustFile: getConfig('wiseService', 'caTrustFile'),
-    authConfig: {
-      httpRealm: getConfig('wiseService', 'httpRealm', 'Moloch'),
-      userIdField: getConfig('wiseService', 'authUserIdField'),
-      discoverURL: getConfig('wiseService', 'authDiscoverURL'),
-      clientId: getConfig('wiseService', 'authClientId'),
-      clientSecret: getConfig('wiseService', 'authClientSecret'),
-      redirectURIs: getConfig('wiseService', 'authRedirectURIs'),
-      trustProxy: getConfig('wiseService', 'authTrustProxy')
-    }
+  Auth.initialize('wiseService', {
+    passwordSecretSection: 'wiseService'
   });
 
   if (Auth.mode === 'anonymous') {


### PR DESCRIPTION
* Auth.initialize now takes a section where all the config will be retrieved from
* Auth.initialize options arg overrides the config from section if needed
* oidc mode now stores sessions in ES instead of memory
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
