### PR TITLE
added new custom-fields-remap section

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -221,24 +221,24 @@ typedef struct arkime_field_info {
     char                     *dbFieldFull;     /* Must be second - this is the full version example:mysql.user-term */
     char                     *dbField;         /* - this is the version used in db writing example:user-term */
     uint32_t                  d_hash;
-    uint32_t                  d_bucket;
-    uint32_t                  d_count;
+    uint16_t                  d_bucket;
+    uint16_t                  d_count;
 
     struct arkime_field_info *e_next, *e_prev;
     char                     *expression;
     uint32_t                  e_hash;
-    uint32_t                  e_bucket;
-    uint32_t                  e_count;
+    uint16_t                  e_bucket;
+    uint16_t                  e_count;
 
-    int                       dbFieldLen;
-    int                       dbGroupNum;
+    int16_t                   dbFieldLen;
+    int16_t                   dbGroupNum;
     char                     *dbGroup;
-    int                       dbGroupLen;
+    int16_t                   dbGroupLen;
     char                     *group;
     char                     *kind;
     char                     *category;
-    int                       pos;
-    ArkimeFieldType          type;
+    int16_t                   pos;
+    ArkimeFieldType           type;
     uint16_t                  flags;
     char                      ruleEnabled;
     char                     *transform;
@@ -269,16 +269,17 @@ typedef struct {
 typedef struct {
     char                 *str;
     union {
-        int                 strLenOrInt;
-        float               f;
+        int               strLenOrInt;
+        float             f;
     };
     int16_t               fieldPos;
+    int16_t               matchPos;
     int8_t                set;
 } ArkimeFieldOp_t;
 
 #define ARKIME_FIELD_OPS_FLAGS_COPY 0x0001
 typedef struct {
-    ArkimeFieldOp_t     *ops;
+    ArkimeFieldOp_t      *ops;
     uint16_t              size;
     uint16_t              num;
     uint16_t              flags;
@@ -1290,6 +1291,7 @@ void arkime_field_define_json(uint8_t *expression, int expression_len, uint8_t *
 int  arkime_field_define_text(char *text, int *shortcut);
 int  arkime_field_define_text_full(char *field, char *text, int *shortcut);
 int  arkime_field_define(char *group, char *kind, char *expression, char *friendlyName, char *dbField, char *help, ArkimeFieldType type, int flags, ...);
+
 int  arkime_field_by_db(const char *dbField);
 int  arkime_field_by_exp(const char *exp);
 const char *arkime_field_string_add(int pos, ArkimeSession_t *session, const char *string, int len, gboolean copy);
@@ -1312,7 +1314,9 @@ void arkime_field_exit();
 void arkime_field_ops_init(ArkimeFieldOps_t *ops, int numOps, uint16_t flags);
 void arkime_field_ops_free(ArkimeFieldOps_t *ops);
 void arkime_field_ops_add(ArkimeFieldOps_t *ops, int fieldPos, char *value, int valuelen);
+void arkime_field_ops_add_match(ArkimeFieldOps_t *ops, int fieldPos, char *value, int valuelen, int matchPos);
 void arkime_field_ops_run(ArkimeSession_t *session, ArkimeFieldOps_t *ops);
+void arkime_field_ops_run_match(ArkimeSession_t *session, ArkimeFieldOps_t *ops, int matchPos);
 
 void *arkime_field_parse_ip(const char *str);
 gboolean arkime_field_ip_equal (gconstpointer v1, gconstpointer v2);

--- a/capture/main.c
+++ b/capture/main.c
@@ -665,8 +665,7 @@ void arkime_quit()
 /******************************************************************************/
 /*
  * Don't actually init nids/pcap until all the pre tags are loaded.
- * TRUE - call again in 1ms
- * FALSE - don't call again
+ * CONTINUE - call again in 1ms
  */
 gboolean arkime_ready_gfunc (gpointer UNUSED(user_data))
 {

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -336,7 +336,7 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
             }
 
             int n = 12;
-            while ((pcapData[n] == 0x81 && pcapData[n + 1] == 0x00) || (pcapData[n] == 0x88 && pcapData[n+1] == 0xa8)) {
+            while ((pcapData[n] == 0x81 && pcapData[n + 1] == 0x00) || (pcapData[n] == 0x88 && pcapData[n + 1] == 0xa8)) {
                 uint16_t vlan = ((uint16_t)(pcapData[n + 2] << 8 | pcapData[n + 3])) & 0xfff;
                 arkime_field_int_add(vlanField, session, vlan);
                 n += 4;

--- a/capture/plugins/taggerUpload.pl
+++ b/capture/plugins/taggerUpload.pl
@@ -10,6 +10,16 @@ use LWP::UserAgent;
 use Digest::MD5 qw(md5_hex);
 use Data::Dumper;
 
+
+sub showHelp($)
+{
+    my ($str) = @_;
+    print $str,"\n";
+    die "$0 [--insecure] ESHOST:ESPORT (ip|host|md5|email|uri) filename [tag1..tagN]";
+}
+
+showHelp("Missing arguments") if (@ARGV < 3);
+
 my $INSECURE = 0;
 if ($ARGV[0] eq "--insecure") {
     $INSECURE = 1;
@@ -22,14 +32,7 @@ if ($host !~ /(http:|https)/) {
     $host = "http://$ARGV[0]";
 }
 
-sub showHelp($)
-{
-    my ($str) = @_;
-    print $str,"\n";
-    die "$0 [--insecure] ESHOST:ESPORT (ip|host|md5|email|uri) filename tag1 [tag2..tagN]";
-}
-
-showHelp("Missing arguments") if (@ARGV < 4);
+showHelp("Missing arguments") if (@ARGV < 3); # Again because of INSECURE
 showHelp("Must be ip, host, or md5 for file type instead of $ARGV[1]") if ($ARGV[1] !~ /^(host|ip|md5|email|uri)$/);
 showHelp("file '$ARGV[2]' not found") if (! -f $ARGV[2]);
 showHelp("file '$ARGV[2]' empty") if (-z $ARGV[2]);
@@ -67,12 +70,16 @@ if ($fields ne "") {
     chop $fields;
     $fields .= "\", ";
 }
+
 my $elements = join ',', @ELEMENTS;
 close (FILE);
 
 my $md5hex = md5_hex($elements);
 
-my $content  = '{' . $fields . '"tags": "' . join(',', @ARGV[3 .. $#ARGV]) . '", "md5":"' . $md5hex .'", "type":"' . $ARGV[1] . '", "data":"' . $elements . '"}'. "\n";
+my $tags = "";
+$tags = '"tags": "' . join(',', @ARGV[3 .. $#ARGV]) . '",' if (@ARGV >= 4);
+
+my $content  = qq({${fields}${tags}"md5":"$md5hex", "type":"$ARGV[1]", "data":"$elements"}\n);
 $response = $userAgent->post("$host/tagger/_doc/$ARGV[2]", "Content-Type" => "application/json;charset=UTF-8", Content => $content);
 print $response->content, "\n";
 

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -97,6 +97,8 @@ arkimeWebURL = localhost:8123/arkime/
 turnOffGraphDays = 30
 disableUserPasswordUI=false
 authMode=digest
+#authMode=form
+#authCookieSecure=false
 loginMessage=Welcome! Test form auth...
 defaultTimeRange=-1
 
@@ -306,6 +308,11 @@ ALLTEST=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIEL
 [custom-fields]
 iscool=kind:termfield;count:true;friendly:Is cool;db:iscool;help:Is Cool String;viewerOnly:true
 sample.md5=db:sample.md5;kind:lotermfield;friendly:Sample MD5;count:true;help:MD5 of the sample
+asset.src=kind:lotermfield;count:true;friendly:Asset Src;db:assetName.str;help:Asset Name Src
+asset.dst=kind:lotermfield;count:true;friendly:Aseet Dst;db:assetName.dst;help:Asset Name Dst
+
+[custom-fields-remap]
+asset=ip.src=asset.src;ip.dst=asset.dst
 
 [custom-views]
 nice=title:Nice;require:http;fields:ip.src,iscool,http.host

--- a/tests/ip.tagger2.json
+++ b/tests/ip.tagger2.json
@@ -1,3 +1,3 @@
-10.0.0.3;tags=byip1;irc.channel=byip1channel;email.x-priority=111
-192.168.177.160;tags=byip2;mysql.user=byip2mysqluser;test.ip=111.111.111.111
-2001:6f8:900:7c0::2;tags=byip2;mysql.user=byip2mysqluser;test.ip=111.111.111.111
+10.0.0.3;tags=byip1;irc.channel=byip1channel;email.x-priority=111;asset=test1
+192.168.177.160;tags=byip2;mysql.user=byip2mysqluser;test.ip=111.111.111.111;asset=test2
+2001:6f8:900:7c0::2;tags=byip2;mysql.user=byip2mysqluser;test.ip=111.111.111.111;asset=test3

--- a/tests/ip.wise
+++ b/tests/ip.wise
@@ -1,4 +1,4 @@
-10.0.0.3;tags=wisebyip1;irc.channel=wisebyip1channel;email.x-priority=999
-192.168.177.160;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21
-128.128.128.0/24;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21
-fe80::211:25ff:fe82:95b5;tags=wisebyip3;mysql.ver=wisebyip3mysqlversion;test.ip=22.22.22.22
+10.0.0.3;tags=wisebyip1;irc.channel=wisebyip1channel;email.x-priority=999;asset=wtest1
+192.168.177.160;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21;asset=wtest2
+128.128.128.0/24;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21;asset=wtest3
+fe80::211:25ff:fe82:95b5;tags=wisebyip3;mysql.ver=wisebyip3mysqlversion;test.ip=22.22.22.22;asset=wtest4

--- a/tests/tagger.t
+++ b/tests/tagger.t
@@ -1,4 +1,4 @@
-use Test::More tests => 56;
+use Test::More tests => 68;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -41,3 +41,13 @@ my $pwd = "*/pcap";
     countTest(2, "date=-1&expression=" . uri_escape("(file=$pwd/http-500-head.pcap||file=$pwd/http-wrapped-header.pcap)&&tags=uritaggertest2"));
     countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/http-500-head.pcap||file=$pwd/http-wrapped-header.pcap)&&http.referer=added1&&tags=firstmatch"));
     countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/http-500-head.pcap||file=$pwd/http-wrapped-header.pcap)&&http.user-agent=added2&&tags=secondmatch"));
+
+# fieldMap tests
+    countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/socks5-rdp.pcap||file=$pwd/bt-udp.pcap||file=$pwd/bigendian.pcap||file=$pwd/v6-http.pcap)&&ip.src=10.0.0.3"));
+    countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/socks5-rdp.pcap||file=$pwd/bt-udp.pcap||file=$pwd/bigendian.pcap||file=$pwd/v6-http.pcap)&&asset.src=test1"));
+
+    countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/socks5-rdp.pcap||file=$pwd/bt-udp.pcap||file=$pwd/bigendian.pcap||file=$pwd/v6-http.pcap)&&ip.dst=10.0.0.3"));
+    countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/socks5-rdp.pcap||file=$pwd/bt-udp.pcap||file=$pwd/bigendian.pcap||file=$pwd/v6-http.pcap)&&asset.dst=test1"));
+
+    countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/socks5-rdp.pcap||file=$pwd/bt-udp.pcap||file=$pwd/bigendian.pcap||file=$pwd/v6-http.pcap)&&ip.dst=2001:6f8:900:7c0::2"));
+    countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/socks5-rdp.pcap||file=$pwd/bt-udp.pcap||file=$pwd/bigendian.pcap||file=$pwd/v6-http.pcap)&&asset.dst=test3"));

--- a/tests/wise.t
+++ b/tests/wise.t
@@ -24,7 +24,8 @@ eq_or_diff(\@wise, from_json('[
 {"field":"tags","len":7,"value":"ipwise2"},
 {"field":"tags","len":9,"value":"ipwisecsv"},
 {"field":"tags","len":9,"value":"wisebyip1"},
-{"field":"irc.channel","len":16,"value":"wisebyip1channel"}
+{"field":"irc.channel","len":16,"value":"wisebyip1channel"},
+{"field":"asset","len":6,"value":"wtest1"}
 ]'),"All 10.0.0.3");
 
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/file:ip/ip/10.0.0.3")->content;
@@ -35,7 +36,8 @@ eq_or_diff(\@wise, from_json('[
 {"field":"tags","len":6,"value":"ipwise"},
 {"field":"tags","len":7,"value":"ipwise2"},
 {"field":"tags","len":9,"value":"wisebyip1"},
-{"field":"irc.channel","len":16,"value":"wisebyip1channel"}
+{"field":"irc.channel","len":16,"value":"wisebyip1channel"},
+{"field":"asset","len":6,"value":"wtest1"}
 ]'),"file:ip 10.0.0.3");
 
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/file:ipblah/ip/10.0.0.3")->content;
@@ -77,28 +79,32 @@ from_json('[
 {"field":"tags","len":7,"value":"ipwise2"},
 {"field":"tags","len":9,"value":"wisebyip1"},
 {"field":"irc.channel","len":16,"value":"wisebyip1channel"},
-{"field":"email.x-priority","len":3,"value":"999"}]
+{"field":"email.x-priority","len":3,"value":"999"},
+{"field":"asset","len":6,"value":"wtest1"}]
 },
 {"key":"128.128.128.0/24","ops":
 [{"field":"tags","len":6,"value":"ipwise"},
 {"field":"tags","len":7,"value":"ipwise2"},
 {"field":"tags","len":9,"value":"wisebyip2"},
 {"field":"mysql.ver","len":21,"value":"wisebyip2mysqlversion"},
-{"field":"test.ip","len":11,"value":"21.21.21.21"}]
+{"field":"test.ip","len":11,"value":"21.21.21.21"},
+{"field":"asset","len":6,"value":"wtest3"}]
 },
 {"key":"192.168.177.160","ops":
 [{"field":"tags","len":6,"value":"ipwise"},
 {"field":"tags","len":7,"value":"ipwise2"},
 {"field":"tags","len":9,"value":"wisebyip2"},
 {"field":"mysql.ver","len":21,"value":"wisebyip2mysqlversion"},
-{"field":"test.ip","len":11,"value":"21.21.21.21"}]
+{"field":"test.ip","len":11,"value":"21.21.21.21"},
+{"field":"asset","len":6,"value":"wtest2"}]
 },
 {"key":"fe80::211:25ff:fe82:95b5","ops":
 [{"field":"tags","len":6,"value":"ipwise"},
 {"field":"tags","len":7,"value":"ipwise2"},
 {"field":"tags","len":9,"value":"wisebyip3"},
 {"field":"mysql.ver","len":21,"value":"wisebyip3mysqlversion"},
-{"field":"test.ip","len":11,"value":"22.22.22.22"}]
+{"field":"test.ip","len":11,"value":"22.22.22.22"},
+{"field":"asset","len":6,"value":"wtest4"}]
 }
 ]', {relaxed=>1}), "file:ip dump");
 
