### PR TITLE
Change how tests auto create users/viewer defaults to digest

### DIFF
--- a/capture/config.c
+++ b/capture/config.c
@@ -734,7 +734,6 @@ void arkime_config_load()
     config.pcapDir          = arkime_config_str_list(keyfile, "pcapDir", NULL);
     config.bpf              = arkime_config_str(keyfile, "bpf", NULL);
     config.yara             = arkime_config_str(keyfile, "yara", NULL);
-    config.emailYara        = arkime_config_str(keyfile, "emailYara", NULL);
     config.rirFile          = arkime_config_str(keyfile, "rirFile", NULL);
     config.ouiFile          = arkime_config_str(keyfile, "ouiFile", NULL);
     config.geoLite2ASN      = arkime_config_str_list(keyfile, "geoLite2ASN", "/var/lib/GeoIP/GeoLite2-ASN.mmdb;/usr/share/GeoIP/GeoLite2-ASN.mmdb;" CONFIG_PREFIX "/etc/GeoLite2-ASN.mmdb");
@@ -808,7 +807,6 @@ void arkime_config_load()
     config.supportSha256         = arkime_config_boolean(keyfile, "supportSha256", FALSE);
     config.reqBodyOnlyUtf8       = arkime_config_boolean(keyfile, "reqBodyOnlyUtf8", TRUE);
     config.compressES            = arkime_config_boolean(keyfile, "compressES", TRUE);
-    config.antiSynDrop           = arkime_config_boolean(keyfile, "antiSynDrop", TRUE);
     config.readTruncatedPackets  = arkime_config_boolean(keyfile, "readTruncatedPackets", FALSE);
     config.trackESP              = arkime_config_boolean(keyfile, "trackESP", FALSE);
     config.yaraEveryPacket       = arkime_config_boolean(keyfile, "yaraEveryPacket", TRUE);
@@ -1298,8 +1296,6 @@ void arkime_config_exit()
         g_free(config.bpf);
     if (config.yara)
         g_free(config.yara);
-    if (config.emailYara)
-        g_free(config.emailYara);
     if (config.pcapDir)
         g_strfreev(config.pcapDir);
     if (config.pcapDirTemplate)

--- a/capture/parsers/tcp.c
+++ b/capture/parsers/tcp.c
@@ -157,7 +157,7 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
         if (tcphdr->th_flags & TH_ACK) {
             session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]++;
 
-            if (!session->haveTcpSession && config.antiSynDrop) {
+            if (!session->haveTcpSession) {
 #ifdef DEBUG_TCP
                 LOG("syn-ack first");
 #endif
@@ -361,9 +361,8 @@ int tcp_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packet, int 
     }
 
     if (isNewSession) {
-        /* If antiSynDrop option is set to true, capture will assume that
-         * if the syn-ack ip4 was captured first then the syn probably got dropped.*/
-        if ((tcphdr->th_flags & TH_SYN) && (tcphdr->th_flags & TH_ACK) && (config.antiSynDrop)) {
+        /* if the syn-ack was captured first then the syn probably got dropped.*/
+        if ((tcphdr->th_flags & TH_SYN) && (tcphdr->th_flags & TH_ACK)) {
             struct in6_addr tmp;
             tmp = session->addr1;
             session->addr1 = session->addr2;

--- a/capture/yara.c
+++ b/capture/yara.c
@@ -92,25 +92,6 @@ void arkime_yara_load(char *name)
     yRules = rules;
 }
 /******************************************************************************/
-void arkime_yara_load_email(char *name)
-{
-    YR_COMPILER *compiler;
-    YR_RULES *rules;
-
-    if (!name)
-        return;
-
-    arkime_yara_open(name, &compiler, &rules);
-
-    if (yEmailRules)
-        arkime_free_later(yEmailRules, (GDestroyNotify) yr_rules_destroy);
-    if (yEmailCompiler)
-        arkime_free_later(yEmailCompiler, (GDestroyNotify) yr_compiler_destroy);
-
-    yEmailCompiler = compiler;
-    yEmailRules = rules;
-}
-/******************************************************************************/
 void arkime_yara_init()
 {
     if (arkime_config_boolean(NULL, "yaraFastMode", TRUE))
@@ -120,9 +101,6 @@ void arkime_yara_init()
 
     if (config.yara)
         arkime_config_monitor_file("yara file", config.yara, arkime_yara_load);
-
-    if (config.emailYara)
-        arkime_config_monitor_file("yara email file", config.emailYara, arkime_yara_load_email);
 }
 
 /******************************************************************************/
@@ -150,12 +128,6 @@ int arkime_yara_callback(YR_SCAN_CONTEXT *UNUSED(context), int message, YR_RULE 
 void  arkime_yara_execute(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(first))
 {
     yr_rules_scan_mem(yRules, (uint8_t *)data, len, yFlags, (YR_CALLBACK_FUNC)arkime_yara_callback, session, 0);
-    return;
-}
-/******************************************************************************/
-void  arkime_yara_email_execute(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(first))
-{
-    yr_rules_scan_mem(yEmailRules, (uint8_t *)data, len, yFlags, (YR_CALLBACK_FUNC)arkime_yara_callback, session, 0);
     return;
 }
 /******************************************************************************/
@@ -232,25 +204,6 @@ void arkime_yara_load(char *name)
     yRules = rules;
 }
 /******************************************************************************/
-void arkime_yara_load_email(char *name)
-{
-    YR_COMPILER *compiler;
-    YR_RULES *rules;
-
-    if (!name)
-        return;
-
-    arkime_yara_open(name, &compiler, &rules);
-
-    if (yEmailRules)
-        arkime_free_later(yEmailRules, (GDestroyNotify) yr_rules_destroy);
-    if (yEmailCompiler)
-        arkime_free_later(yEmailCompiler, (GDestroyNotify) yr_compiler_destroy);
-
-    yEmailCompiler = compiler;
-    yEmailRules = rules;
-}
-/******************************************************************************/
 void arkime_yara_init()
 {
     if (arkime_config_boolean(NULL, "yaraFastMode", TRUE))
@@ -260,9 +213,6 @@ void arkime_yara_init()
 
     if (config.yara)
         arkime_config_monitor_file("yara file", config.yara, arkime_yara_load);
-
-    if (config.emailYara)
-        arkime_config_monitor_file("yara email file", config.emailYara, arkime_yara_load_email);
 }
 
 /******************************************************************************/
@@ -289,12 +239,6 @@ int arkime_yara_callback(int message, YR_RULE *rule, ArkimeSession_t *session)
 void  arkime_yara_execute(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(first))
 {
     yr_rules_scan_mem(yRules, (uint8_t *)data, len, yFlags, (YR_CALLBACK_FUNC)arkime_yara_callback, session, 0);
-    return;
-}
-/******************************************************************************/
-void  arkime_yara_email_execute(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(first))
-{
-    yr_rules_scan_mem(yEmailRules, (uint8_t *)data, len, yFlags, (YR_CALLBACK_FUNC)arkime_yara_callback, session, 0);
     return;
 }
 /******************************************************************************/
@@ -355,7 +299,6 @@ void arkime_yara_init()
     yr_initialize();
 
     arkime_yara_open(config.yara, &yCompiler, &yRules);
-    arkime_yara_open(config.emailYara, &yEmailCompiler, &yEmailRules);
 }
 
 /******************************************************************************/
@@ -382,12 +325,6 @@ int arkime_yara_callback(int message, YR_RULE *rule, ArkimeSession_t *session)
 void  arkime_yara_execute(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(first))
 {
     yr_rules_scan_mem(yRules, (uint8_t *)data, len, 0, (YR_CALLBACK_FUNC)arkime_yara_callback, session, 0);
-    return;
-}
-/******************************************************************************/
-void  arkime_yara_email_execute(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(first))
-{
-    yr_rules_scan_mem(yEmailRules, (uint8_t *)data, len, 0, (YR_CALLBACK_FUNC)arkime_yara_callback, session, 0);
     return;
 }
 /******************************************************************************/
@@ -448,7 +385,6 @@ void arkime_yara_init()
     yr_initialize();
 
     arkime_yara_open(config.yara, &yCompiler, &yRules);
-    arkime_yara_open(config.emailYara, &yEmailCompiler, &yEmailRules);
 }
 
 /******************************************************************************/
@@ -475,12 +411,6 @@ int arkime_yara_callback(int message, YR_RULE *rule, ArkimeSession_t *session)
 void  arkime_yara_execute(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(first))
 {
     yr_rules_scan_mem(yRules, (uint8_t *)data, len, (YR_CALLBACK_FUNC)arkime_yara_callback, session, FALSE, 0);
-    return;
-}
-/******************************************************************************/
-void  arkime_yara_email_execute(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(first))
-{
-    yr_rules_scan_mem(yEmailRules, (uint8_t *)data, len, (YR_CALLBACK_FUNC)arkime_yara_callback, session, FALSE, 0);
     return;
 }
 /******************************************************************************/

--- a/common/auth.js
+++ b/common/auth.js
@@ -176,7 +176,6 @@ class Auth {
     const addBasic = Auth.mode.startsWith('basic+');
     if (addBasic) {
       Auth.mode = Auth.mode.slice(6);
-      Auth.#logoutUrl ??= `${Auth.basePath}logout`;
     }
 
     let sessionAuth = false;
@@ -187,7 +186,6 @@ class Auth {
     case 'basic':
       check('httpRealm');
       Auth.#strategies = ['basic'];
-      Auth.#logoutUrl ??= `${Auth.basePath}logout`;
       break;
     case 'digest':
       check('httpRealm');
@@ -207,6 +205,7 @@ class Auth {
       Auth.#strategies = ['form'];
       Auth.#passportAuthOptions = { session: true, failureRedirect: `${Auth.#basePath}auth` };
       sessionAuth = true;
+      Auth.#logoutUrl ??= `${Auth.#basePath}logout`;
       break;
     case 'headerOnly':
       Auth.#strategies = ['header'];
@@ -217,7 +216,6 @@ class Auth {
       break;
     case 'header+basic':
       Auth.#strategies = ['header', 'basic'];
-      Auth.#logoutUrl ??= `${Auth.basePath}logout`;
       break;
     case 's2s':
       Auth.#strategies = ['s2s'];

--- a/common/auth.js
+++ b/common/auth.js
@@ -608,29 +608,7 @@ class Auth {
       User.getUserCache(userId, (err, user) => {
         if (user) {
           user.setLastUsed();
-          return done(null, user);
         }
-        user = Object.assign(new User(), {
-          userId,
-          enabled: true,
-          webEnabled: true,
-          headerAuthEnabled: false,
-          emailSearch: true,
-          removeEnabled: true,
-          packetSearch: true,
-          settings: {},
-          welcomeMsgNum: 1
-        });
-
-        if (userId === 'superAdmin') {
-          user.roles = ['superAdmin'];
-        } else if (userId === 'anonymous') {
-          user.roles = ['arkimeAdmin', 'cont3xtUser', 'parliamentUser', 'usersAdmin', 'wiseUser'];
-        } else {
-          user.roles = ['arkimeUser', 'cont3xtUser', 'parliamentUser', 'wiseUser'];
-        }
-
-        user.expandFromRoles();
         return done(null, user);
       });
     }));
@@ -700,6 +678,7 @@ class Auth {
           welcomeMsgNum: 1,
           roles: ['arkimeAdmin', 'cont3xtUser', 'parliamentUser', 'usersAdmin', 'wiseUser']
         });
+        user.expandFromRoles();
         return done(null, user);
       }
 

--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -167,7 +167,7 @@ if [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ]; then
     WITHGLIB=" "
     WITHCURL=" "
   fi
-  sudo yum -y install --skip-broken wget curl pcre pcre-devel pkgconfig flex bison gcc-c++ zlib-devel e2fsprogs-devel openssl-devel file-devel make gettext libuuid-devel perl-JSON bzip2-libs bzip2-devel perl-libwww-perl libpng-devel xz libffi-devel readline-devel libtool libyaml-devel perl-Socket6 perl-Test-Differences
+  sudo yum -y install --skip-broken wget curl pcre pcre-devel pkgconfig flex bison gcc-c++ zlib-devel e2fsprogs-devel openssl-devel file-devel make gettext libuuid-devel perl-JSON bzip2-libs bzip2-devel perl-libwww-perl libpng-devel xz libffi-devel readline-devel libtool libyaml-devel perl-Socket6 perl-Test-Differences perl-Try-Tiny
   if [ $? -ne 0 ]; then
     echo "ARKIME: yum failed"
     exit 1

--- a/release/checkSettingsPage.pl
+++ b/release/checkSettingsPage.pl
@@ -6,13 +6,14 @@ my %settings;
 my $capture = `egrep -h 'arkime_config_(str|int|boolean|double).*"' ../capture/*.c ../capture/*/*.c ../capture/*/*/*.c`;
 foreach my $line (split("\n", $capture)) {
     my ($match) = $line =~ /"([^"]*)"/;
+    next if ($match =~ /^(nodeClass)$/);
     $settings{$match} = $line;
 }
 
 my $viewer = `egrep -h 'Config.get(\\(|Full|Array|ArrayFull)' ../viewer/*.js ../common/*.js`;
 foreach my $line (split("\n", $viewer)) {
     my ($match) = $line =~ /get[^"']*["']([^"']*)["']/;
-    next if ($match eq "default");
+    next if ($match =~ /^(default|s2sRegressionTests)$/);
     $settings{$match} = $line;
 
     #print "$match => $line\n";

--- a/release/checkSettingsPage.pl
+++ b/release/checkSettingsPage.pl
@@ -3,7 +3,7 @@ use strict;
 use Data::Dumper;
 
 my %settings;
-my $capture = `egrep -h 'moloch_config_(str|int|boolean|double).*"' ../capture/*.c ../capture/*/*.c ../capture/*/*/*.c`;
+my $capture = `egrep -h 'arkime_config_(str|int|boolean|double).*"' ../capture/*.c ../capture/*/*.c ../capture/*/*/*.c`;
 foreach my $line (split("\n", $capture)) {
     my ($match) = $line =~ /"([^"]*)"/;
     $settings{$match} = $line;

--- a/release/checkSettingsPage.pl
+++ b/release/checkSettingsPage.pl
@@ -9,10 +9,13 @@ foreach my $line (split("\n", $capture)) {
     $settings{$match} = $line;
 }
 
-my $viewer = `egrep -h 'Config.get(\\(|Full)' ../viewer/*.js`;
+my $viewer = `egrep -h 'Config.get(\\(|Full|Array|ArrayFull)' ../viewer/*.js ../common/*.js`;
 foreach my $line (split("\n", $viewer)) {
     my ($match) = $line =~ /get[^"']*["']([^"']*)["']/;
+    next if ($match eq "default");
     $settings{$match} = $line;
+
+    #print "$match => $line\n";
 }
 
 foreach my $setting (keys (%settings)) {
@@ -20,15 +23,14 @@ foreach my $setting (keys (%settings)) {
         print "***Not a real setting $setting\n";
         next;
     }
-    my $lcsetting = lc($setting);
 
-    my $output = `egrep  '(id="$lcsetting"|^$setting\\|)' ../../arkimeweb/settings.html ../../arkimeweb/_wiki/wise.md`;
+    my $output = `egrep  'key: $setting' ../../arkimeweb/settings.html ../../arkimeweb/_wiki/wise.md ../../arkimeweb/_data/*/*`;
     if ($output eq "") {
-        print "MISSING id tag id=\"$lcsetting\" => $settings{$setting}\n";
+        print "MISSING key: $setting\n";
     }
 
-    $output = `egrep  '( $setting\$|>$setting<|^$setting\\|)' ../../arkimeweb/settings.html ../../arkimeweb/_wiki/wise.md`;
-    if ($output eq "") {
-        print "MISSING $setting\n";
-    }
+    #    $output = `egrep  '( $setting\$|>$setting<|^$setting\\|)' ../../arkimeweb/settings.html ../../arkimeweb/_wiki/wise.md ../../arkimeweb/_data/settings/*`;
+    #if ($output eq "") {
+    #    print "MISSING $setting\n";
+    #}
 }

--- a/tests/ArkimeTest.pm
+++ b/tests/ArkimeTest.pm
@@ -1,9 +1,10 @@
 package ArkimeTest;
 use Exporter;
+use Carp;
 use strict;
 use Test::More;
 @ArkimeTest::ISA = qw(Exporter);
-@ArkimeTest::EXPORT = qw (esGet esPost esPut esDelete esCopy viewerGet viewerGetToken viewerGet2 viewerDelete viewerDeleteToken viewerDeleteToken2 viewerPost viewerPost2 viewerPostToken viewerPostToken2 countTest countTestToken countTest2 countTestMulti errTest bin2hex mesGet mesPost multiGet multiPost getTokenCookie getTokenCookie2 parliamentGet parliamentGetToken parliamentPost parliamentPostToken parliamentPut parliamentPutToken parliamentDelete parliamentDeleteToken getParliamentTokenCookie waitFor viewerPutToken viewerPut getCont3xtTokenCookie cont3xtGet cont3xtGetToken cont3xtPut cont3xtPutToken cont3xtDelete cont3xtDeleteToken cont3xtPost cont3xtPostToken);
+@ArkimeTest::EXPORT = qw (esGet esPost esPut esDelete esCopy viewerGet viewerGetToken viewerGet2 viewerDelete viewerDeleteToken viewerDeleteToken2 viewerPost viewerPost2 viewerPostToken viewerPostToken2 countTest countTestToken countTest2 countTestMulti errTest bin2hex mesGet mesPost multiGet multiPost getTokenCookie getTokenCookie2 parliamentGet parliamentGetToken parliamentPost parliamentPostToken parliamentPut parliamentPutToken parliamentDelete parliamentDeleteToken getParliamentTokenCookie waitFor viewerPutToken viewerPut getCont3xtTokenCookie cont3xtGet cont3xtGetToken cont3xtPut cont3xtPutToken cont3xtDelete cont3xtDeleteToken cont3xtPost cont3xtPostToken addUser clearIndex);
 
 use LWP::UserAgent;
 use HTTP::Request::Common;
