### PR TITLE
redo config AGAIN, central logger w/ config

### DIFF
--- a/common/auth.js
+++ b/common/auth.js
@@ -76,7 +76,6 @@ class Auth {
   // ----------------------------------------------------------------------------
   /**
    * Initialize the Auth subsystem
-   * @param {string} section The section to get all options from if they use standard name
    * @param {string} options.mode=digest What auth mode to run in
    * @param {string} options.basePath=/ What the web base path is for the app
    * @param {string} options.userNameHeader In header auth mode, which http header has the user id
@@ -89,29 +88,29 @@ class Auth {
    * @param {object} options.authConfig options specific to each auth mode
    * @param {object} options.caTrustFile Optional path to CA certificate file to use for external authentication
    */
-  static initialize (section, options) {
+  static initialize (options) {
     // Make sure all options we need below are set
     options ??= {};
-    options.mode ??= ArkimeConfig.get(section, 'authMode');
-    options.userNameHeader ??= ArkimeConfig.get(section, 'userNameHeader');
-    options.passwordSecret ??= ArkimeConfig.get(options.passwordSecretSection ?? section, 'passwordSecret');
-    options.serverSecret ??= ArkimeConfig.get(section, 'serverSecret');
-    options.requiredAuthHeader ??= ArkimeConfig.get(section, 'requiredAuthHeader');
-    options.requiredAuthHeaderVal ??= ArkimeConfig.get(section, 'requiredAuthHeaderVal');
-    options.userAutoCreateTmpl ??= ArkimeConfig.get(section, 'userAutoCreateTmpl');
-    options.userAuthIps = ArkimeConfig.getArray(section, 'userAuthIps');
-    options.caTrustFile ??= ArkimeConfig.get(section, 'caTrustFile');
+    options.mode ??= ArkimeConfig.get('authMode');
+    options.userNameHeader ??= ArkimeConfig.get('userNameHeader');
+    options.passwordSecret ??= ArkimeConfig.getFull(options.passwordSecretSection ?? undefined, 'passwordSecret');
+    options.serverSecret ??= ArkimeConfig.get('serverSecret');
+    options.requiredAuthHeader ??= ArkimeConfig.get('requiredAuthHeader');
+    options.requiredAuthHeaderVal ??= ArkimeConfig.get('requiredAuthHeaderVal');
+    options.userAutoCreateTmpl ??= ArkimeConfig.get('userAutoCreateTmpl');
+    options.userAuthIps = ArkimeConfig.getArray('userAuthIps');
+    options.caTrustFile ??= ArkimeConfig.get('caTrustFile');
 
     options.authConfig ??= {};
-    options.authConfig.httpRealm ??= ArkimeConfig.get(section, 'httpRealm', 'Moloch');
-    options.authConfig.userIdField ??= ArkimeConfig.get(section, 'authUserIdField');
-    options.authConfig.discoverURL ??= ArkimeConfig.get(section, 'authDiscoverURL');
-    options.authConfig.clientId ??= ArkimeConfig.get(section, 'authClientId');
-    options.authConfig.clientSecret ??= ArkimeConfig.get(section, 'authClientSecret');
-    options.authConfig.redirectURIs ??= ArkimeConfig.get(section, 'authRedirectURIs');
-    options.authConfig.trustProxy ??= ArkimeConfig.get(section, 'authTrustProxy');
-    options.authConfig.cookieSameSite ??= ArkimeConfig.get(section, 'authCookieSameSite');
-    options.authConfig.cookieSecure ??= ArkimeConfig.get(section, 'authCookieSecure', true);
+    options.authConfig.httpRealm ??= ArkimeConfig.get('httpRealm', 'Moloch');
+    options.authConfig.userIdField ??= ArkimeConfig.get('authUserIdField');
+    options.authConfig.discoverURL ??= ArkimeConfig.get('authDiscoverURL');
+    options.authConfig.clientId ??= ArkimeConfig.get('authClientId');
+    options.authConfig.clientSecret ??= ArkimeConfig.get('authClientSecret');
+    options.authConfig.redirectURIs ??= ArkimeConfig.get('authRedirectURIs');
+    options.authConfig.trustProxy ??= ArkimeConfig.get('authTrustProxy');
+    options.authConfig.cookieSameSite ??= ArkimeConfig.get('authCookieSameSite');
+    options.authConfig.cookieSecure ??= ArkimeConfig.get('authCookieSecure', true);
 
     if (ArkimeConfig.debug > 1) {
       console.log('Auth.initialize', options);
@@ -244,7 +243,7 @@ class Auth {
         resave: false,
         saveUninitialized: true,
         cookie: { path: Auth.#basePath, secure: Auth.#authConfig.cookieSecure, sameSite: Auth.#authConfig.cookieSameSite ?? 'Lax', maxAge: 24 * 60 * 60 * 1000 },
-        store: new ESStore({ section })
+        store: new ESStore({ })
       }));
       Auth.#authRouter.use(passport.initialize());
       Auth.#authRouter.use(passport.session());
@@ -1021,7 +1020,7 @@ class ESStore extends expressSession.Store {
       ESStore.#client = User.getClient();
       ESStore.start();
     }, 100);
-    const prefix = ArkimeUtil.formatPrefix(ArkimeConfig.get(options.section, 'usersPrefix', ArkimeConfig.get(options.section, 'prefix', 'arkime_')));
+    const prefix = ArkimeUtil.formatPrefix(ArkimeConfig.get('usersPrefix', ArkimeConfig.get('prefix', 'arkime_')));
     ESStore.#index = `${prefix}sids_v50`;
   }
 

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -135,10 +135,10 @@ class Integration {
     //   cacheTimeout in cont3xt section
     //   cacheTimeout in integration code
     //   60 minutes
-    integration.cacheTimeout = ArkimeUtil.parseTimeStr(integration.getConfig('cacheTimeout', ArkimeConfig.get('cont3xt', 'cacheTimeout', integration.cacheTimeout ?? '1h'))) * 1000;
+    integration.cacheTimeout = ArkimeUtil.parseTimeStr(integration.getConfig('cacheTimeout', ArkimeConfig.get('cacheTimeout', integration.cacheTimeout ?? '1h'))) * 1000;
 
     // cachePolicy
-    integration.cachePolicy = integration.getConfig('cachePolicy', ArkimeConfig.get('cont3xt', 'cachePolicy', integration.cachePolicy ?? 'shared'));
+    integration.cachePolicy = integration.getConfig('cachePolicy', ArkimeConfig.get('cachePolicy', integration.cachePolicy ?? 'shared'));
     switch (integration.cachePolicy) {
     case 'none':
       integration.cacheable = false;
@@ -820,7 +820,7 @@ class Integration {
       for (const setting in integration.settings) {
         if (integration.settings[setting].required) {
           cnt++;
-          if (ArkimeConfig.get(integration.name, setting) === undefined) {
+          if (ArkimeConfig.getFull(integration.section ?? integration.name, setting) === undefined) {
             globalConfiged = false;
             break;
           }
@@ -900,12 +900,12 @@ class Integration {
 
   // Return a config value for this integration
   getConfig (k, d) {
-    return ArkimeConfig.get(this.section ?? this.name, k, d);
+    return ArkimeConfig.getFull(this.section ?? this.name, k, d);
   }
 
   // Return a config value for this integration
   getConfigArray (k, d, sep) {
-    return ArkimeConfig.getArray(this.section ?? this.name, k, d, sep);
+    return ArkimeConfig.getFullArray(this.section ?? this.name, k, d, sep);
   }
 
   // Return a config value for this integration, but first check the user config
@@ -921,11 +921,11 @@ class Integration {
       if (keys[configName]?.[key]) { return keys[configName]?.[key]; }
     }
 
-    return ArkimeConfig.get(this.configName ?? this.section ?? this.name, key, d);
+    return ArkimeConfig.getFull(this.configName ?? this.section ?? this.name, key, d);
   }
 
   userAgent () {
-    ArkimeConfig.get('cont3xt', 'userAgent', 'cont3xt');
+    this.getConfig('userAgent', ArkimeConfig.get('userAgent', 'cont3xt'));
   }
 
   normalizeCard () {

--- a/viewer/apiConnections.js
+++ b/viewer/apiConnections.js
@@ -11,7 +11,7 @@ const SessionAPIs = require('./apiSessions');
 
 let fieldsMap;
 
-Config.loaded(() => {
+ArkimeConfig.loaded(() => {
   if (!fieldsMap) {
     setTimeout(() => { // make sure db.js loads before fetching fields
       ViewerUtils.loadFields()

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -42,7 +42,7 @@ let prefix;
 const esSSLOptions = { rejectUnauthorized: !ArkimeConfig.insecure };
 let authHeader;
 
-Config.loaded(() => {
+ArkimeConfig.loaded(() => {
   elasticsearch = Config.get('elasticsearch');
   sensors = Config.configMap('esproxy-sensors');
   oldprefix = prefix === 'arkime_' ? '' : prefix;
@@ -89,7 +89,7 @@ Config.loaded(() => {
 let elasticsearchTee;
 let authHeaderTee;
 
-Config.loaded(() => {
+ArkimeConfig.loaded(() => {
   elasticsearchTee = Config.sectionGet('tee', 'elasticsearch');
   const esAPIKeyTee = Config.sectionGet('tee', 'elasticsearchAPIKey');
   const esBasicAuthTee = Config.sectionGet('tee', 'elasticsearchBasicAuth');
@@ -123,7 +123,7 @@ const postExact = {
 const putExact = {
 };
 
-Config.loaded(() => {
+ArkimeConfig.loaded(() => {
   getExact[`/_template/${prefix}sessions3_template`] = 1;
   getExact[`/_template/${oldprefix}sessions2_template`] = 1;
   getExact[`/${oldprefix}sessions2-*/_alias`] = 1;
@@ -463,7 +463,7 @@ const httpsAgent = new https.Agent(Object.assign({ keepAlive: true, keepAliveMse
 async function main () {
   await Config.initialize();
 
-  ArkimeUtil.createHttpServer([Config.nodeName(), 'default'], app, Config.get('esProxyHost'), Config.get('esProxyPort', '7200'));
+  ArkimeUtil.createHttpServer(app, Config.get('esProxyHost'), Config.get('esProxyPort', '7200'));
 }
 
 main();

--- a/viewer/internals.js
+++ b/viewer/internals.js
@@ -87,7 +87,7 @@ internals.initialize = (app) => {
   internals.isProduction = app.get('env') === 'production';
 };
 
-Config.loaded(() => {
+ArkimeConfig.loaded(() => {
 // build internals
   internals.elasticBase = Config.getArray('elasticsearch', 'http://localhost:9200');
   internals.remoteClusters = Config.configMap('remote-clusters', 'moloch-clusters');

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -32,7 +32,7 @@ const ArkimeUtil = require('../common/arkimeUtil');
 const ArkimeConfig = require('../common/arkimeConfig');
 
 const esSSLOptions = { rejectUnauthorized: !ArkimeConfig.insecure };
-Config.loaded(() => {
+ArkimeConfig.loaded(() => {
   const esClientKey = Config.get('esClientKey');
   const esClientCert = Config.get('esClientCert');
   const caTrustFile = Config.get('caTrustFile');
@@ -82,7 +82,6 @@ function saveBody (req, res, next) {
 }
 
 // app.configure
-const logger = require('morgan');
 const favicon = require('serve-favicon');
 const compression = require('compression');
 
@@ -91,7 +90,7 @@ const app = express();
 
 app.enable('jsonp callback');
 app.use(favicon(path.join(__dirname, '/public/favicon.ico')));
-app.use(logger(':date \x1b[1m:method\x1b[0m \x1b[33m:url\x1b[0m :res[content-length] bytes :response-time ms'));
+ArkimeUtil.logger(app);
 app.use(saveBody);
 app.use(compression());
 app.use(function (req, res, next) {
@@ -1189,7 +1188,7 @@ async function premain () {
   activeESNodes = nodes.slice();
   console.log(nodes);
 
-  ArkimeUtil.createHttpServer([Config.nodeName(), 'default'], app, Config.get('multiESHost'), Config.get('multiESPort', 8200));
+  ArkimeUtil.createHttpServer(app, Config.get('multiESHost'), Config.get('multiESPort', 8200));
 }
 
 premain();


### PR DESCRIPTION
Redo config again so ArkimeConfig.get now uses a default set of sections sent on initialize, added getFull for old behaviour

Moved logger creation to ArkimeUtil so all tools can be configured the same

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