@@ -331,7 +337,7 @@ $wise = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8081/config/save",
 eq_or_diff($wise, '{"success":true,"text":"Would save, but regressionTests"}');
 
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/source/file:ip/get")->content;
-is($wise, '{"success":true,"raw":"10.0.0.3;tags=wisebyip1;irc.channel=wisebyip1channel;email.x-priority=999\\n192.168.177.160;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21\\n128.128.128.0/24;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21\\nfe80::211:25ff:fe82:95b5;tags=wisebyip3;mysql.ver=wisebyip3mysqlversion;test.ip=22.22.22.22\\n"}');
+is($wise, '{"success":true,"raw":"10.0.0.3;tags=wisebyip1;irc.channel=wisebyip1channel;email.x-priority=999;asset=wtest1\\n192.168.177.160;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21;asset=wtest2\\n128.128.128.0/24;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21;asset=wtest3\\nfe80::211:25ff:fe82:95b5;tags=wisebyip3;mysql.ver=wisebyip3mysqlversion;test.ip=22.22.22.22;asset=wtest4\\n"}');
 
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/source/notfound/get")->content;
 is($wise, '{"success":false,"text":"Source notfound not found"}');

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -959,7 +959,12 @@ function processQueryResponse0 (req, res, queries, results) {
   res.end();
 }
 // ----------------------------------------------------------------------------
-//
+// pos len value
+// 0   4   flags
+// 4   2   2
+// 8   32  md5 of fields
+// 40  2   length of fields info if md5 unknown
+// 42  L   fields info
 function processQueryResponse2 (req, res, queries, results) {
   const hashes = (req.query.hashes || '').split(',');
 


### PR DESCRIPTION
The custom-fields-remap section allows the user to list ops fields (rules, wise, tagger) that should actually be remapped into multiple fields. This will allow you to set an asset.src and asset.dst for example instead of just asset.

Also fixed a wise plugin bug where it wasn't handling multiple field lists correctly

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
