### PR TITLE
fix wise form and oidc auth

### DIFF
--- a/wiseService/vueapp/index.html
+++ b/wiseService/vueapp/index.html
@@ -9,7 +9,7 @@
   </head>
   <script nonce="{{ nonce }}">
     const VERSION = '{{ version }}';
-    const LOGOUT_URL = '{{ LOGOUT_URL }}';
+    const LOGOUT_URL = '{{ logoutUrl }}';
   </script>
   <body>
     <!--vue-ssr-outlet-->

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -1115,6 +1115,7 @@ app.get('/types/:source?', [ArkimeUtil.noCacheJson], (req, res) => {
 app.get('/:source/:typeName/:value', [ArkimeUtil.noCacheJson], function (req, res, next) {
   // Poor route planning by ALW, shame
   if (req.params.source === 'source' && req.params.value === 'get') { return next(); }
+  if (req.params.source === 'auth') { return next(); }
 
   const source = internals.sources.get(req.params.source);
   if (!source) {


### PR DESCRIPTION
form auth didn't have LOGOUT_URL set right, oidc auth didn't get /auth/* callbacks called correctly

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
