### PR TITLE
new cert callback, remove bool from viewer/config.js

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -156,6 +156,7 @@ typedef struct arkime_certsinfo {
     char                     isCA;
     const char              *publicAlgorithm;
     const char              *curve;
+    GHashTable              *extra;
 } ArkimeCertsInfo_t;
 
 typedef struct {

--- a/capture/db.c
+++ b/capture/db.c
@@ -518,6 +518,7 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
     uint8_t               *dataPtr;
     uint32_t               jsonSize;
     gpointer               ikey;
+    gpointer               ival;
     char                   ipsrc[INET6_ADDRSTRLEN];
     char                   ipdst[INET6_ADDRSTRLEN];
 
@@ -1302,6 +1303,13 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
                 }
                 BSB_EXPORT_sprintf(jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)certs->notAfter - (int64_t)certs->notBefore) / (60 * 60 * 24));
                 BSB_EXPORT_sprintf(jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)certs->notAfter - (int64_t)certs->notBefore));
+
+                if (certs->extra) {
+                    g_hash_table_iter_init (&iter, certs->extra);
+                    while (g_hash_table_iter_next (&iter, &ikey, &ival)) {
+                        BSB_EXPORT_sprintf(jbsb, "\"%s\":\"%s\",", (char *)ikey, (char *)ival);
+                    }
+                }
 
                 BSB_EXPORT_rewind(jbsb, 1); // Remove last comma
 

--- a/capture/field.c
+++ b/capture/field.c
@@ -1399,6 +1399,9 @@ void arkime_field_certsinfo_free (ArkimeCertsInfo_t *certs)
     if (certs->serialNumber)
         free(certs->serialNumber);
 
+    if (certs->extra)
+        g_hash_table_destroy(certs->extra);
+
     ARKIME_TYPE_FREE(ArkimeCertsInfo_t, certs);
 }
 /******************************************************************************/

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -33,6 +33,7 @@ LOCAL GChecksum *checksums256[ARKIME_MAX_PACKET_THREADS];
 LOCAL uint32_t tls_process_client_hello_func;
 LOCAL uint32_t tls_process_server_hello_func;
 LOCAL uint32_t tls_process_server_certificate_func;
+LOCAL uint32_t tls_process_certificate_wInfo_func;
 
 /******************************************************************************/
 LOCAL void tls_certinfo_process(ArkimeCertInfo_t *ci, BSB *bsb)
@@ -555,6 +556,8 @@ LOCAL uint32_t tls_process_server_certificate(ArkimeSession_t *session, const ui
         }
 
         BSB_IMPORT_skip(cbsb, clen + 3);
+
+        arkime_parser_call_named_func(tls_process_certificate_wInfo_func, session, cdata + 3, clen, certs);
 
         continue;
 
@@ -1194,5 +1197,6 @@ void arkime_parser_init()
     tls_process_client_hello_func = arkime_parser_add_named_func("tls_process_client_hello", tls_process_client_hello_data);
     tls_process_server_hello_func = arkime_parser_add_named_func("tls_process_server_hello", tls_process_server_hello);
     tls_process_server_certificate_func = arkime_parser_add_named_func("tls_process_server_certificate", tls_process_server_certificate);
+    tls_process_certificate_wInfo_func = arkime_parser_get_named_func("tls_process_certificate_wInfo");
 }
 

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -64,11 +64,11 @@ function makeS3 (node, region, bucket) {
 
   bucket ??= Config.getFull(node, 's3Bucket');
   const bucketHasDot = bucket.indexOf('.') >= 0;
-  if (Config.getBoolFull(node, 's3PathAccessStyle', bucketHasDot) === true) {
+  if (Config.getFull(node, 's3PathAccessStyle', bucketHasDot) === true) {
     s3Params.s3ForcePathStyle = true;
   }
 
-  if (Config.getBoolFull(node, 's3UseHttp', false) === true) {
+  if (Config.getFull(node, 's3UseHttp', false) === true) {
     s3Params.sslEnabled = false;
   }
 

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -109,21 +109,6 @@ class Config {
   static get = ArkimeConfig.get;
 
   // ----------------------------------------------------------------------------
-  static getBoolFull (node, key, defaultValue) {
-    const value = Config.getFull(node, key);
-    if (value !== undefined) {
-      if (value === 'true' || value === '1') {
-        return true;
-      } else if (value === 'false' || value === '0') {
-        return false;
-      } else {
-        console.log('ERROR - invalid value for ', key);
-      }
-    }
-    return defaultValue;
-  };
-
-  // ----------------------------------------------------------------------------
   // Return an array split on separator, remove leading/trailing spaces, remove empty elements
   static getArray = ArkimeConfig.getArray;
 


### PR DESCRIPTION
* new named function called per cert with the certsinfo structure
* new extra certsinfo hashtable that plugins can add fields to that db.c saves
* removed old Config.getBoolFull since getFull does bool true/false now

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
