### PR TITLE
Added additional logic to detect 802.1ad VLAN tags during capture

### DIFF
--- a/capture/packet.c
+++ b/capture/packet.c
@@ -336,7 +336,7 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
             }
 
             int n = 12;
-            while (pcapData[n] == 0x81 && pcapData[n + 1] == 0x00) {
+            while ((pcapData[n] == 0x81 && pcapData[n + 1] == 0x00) || (pcapData[n] == 0x88 && pcapData[n+1] == 0xa8)) {
                 uint16_t vlan = ((uint16_t)(pcapData[n + 2] << 8 | pcapData[n + 3])) & 0xfff;
                 arkime_field_int_add(vlanField, session, vlan);
                 n += 4;


### PR DESCRIPTION
Added additional logic to detect 802.1ad VLAN tags during capture

**Clearly describe the problem and solution**

Arkime Session Viewer does not properly display stacked VLAN tag values specifically if a packet in a given session has an outer VLAN flag of 802.1ad. Subsequently, any inner 802.1Q VLAN tag values are not recorded either. This does not affect the raw PCAP file as we are able to view all VLAN tags once  the PCAP file has been downloaded and opened in Wireshark. 

Note, if another packet in a given session only has a 802.1Q VLAN tag, then the Arkime viewer will display its VLAN tag values properly. This bug only applies if a packet in a given session has an outer VLAN flag of 802.1ad. This results in the Arkime viewer only displaying a partial list of all VLAN tag values in a given session.

Looking into the codebase, `capture/packet.c` currently only checks for 802.1Q VLAN flag for a given session. It does not look for the 802.1ad flag while parsing a session for VLANs. In our environment, we noticed several packets where 802.1ad VLAN flag was at the 12th and 13th hexadecimal position and the 802.1Q VLAN flag was in the 16th and 17th hexadecimal position. 

To address this, we added additional logic in the conditional to check for the 802.1ad and 802.1Q flags. Since the current logic already loops through and checks for nested VLANs, this should support nested VLAN cases. 


**Relevant issue number(s) if applicable**
N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
No

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
No

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