@@ -11,10 +12,12 @@ use JSON;
 use URI::Escape;
 use Data::Dumper;
 use IO::Socket::INET;
+use Try::Tiny;
 
 $ArkimeTest::userAgent = LWP::UserAgent->new(timeout => 120);
 $ArkimeTest::host = "127.0.0.1";
 $ArkimeTest::elasticsearch = $ENV{ELASTICSEARCH} || "http://127.0.0.1:9200";
+$ArkimeTest::es = "-o 'elasticsearch=$ArkimeTest::elasticsearch' -o 'usersElasticsearch=$ArkimeTest::elasticsearch' $ENV{INSECURE}";
 
 if ($ENV{INSECURE} eq "--insecure") {
     $ArkimeTest::userAgent->ssl_opts(
@@ -24,6 +27,13 @@ if ($ENV{INSECURE} eq "--insecure") {
 }
 
 ################################################################################
+sub my_from_json
+{
+my ($url, $json, $debug) = @_;
+
+    return try { from_json($json); } catch { Carp::confess "$url - not JSON - '$json'"; };
+}
+################################################################################
 sub viewerGet {
 my ($url, $debug) = @_;
 
@@ -31,8 +41,7 @@ my ($url, $debug) = @_;
     diag $url, " response:", $response->content if ($debug);
     my $tmp = $response->content;
     $tmp =~ s,/[-0-9A-Za-z./_]+tests/pcap/,/DIR/tests/pcap/,g;
-    my $json = from_json($tmp);
-    return ($json);
+    return my_from_json($url, $tmp, $debug);
 }
 ################################################################################
 sub viewerGetToken {
@@ -42,8 +51,7 @@ my ($url, $token, $debug) = @_;
     diag $url, " response:>", $response->content, "<:\n" if ($debug);
     my $tmp = $response->content;
     $tmp =~ s,/[-0-9A-Za-z./_]+tests/pcap/,/DIR/tests/pcap/,g;
-    my $json = from_json($tmp);
-    return ($json);
+    return my_from_json($url, $tmp, $debug);
 }
 ################################################################################
 sub viewerGet2 {
@@ -53,8 +61,7 @@ my ($url, $debug) = @_;
     diag $url, " response:", $response->content if ($debug);
     my $tmp = $response->content;
     $tmp =~ s,/[-0-9A-Za-z./_]+tests/pcap/,/DIR/tests/pcap/,g;
-    my $json = from_json($tmp);
-    return ($json);
+    return my_from_json($url, $tmp, $debug);
 }
 ################################################################################
 sub multiGet {
@@ -64,8 +71,7 @@ my ($url, $debug) = @_;
     diag $url, " response:", $response->content if ($debug);
     my $tmp = $response->content;
     $tmp =~ s,/[-0-9A-Za-z./_]+tests/pcap/,/DIR/tests/pcap/,g;
-    my $json = from_json($tmp);
-    return ($json);
+    return my_from_json($url, $tmp, $debug);
 }
 ################################################################################
 sub viewerDelete {
@@ -73,8 +79,7 @@ my ($url, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::_simple_req("DELETE", "http://$ArkimeTest::host:8123$url"));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub viewerDeleteToken {
@@ -82,8 +87,7 @@ my ($url, $token, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::_simple_req("DELETE", "http://$ArkimeTest::host:8123$url", "x-arkime-cookie" => $token));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub viewerDeleteToken2 {
@@ -91,8 +95,7 @@ my ($url, $token, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::_simple_req("DELETE", "http://$ArkimeTest::host:8124$url", "x-arkime-cookie" => $token));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub viewerPost {
@@ -108,8 +111,7 @@ my ($url, $content, $debug) = @_;
     diag $url, " response:", $response->content if ($debug);
     my $tmp = $response->content;
     $tmp =~ s,/[-0-9A-Za-z./_]+tests/pcap/,/DIR/tests/pcap/,g;
-    my $json = from_json($tmp);
-    return ($json);
+    return my_from_json($url, $tmp, $debug);
 }
 ################################################################################
 sub multiPost {
@@ -125,8 +127,7 @@ my ($url, $content, $debug) = @_;
     diag $url, " response:", $response->content if ($debug);
     my $tmp = $response->content;
     $tmp =~ s,/[-0-9A-Za-z./_]+tests/pcap/,/DIR/tests/pcap/,g;
-    my $json = from_json($tmp);
-    return ($json);
+    return my_from_json($url, $tmp, $debug);
 }
 ################################################################################
 sub viewerPost2 {
@@ -140,8 +141,7 @@ my ($url, $content, $debug) = @_;
     }
 
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub viewerPostToken {
@@ -153,8 +153,7 @@ my ($url, $content, $token, $debug) = @_;
     } else {
         $response = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123$url", Content => $content, "x-arkime-cookie" => $token);
     }
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub viewerPostToken2 {
@@ -167,8 +166,7 @@ my ($url, $content, $token, $debug) = @_;
         $response = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8124$url", Content => $content, "x-arkime-cookie" => $token);
     }
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub viewerPut {
@@ -182,8 +180,7 @@ my ($url, $content, $debug) = @_;
     }
 
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub viewerPutToken {
@@ -195,8 +192,7 @@ my ($url, $content, $token, $debug) = @_;
         $response = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8123$url", Content => $content, "x-arkime-cookie" => $token);
     }
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub mesGet {
@@ -204,54 +200,48 @@ my ($url, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8200$url");
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub mesPost {
-my ($url, $content) = @_;
+my ($url, $content, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8200$url", Content => $content);
     #print $url, " response:", $response->content, "\n";
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub esGet {
-my ($url) = @_;
+my ($url, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->get("$ArkimeTest::elasticsearch$url");
     #print "$ArkimeTest::elasticsearch$url", " response:", $response->content;
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub esPost {
-my ($url, $content) = @_;
+my ($url, $content, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->post("$ArkimeTest::elasticsearch$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8");
     #diag $url, " response:", $response->content;
     #print "$ArkimeTest::elasticsearch$url content:", $content,"\n response:", $response->content;
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub esPut {
-my ($url, $content) = @_;
+my ($url, $content, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->put("$ArkimeTest::elasticsearch$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8");
     #diag $url, " response:", $response->content;
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub esDelete {
-my ($url) = @_;
+my ($url, $debug) = @_;
 
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::_simple_req("DELETE", "$ArkimeTest::elasticsearch$url"));
     #print $url, " response:", $response->content;
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub esCopy
@@ -341,9 +331,9 @@ my ($userId) = @_;
 
     my $setCookie;
     if ($userId) {
-        $setCookie = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/makeToken?arkimeRegressionUser=$userId")->{"_headers"}->{"set-cookie"};
+        $setCookie = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/regressionTests/makeToken?arkimeRegressionUser=$userId")->{"_headers"}->{"set-cookie"};
     } else {
-        $setCookie = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/makeToken")->{"_headers"}->{"set-cookie"};
+        $setCookie = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/regressionTests/makeToken")->{"_headers"}->{"set-cookie"};
     }
 
     $setCookie =~ /ARKIME-COOKIE=([^;]*)/;
@@ -388,24 +378,21 @@ sub parliamentGet {
 my ($url, $debug) = @_;
     my $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8008$url");
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub parliamentGetToken {
 my ($url, $token, $debug) = @_;
     my $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8008$url", "x-parliament-token" => $token);
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub parliamentPost {
 my ($url, $content, $debug) = @_;
     my $response = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8008$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8");
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub parliamentPostToken {
@@ -416,16 +403,14 @@ my ($url, $content, $token, $debug) = @_;
     } else {
         $response = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8008$url", Content => $content, "x-parliament-cookie" => $token);
     }
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub parliamentPut {
 my ($url, $content, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::PUT("http://$ArkimeTest::host:8008$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8"));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub parliamentPutToken {
@@ -437,24 +422,21 @@ my ($url, $content, $token, $debug) = @_;
         $response = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8008$url", Content => $content, "x-parliament-cookie" => $token);
     }
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub parliamentDelete {
 my ($url, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::DELETE("http://$ArkimeTest::host:8008$url"));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub parliamentDeleteToken {
 my ($url, $token, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::DELETE("http://$ArkimeTest::host:8008$url", "x-parliament-cookie" => $token));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub cont3xtGet {
@@ -462,16 +444,14 @@ my ($url, $debug) = @_;
     my $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:3218$url");
     diag $url, " response:", $response->content if ($debug);
     my $tmp = $response->content;
-    my $json = from_json($tmp);
-    return ($json);
+    return my_from_json($url, $tmp, $debug);
 }
 ################################################################################
 sub cont3xtGetToken {
 my ($url, $token, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::GET("http://$ArkimeTest::host:3218$url", "x-cont3xt-cookie" => $token));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub cont3xtPut {
@@ -479,8 +459,7 @@ my ($url, $content, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::PUT("http://$ArkimeTest::host:3218$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8"));
     diag $url, " response:", $response->content if ($debug);
     return $response->content if ($response->content =~ /^[^[{]/);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub cont3xtPutToken {
@@ -488,8 +467,7 @@ my ($url, $content, $token, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::PUT("http://$ArkimeTest::host:3218$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8", "x-cont3xt-cookie" => $token));
     diag $url, " response:", $response->content if ($debug);
     return $response->content if ($response->content =~ /^[^\[{]/);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub cont3xtPost {
@@ -497,8 +475,7 @@ my ($url, $content, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::POST("http://$ArkimeTest::host:3218$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8"));
     diag $url, " response:", $response->content if ($debug);
     return $response->content if ($response->content =~ /^[^\[{]/);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub cont3xtPostToken {
@@ -506,24 +483,21 @@ my ($url, $content, $token, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::POST("http://$ArkimeTest::host:3218$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8", "x-cont3xt-cookie" => $token));
     diag $url, " response:", $response->content if ($debug);
     return $response->content if ($response->content =~ /^[^\[{]/);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub cont3xtDelete {
 my ($url, $content, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::DELETE("http://$ArkimeTest::host:3218$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8"));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub cont3xtDeleteToken {
 my ($url, $content, $token, $debug) = @_;
     my $response = $ArkimeTest::userAgent->request(HTTP::Request::Common::DELETE("http://$ArkimeTest::host:3218$url", Content => $content, "Content-Type" => "application/json;charset=UTF-8", "x-cont3xt-cookie" => $token));
     diag $url, " response:", $response->content if ($debug);
-    my $json = from_json($response->content);
-    return ($json);
+    return my_from_json($url, $response->content, $debug);
 }
 ################################################################################
 sub waitFor {
@@ -543,6 +517,17 @@ my ($host, $port, $extraSleep) = @_;
         sleep 1;
     }
     sleep ($extraSleep) if (defined $extraSleep);
+}
+################################################################################
+sub addUser {
+    return system("cd ../viewer ; node addUser.js $ArkimeTest::es -c ../tests/config.test.ini $_[0]");
+}
+################################################################################
+sub clearIndex {
+my ($index) = @_;
+    esGet("/_flush");
+    esGet("/_refresh");
+    return esPost("/$index/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }');
 }
 
 return 1;

--- a/tests/api-buildquery.t
+++ b/tests/api-buildquery.t
@@ -22,8 +22,10 @@ my ($expression, $expected, $debug) = @_;
     }
 }
 
+# Delete shortcuts
+clearIndex("tests_lookups");
+
 # Create shortcuts for testing
-esPost("/tests_lookups/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }');
 my $token = getTokenCookie();
 my $ipshortcut1 = viewerPostToken("/api/shortcut", '{"name":"ipshortcut1","type":"ip","value":"10.10.10.10"}', $token)->{shortcut}->{id};
 my $ipshortcut2 = viewerPostToken("/api/shortcut", '{"name":"ipshortcut2","type":"ip","value":"10.10.10.10"}', $token)->{shortcut}->{id};
@@ -265,4 +267,4 @@ doTest('stoptime==]"2014/02/26 10:27:57", "2014-06-10T10:10:10-05:00"[', '{"bool
 doTest('stoptime!=]"2014/02/26 10:27:57", "2014-06-10T10:10:10-05:00"[', '{"bool":{"must_not":{"bool":{"filter":[{"range":{"lastPacket":{"lte":"2014-02-26T10:27:57-05:00","gte":"2014-02-26T10:27:57-05:00"}}},{"range":{"lastPacket":{"gte":"2014-06-10T11:10:10-04:00","lte":"2014-06-10T11:10:10-04:00"}}}]}}}}');
 
 # Delete shortcuts
-esPost("/tests_lookups/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }');
+clearIndex("tests_lookups");

--- a/tests/api-cron.t
+++ b/tests/api-cron.t
@@ -11,63 +11,65 @@ my $json;
 my $token = getTokenCookie();
 my $suffix = int(rand()*1000000);
 
-$json = viewerPostToken("/api/user", '{"userId": "test1", "userName": "UserName", "enabled":true, "password":"password", "roles":["arkimeUser"]}', $token);
-$json = viewerPostToken("/api/user", '{"userId": "test2", "userName": "UserName", "enabled":true, "password":"password", "roles":["cont3xtUser"]}', $token);
+clearIndex("tests_queries");
 
-my $test1Token = getTokenCookie("test1");
-my $test2Token = getTokenCookie("test2");
+$json = viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "UserName", "enabled":true, "password":"password", "roles":["arkimeUser"]}', $token);
+$json = viewerPostToken("/api/user", '{"userId": "sac-test2", "userName": "UserName", "enabled":true, "password":"password", "roles":["arkimeUser", "cont3xtUser"]}', $token);
+
+my $test1Token = getTokenCookie("sac-test1");
+my $test2Token = getTokenCookie("sac-test2");
 
 # periodic query field validation
 $json = viewerPostToken("/api/cron", '{}', $token);
 ok(!$json->{success}, "query must have name");
-$json = viewerPostToken("/api/cron", '{"name":"test1"}', $token);
+$json = viewerPostToken("/api/cron", '{"name":"sac-test1"}', $token);
 ok(!$json->{success}, "query must have query expression");
-$json = viewerPostToken("/api/cron", '{"name":"test1","query":"protocols == tls"}', $token);
+$json = viewerPostToken("/api/cron", '{"name":"sac-test1","query":"protocols == tls"}', $token);
 ok(!$json->{success}, "query must have query action");
-$json = viewerPostToken("/api/cron", '{"name":"test1","query":"protocols == tls","action":"tag"}', $token);
+$json = viewerPostToken("/api/cron", '{"name":"sac-test1","query":"protocols == tls","action":"tag"}', $token);
 ok(!$json->{success}, "query must have query tag(s)");
 
 # can create periodic query
-$json = viewerPostToken("/api/cron", '{"name":"test1","query":"protocols == tls","action":"tag","tags":"tls"}', $token);
+$json = viewerPostToken("/api/cron", '{"name":"sac-test1","query":"protocols == tls","action":"tag","tags":"tls"}', $token);
 ok($json->{success}, "query can be created");
 my $key = $json->{query}->{key};
 
 # can update periodic query
-$json = viewerPostToken("/api/cron/$key", '{"name":"test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3"}', $token);
+$json = viewerPostToken("/api/cron/$key", '{"name":"sac-test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"sac-test2,test3"}', $token);
 ok($json->{success}, "query can be updated");
-eq_or_diff($json->{query}->{name}, "test1update", "query was updated");
-eq_or_diff($json->{query}->{users}, "test2", "query users was updated");
+eq_or_diff($json->{query}->{name}, "sac-test1update", "query was updated");
+eq_or_diff($json->{query}->{users}, "sac-test2", "query users was updated");
 eq_or_diff($json->{invalidUsers}->[0], "test3", "returns invalid users");
 
 # can get periodic queries
 $json = viewerGetToken("/api/crons", $token);
-eq_or_diff($json->[0]->{name}, "test1update", "can fetch queries");
+eq_or_diff($json->[0]->{name}, "sac-test1update", "can fetch queries");
 
-# test2 can see query because it is shared with their user
-$json = viewerGetToken("/api/crons?arkimeRegressionUser=test2", $test2Token);
-eq_or_diff($json->[0]->{name}, "test1update", "test2 user can see query");
-ok(!exists $json->[0]->{users}, "test2 user cannot see users");
-ok(!exists $json->[0]->{roles}, "test2 user cannot see roles");
+# sac-test2 can see query because it is shared with their user
+$json = viewerGetToken("/api/crons?arkimeRegressionUser=sac-test2", $test2Token);
+eq_or_diff($json->[0]->{name}, "sac-test1update", "sac-test2 user can see query");
+ok(!exists $json->[0]->{users}, "sac-test2 user cannot see users");
+ok(!exists $json->[0]->{roles}, "sac-test2 user cannot see roles");
 
-# but test1 cannot
-$json = viewerGetToken("/api/crons?arkimeRegressionUser=test1", $test1Token);
-is (@{$json}, 0, "test1 cannot see queries not shared with them");
+# but sac-test1 cannot
+$json = viewerGetToken("/api/crons?arkimeRegressionUser=sac-test1", $test1Token);
+is (@{$json}, 0, "sac-test1 cannot see queries not shared with them");
 
 # update roles
-$json = viewerPostToken("/api/cron/$key", '{"name":"test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3", "roles":["arkimeUser"],"editRoles":["cont3xtUser"]}', $token);
+$json = viewerPostToken("/api/cron/$key", '{"name":"sac-test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"sac-test2,test3", "roles":["arkimeUser"],"editRoles":["cont3xtUser"]}', $token);
 ok($json->{success}, "query roles can be updated");
 eq_or_diff($json->{query}->{roles}->[0], "arkimeUser", "query roles was updated");
 eq_or_diff($json->{query}->{editRoles}->[0], "cont3xtUser", "query editRoles was updated");
 
-# can share with test1 via roles
-$json = viewerGetToken("/api/crons?arkimeRegressionUser=test1", $test1Token);
-eq_or_diff($json->[0]->{name}, "test1update", "test1 user can see query");
-ok(!exists $json->[0]->{users}, "test1 user cannot see users");
-ok(!exists $json->[0]->{roles}, "test1 user cannot see roles");
+# can share with sac-test1 via roles
+$json = viewerGetToken("/api/crons?arkimeRegressionUser=sac-test1", $test1Token);
+eq_or_diff($json->[0]->{name}, "sac-test1update", "sac-test1 user can see query");
+ok(!exists $json->[0]->{users}, "sac-test1 user cannot see users");
+ok(!exists $json->[0]->{roles}, "sac-test1 user cannot see roles");
 
 # admin can view all periodic queries when all param is supplied
 my $files = '(file == */https-connect.pcap || file == */https-generalizedtime.pcap || file == */https2-301-get.pcap || file == */https3-301-get.pcap)';
-$json = viewerPostToken("/api/cron?arkimeRegressionUser=test1", qq({"name":"asdf","since":-1,"query":"protocols == tls && $files","action":"tag","tags":"test$suffix"}), $test1Token);
+$json = viewerPostToken("/api/cron?arkimeRegressionUser=sac-test1", qq({"name":"asdf","since":-1,"query":"protocols == tls && $files","action":"tag","tags":"test$suffix"}), $test1Token);
 my $key2 = $json->{query}->{key};
 $json = viewerGet("/api/crons?arkimeRegressionUser=anonymous");
 is (@{$json}, 1, "returns 1 query without all flag");
@@ -75,39 +77,39 @@ $json = viewerGet("/api/crons?arkimeRegressionUser=anonymous&all=true");
 is (@{$json}, 2, "returns 2 queries with all flag");
 
 
-# test2 can update using editRoles
-$json = viewerPostToken("/api/cron/$key?arkimeRegressionUser=test2", '{"name":"good name","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3", "roles":["arkimeUser"], "editRoles":["cont3xtUser"]}', $test2Token);
+# sac-test2 can update using editRoles
+$json = viewerPostToken("/api/cron/$key?arkimeRegressionUser=sac-test2", '{"name":"good name","query":"protocols == tls","action":"tag","tags":"tls","users":"sac-test2,test3", "roles":["arkimeUser"], "editRoles":["cont3xtUser"]}', $test2Token);
 ok($json->{success}, "editRoles user can update query");
 
 # shared user cannot update query
-$json = viewerPostToken("/api/cron/$key?arkimeRegressionUser=test1", '{"name":"bad name","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3", "roles":["arkimeUser"]}', $test1Token);
+$json = viewerPostToken("/api/cron/$key?arkimeRegressionUser=sac-test1", '{"name":"bad name","query":"protocols == tls","action":"tag","tags":"tls","users":"sac-test2,test3", "roles":["arkimeUser"]}', $test1Token);
 ok(!$json->{success}, "shared user cannot update query");
 
 # shared user cannot delete query
-$json = viewerDeleteToken("/api/cron/$key?arkimeRegressionUser=test1", $test1Token);
+$json = viewerDeleteToken("/api/cron/$key?arkimeRegressionUser=sac-test1", $test1Token);
 ok(!$json->{success}, "shared user cannot delete query");
 
-# test1 cannot transfer ownership (not admin or creator)
-$json = viewerPostToken("/api/cron/$key?arkimeRegressionUser=test1", '{"creator":"test1","name":"test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3", "roles":["arkimeUser"],"editRoles":["cont3xtUser"]}', $test1Token);
+# sac-test1 cannot transfer ownership (not admin or creator)
+$json = viewerPostToken("/api/cron/$key?arkimeRegressionUser=sac-test1", '{"creator":"sac-test1","name":"sac-test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"sac-test2,test3", "roles":["arkimeUser"],"editRoles":["cont3xtUser"]}', $test1Token);
 ok(!$json->{success}, "cannot transfer ownership without being admin or creator");
 eq_or_diff($json->{text}, "Permission denied");
 
 # can't transfer ownership to invalid user
-$json = viewerPostToken("/api/cron/$key", '{"creator":"asdf","name":"test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3", "roles":["arkimeUser"],"editRoles":["cont3xtUser"]}', $token);
+$json = viewerPostToken("/api/cron/$key", '{"creator":"asdf","name":"sac-test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"sac-test2,test3", "roles":["arkimeUser"],"editRoles":["cont3xtUser"]}', $token);
 ok(!$json->{success}, "cannot transfer ownership to an invalid user");
 eq_or_diff($json->{text}, "User not found");
 
 # can transfer ownership
-$json = viewerPostToken("/api/cron/$key", '{"creator":"test1","name":"test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3", "roles":["arkimeUser"],"editRoles":["cont3xtUser"]}', $token);
+$json = viewerPostToken("/api/cron/$key", '{"creator":"sac-test1","name":"sac-test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"sac-test2,test3", "roles":["arkimeUser"],"editRoles":["cont3xtUser"]}', $token);
 ok($json->{success}, "can transfer ownership to valid user");
-eq_or_diff($json->{query}->{creator}, "test1");
+eq_or_diff($json->{query}->{creator}, "sac-test1");
 
-# test2 can delete using editRoles
-$json = viewerDeleteToken("/api/cron/$key?arkimeRegressionUser=test2", $test2Token);
+# sac-test2 can delete using editRoles
+$json = viewerDeleteToken("/api/cron/$key?arkimeRegressionUser=sac-test2", $test2Token);
 ok($json->{success}, "query can be deleted");
 
 # can not update primary-viewer periodic query
-$json = viewerPostToken("/api/cron/primary-viewer", '{"name":"test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"test2,test3"}', $token);
+$json = viewerPostToken("/api/cron/primary-viewer", '{"name":"sac-test1update","query":"protocols == tls","action":"tag","tags":"tls","users":"sac-test2,test3"}', $token);
 eq_or_diff($json, from_json('{"text": "Bad query key", "success": false}'));
 
 # can not delete primary-viewer periodic queries
@@ -119,7 +121,7 @@ viewerGet("/regressionTests/processCronQueries");
 
 # Check result
 $json = viewerGet("/api/crons?arkimeRegressionUser=anonymous&all=true");
-is ($json->[0]->{creator}, "test1");
+is ($json->[0]->{creator}, "sac-test1");
 is ($json->[0]->{name}, "asdf");
 is ($json->[0]->{key}, $key2);
 is ($json->[0]->{count}, "4");
@@ -128,6 +130,6 @@ countTest(4, "date=-1&expression=" . uri_escape("${files} && protocols==tls"));
 countTest(4, "date=-1&expression=" . uri_escape("${files} && tags=test${suffix}"));
 
 # cleanup
-$json = viewerDeleteToken("/api/cron/$key2?arkimeRegressionUser=test1", $test1Token);
-$json = viewerDeleteToken("/api/user/test1", $token);
-$json = viewerDeleteToken("/api/user/test2", $token);
+$json = viewerDeleteToken("/api/cron/$key2?arkimeRegressionUser=sac-test1", $test1Token);
+$json = viewerDeleteToken("/api/user/sac-test1", $token);
+$json = viewerDeleteToken("/api/user/sac-test2", $token);

--- a/tests/api-encodings.t
+++ b/tests/api-encodings.t
@@ -10,7 +10,6 @@ my $json;
 
 my $prefix = int(rand()*100000);
 my $token = getTokenCookie();
-my $es = "-o 'elasticsearch=$ArkimeTest::elasticsearch' $ENV{INSECURE}";
 
 sub doTest {
     my ($encryption, $compression, $blocksize, $shortheader) = @_;
@@ -22,7 +21,7 @@ sub doTest {
     #diag $btag;
 
   ###### wireshark-bdat.pcap - run
-    $cmd = "../capture/capture $es -c config.test.ini -n test --copy -r pcap/wireshark-bdat.pcap --tag $btag -o simpleCompression=$compression";
+    $cmd = "../capture/capture $ArkimeTest::es -c config.test.ini -n test --copy -r pcap/wireshark-bdat.pcap --tag $btag -o simpleCompression=$compression";
     if (defined $encryption) {
         $cmd .= " -o simpleEncoding=$encryption -o simpleKEKId=test";
     }
@@ -36,7 +35,7 @@ sub doTest {
     system("$cmd");
 
   ###### socks-http-pass.pcap - run
-    $cmd = "../capture/capture $es -c config.test.ini -n test --copy -r pcap/socks-http-pass.pcap --tag $stag -o simpleCompression=$compression";
+    $cmd = "../capture/capture $ArkimeTest::es -c config.test.ini -n test --copy -r pcap/socks-http-pass.pcap --tag $stag -o simpleCompression=$compression";
     if (defined $encryption) {
         $cmd .= " -o simpleEncoding=$encryption -o simpleKEKId=test";
     }
@@ -100,7 +99,7 @@ $json = esGet("/tests_files/_search?q=node:test&sort=num:desc&size=20");
 foreach my $item (@{$json->{hits}->{hits}}) {
     next if (exists $item->{_source}->{uncompressedBits});
     next if (!exists $item->{_source}->{dek});
-    my $cmd = "(cd ../viewer; node decryptPcap.js $es -n test -c ../tests/config.test.ini $item->{_source}->{name} > $item->{_source}->{name}.pcap)";
+    my $cmd = "(cd ../viewer; node decryptPcap.js $ArkimeTest::es -n test -c ../tests/config.test.ini $item->{_source}->{name} > $item->{_source}->{name}.pcap)";
     system($cmd);
     open my $in, '<', "$item->{_source}->{name}.pcap" or die "error opening $item->{_source}->{name}.pcap $!";
     read ($in, my $data, 4);

--- a/tests/api-history.t
+++ b/tests/api-history.t
@@ -136,13 +136,13 @@ my ($url) = @_;
 
 # An admin user should see forced expressions for users
     # create a user with a forced expression
-    $json = viewerPostToken("/api/user", '{"userId": "historytest2", "userName": "UserName", "enabled":true, "password":"password","expression":"protocols == udp"}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-historytest3", "userName": "UserName", "enabled":true, "password":"password","expression":"protocols == udp", "roles": ["arkimeUser"]}', $token);
     sleep(1);
     esGet("/_refresh");
     esGet("/_flush");
 
     # issue a request as the user with the forced expression
-    countTest(1, "arkimeRegressionUser=historytest2&date=-1&expression=" . uri_escape("(file=$pwd/socks-https-example.pcap||file=$pwd/dns-mx.pcap)&&tags=domainwise"));
+    countTest(1, "arkimeRegressionUser=sac-historytest3&date=-1&expression=" . uri_escape("(file=$pwd/socks-https-example.pcap||file=$pwd/dns-mx.pcap)&&tags=domainwise"));
     sleep(2);
     esGet("/_refresh");
     esGet("/_flush");
@@ -164,7 +164,7 @@ my ($url) = @_;
     is ($found2, 1, "Admin should see forcedExpression in history");
 
 # A nonadmin user should not see forcedExpression
-  $json = viewerGet("/api/histories?arkimeRegressionUser=historytest2");
+  $json = viewerGet("/api/histories?arkimeRegressionUser=sac-historytest3");
 
   my $found3 = 0;
   foreach my $item4 (@{$json->{data}}) {
@@ -185,7 +185,7 @@ my ($url) = @_;
     esGet("/_refresh");
     esGet("/_flush");
 
-    $json = viewerDeleteToken("/api/user/historytest2", $token);
+    $json = viewerDeleteToken("/api/user/sac-historytest3", $token);
     sleep(1);
     esGet("/_refresh");
     esGet("/_flush");
@@ -194,7 +194,7 @@ my ($url) = @_;
     $json = viewerGet("/api/histories?arkimeRegressionUser=anonymous&sortField=timestamp&desc=true");
     is ($json->{recordsFiltered}, 2, "Delete: recordsFiltered");
     $item = $json->{data}->[0];
-    is ($item->{api}, "/api/user/historytest2", "Delete: api");
+    is ($item->{api}, "/api/user/sac-historytest3", "Delete: api");
     is ($item->{userId}, "anonymous", "Delete: userId");
     ok (!exists $item->{body}->{password}, "Delete: should have no password item");
     ok (!exists $item->{body}->{newPassword}, "Delete: should have no newPassword item");

--- a/tests/api-multies.t
+++ b/tests/api-multies.t
@@ -7,6 +7,9 @@ use Data::Dumper;
 use Test::Differences;
 use strict;
 
+# clean old users
+    clearIndex("tests_users");
+
 my $json;
 
     $json = mesGet("/");

--- a/tests/api-scrub.t
+++ b/tests/api-scrub.t
@@ -9,14 +9,13 @@ use strict;
 
 my $copytest = getcwd() . "/copytest.pcap";
 my $token = getTokenCookie();
-my $es = "-o 'elasticsearch=$ArkimeTest::elasticsearch'";
 
 countTest(0, "date=-1&expression=" . uri_escape("file=$copytest"));
 
 system("../db/db.pl --prefix tests $ArkimeTest::elasticsearch rm $copytest 2>&1 1>/dev/null");
 viewerPost("/regressionTests/flushCache");
 system("/bin/cp pcap/socks-http-example.pcap copytest.pcap");
-system("../capture/capture $es -c config.test.ini -n test -r copytest.pcap $ENV{INSECURE}");
+system("../capture/capture $ArkimeTest::es -c config.test.ini -n test -r copytest.pcap $ENV{INSECURE}");
 esGet("/_flush");
 esGet("/_refresh");
 

--- a/tests/api-unique.t
+++ b/tests/api-unique.t
@@ -7,7 +7,7 @@ use strict;
 
 # create user with time limit
 my $token = getTokenCookie();
-viewerPostToken("/api/user", '{"userId": "test1", "userName": "test1", "enabled":true, "password":"password", "timeLimit":"72"}', $token);
+viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "sac-test1", "enabled":true, "password":"password", "timeLimit":"72", "roles":["arkimeUser"]}', $token);
 
 sub get {
 my ($param) = @_;
@@ -217,7 +217,7 @@ eq_or_diff($txt,
 /DIR/tests/pcap/v6-http.pcap, 6
 ", "filename counts");
 
-$txt = get("date=-1&field=node&expression=$files&counts=1&arkimeRegressionUser=test1");
+$txt = get("date=-1&field=node&expression=$files&counts=1&arkimeRegressionUser=sac-test1");
 eq_or_diff($txt, "User time limit (72 hours) exceeded\n");
 
-viewerDeleteToken("/api/user/test1", $token);
+viewerDeleteToken("/api/user/sac-test1", $token);

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,4 +1,4 @@
-use Test::More tests => 162;
+use Test::More tests => 166;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -10,36 +10,35 @@ use strict;
 my $json;
 
 # clean old users
-    esPost("/tests_users/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }', 1);
+    clearIndex("tests_users");
 
 # Get tokens
     my $token = getTokenCookie();
     my $token2 = getTokenCookie2();
-    my $test1Token = getTokenCookie('test1');
-    my $test2Token = getTokenCookie('test2');
     my $superAdminToken = getTokenCookie('superAdmin');
 
 # clean old crons
-    esPost("/tests_queries/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }');
+    clearIndex("tests_queries");
 
 # users
     my $users = viewerPost("/api/users", "");
-    is (@{$users->{data}}, 0, "Empty users table");
+    is (@{$users->{data}}, 1, "anonymous, superAdmin");
 
 # csv
     my $csv = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/users.csv", Content => "")->content;
     $csv =~ s/\r//g;
     eq_or_diff ($csv, 'userId, userName, enabled, webEnabled, headerAuthEnabled, roles, emailSearch, removeEnabled, packetSearch, hideStats, hideFiles, hidePcap, disablePcapDownload, expression, timeLimit
+anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
 ', "CSV Users");
 
 # Can't create system rule
     $json = viewerPostToken("/api/user", '{"userId": "usersAdmin", "userName": "UserName", "enabled":true, "password":"password"}', $token);
     eq_or_diff($json, from_json('{"text": "User ID can\'t be a system role id", "success": false}'));
 
-    $json = viewerPostToken("/api/user/usersAdmin", '{"userId": "usersAdmin", "userName": "UserName", "enabled":true, "password":"password", "roles":["superAdmin"]}', $token);
+    $json = viewerPostToken("/api/user/usersAdmin", '{"userName": "UserName", "enabled":true, "password":"password", "roles":["superAdmin"]}', $token);
     eq_or_diff($json, from_json('{"text": "User ID can\'t be a system role id", "success": false}'));
 
-    $json = viewerPostToken("/api/user/usersAdmin\u001b", '{"userId": "usersAdmin\u001b", "userName": "UserName", "enabled":true, "password":"password", "roles":["arkimeUser"]}', $token);
+    $json = viewerPostToken("/api/user/sac-usersAdmin!", '{"userId": "usersAdmin\u001b", "userName": "UserName", "enabled":true, "password":"password", "roles":["arkimeUser"]}', $token);
     eq_or_diff($json, from_json('{"text": "User not found", "success": false}'));
 
 # Create Missing/Emptry fields
@@ -52,54 +51,57 @@ my $json;
     $json = viewerPostToken("/api/user", '{"userId": "<script>", "userName": "UserName", "enabled":true, "password":"password"}', $token);
     eq_or_diff($json, from_json('{"text": "User ID must be word characters", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "test1", "enabled":true, "password":"password"}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-test1", "enabled":true, "password":"password"}', $token);
     eq_or_diff($json, from_json('{"text": "Missing/Empty required fields", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "test1", "userName": "", "enabled":true, "password":"password"}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "", "enabled":true, "password":"password"}', $token);
     eq_or_diff($json, from_json('{"text": "Missing/Empty required fields", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "test1", "userName": " ", "enabled":true, "password":"password"}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": " ", "enabled":true, "password":"password"}', $token);
     eq_or_diff($json, from_json('{"text": "Username can not be empty", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "test1", "userName": "UserName", "enabled":true}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "UserName", "enabled":true}', $token);
     eq_or_diff($json, from_json('{"text": "Password needs to be at least 3 characters", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "test1", "userName": "UserName", "enabled":true, "password":""}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "UserName", "enabled":true, "password":""}', $token);
     eq_or_diff($json, from_json('{"text": "Password needs to be at least 3 characters", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "test1", "userName": "UserName", "enabled":true, "password":"ab"}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "UserName", "enabled":true, "password":"ab"}', $token);
     eq_or_diff($json, from_json('{"text": "Password needs to be at least 3 characters", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "test1", "userName": "UserName", "enabled":true, "password":"abc", "expression": false}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "UserName", "enabled":true, "password":"abc", "expression": false}', $token);
     eq_or_diff($json, from_json('{"text": "Expression must be a string when present", "success": false}'));
 
 # Add User 1
-    $json = viewerPostToken("/api/user", '{"userId": "test1", "userName": "UserName", "enabled":true, "password":"password"}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "UserName", "enabled":true, "password":"password", "roles": ["arkimeUser"]}', $token);
     eq_or_diff($json, from_json('{"text": "User created succesfully", "success": true}'));
 
     $users = viewerPost("/api/users?arkimeRegressionUser=notadmin", "");
     eq_or_diff($users, from_json('{"text": "You do not have permission to access this resource", "success": false}'));
 
-    $users = viewerPost("/api/users", "");
-    is (@{$users->{data}}, 1, "Check add #1");
-
-    eq_or_diff($users->{data}->[0], from_json('{"roles": [], "userId": "test1", "removeEnabled": false, "expression": "", "headerAuthEnabled": false, "userName": "UserName", "id": "test1", "emailSearch": false, "enabled": true, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "lastUsed": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Add", { context => 3 });
-
-
-    # This will set a lastUsed time, make sure DB is updated with sleep
-    my $test1Token = getTokenCookie("test1");
-    sleep(1);
     esGet("/_flush");
     esGet("/_refresh");
 
+    $users = viewerPost("/api/users", "");
+    is (@{$users->{data}}, 3, "Check add #1");
+
+    eq_or_diff($users->{data}->[2], from_json('{"roles": ["arkimeUser"], "userId": "sac-test1", "removeEnabled": false, "expression": "", "headerAuthEnabled": false, "userName": "UserName", "id": "sac-test1", "emailSearch": false, "enabled": true, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "lastUsed": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Add", { context => 3 });
+
+
+    # This will set a lastUsed time, make sure DB is updated with sleep
+    sleep(1);
+    esGet("/_flush");
+    esGet("/_refresh");
+    my $test1Token = getTokenCookie("sac-test1");
+
     $users = viewerPost2("/api/users", "");
-    is (@{$users->{data}}, 1, "Check add #2");
+    is (@{$users->{data}}, 3, "Check add #2");
 
-    is (exists $users->{data}->[0]->{lastUsed}, 1, "last used exists #1");
-    my $lastUsedTimestamp1 = $users->{data}->[0]->{lastUsed};
-    delete $users->{data}->[0]->{lastUsed};
+    is (exists $users->{data}->[1]->{lastUsed}, 1, "last used exists #1");
+    my $lastUsedTimestamp1 = $users->{data}->[1]->{lastUsed};
+    delete $users->{data}->[2]->{lastUsed};
 
-    eq_or_diff($users->{data}->[0], from_json('{"roles": [], "userId": "test1", "removeEnabled": false, "expression": "", "headerAuthEnabled": false, "userName": "UserName", "id": "test1", "emailSearch": false, "enabled": true, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "roleAssigners": []}', {relaxed => 1}), "Test User Add", { context => 3 });
+    eq_or_diff($users->{data}->[2], from_json('{"roles": ["arkimeUser"], "userId": "sac-test1", "removeEnabled": false, "expression": "", "headerAuthEnabled": false, "userName": "UserName", "id": "sac-test1", "emailSearch": false, "enabled": true, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "roleAssigners": []}', {relaxed => 1}), "Test User Add", { context => 3 });
 
 # Check appinfo works
     $json = viewerGetToken("/api/appInfo", $token);
@@ -112,17 +114,21 @@ my $json;
     eq_or_diff($json, from_json('{"text": "Can not create superAdmin unless you are superAdmin", "success": false}'));
 
 # Can we update superAdmin
-    $json = viewerPostToken("/api/user/test1", '{"userId":"test1", "userName":"UserNameUpdated", "removeEnabled":true, "headerAuthEnabled":true, "expression":"foo", "emailSearch":true, "webEnabled":true, "roles":["superAdmin"], "packetSearch": false}', $token);
+    $json = viewerPostToken("/api/user/sac-test1", '{"userName":"UserNameUpdated", "removeEnabled":true, "headerAuthEnabled":true, "expression":"foo", "emailSearch":true, "webEnabled":true, "roles":["superAdmin"], "packetSearch": false}', $token);
     eq_or_diff($json, from_json('{"text": "Can not modify superAdmin unless you are superAdmin", "success": false}'));
 
-    $json = viewerPostToken("/api/user/test1", '{"userId":"test1", "userName":"UserNameUpdated", "removeEnabled":true, "headerAuthEnabled":true, "expression":"foo", "emailSearch":true, "webEnabled":true, "roles":["usersAdmin"], "packetSearch": false}', $token);
+    $json = viewerPostToken("/api/user/sac-test1", '{"userName":"UserNameUpdated", "removeEnabled":true, "headerAuthEnabled":true, "expression":"foo", "emailSearch":true, "webEnabled":true, "roles":["usersAdmin"], "packetSearch": false}', $token);
     eq_or_diff($json, from_json('{"text": "Only superAdmin user can enable Admin roles on a user", "success": false}'));
 # Update User Server 1
-    $json = viewerPostToken("/api/user/test1?arkimeRegressionUser=superAdmin", '{"userId":"test1", "userName":"UserNameUpdated", "removeEnabled":true, "headerAuthEnabled":true, "expression":"foo", "emailSearch":true, "webEnabled":true, "roles":["usersAdmin"], "packetSearch": false}', $superAdminToken);
-    eq_or_diff($json, from_json('{"text": "User test1 updated successfully", "success": true}'));
+    $json = viewerPostToken("/api/user/sac-test1?arkimeRegressionUser=superAdmin", '{"userName":"UserNameUpdated", "removeEnabled":true, "headerAuthEnabled":true, "expression":"foo", "emailSearch":true, "webEnabled":true, "roles":["usersAdmin", "arkimeUser"], "packetSearch": false}', $superAdminToken);
+    eq_or_diff($json, from_json('{"text": "User sac-test1 updated successfully", "success": true}'));
 
-    $users = viewerPost("/api/users?arkimeRegressionUser=test1", "");
-    is (@{$users->{data}}, 1, "Check Update #1");
+    esGet("/_flush");
+    esGet("/_refresh");
+
+    my $sacpos=2;
+    $users = viewerPost("/api/users?arkimeRegressionUser=sac-test1", "");
+    is (@{$users->{data}}, 4, "Check Update #1");
 
     # Force last used to be increased
     esGet("/_flush");
@@ -130,64 +136,72 @@ my $json;
     sleep(2);
 
     $users = viewerPost("/api/users", "");
-    is (exists $users->{data}->[0]->{lastUsed}, 1, "last used exists #2");
-    my $lastUsedTimestamp2 = $users->{data}->[0]->{lastUsed};
+    is (exists $users->{data}->[$sacpos]->{lastUsed}, 1, "last used exists #2");
+    my $lastUsedTimestamp2 = $users->{data}->[$sacpos]->{lastUsed};
     cmp_ok($lastUsedTimestamp1, '<', $lastUsedTimestamp2, "last used updated");
-    delete $users->{data}->[0]->{lastUsed};
+    delete $users->{data}->[$sacpos]->{lastUsed};
 
-    eq_or_diff($users->{data}->[0], from_json('{"roles": ["usersAdmin"], "userId": "test1", "removeEnabled": true, "expression": "foo", "headerAuthEnabled": true, "userName": "UserNameUpdated", "id": "test1", "emailSearch": true, "enabled": false, "webEnabled": true, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
+    eq_or_diff($users->{data}->[$sacpos], from_json('{"roles": ["usersAdmin", "arkimeUser"], "userId": "sac-test1", "removeEnabled": true, "expression": "foo", "headerAuthEnabled": true, "userName": "UserNameUpdated", "id": "sac-test1", "emailSearch": true, "enabled": false, "webEnabled": true, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
 
     $users = viewerPost2("/api/users", "");
-    is (@{$users->{data}}, 1, "Check Update #2");
-    is (exists $users->{data}->[0]->{lastUsed}, 1, "last used exists #3");
-    delete $users->{data}->[0]->{lastUsed};
-    eq_or_diff($users->{data}->[0], from_json('{"roles": ["usersAdmin"], "userId": "test1", "removeEnabled": true, "expression": "foo", "headerAuthEnabled": true, "userName": "UserNameUpdated", "id": "test1", "emailSearch": true, "enabled": false, "webEnabled": true, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
+    is (@{$users->{data}}, 4, "Check Update #2");
+    is (exists $users->{data}->[$sacpos]->{lastUsed}, 1, "last used exists #3");
+    delete $users->{data}->[$sacpos]->{lastUsed};
+    eq_or_diff($users->{data}->[$sacpos], from_json('{"roles": ["usersAdmin", "arkimeUser"], "userId": "sac-test1", "removeEnabled": true, "expression": "foo", "headerAuthEnabled": true, "userName": "UserNameUpdated", "id": "sac-test1", "emailSearch": true, "enabled": false, "webEnabled": true, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
 
 # update user settings
-    $json = viewerPostToken("/api/user/settings?arkimeRegressionUser=test1", '{"logo":"testlogo.png","__proto":{"bad":"stuff"}}', $test1Token);
+    $json = viewerPostToken("/api/user/settings?arkimeRegressionUser=sac-test1", '{"logo":"testlogo.png","__proto":{"bad":"stuff"}}', $test1Token);
     eq_or_diff($json, from_json('{"text": "Updated user settings successfully", "success": true}'));
 
-    $json = viewerGetToken("/api/user/settings?arkimeRegressionUser=test1", $test1Token);
+    $json = viewerGetToken("/api/user/settings?arkimeRegressionUser=sac-test1", $test1Token);
     ok(!exists $json->{__proto__}, "no prototype pollution");
     eq_or_diff($json->{logo}, "testlogo.png");
 
 # Add User 2
-    my $json = viewerPostToken2("/api/user", '{"userId": "test2", "userName": "UserName2", "enabled":true, "password":"password"}', $token2);
+    my $json = viewerPostToken2("/api/user", '{"userId": "sac-test2", "userName": "UserName2", "enabled":true, "password":"password"}', $token2);
+    eq_or_diff($json, from_json('{"text": "User created succesfully", "success": true}'));
+
+    esGet("/_flush");
+    esGet("/_refresh");
+    # flush the cache on 1 since we created the user on 2
+    viewerPost("/regressionTests/flushCache");
+    my $test2pos = 3;
+    my $test2Token = getTokenCookie('sac-test2');
 
     $users = viewerPost("/api/users", "");
-    is (@{$users->{data}}, 2, "Check second add #1");
-    eq_or_diff($users->{data}->[1], from_json('{"roles": [], "userId": "test2", "removeEnabled": false, "expression": "", "headerAuthEnabled": false, "userName": "UserName2", "id": "test2", "emailSearch": false, "enabled": true, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "lastUsed": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Add", { context => 3 });
+    is (@{$users->{data}}, 5, "Check second add #1");
+    eq_or_diff($users->{data}->[$test2pos], from_json('{"roles": [], "lastUsed": 0, "userId": "sac-test2", "removeEnabled": false, "expression": "", "headerAuthEnabled": false, "userName": "UserName2", "id": "sac-test2", "emailSearch": false, "enabled": true, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "roleAssigners": [], "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false}', {relaxed => 1}), "Test User Add", { context => 3 });
 
     $users = viewerPost2("/api/users", "");
-    is (@{$users->{data}}, 2, "Check second add #2");
-    eq_or_diff($users->{data}->[1], from_json('{"roles": [], "userId": "test2", "removeEnabled": false, "expression": "", "headerAuthEnabled": false, "userName": "UserName2", "id": "test2", "emailSearch": false, "enabled": true, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "lastUsed": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Add", { context => 3 });
+    is (@{$users->{data}}, 5, "Check second add #2");
+    eq_or_diff($users->{data}->[$test2pos], from_json('{"roles": [], "lastUsed": 0, "userId": "sac-test2", "removeEnabled": false, "expression": "", "headerAuthEnabled": false, "userName": "UserName2", "id": "sac-test2", "emailSearch": false, "enabled": true, "webEnabled": false, "packetSearch": false, "welcomeMsgNum": 0, "roleAssigners": [], "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false}', {relaxed => 1}), "Test User Add", { context => 3 });
 
 # Filter
     $users = viewerPost("/api/users", "filter=test");
     is (@{$users->{data}}, 2, "filter both");
-    is ($users->{recordsTotal}, 2);
+    is ($users->{recordsTotal}, 5);
     is ($users->{recordsFiltered}, 2);
 
-    $users = viewerPost("/api/users", "filter=test1");
+    $users = viewerPost("/api/users", "filter=sac-test1");
     is (@{$users->{data}}, 1, "filter one");
-    is ($users->{recordsTotal}, 2);
+    is ($users->{recordsTotal}, 5);
     is ($users->{recordsFiltered}, 1);
 
 # start, length
     $users = viewerPost("/api/users", "start=0&length=2");
     is (@{$users->{data}}, 2, "start=0&length=2");
-    is ($users->{recordsTotal}, 2);
-    is ($users->{recordsFiltered}, 2);
+    is ($users->{recordsTotal}, 5);
+    is ($users->{recordsFiltered}, 5);
 
     $users = viewerPost("/api/users", "start=1&length=2");
-    is (@{$users->{data}}, 1, "start=1&length=2");
-    is ($users->{recordsTotal}, 2);
-    is ($users->{recordsFiltered}, 2);
+    is (@{$users->{data}}, 2, "start=1&length=2");
+    is ($users->{recordsTotal}, 5);
+    is ($users->{recordsFiltered}, 5);
 
     $users = viewerPost("/api/users", "start=0&length=1");
     is (@{$users->{data}}, 1, "start=1&length=1");
-    is ($users->{recordsTotal}, 2);
-    is ($users->{recordsFiltered}, 2);
+    is ($users->{recordsTotal}, 5);
+    is ($users->{recordsFiltered}, 5);
 
     $users = viewerPost("/api/users", "start=666&length=100000");
     is (@{$users->{data}}, 0, "start=0&length=100000");
@@ -195,134 +209,138 @@ my $json;
     is ($users->{recordsFiltered}, 0);
 
 # Update User Shared Server
-    $json = viewerPostToken2("/api/user/test2", '{"userId":"test2","userName":"UserNameUpdated2", "enabled":true, "removeEnabled":false, "headerAuthEnabled":true, "expression":"foo", "emailSearch":true, "webEnabled":true, "roles": [], "packetSearch": false}', $token2);
+    $json = viewerPostToken2("/api/user/sac-test2", '{"userName":"UserNameUpdated2", "enabled":true, "removeEnabled":false, "headerAuthEnabled":true, "expression":"foo", "emailSearch":true, "webEnabled":true, "roles": [], "packetSearch": false}', $token2);
+    eq_or_diff($json, from_json('{"text": "User sac-test2 updated successfully", "success": true}'));
 
     $users = viewerPost("/api/users", "");
-    is (@{$users->{data}}, 2, "Check second Update #1");
-    delete $users->{data}->[1]->{lastUsed};
-    eq_or_diff($users->{data}->[1], from_json('{"roles": [], "userId": "test2", "removeEnabled": false, "expression": "foo", "headerAuthEnabled": true, "userName": "UserNameUpdated2", "id": "test2", "emailSearch": true, "enabled": true, "webEnabled": true, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
+    is (@{$users->{data}}, 5, "Check second Update #1");
+    delete $users->{data}->[$test2pos]->{lastUsed};
+    eq_or_diff($users->{data}->[$test2pos], from_json('{"roles": [], "userId": "sac-test2", "removeEnabled": false, "expression": "foo", "headerAuthEnabled": true, "userName": "UserNameUpdated2", "id": "sac-test2", "emailSearch": true, "enabled": true, "webEnabled": true, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
 
     $users = viewerPost2("/api/users", "");
-    is (@{$users->{data}}, 2, "Check second Update #2");
-    delete $users->{data}->[1]->{lastUsed};
-    eq_or_diff($users->{data}->[1], from_json('{"roles": [], "userId": "test2", "removeEnabled": false, "expression": "foo", "headerAuthEnabled": true, "userName": "UserNameUpdated2", "id": "test2", "emailSearch": true, "enabled": true, "webEnabled": true, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
+    is (@{$users->{data}}, 5, "Check second Update #2");
+    delete $users->{data}->[$test2pos]->{lastUsed};
+    eq_or_diff($users->{data}->[$test2pos], from_json('{"roles": [], "userId": "sac-test2", "removeEnabled": false, "expression": "foo", "headerAuthEnabled": true, "userName": "UserNameUpdated2", "id": "sac-test2", "emailSearch": true, "enabled": true, "webEnabled": true, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
 
 # Reverse settings
-    $json = viewerPostToken2("/api/user/test2", '{"userId":"test2","userName":"UserNameUpdated3", "enabled":false, "removeEnabled":true, "headerAuthEnabled":false, "expression":"", "emailSearch":false, "webEnabled":false, "roles": [], "packetSearch": false}', $token2);
+    $json = viewerPostToken2("/api/user/sac-test2", '{"userName":"UserNameUpdated3", "enabled":false, "removeEnabled":true, "headerAuthEnabled":false, "expression":"", "emailSearch":false, "webEnabled":false, "roles": [], "packetSearch": false}', $token2);
+    eq_or_diff($json, from_json('{"text": "User sac-test2 updated successfully", "success": true}'));
 
     $users = viewerPost("/api/users", "");
-    is (@{$users->{data}}, 2, "Check second Update #1");
-    delete $users->{data}->[1]->{lastUsed};
-    eq_or_diff($users->{data}->[1], from_json('{"roles": [], "userId": "test2", "removeEnabled": true, "expression": "", "headerAuthEnabled": false, "userName": "UserNameUpdated3", "id": "test2", "emailSearch": false, "enabled": false, "webEnabled": false, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
+    is (@{$users->{data}}, 5, "Check second Update #1");
+    delete $users->{data}->[$test2pos]->{lastUsed};
+    eq_or_diff($users->{data}->[$test2pos], from_json('{"roles": [], "userId": "sac-test2", "removeEnabled": true, "expression": "", "headerAuthEnabled": false, "userName": "UserNameUpdated3", "id": "sac-test2", "emailSearch": false, "enabled": false, "webEnabled": false, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
 
     $users = viewerPost2("/api/users", "");
-    is (@{$users->{data}}, 2, "Check second Update #2");
-    delete $users->{data}->[1]->{lastUsed};
-    eq_or_diff($users->{data}->[1], from_json('{"roles": [], "userId": "test2", "removeEnabled": true, "expression": "", "headerAuthEnabled": false, "userName": "UserNameUpdated3", "id": "test2", "emailSearch": false, "enabled": false, "webEnabled": false, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
+    is (@{$users->{data}}, 5, "Check second Update #2");
+    delete $users->{data}->[$test2pos]->{lastUsed};
+    eq_or_diff($users->{data}->[$test2pos], from_json('{"roles": [], "userId": "sac-test2", "removeEnabled": true, "expression": "", "headerAuthEnabled": false, "userName": "UserNameUpdated3", "id": "sac-test2", "emailSearch": false, "enabled": false, "webEnabled": false, "packetSearch": false, "disablePcapDownload": false, "hideFiles": false, "hidePcap": false, "hideStats": false, "welcomeMsgNum": 0, "roleAssigners": []}', {relaxed => 1}), "Test User Update", { context => 3 });
 
 # Column
-    my $info = viewerGet("/api/user/columns?arkimeRegressionUser=test1");
+    my $info = viewerGet("/api/user/columns?arkimeRegressionUser=sac-test1");
     eq_or_diff($info, from_json("[]"), "column: empty");
 
-    $info = viewerPostToken("/api/user/column?arkimeRegressionUser=test1", '{"name": "column1", "columns": ["srcIp","dstIp"], "order": [["lastPacket", "asc"]]}', $test1Token);
+    $info = viewerPostToken("/api/user/column?arkimeRegressionUser=sac-test1", '{"name": "column1", "columns": ["srcIp","dstIp"], "order": [["lastPacket", "asc"]]}', $test1Token);
     ok($info->{success}, "column: create success");
     is($info->{name}, "column1", "column: create name");
 
-    $info = viewerPostToken("/api/user/column?arkimeRegressionUser=test1", '{"name": "column2", "columns": ["srcIp","dstIp"], "order": [["lastPacket", "asc"]]}', $test1Token);
+    $info = viewerPostToken("/api/user/column?arkimeRegressionUser=sac-test1", '{"name": "column2", "columns": ["srcIp","dstIp"], "order": [["lastPacket", "asc"]]}', $test1Token);
     ok($info->{success}, "column: create success");
     is($info->{name}, "column2", "column: create name");
 
-    $info = viewerGet("/api/user/columns?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user/columns?arkimeRegressionUser=sac-test1");
     eq_or_diff($info, from_json('[{"name":"column1","order":[["lastPacket","asc"]],"columns":["srcIp","dstIp"]},{"name":"column2","order":[["lastPacket","asc"]],"columns":["srcIp","dstIp"]}]'), "column: 1 item");
 
-    $info = viewerGet("/api/user/columns?arkimeRegressionUser=anonymous&userId=test1");
+    $info = viewerGet("/api/user/columns?arkimeRegressionUser=anonymous&userId=sac-test1");
     eq_or_diff($info, from_json('[{"name":"column1","order":[["lastPacket","asc"]],"columns":["srcIp","dstIp"]},{"name":"column2","order":[["lastPacket","asc"]],"columns":["srcIp","dstIp"]}]'), "column: 1 item admin");
 
-    $info = viewerDeleteToken("/api/user/column/fred?arkimeRegressionUser=test1", $test1Token);
+    $info = viewerDeleteToken("/api/user/column/fred?arkimeRegressionUser=sac-test1", $test1Token);
     ok(! $info->{success}, "column: delete not found");
 
-    $info = viewerGet("/api/user/columns?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user/columns?arkimeRegressionUser=sac-test1");
     eq_or_diff($info, from_json('[{"name":"column1","order":[["lastPacket","asc"]],"columns":["srcIp","dstIp"]},{"name":"column2","order":[["lastPacket","asc"]],"columns":["srcIp","dstIp"]}]'), "column: 1 item");
 
-    $info = viewerPutToken("/api/user/column/column1?arkimeRegressionUser=test1", '{"name": "column1", "columns": ["srcIp","dstIp","info"], "order": [["lastPacket","asc"]]}', $test1Token);
+    $info = viewerPutToken("/api/user/column/column1?arkimeRegressionUser=sac-test1", '{"name": "column1", "columns": ["srcIp","dstIp","info"], "order": [["lastPacket","asc"]]}', $test1Token);
     ok($info->{success}, "column: update");
 
-    $info = viewerDeleteToken("/api/user/column/column1?arkimeRegressionUser=test1", $test1Token);
+    $info = viewerDeleteToken("/api/user/column/column1?arkimeRegressionUser=sac-test1", $test1Token);
     ok($info->{success}, "column: delete found");
 
-    $info = viewerDeleteToken("/api/user/column/column2?arkimeRegressionUser=test1", $test1Token);
+    $info = viewerDeleteToken("/api/user/column/column2?arkimeRegressionUser=sac-test1", $test1Token);
     ok($info->{success}, "column: delete found");
 
-    $info = viewerGet("/api/user/columns?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user/columns?arkimeRegressionUser=sac-test1");
     eq_or_diff($info, from_json("[]"), "column: empty");
 
 
 # Current
-    $info = viewerGet("/api/user?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user?arkimeRegressionUser=sac-test1");
     ok(!exists $info->{passStore}, "current: no passtore");
 
 # spiview fields
-    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=sac-test1");
     eq_or_diff($info, from_json("[]"), "spiview fields: empty");
 
-    $info = viewerPostToken("/api/user/spiview?arkimeRegressionUser=test1", '{"name": "sfields1", "fields": ["srcIp","dstIp"]}', $test1Token);
+    $info = viewerPostToken("/api/user/spiview?arkimeRegressionUser=sac-test1", '{"name": "sfields1", "fields": ["srcIp","dstIp"]}', $test1Token);
     ok($info->{success}, "spiview fields: create success");
     is($info->{name}, "sfields1", "spiview fields: create name");
 
-    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=sac-test1");
     eq_or_diff($info, from_json('[{"name":"sfields1","fields":["srcIp","dstIp"]}]'), "spiview fields: 1 item");
 
-    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=anonymous&userId=test1");
+    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=anonymous&userId=sac-test1");
     eq_or_diff($info, from_json('[{"name":"sfields1","fields":["srcIp","dstIp"]}]'), "spiview fields: 1 item admin");
 
-    $info = viewerPutToken("/api/user/spiview/sfields1?arkimeRegressionUser=test1", '{"name": "sfields1", "fields": ["srcIp","dstIp","node"]}', $test1Token);
+    $info = viewerPutToken("/api/user/spiview/sfields1?arkimeRegressionUser=sac-test1", '{"name": "sfields1", "fields": ["srcIp","dstIp","node"]}', $test1Token);
     ok($info->{success}, "spiview fields: update success");
 
-    $info = viewerDeleteToken("/api/user/spiview/fred?arkimeRegressionUser=test1", $test1Token);
+    $info = viewerDeleteToken("/api/user/spiview/fred?arkimeRegressionUser=sac-test1", $test1Token);
     ok(!$info->{success}, "spiview fields: delete not found");
 
-    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=sac-test1");
     eq_or_diff($info, from_json('[{"name":"sfields1","fields":["srcIp","dstIp","node"]}]'), "spiview fields: 1 item");
 
-    $info = viewerDeleteToken("/api/user/spiview/sfields1?arkimeRegressionUser=test1", $test1Token);
+    $info = viewerDeleteToken("/api/user/spiview/sfields1?arkimeRegressionUser=sac-test1", $test1Token);
     ok($info->{success}, "spiview fields: delete found");
 
-    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user/spiview?arkimeRegressionUser=sac-test1");
     eq_or_diff($info, from_json("[]"), "spiview fields: empty");
 
 # Messages
-    $info = viewerPutToken("/api/user/test1/acknowledge", '{"msgNum":2}', $token2);
+    $info = viewerPutToken("/api/user/sac-test1/acknowledge", '{"msgNum":2}', $token2);
     ok(!$info->{success}, "can't update welcome message number for another user");
 
-    $info = viewerPutToken("/api/user/test1/acknowledge?arkimeRegressionUser=test1", '{}', $test1Token);
+    $info = viewerPutToken("/api/user/sac-test1/acknowledge?arkimeRegressionUser=sac-test1", '{}', $test1Token);
     eq_or_diff($info, from_json('{"text": "Message number required", "success": false}'));
 
-    $info = viewerPutToken("/api/user/test1/acknowledge?arkimeRegressionUser=test1", '{"msgNum":"foo"}', $test1Token);
+    $info = viewerPutToken("/api/user/sac-test1/acknowledge?arkimeRegressionUser=sac-test1", '{"msgNum":"foo"}', $test1Token);
     eq_or_diff($info, from_json('{"text": "welcomeMsgNum is not integer", "success": false}'));
 
-    $info = viewerPutToken("/api/user/test1/acknowledge?arkimeRegressionUser=test1", '{"msgNum":2}', $test1Token);
+    $info = viewerPutToken("/api/user/sac-test1/acknowledge?arkimeRegressionUser=sac-test1", '{"msgNum":2}', $test1Token);
     ok($info->{success}, "update welcome message number");
 
-    $info = viewerGet("/api/user?arkimeRegressionUser=test1");
+    $info = viewerGet("/api/user?arkimeRegressionUser=sac-test1");
     eq_or_diff($info->{welcomeMsgNum}, 2, "welcome message number is correct");
 
 # user time limit
-    $json = viewerPostToken2("/api/user/test2", '{"timeLimit":"72"}', $token2);
+    $json = viewerPostToken("/api/user/sac-test2", '{"timeLimit":"72", "roles": ["arkimeUser"]}', $token);
+    eq_or_diff($json, from_json('{"text": "User sac-test2 updated successfully", "success": true}'));
+
     $users = viewerPost("/api/users", "");
-    eq_or_diff($users->{data}->[1]->{timeLimit}, 72, "time limit updated");
-    $json = viewerGet("/sessions.json?arkimeRegressionUser=test2&date=-1");
+    eq_or_diff($users->{data}->[$test2pos]->{timeLimit}, 72, "time limit updated");
+    $json = viewerGet("/sessions.json?arkimeRegressionUser=sac-test2&date=-1");
     eq_or_diff($json->{error}, "User time limit (72 hours) exceeded", "user can't exceed their time limit");
-    $json = viewerGet("/api/sessions?arkimeRegressionUser=test2&date=72");
+    $json = viewerGet("/api/sessions?arkimeRegressionUser=sac-test2&date=72");
     is (exists $json->{data}, 1, "user can make a query within their time range");
 
 # valueActions tests
-    $json = viewerGet("/api/valueactions?arkimeRegressionUser=test1");
-    eq_or_diff($json->{reverseDNS}, from_json('{"url": "api/reversedns?ip=%TEXT%", "name": "Get Reverse DNS", "actionType": "fetch", "category": "ip"}'), 'test1 valueActions');
-    eq_or_diff($json->{USERTEST}, from_json('{"url": "https://example.com", "name": "usertest", "category": "url"}'), 'test1 valueActions');
+    $json = viewerGet("/api/valueactions?arkimeRegressionUser=sac-test1");
+    eq_or_diff($json->{reverseDNS}, from_json('{"url": "api/reversedns?ip=%TEXT%", "name": "Get Reverse DNS", "actionType": "fetch", "category": "ip"}'), 'sac-test1 valueActions');
+    eq_or_diff($json->{USERTEST}, from_json('{"url": "https://example.com", "name": "usertest", "category": "url"}'), 'sac-test1 valueActions');
 
     # not web enabled
-    $json = viewerGet("/api/valueactions?arkimeRegressionUser=test2");
-    eq_or_diff($json, from_json('{"text": "You do not have permission to access this resource", "success": false}'), 'test2 valueActions');
+    $json = viewerGet("/api/valueactions?arkimeRegressionUser=sac-test2");
+    eq_or_diff($json, from_json('{"text": "You do not have permission to access this resource", "success": false}'), 'sac-test2 valueActions');
 
     $json = viewerGet("/api/valueactions?arkimeRegressionUser=test100");
     ok(! exists $json->{USERTEST});
@@ -331,11 +349,11 @@ my $json;
     ok(! exists $json->{USERTEST});
 
 # fieldActions tests
-    $json = viewerGet("/api/fieldActions?arkimeRegressionUser=test1");
+    $json = viewerGet("/api/fieldActions?arkimeRegressionUser=sac-test1");
     eq_or_diff($json->{ASDF}, from_json('{"url": "https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%", "name": "Field Action %FIELDNAME%!", "category": "ip"}'), 'fetches field actions');
 
     # not web enabled
-    $json = viewerGet("/api/fieldActions?arkimeRegressionUser=test2");
+    $json = viewerGet("/api/fieldActions?arkimeRegressionUser=sac-test2");
     eq_or_diff($json, from_json('{"text": "You do not have permission to access this resource", "success": false}'), 'user cannot access field action');
 
     # not a user:
@@ -347,135 +365,142 @@ my $json;
     eq_or_diff($json, from_json('{"ALLTEST":{"url":"https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%","all":true,"name":"All Field Action %FIELDNAME%!"},"ALLTESTWISE":{"url":"http:/www.example.com","all":true,"name":"AllWiseTest"}}'), 'notUser fieldActions');
 
 # state tests
-    $json = viewerPostToken("/api/user/state/state1?arkimeRegressionUser=test1", '{"order":"test","visibleHeaders":["firstPacket","lastPacket","src","srcPort","dst","dstPort","totPackets","dbby","node"]}', $test1Token);
+    $json = viewerPostToken("/api/user/state/state1?arkimeRegressionUser=sac-test1", '{"order":"test","visibleHeaders":["firstPacket","lastPacket","src","srcPort","dst","dstPort","totPackets","dbby","node"]}', $test1Token);
     ok($json->{success}, "state create success");
-    $json = viewerPostToken("/api/user/state/state1?arkimeRegressionUser=test1", '{"order":[["firstPacket","asc"]],"visibleHeaders":["firstPacket","lastPacket"]}', $test1Token);
+    $json = viewerPostToken("/api/user/state/state1?arkimeRegressionUser=sac-test1", '{"order":[["firstPacket","asc"]],"visibleHeaders":["firstPacket","lastPacket"]}', $test1Token);
     ok($json->{success}, "state update success");
-    $json = viewerGetToken("/api/user/state/state1?arkimeRegressionUser=test1", $test1Token);
+    $json = viewerGetToken("/api/user/state/state1?arkimeRegressionUser=sac-test1", $test1Token);
     eq_or_diff($json->{order}, from_json('[["firstPacket","asc"]]'), "share fetch success");
     eq_or_diff($json->{visibleHeaders}, from_json('["firstPacket","lastPacket"]'), "share fetch success");
 
 # roles
-    $json = viewerPostToken("/api/user", '{"userId": "role:test1", "userName": "UserName", "enabled":true, "roles":"bad"}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "role:sac-test1", "userName": "UserName", "enabled":true, "roles":"bad"}', $token);
     eq_or_diff($json, from_json('{"text": "Roles field must be an array of strings", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "role:test1", "userName": "UserName", "enabled":true, "roles":[false]}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "role:sac-test1", "userName": "UserName", "enabled":true, "roles":[false]}', $token);
     eq_or_diff($json, from_json('{"text": "Roles field must be an array of strings", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "role:test1", "userName": "UserName", "enabled":true, "roles": ["role:test1"]}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "role:sac-test1", "userName": "UserName", "enabled":true, "roles": ["role:sac-test1"]}', $token);
     eq_or_diff($json, from_json('{"text": "Can\'t have circular role dependencies", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "role:test1", "userName": "UserName", "enabled":true}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "role:sac-test1", "userName": "UserName", "enabled":true}', $token);
     eq_or_diff($json, from_json('{"text": "Role created succesfully", "success": true}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "role:test2", "userName": "UserName", "enabled":true, "roles":["role:test1", "superAdmin"]}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "role:sac-test2", "userName": "UserName", "enabled":true, "roles":["role:sac-test1", "superAdmin"]}', $token);
     eq_or_diff($json, from_json('{"text": "User defined roles can\'t have superAdmin", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "role:test2", "userName": "UserName", "enabled":true, "roles":["role:test1", "usersAdmin"]}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "role:sac-test2", "userName": "UserName", "enabled":true, "roles":["role:sac-test1", "usersAdmin"]}', $token);
     eq_or_diff($json, from_json('{"text": "User defined roles can\'t have a system Admin role", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "role:test2", "userName": "UserName", "enabled":true, "roles":["role:test1"]}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "role:sac-test2", "userName": "UserName", "enabled":true, "roles":["role:sac-test1"]}', $token);
     eq_or_diff($json, from_json('{"text": "Role created succesfully", "success": true}'));
 
-    $json = viewerPost("/api/users?arkimeRegressionUser=role:test1", "");
+    $json = viewerPost("/api/users?arkimeRegressionUser=role:sac-test1", "");
     eq_or_diff($json, from_json('{"text": "Can not authenticate with role", "success": false}'));
 
 # role tests
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "role:test1", "roles":["superAdmin"]}', $token);
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"roles":["superAdmin"]}', $token);
     eq_or_diff($json, from_json('{"text": "User defined roles can\'t have superAdmin", "success": false}'));
 
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "role:test1", "roles":["usersAdmin"]}', $token);
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"roles":["usersAdmin"]}', $token);
     eq_or_diff($json, from_json('{"text": "User defined roles can\'t have a system Admin role", "success": false}'));
 
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "role:test1", "roles":"usersAdmin"}', $token);
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"roles":"usersAdmin"}', $token);
     eq_or_diff($json, from_json('{"text": "Roles field must be an array of strings", "success": false}'));
 
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "role:test1", "roles":[false]}', $token);
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"roles":[false]}', $token);
     eq_or_diff($json, from_json('{"text": "Roles field must be an array of strings", "success": false}'));
 
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "role:test1", "roles":["role:test1"]}', $token);
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"roles":["role:sac-test1"]}', $token);
     eq_or_diff($json, from_json('{"text": "Can\'t have circular role dependencies", "success": false}'));
 
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "test1", "userName": "test1", "enabled":true, "password":"password", "roles": ["arkimeUser","user"]}', $token);
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"userName": "sac-test1", "enabled":true, "password":"password", "roles": ["arkimeUser","user"]}', $token);
     eq_or_diff($json, from_json('{"text": "User roles must be system roles or start with \"role:\"", "success": false}'));
 
-    $json = viewerPostToken("/api/user", '{"userId": "asdf", "userName": "asdf", "enabled":true, "password":"password", "roles":["role:test1","user"]}', $token);
+    $json = viewerPostToken("/api/user", '{"userId": "asdf", "userName": "asdf", "enabled":true, "password":"password", "roles":["role:sac-test1","user"]}', $token);
     eq_or_diff($json, from_json('{"text": "User roles must be system roles or start with \"role:\"", "success": false}'));
 
 # role assigner
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "role:test1", "userName": "UserName", "enabled":true, "roleAssigners": "foo"}', $token);
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"userName": "UserName", "enabled":true, "roleAssigners": "foo"}', $token);
     eq_or_diff($json, from_json('{"text": "roleAssigners field must be an array of strings", "success": false}'));
 
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "role:test1", "userName": "UserName", "enabled":true, "roleAssigners": [false]}', $token);
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"userName": "UserName", "enabled":true, "roleAssigners": [false]}', $token);
     eq_or_diff($json, from_json('{"text": "roleAssigners field must be an array of strings", "success": false}'));
 
-    $json = viewerPostToken("/api/user/role:test1", '{"userId": "role:test1", "userName": "UserName", "enabled":true, "roleAssigners": ["test1"]}', $token);
-    eq_or_diff($json, from_json('{"text": "User role:test1 updated successfully", "success": true}'));
+    $json = viewerPostToken("/api/user/role:sac-test1", '{"userName": "UserName", "enabled":true, "roleAssigners": ["sac-test1"]}', $token);
+    eq_or_diff($json, from_json('{"text": "User role:sac-test1 updated successfully", "success": true}'));
 
-    $json = viewerPost("/api/users", "filter=role:test1");
-    eq_or_diff($json->{data}->[0]->{roleAssigners}, from_json('["test1"]'));
+    $json = viewerPost("/api/users", "filter=role:sac-test1");
+    eq_or_diff($json->{data}->[0]->{roleAssigners}, from_json('["sac-test1"]'));
 
-    $json = viewerPostToken("/api/users/min?arkimeRegressionUser=test1", "", $test1Token);
-    eq_or_diff($json, from_json('{"data":[{"userName":"UserNameUpdated","userId":"test1"},{"userId":"test2","userName":"UserNameUpdated3"}],"success":true}'));
+    $json = viewerPostToken("/api/users/min?arkimeRegressionUser=sac-test1", "", $test1Token);
+    eq_or_diff($json, from_json('{"data":[{"userName":"","userId":"anonymous"},{"userId":"notadmin","userName":""},{"userName":"UserNameUpdated","userId":"sac-test1"},{"userName":"UserNameUpdated3","userId":"sac-test2"},{"userName":"","userId":"superAdmin"},{"userId":"test100","userName":""},{"userName":"","userId":"test101"}],"success":true}'));
 
-    $json = viewerPostToken("/api/users/min?arkimeRegressionUser=test1", '{"roleId": "role:test1"}', $test1Token);
-    eq_or_diff($json, from_json('{"data":[{"hasRole": false, "userName":"UserNameUpdated","userId":"test1"},{"hasRole": false, "userId":"test2","userName":"UserNameUpdated3"}],"success":true}'));
+    # yes - hasRole
+    $json = viewerPostToken("/api/users/min?arkimeRegressionUser=sac-test1", '{"roleId": "role:sac-test1"}', $test1Token);
+    eq_or_diff($json, from_json('{"data":[{"userName":"","hasRole":false,"userId":"anonymous"},{"userName":"","userId":"notadmin","hasRole":false},{"userId":"sac-test1","hasRole":false,"userName":"UserNameUpdated"},{"hasRole":false,"userId":"sac-test2","userName":"UserNameUpdated3"},{"userName":"","hasRole":false,"userId":"superAdmin"},{"userName":"","hasRole":false,"userId":"test100"},{"userName":"","userId":"test101","hasRole":false}],"success":true}'));
 
-    $json = viewerPostToken("/api/users/min?arkimeRegressionUser=test2", "", $test2Token);
-    eq_or_diff($json, from_json('{"data":[{"userName":"UserNameUpdated","userId":"test1"},{"userId":"test2","userName":"UserNameUpdated3"}],"success":true}'));
+    # no - hasRole
+    $json = viewerPostToken("/api/users/min?arkimeRegressionUser=sac-test2", "", $test2Token);
+    eq_or_diff($json, from_json('{"data":[{"userName":"","userId":"anonymous"},{"userName":"","userId":"notadmin"},{"userId":"sac-test1","userName":"UserNameUpdated"},{"userId":"sac-test2","userName":"UserNameUpdated3"},{"userName":"","userId":"superAdmin"},{"userName":"","userId":"test100"},{"userName":"","userId":"test101"}],"success":true}'));
 
-    $json = viewerPostToken("/api/users/min?arkimeRegressionUser=test2", '{"roleId": "role:test1"}', $test2Token);
+    $json = viewerPostToken("/api/users/min?arkimeRegressionUser=sac-test2", '{"roleId": "role:sac-test1"}', $test2Token);
     eq_or_diff($json, from_json('{"text": "You do not have permission to access this resource","success":false}'));
 
-    $json = viewerPostToken("/api/user/test1/assignment?arkimeRegressionUser=test1", '{"roleId": "role:test1", "newRoleState": true}', $test1Token);
-    eq_or_diff($json, from_json('{"text": "User test1\'s role role:test1 updated successfully","success":true}'));
+    $json = viewerPostToken("/api/user/sac-test1/assignment?arkimeRegressionUser=sac-test1", '{"roleId": "role:sac-test1", "newRoleState": true}', $test1Token);
+    eq_or_diff($json, from_json('{"text": "User sac-test1\'s role role:sac-test1 updated successfully","success":true}'));
 
-    $json = viewerPostToken("/api/user/test1/assignment?arkimeRegressionUser=test1", '{"roleId": "role:test1", "newRoleState": true}', $test1Token);
+    $json = viewerPostToken("/api/user/sac-test1/assignment?arkimeRegressionUser=sac-test1", '{"roleId": "role:sac-test1", "newRoleState": true}', $test1Token);
 
-    $json = viewerPostToken("/api/user/test1/assignment?arkimeRegressionUser=test1", '{"roleId": "role:test1", "newRoleState": false}', $test1Token);
-    eq_or_diff($json, from_json('{"text": "User test1\'s role role:test1 updated successfully","success":true}'));
+    $json = viewerPostToken("/api/user/sac-test1/assignment?arkimeRegressionUser=sac-test1", '{"roleId": "role:sac-test1", "newRoleState": false}', $test1Token);
+    eq_or_diff($json, from_json('{"text": "User sac-test1\'s role role:sac-test1 updated successfully","success":true}'));
 
-    $json = viewerPostToken("/api/user/test1/assignment?arkimeRegressionUser=test1", '{"roleId": "role:test1", "newRoleState": false}', $test1Token);
+    $json = viewerPostToken("/api/user/sac-test1/assignment?arkimeRegressionUser=sac-test1", '{"roleId": "role:sac-test1", "newRoleState": false}', $test1Token);
     eq_or_diff($json, from_json('{"text": "Can not remove a role that the user does not have","success":false}'));
 
-    $json = viewerPostToken("/api/user/test1/assignment?arkimeRegressionUser=test1", '{"roleId": "role:test1", "newRoleState": "true"}', $test1Token);
+    $json = viewerPostToken("/api/user/sac-test1/assignment?arkimeRegressionUser=sac-test1", '{"roleId": "role:sac-test1", "newRoleState": "true"}', $test1Token);
     eq_or_diff($json, from_json('{"text": "Missing boolean newRoleState","success":false}'));
 
-    $json = viewerPostToken("/api/user/test1/assignment?arkimeRegressionUser=test1", '{"roleId": "role:unknown", "newRoleState": true}', $test1Token);
+    $json = viewerPostToken("/api/user/sac-test1/assignment?arkimeRegressionUser=sac-test1", '{"roleId": "role:unknown", "newRoleState": true}', $test1Token);
     eq_or_diff($json, from_json('{"text": "You do not have permission to access this resource","success":false}'));
 
-    $json = viewerPostToken("/api/user/test1/assignment?arkimeRegressionUser=test1", '{"roleId": false, "newRoleState": true}', $test1Token);
+    $json = viewerPostToken("/api/user/sac-test1/assignment?arkimeRegressionUser=sac-test1", '{"roleId": false, "newRoleState": true}', $test1Token);
     eq_or_diff($json, from_json('{"text": "You do not have permission to access this resource","success":false}'));
 
 # csv
     my $csv = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/users.csv", Content => "")->content;
     $csv =~ s/\r//g;
     eq_or_diff ($csv, 'userId, userName, enabled, webEnabled, headerAuthEnabled, roles, emailSearch, removeEnabled, packetSearch, hideStats, hideFiles, hidePcap, disablePcapDownload, expression, timeLimit
-role:test1,UserName,true,false,false,"",false,false,false,false,false,false,false,,
-role:test2,UserName,true,false,false,"role:test1",false,false,false,false,false,false,false,,
-test1,UserNameUpdated,false,true,true,"usersAdmin",true,true,false,false,false,false,false,foo,
-test2,UserNameUpdated3,false,false,false,"",false,false,false,false,false,false,false,,72
+anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
+notadmin,,true,true,false,"arkimeUser, cont3xtUser, parliamentUser, wiseUser",true,true,true,,,,,,
+role:sac-test1,UserName,true,false,false,"",false,false,false,false,false,false,false,,
+role:sac-test2,UserName,true,false,false,"role:sac-test1",false,false,false,false,false,false,false,,
+sac-test1,UserNameUpdated,false,true,true,"usersAdmin, arkimeUser",true,true,false,false,false,false,false,foo,
+sac-test2,UserNameUpdated3,false,false,false,"arkimeUser",false,false,false,false,false,false,false,,72
+superAdmin,,true,true,false,"superAdmin",true,true,true,,,,,,
+test100,,true,true,false,"arkimeUser, cont3xtUser, parliamentUser, wiseUser",true,true,true,,,,,,
+test101,,true,true,false,"arkimeUser, cont3xtUser, parliamentUser, wiseUser",true,true,true,,,,,,
 ', "CSV Users 2");
 
 # Delete Users
-    $json = viewerDeleteToken("/api/user/test1", $token);
-    $json = viewerDeleteToken("/api/user/test2", $token);
-    $json = viewerDeleteToken("/api/user/role:test1", $token);
-    $json = viewerDeleteToken("/api/user/role:test2", $token);
+    $json = viewerDeleteToken("/api/user/notadmin", $token);
+    $json = viewerDeleteToken("/api/user/sac-test1", $token);
+    $json = viewerDeleteToken("/api/user/sac-test2", $token);
+    $json = viewerDeleteToken("/api/user/role:sac-test1", $token);
+    $json = viewerDeleteToken("/api/user/role:sac-test2", $token);
     esGet("/_refresh");
     $users = viewerPost("/api/users", "");
-    is (@{$users->{data}}, 0, "Removed user #1");
+    is ($users->{data}->[1]->{userId}, "superAdmin", "Removed user #1");
     $users = viewerPost2("/api/users", "");
-    is (@{$users->{data}}, 0, "Removed user #2");
+    is ($users->{data}->[1]->{userId}, "superAdmin", "Removed user #2");
 
 #####
 # Roles Tests - Some of these are repeats
-my $es = "-o 'elasticsearch=$ArkimeTest::elasticsearch' -o 'usersElasticsearch=$ArkimeTest::elasticsearch' $ENV{INSECURE}";
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testsuperadmin testsuperadmin testsuperadmin --roles superAdmin");
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testusersadmin testusersadmin testusersadmin --roles usersAdmin,cont3xtAdmin");
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testarkimeadmin testarkimeadmin testarkimeadmin --roles arkimeAdmin");
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testcont3xtadmin testcont3xtadmin testcont3xtadmin --roles cont3xtAdmin");
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser testuser testuser testuser");
+addUser("-n testuser testsuperadmin testsuperadmin testsuperadmin --roles superAdmin");
+addUser("-n testuser testusersadmin testusersadmin testusersadmin --roles usersAdmin,cont3xtAdmin,arkimeUser");
+addUser("-n testuser testarkimeadmin testarkimeadmin testarkimeadmin --roles arkimeAdmin");
+addUser("-n testuser testcont3xtadmin testcont3xtadmin testcont3xtadmin --roles cont3xtAdmin,arkimeUser");
+addUser("-n testuser testuser testuser testuser");
 
 my $tuToken = getTokenCookie('testuser');
 my $saToken = getTokenCookie('testsuperadmin');
@@ -495,10 +520,10 @@ my $uaToken = getTokenCookie('testusersadmin');
     eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
 
 # Password changing - by usersAdmin
-    $json = viewerPostToken('/api/user/password?arkimeRegressionUser=testusersadmin&userId=testuser', '{"newPassword": "test1"}', $uaToken);
+    $json = viewerPostToken('/api/user/password?arkimeRegressionUser=testusersadmin&userId=testuser', '{"newPassword": "sac-test1"}', $uaToken);
     eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
 
-    $json = viewerPostToken('/api/user/password?arkimeRegressionUser=testusersadmin&userId=testarkimeadmin', '{"newPassword": "test2"}', $uaToken);
+    $json = viewerPostToken('/api/user/password?arkimeRegressionUser=testusersadmin&userId=testarkimeadmin', '{"newPassword": "sac-test2"}', $uaToken);
     eq_or_diff($json, from_json('{"text": "Not allowed to change arkimeAdmin password", "success": false}'));
 
     $json = viewerPostToken('/api/user/password?arkimeRegressionUser=testusersadmin&userId=testcont3xtadmin', '{"newPassword": "test3"}', $uaToken);
@@ -515,31 +540,31 @@ my $uaToken = getTokenCookie('testusersadmin');
     eq_or_diff($json, from_json('{"text": "Changed password successfully", "success": true}'));
 
 # Make sure only superadmin can create superadmin
-    $json = viewerPostToken("/api/user?arkimeRegressionUser=testsuperadmin", '{"userId": "testsuperadmin1", "userName": "testsuperadmin1", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $saToken);
+    $json = viewerPostToken("/api/user?arkimeRegressionUser=testsuperadmin", '{"userId": "sac-testsuperadmin1", "userName": "testsuperadmin1", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $saToken);
     eq_or_diff($json, from_json('{"text": "User created succesfully", "success": true}'));
 
-    $json = viewerPostToken("/api/user?arkimeRegressionUser=testusersadmin", '{"userId": "testsuperadmin2", "userName": "testsuperadmin2", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $uaToken);
+    $json = viewerPostToken("/api/user?arkimeRegressionUser=testusersadmin", '{"userId": "sac-testsuperadmin2", "userName": "testsuperadmin2", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $uaToken);
     eq_or_diff($json, from_json('{"text": "Can not create superAdmin unless you are superAdmin", "success": false}'));
 
 
 # Add super admin - only superadmin can add
-    $json = viewerPostToken("/api/user/testuser?arkimeRegressionUser=testusersadmin", '{"userId": "testuser", "userName": "testuser", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $uaToken);
+    $json = viewerPostToken("/api/user/testuser?arkimeRegressionUser=testusersadmin", '{"userName": "testuser", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $uaToken);
     eq_or_diff($json, from_json('{"text": "Can not modify superAdmin unless you are superAdmin", "success": false}'));
 
-    $json = viewerPostToken("/api/user/testuser?arkimeRegressionUser=testsuperadmin", '{"userId": "testuser", "userName": "testuser", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $saToken);
+    $json = viewerPostToken("/api/user/testuser?arkimeRegressionUser=testsuperadmin", '{"userName": "testuser", "enabled":true, "password":"password", "roles": ["superAdmin"]}', $saToken);
     eq_or_diff($json, from_json('{"text": "User testuser updated successfully", "success": true}'));
 
 
 # Remove super admin - only superadmin can remove
-    $json = viewerPostToken("/api/user/testsuperadmin?arkimeRegressionUser=testusersadmin", '{"userId": "testsuperadmin", "userName": "testsuperadmin", "enabled":true, "password":"password", "roles": ["arkimeAdmin"]}', $uaToken);
+    $json = viewerPostToken("/api/user/testsuperadmin?arkimeRegressionUser=testusersadmin", '{"userName": "testsuperadmin", "enabled":true, "password":"password", "roles": ["arkimeAdmin"]}', $uaToken);
     eq_or_diff($json, from_json('{"text": "Can not disable superAdmin unless you are superAdmin", "success": false}'));
 
-    $json = viewerPostToken("/api/user/testuser?arkimeRegressionUser=testusersadmin", '{"userId": "testuser", "userName": "testuser", "enabled":true, "password":"password", "roles": ["arkimeAdmin"]}', $uaToken);
+    $json = viewerPostToken("/api/user/testuser?arkimeRegressionUser=testusersadmin", '{"userName": "testuser", "enabled":true, "password":"password", "roles": ["arkimeAdmin"]}', $uaToken);
     eq_or_diff($json, from_json('{"text": "Can not disable superAdmin unless you are superAdmin", "success": false}'));
 
-    $json = viewerPostToken("/api/user/testuser?arkimeRegressionUser=testsuperadmin", '{"userId": "testuser", "userName": "testuser", "enabled":true, "password":"password", "roles": ["arkimeAdmin"]}', $saToken);
+    $json = viewerPostToken("/api/user/testuser?arkimeRegressionUser=testsuperadmin", '{"userName": "testuser", "enabled":true, "password":"password", "roles": ["arkimeAdmin"]}', $saToken);
     eq_or_diff($json, from_json('{"text": "User testuser updated successfully", "success": true}'));
 
 
 # clean old users
-    esPost("/tests_users/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }', 1);
+    clearIndex("tests_users");

--- a/tests/api-views.t
+++ b/tests/api-views.t
@@ -1,149 +1,148 @@
-use Test::More tests => 41;
+use Test::More tests => 40;
 use ArkimeTest;
 use JSON;
 use Test::Differences;
 use Data::Dumper;
 use strict;
 
-esPost("/tests_views/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }', 1);
+# clean old users
+clearIndex("tests_users");
+
+clearIndex("tests_views");
 
 my $adminToken = getTokenCookie();
-my $token = getTokenCookie('test1');
-my $token2 = getTokenCookie('test2');
+my $token = getTokenCookie('sac-test1');
+my $token2 = getTokenCookie('sac-test2');
 
 # create test users
-viewerPostToken("/api/user", '{"userId": "test1", "userName": "test1", "enabled":true, "password":"password", "roles":["arkimeUser"]}', $adminToken);
-viewerPostToken("/api/user", '{"userId": "test2", "userName": "test2", "enabled":true, "password":"password", "roles":["cont3xtUser"]}', $adminToken);
+viewerPostToken("/api/user", '{"userId": "sac-test1", "userName": "sac-test1", "enabled":true, "password":"password", "roles":["arkimeUser"]}', $adminToken);
+viewerPostToken("/api/user", '{"userId": "sac-test2", "userName": "sac-test2", "enabled":true, "password":"password", "roles":["arkimeUser", "cont3xtUser"]}', $adminToken);
 
 # No views
-my $info = viewerGet("/api/views?arkimeRegressionUser=test1");
+my $info = viewerGet("/api/views?arkimeRegressionUser=sac-test1");
 eq_or_diff($info->{data}, from_json("[]"), "empty views");
 
 # create view and and it gets returned and sanitizes name
-$info = viewerPostToken("/api/view?arkimeRegressionUser=test1", '{"name": "view1~`!@#$%^&*()[]{};<>?/", "expression": "ip == 1.2.3.4"}', $token);
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test1", '{"name": "view1~`!@#$%^&*()[]{};<>?/", "expression": "ip == 1.2.3.4"}', $token);
 my $id1 = $info->{view}->{id};
 ok($info->{success}, "create view success");
 delete $info->{view}->{id};
-eq_or_diff($info->{view}, from_json('{"expression":"ip == 1.2.3.4","user":"test1","name":"view1","users":""}'), "view: 1 item");
+eq_or_diff($info->{view}, from_json('{"expression":"ip == 1.2.3.4","user":"sac-test1","name":"view1","users":""}'), "view: 1 item");
 
 # fetch views returns newly created view
-$info = viewerGet("/api/views?arkimeRegressionUser=test1");
+$info = viewerGet("/api/views?arkimeRegressionUser=sac-test1");
 eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal");
 delete $info->{data}->[0]->{id};
-eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 1.2.3.4","user":"test1","name":"view1","users":""}'), "view: 1 item");
+eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 1.2.3.4","user":"sac-test1","name":"view1","users":""}'), "view: 1 item");
 
-# admin can see test1 user's views
-$info = viewerGet("/api/views?arkimeRegressionUser=anonymous&userId=test1");
+# admin can see sac-test1 user's views
+$info = viewerGet("/api/views?arkimeRegressionUser=anonymous&userId=sac-test1");
 eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal");
 delete $info->{data}->[0]->{id};
-eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 1.2.3.4","user":"test1","name":"view1","users":""}'), "admin can view test1's view");
+eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 1.2.3.4","user":"sac-test1","name":"view1","users":""}'), "admin can view sac-test1's view");
 
 # fail delete with invalid id
-$info = viewerDeleteToken("/api/view/badid?arkimeRegressionUser=test1", $token);
+$info = viewerDeleteToken("/api/view/badid?arkimeRegressionUser=sac-test1", $token);
 ok(!$info->{success}, "can't delete with bad id");
 
 # still see 1 view because it wasn't deleted
-$info = viewerGet("/api/views?arkimeRegressionUser=test1");
+$info = viewerGet("/api/views?arkimeRegressionUser=sac-test1");
 eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal");
 delete $info->{data}->[0]->{id};
-eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 1.2.3.4","user":"test1","name":"view1","users":""}'), "view wasn't deleted");
+eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 1.2.3.4","user":"sac-test1","name":"view1","users":""}'), "view wasn't deleted");
 
 # can update view and share it with arkimeUser roles
-$info = viewerPutToken("/api/view/${id1}?arkimeRegressionUser=test1", '{"name": "view1update", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"]}', $token);
+$info = viewerPutToken("/api/view/${id1}?arkimeRegressionUser=sac-test1", '{"name": "view1update", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"]}', $token);
 is ($info->{view}->{id}, $id1);
 delete $info->{view}->{id};
-eq_or_diff($info->{view}, from_json('{"expression":"ip == 4.3.2.1","user":"test1","name":"view1update","roles":["arkimeUser"],"users":""}'), "view fields updated");
+eq_or_diff($info->{view}, from_json('{"expression":"ip == 4.3.2.1","user":"sac-test1","name":"view1update","roles":["arkimeUser"],"users":""}'), "view fields updated");
 ok($info->{success}, "update view success");
-$info = viewerGet("/api/views?arkimeRegressionUser=test1");
+$info = viewerGet("/api/views?arkimeRegressionUser=sac-test1");
 delete $info->{data}->[0]->{id};
-eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 4.3.2.1","user":"test1","name":"view1update","roles":["arkimeUser"],"users":""}'), "view fields updated");
-
-# test2 doesn't have arkimeUser role so they can't see the view
-$info = viewerGet("/api/views?arkimeRegressionUser=test2");
-eq_or_diff($info->{recordsTotal}, 0, "returns 0 recordsTotal for test2 user");
+eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 4.3.2.1","user":"sac-test1","name":"view1update","roles":["arkimeUser"],"users":""}'), "view fields updated");
 
 # can update users
-$info = viewerPutToken("/api/view/${id1}?arkimeRegressionUser=test1", '{"name": "view1update", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"test2"}', $token);
-$info = viewerGet("/api/views?arkimeRegressionUser=test1");
-eq_or_diff($info->{data}->[0]->{users}, "test2", "view users field udpated");
+$info = viewerPutToken("/api/view/${id1}?arkimeRegressionUser=sac-test1", '{"name": "view1update", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"sac-test2"}', $token);
+$info = viewerGet("/api/views?arkimeRegressionUser=sac-test1");
+eq_or_diff($info->{data}->[0]->{users}, "sac-test2", "view users field udpated");
 
-# test2 can see view because it is shared with him via users field
-$info = viewerGet("/api/views?arkimeRegressionUser=test2");
-eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal for test2 user");
+# sac-test2 can see view because it is shared with him via users field
+$info = viewerGet("/api/views?arkimeRegressionUser=sac-test2");
+eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal for sac-test2 user");
 delete $info->{data}->[0]->{id};
-# and it doesn't show users and roles field because test2 is not the creator
-eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 4.3.2.1","user":"test1","name":"view1update"}'), "can't see roles and users fields");
+# and it doesn't show users and roles field because sac-test2 is not the creator
+eq_or_diff($info->{data}->[0], from_json('{"expression":"ip == 4.3.2.1","user":"sac-test1","name":"view1update"}'), "can't see roles and users fields");
 
 # can not delete view from other user
-$info = viewerDeleteToken("/api/view/${id1}?arkimeRegressionUser=test2", $token2);
+$info = viewerDeleteToken("/api/view/${id1}?arkimeRegressionUser=sac-test2", $token2);
 ok(!$info->{success}, "can't delete view created by an other user");
 
 # can delete view with id
-$info = viewerDeleteToken("/api/view/${id1}?arkimeRegressionUser=test1", $token);
+$info = viewerDeleteToken("/api/view/${id1}?arkimeRegressionUser=sac-test1", $token);
 ok($info->{success}, "can delete view");
 
 # can create a view with users and roles
-$info = viewerPostToken("/api/view?arkimeRegressionUser=test2", '{"name": "view2", "expression": "ip == 10.0.0.1", "roles":["arkimeUser"], "users":"baduser,test1"}', $token2);
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test2", '{"name": "view2", "expression": "ip == 10.0.0.1", "roles":["arkimeUser"], "users":"baduser,sac-test1"}', $token2);
 my $id2 = $info->{view}->{id};
 ok($info->{success}, "can create view with roles and users");
 eq_or_diff($info->{invalidUsers}, from_json('["baduser"]'), "returns invalid users");
-eq_or_diff($info->{view}->{users}, "test1", "has one valid user added to the view");
+eq_or_diff($info->{view}->{users}, "sac-test1", "has one valid user added to the view");
 eq_or_diff($info->{view}->{roles}, from_json('["arkimeUser"]'), "added roles");
 
 # can remove users and update editRoles
-$info = viewerPutToken("/api/view/${id2}?arkimeRegressionUser=test2", '{"name": "view2", "expression": "ip == 10.0.0.1", "roles":["arkimeUser"], "users":""}', $token2);
+$info = viewerPutToken("/api/view/${id2}?arkimeRegressionUser=sac-test2", '{"name": "view2", "expression": "ip == 10.0.0.1", "roles":["arkimeUser"], "users":""}', $token2);
 ok($info->{success}, "can update users");
 eq_or_diff($info->{view}->{users}, "", "removed users from view");
 
-# test1 user can see the view created by test2 because one is shared via the arkimeUser role
-$info = viewerGet("/api/views?arkimeRegressionUser=test1");
+# sac-test1 user can see the view created by sac-test2 because one is shared via the arkimeUser role
+$info = viewerGet("/api/views?arkimeRegressionUser=sac-test1");
 delete $info->{data}->[0]->{id};
-eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal for test1 user");
-eq_or_diff($info->{data}->[0], from_json('{"name": "view2", "expression": "ip == 10.0.0.1","user":"test2"}'), "view fields updated");
+eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal for sac-test1 user");
+eq_or_diff($info->{data}->[0], from_json('{"name": "view2", "expression": "ip == 10.0.0.1","user":"sac-test2"}'), "view fields updated");
 
 # admin can view all views when all param is supplied
-$info = viewerPostToken("/api/view?arkimeRegressionUser=test1", '{"name": "asdf", "expression": "ip == 1.2.3.4"}', $token);
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test1", '{"name": "asdf", "expression": "ip == 1.2.3.4"}', $token);
 my $id3 = $info->{view}->{id};
 $info = viewerGet("/api/views?arkimeRegressionUser=anonymous");
 eq_or_diff($info->{recordsTotal}, 1, "returns 1 recordsTotal without all flag");
 $info = viewerGet("/api/views?arkimeRegressionUser=anonymous&all=true");
 eq_or_diff($info->{recordsTotal}, 2, "returns 2 recordsTotal with all flag");
 
-# test2 can edit view using editRoles
-$info = viewerPostToken("/api/view?arkimeRegressionUser=test1", '{"name": "view4", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"]}', $token);
+# sac-test2 can edit view using editRoles
+$info = viewerPostToken("/api/view?arkimeRegressionUser=sac-test1", '{"name": "view4", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"]}', $token);
 my $id4 = $info->{view}->{id};
 eq_or_diff($info->{view}->{editRoles}, from_json('["cont3xtUser"]'), "added editRoles");
-$info = viewerPutToken("/api/view/${id4}?arkimeRegressionUser=test2", '{"name": "updated!", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"]}', $token2);
+$info = viewerPutToken("/api/view/${id4}?arkimeRegressionUser=sac-test2", '{"name": "updated!", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"]}', $token2);
 ok($info->{success}, "can update view with editRoles");
 
-# test2 cannot transfer ownership (not admin or creator)
-$info = viewerPutToken("/api/view/${id4}?arkimeRegressionUser=test2", '{"name": "view4", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"], "user":"asdf"}', $token2);
+# sac-test2 cannot transfer ownership (not admin or creator)
+$info = viewerPutToken("/api/view/${id4}?arkimeRegressionUser=sac-test2", '{"name": "view4", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"], "user":"asdf"}', $token2);
 ok(!$info->{success}, "cannot transfer ownership without being admin or creator");
 eq_or_diff($info->{text}, "Permission denied");
 
 # can't transfer ownership to invalid user
-$info = viewerPutToken("/api/view/${id4}?arkimeRegressionUser=test1", '{"name": "view4", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"], "user":"asdf"}', $token);
+$info = viewerPutToken("/api/view/${id4}?arkimeRegressionUser=sac-test1", '{"name": "view4", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"], "user":"asdf"}', $token);
 ok(!$info->{success}, "cannot transfer ownership to an invalid user");
 eq_or_diff($info->{text}, "User not found");
 
 # can transfer ownership
-$info = viewerPutToken("/api/view/${id4}?arkimeRegressionUser=test1", '{"name": "view4", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"], "user":"test2"}', $token);
+$info = viewerPutToken("/api/view/${id4}?arkimeRegressionUser=sac-test1", '{"name": "view4", "expression": "ip == 4.3.2.1", "roles":["arkimeUser"], "users":"", "editRoles":["cont3xtUser"], "user":"sac-test2"}', $token);
 ok($info->{success}, "can transfer ownership to valid user");
-eq_or_diff($info->{view}->{user}, "test2");
+eq_or_diff($info->{view}->{user}, "sac-test2");
 
-# test2 can delete view using editRoles (plus bonus cleanup)
-viewerDeleteToken("/api/view/${id4}?arkimeRegressionUser=test2", $token2);
+# sac-test2 can delete view using editRoles (plus bonus cleanup)
+viewerDeleteToken("/api/view/${id4}?arkimeRegressionUser=sac-test2", $token2);
 
 # cleanup views
-viewerDeleteToken("/api/view/${id2}?arkimeRegressionUser=test2", $token2);
-viewerDeleteToken("/api/view/${id3}?arkimeRegressionUser=test1", $token);
+viewerDeleteToken("/api/view/${id2}?arkimeRegressionUser=sac-test2", $token2);
+viewerDeleteToken("/api/view/${id3}?arkimeRegressionUser=sac-test1", $token);
 
 # views are empty
-$info = viewerGet("/api/views?arkimeRegressionUser=test1");
+$info = viewerGet("/api/views?arkimeRegressionUser=sac-test1");
 eq_or_diff($info->{recordsTotal}, 0, "returns 0 recordsTotal");
 eq_or_diff($info->{recordsFiltered}, 0, "returns 0 recordsFiltered");
 eq_or_diff($info->{data}, from_json("[]"), "empty views");
 
 # cleanup users
-viewerDeleteToken2("/api/user/test1", $adminToken);
-viewerDeleteToken2("/api/user/test2", $adminToken);
+viewerDeleteToken2("/api/user/sac-test1", $adminToken);
+viewerDeleteToken2("/api/user/sac-test2", $adminToken);

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -298,7 +298,7 @@ VTURL=url:https://www.virustotal.com/latest-scan/%URL%;name:Virus Total URL;cate
 ALLTESTConfig=url:http:/www.example.com;name:AllConfigTest;all:true
 
 [field-actions]
-ASDF=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%;name:Field Action %FIELDNAME%!;category:ip;users:admin,test1
+ASDF=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%;name:Field Action %FIELDNAME%!;category:ip;users:admin,sac-test1
 ALLTEST=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%;name:All Field Action %FIELDNAME%!;all:true
 
 [custom-fields]

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -6,16 +6,16 @@ use ArkimeTest;
 use JSON;
 use strict;
 
-esPost("/cont3xt_links/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }');
-esPost("/cont3xt_overviews/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }');
-esPost("/cont3xt_history/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }');
-esPost("/cont3xt_views/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "match_all": {} } }');
+clearIndex("cont3xt_links");
+clearIndex("cont3xt_overviews");
+clearIndex("cont3xt_history");
+clearIndex("cont3xt_views");
 
 my $token = getCont3xtTokenCookie();
 
-# create test cont3xtUser and get their token
-viewerPostToken("/api/user", '{"userId": "test", "userName": "test", "enabled":true, "password":"password", "roles":["cont3xtUser"]}', $token);
-my $token2 = getTokenCookie('test');
+# create sac-test cont3xtUser and get their token
+viewerPostToken("/api/user", '{"userId": "sac-test", "userName": "test", "enabled":true, "password":"password", "roles":["cont3xtUser"]}', $token);
+my $token2 = getTokenCookie('sac-test');
 
 my $json;
 ################################################################################
@@ -243,7 +243,7 @@ delete $json->{linkGroups}->[0]->{_id};
 eq_or_diff($json, from_json('{"linkGroups":[{"creator":"anonymous","_editable":true,"_viewable":true,"viewRoles":["cont3xtUser"],"links":[{"url":"http://www.foobar.com","itypes":["ip", "hash"],"name":"foo1"}],"name":"Links1","editRoles":["superAdmin"]}],"success":true}'));
 
 # can't transfer ownership (not admin or creator)
-$json = cont3xtPutToken("/api/linkGroup/$id?arkimeRegressionUser=test", to_json({
+$json = cont3xtPutToken("/api/linkGroup/$id?arkimeRegressionUser=sac-test", to_json({
   name => "Links1",
   viewRoles => ["cont3xtUser"],
   editRoles => ["superAdmin"],
@@ -252,7 +252,7 @@ $json = cont3xtPutToken("/api/linkGroup/$id?arkimeRegressionUser=test", to_json(
     url => "http://www.foobar.com",
     itypes => ["ip", "hash"]
   }],
-  creator => "test"
+  creator => "sac-test"
 }), $token2);
 eq_or_diff($json, from_json('{"success": false, "text": "Permission denied"}'));
 
@@ -280,15 +280,15 @@ $json = cont3xtPutToken("/api/linkGroup/$id", to_json({
     url => "http://www.foobar.com",
     itypes => ["ip", "hash"]
   }],
-  creator => "test"
+  creator => "sac-test"
 }), $token);
 eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 
 # delete link group requires token
-$json = cont3xtDelete("/api/linkGroup/$id?arkimeRegressionUser=test", "{}");
+$json = cont3xtDelete("/api/linkGroup/$id?arkimeRegressionUser=sac-test", "{}");
 eq_or_diff($json, from_json('{"success": false, "text": "Missing token"}'));
 
-$json = cont3xtDeleteToken("/api/linkGroup/$id?arkimeRegressionUser=test", "{}", $token2);
+$json = cont3xtDeleteToken("/api/linkGroup/$id?arkimeRegressionUser=sac-test", "{}", $token2);
 eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 
 $json = cont3xtDeleteToken("/api/linkGroup/foo", "{}", $token);
@@ -624,8 +624,8 @@ delete $json->{overviews}->[0]->{_id};
 eq_or_diff($json, from_json('{"overviews":[{"creator":"anonymous","_editable":true,"_viewable": true, "viewRoles":["cont3xtUser"],"fields":[{"type":"linked","from":"Foo","field":"bar_field"},{"type":"custom","from":"Foo","custom":"foo.bar"}],"name":"Overview1 v2","title":"Overview v2 of %{query}","iType":"ip","editRoles":["superAdmin"]}],"success":true}'));
 
 # can't transfer ownership (not admin or creator)
-$json = cont3xtPutToken("/api/overview/$id?arkimeRegressionUser=test", to_json({
-    creator => "test"
+$json = cont3xtPutToken("/api/overview/$id?arkimeRegressionUser=sac-test", to_json({
+    creator => "sac-test"
 }), $token2);
 eq_or_diff($json, from_json('{"success": false, "text": "Permission denied"}'));
 
@@ -665,7 +665,7 @@ $json = cont3xtPutToken("/api/overview/$id", to_json({
         from  => "Foo",
         custom => "foo.bar"
     }],
-    creator => "test"
+    creator => "sac-test"
 }), $token);
 eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 
@@ -673,7 +673,7 @@ eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 $json = cont3xtDelete("/api/overview/$id", "{}");
 eq_or_diff($json, from_json('{"success": false, "text": "Missing token"}'));
 
-$json = cont3xtDeleteToken("/api/overview/$id?arkimeRegressionUser=test", "{}", $token2);
+$json = cont3xtDeleteToken("/api/overview/$id?arkimeRegressionUser=sac-test", "{}", $token2);
 eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 
 $json = cont3xtDeleteToken("/api/overview/foo", "{}", $token);
@@ -945,8 +945,8 @@ is($json->{views}->[1]->{name}, "view2changed");
 is (scalar @{$json->{views}}, 2);
 
 # can't transfer ownership (not admin or creator)
-$json = cont3xtPutToken("/api/view/$id?arkimeRegressionUser=test", to_json({
-    creator => "test"
+$json = cont3xtPutToken("/api/view/$id?arkimeRegressionUser=sac-test", to_json({
+    creator => "sac-test"
 }), $token2);
 eq_or_diff($json, from_json('{"success": false, "text": "Permission denied"}'));
 
@@ -960,7 +960,7 @@ eq_or_diff($json, from_json('{"success": false, "text": "User not found"}'));
 # can transfer ownership to valid user
 $json = cont3xtPutToken("/api/view/$id", to_json({
     name => "view2changed",
-    creator => "test"
+    creator => "sac-test"
 }), $token);
 eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 
@@ -968,7 +968,7 @@ eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 $json = cont3xtDelete("/api/view/$id", '{}');
 eq_or_diff($json, from_json('{"success": false, "text": "Missing token"}'));
 
-$json = cont3xtDeleteToken("/api/view/$id?arkimeRegressionUser=test", '{}', $token2);
+$json = cont3xtDeleteToken("/api/view/$id?arkimeRegressionUser=sac-test", '{}', $token2);
 eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 
 $json = cont3xtDeleteToken('/api/view/foo', '{}', $token);

--- a/tests/fieldactions.ini
+++ b/tests/fieldactions.ini
@@ -1,2 +1,2 @@
-ASDFWISE=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%;name:Field Action %FIELDNAME%!;category:ip;users:admin,test1;notUsers:test101
+ASDFWISE=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%;name:Field Action %FIELDNAME%!;category:ip;users:admin,sac-test1;notUsers:test101
 ALLTESTWISE=url:http:/www.example.com;name:AllWiseTest;all:true

--- a/tests/parliament.t
+++ b/tests/parliament.t
@@ -11,13 +11,12 @@ my $result;
 
 my $version = 7;
 
-my $es = "-o 'elasticsearch=$ArkimeTest::elasticsearch' -o 'usersElasticsearch=$ArkimeTest::elasticsearch' $ENV{INSECURE}";
 # create user without parliament role
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser arkimeUserP arkimeUserP arkimeUserP --roles 'arkimeUser' ");
+addUser("-n testuser arkimeUserP arkimeUserP arkimeUserP --roles 'arkimeUser' ");
 # create user with parliament role
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser parliamentUserP parliamentUserP parliamentUserP --roles 'parliamentUser' ");
+addUser("-n testuser parliamentUserP parliamentUserP parliamentUserP --roles 'parliamentUser' ");
 # create user with parliament admin role
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser parliamentAdminP parliamentAdminP parliamentAdminP --roles 'parliamentAdmin' ");
+addUser("-n testuser parliamentAdminP parliamentAdminP parliamentAdminP --roles 'parliamentAdmin' ");
 
 # authenticate non parliament user
 $ArkimeTest::userAgent->credentials( "$ArkimeTest::host:8008", 'Moloch', 'arkimeUserP', 'arkimeUserP' );

--- a/tests/valueactions.ini
+++ b/tests/valueactions.ini
@@ -1,5 +1,5 @@
 VTIP=url:https://www.virustotal.com/en/ip-address/%TEXT%/information/;name:Virus Total IP;category:ip
 VTHOST=url:https://www.virustotal.com/en/domain/%HOST%/information/;name:Virus Total Host;category:host
 VTURL=url:https://www.virustotal.com/latest-scan/%URL%;name:Virus Total URL;category:url
-USERTEST=url:https://example.com;name:usertest;category:url;users:test1;notUsers:test101
+USERTEST=url:https://example.com;name:usertest;category:url;users:sac-test1;notUsers:test101
 ALLTESTWISE=url:http:/www.example.com;name:AllWiseTest;all:true

--- a/tests/wise.t
+++ b/tests/wise.t
@@ -11,9 +11,8 @@ use strict;
 my $wise;
 my @wise;
 
-my $es = "-o 'elasticsearch=$ArkimeTest::elasticsearch' -o 'usersElasticsearch=$ArkimeTest::elasticsearch' $ENV{INSECURE}";
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser wiseUser wiseUser wiseUser --roles 'wiseUser' ");
-system("cd ../viewer ; node addUser.js $es -c ../tests/config.test.ini -n testuser wiseAdmin wiseAdmin wiseAdmin --roles 'wiseAdmin' ");
+addUser("-n testuser wiseUser wiseUser wiseUser --roles 'wiseUser' ");
+addUser("-n testuser wiseAdmin wiseAdmin wiseAdmin --roles 'wiseAdmin' ");
 
 # IP Query
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/ip/10.0.0.3")->content;
@@ -132,7 +131,7 @@ eq_or_diff(from_json($wise), from_json('[{"field":"email.dst","len":10,"value":"
 '),"ALL 12345678\@aol.com");
 
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/rightClicks")->content;
-eq_or_diff(from_json($wise), from_json('{"ALLTESTWISE":{"url":"http:/www.example.com","all":true,"name":"AllWiseTest"},"USERTEST":{"url": "https://example.com", "name": "usertest", "category": "url","users":{"test1":1},"notUsers":{"test101":1}},"VTIP":{"url":"https://www.virustotal.com/en/ip-address/%TEXT%/information/","name":"Virus Total IP","category":"ip"},"VTHOST":{"url":"https://www.virustotal.com/en/domain/%HOST%/information/","name":"Virus Total Host","category":"host"},"VTURL":{"url":"https://www.virustotal.com/latest-scan/%URL%","name":"Virus Total URL","category":"url"}}'),"right clicks");
+eq_or_diff(from_json($wise), from_json('{"ALLTESTWISE":{"url":"http:/www.example.com","all":true,"name":"AllWiseTest"},"USERTEST":{"url": "https://example.com", "name": "usertest", "category": "url","users":{"sac-test1":1},"notUsers":{"test101":1}},"VTIP":{"url":"https://www.virustotal.com/en/ip-address/%TEXT%/information/","name":"Virus Total IP","category":"ip"},"VTHOST":{"url":"https://www.virustotal.com/en/domain/%HOST%/information/","name":"Virus Total Host","category":"host"},"VTURL":{"url":"https://www.virustotal.com/latest-scan/%URL%","name":"Virus Total URL","category":"url"}}'),"right clicks");
 
 my $pwd = "*/pcap";
 
@@ -256,11 +255,11 @@ eq_or_diff($info->{"wise.int.cnt"}, from_json('{"friendlyName":"Int Cnt","type":
 
 # Field Actions
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/fieldActions")->content;
-eq_or_diff($wise, '{"ASDFWISE":{"url":"https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%","name":"Field Action %FIELDNAME%!","category":"ip","users":{"admin":1,"test1":1},"notUsers":{"test101":1}},"ALLTESTWISE":{"url":"http:/www.example.com","name":"AllWiseTest","all":true}}');
+eq_or_diff($wise, '{"ASDFWISE":{"url":"https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%","name":"Field Action %FIELDNAME%!","category":"ip","users":{"admin":1,"sac-test1":1},"notUsers":{"test101":1}},"ALLTESTWISE":{"url":"http:/www.example.com","name":"AllWiseTest","all":true}}');
 
 # Value Actions
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/valueActions")->content;
-eq_or_diff($wise, '{"VTIP":{"url":"https://www.virustotal.com/en/ip-address/%TEXT%/information/","name":"Virus Total IP","category":"ip"},"VTHOST":{"url":"https://www.virustotal.com/en/domain/%HOST%/information/","name":"Virus Total Host","category":"host"},"VTURL":{"url":"https://www.virustotal.com/latest-scan/%URL%","name":"Virus Total URL","category":"url"},"USERTEST":{"url":"https://example.com","name":"usertest","category":"url","users":{"test1":1},"notUsers":{"test101":1}},"ALLTESTWISE":{"url":"http:/www.example.com","name":"AllWiseTest","all":true}}');
+eq_or_diff($wise, '{"VTIP":{"url":"https://www.virustotal.com/en/ip-address/%TEXT%/information/","name":"Virus Total IP","category":"ip"},"VTHOST":{"url":"https://www.virustotal.com/en/domain/%HOST%/information/","name":"Virus Total Host","category":"host"},"VTURL":{"url":"https://www.virustotal.com/latest-scan/%URL%","name":"Virus Total URL","category":"url"},"USERTEST":{"url":"https://example.com","name":"usertest","category":"url","users":{"sac-test1":1},"notUsers":{"test101":1}},"ALLTESTWISE":{"url":"http:/www.example.com","name":"AllWiseTest","all":true}}');
 
 # __proto__
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/file:mac/__proto__/00:12:1e:f2:61:3d")->content;

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1989,7 +1989,6 @@ app.use(cspHeader, setCookie, (req, res) => {
     titleConfig,
     path: Config.basePath(),
     version: version.version,
-    devMode: Config.get('devMode', false),
     demoMode: Config.get('demoMode', false),
     multiViewer: internals.multiES,
     hasUsersES: !!Config.get('usersElasticsearch', false),

--- a/viewer/viewerUtils.js
+++ b/viewer/viewerUtils.js
@@ -610,7 +610,7 @@ class ViewerUtils {
   // check for anonymous mode before fetching user cache and return anonymous
   // user or the user requested by the userId
   static getUserCacheIncAnon (userId, cb) {
-    if (internals.noPasswordSecret) { // user is anonymous
+    if (Auth.isAnonymousMode()) { // user is anonymous
       User.getUserCache('anonymous', (err, anonUser) => {
         const anon = Object.assign(new User(), internals.anonymousUser);
 

--- a/viewer/vueapp/index.html
+++ b/viewer/vueapp/index.html
@@ -12,7 +12,6 @@
     <script nonce="{{ nonce }}">
       const TITLE_CONFIG = '{{ titleConfig }}';
       const DEMO_MODE = {{ demoMode }};
-      const DEV_MODE = {{ devMode }};
       const VERSION = '{{ version }}';
       const PATH = '{{ path }}';
       const MULTIVIEWER = {{ multiViewer }};

--- a/viewer/vueapp/src/main.js
+++ b/viewer/vueapp/src/main.js
@@ -65,7 +65,6 @@ new Vue({
     Vue.prototype.$constants = {
       TITLE_CONFIG,
       DEMO_MODE,
-      DEV_MODE,
       VERSION,
       PATH,
       MULTIVIEWER,


### PR DESCRIPTION
* fixed bug with updateUser not using correct userId for circular check

* viewer no longer treats lack of password Secret as anonymous, must use authMode=anonymous

* viewer tests makeToken is now a real endpoint instead of a sideeffect

* tests auto create users in db unless id starts with sac-

* ArkimeTest addUser - creates users with addUser.js

* ArkimeTest clearIndex - deletes everything in index

* ArkimeTest json parsing now has stack trace and error

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
