### PR TITLE
remove /hunt from the old api list and test all tabs :) fix #2531

### DIFF
--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1163,7 +1163,6 @@ app.all([
   '/lookups',
   '/lookups/:id',
   '/hunt/list',
-  '/hunt',
   '/hunt/:id',
   '/hunt/:id/cancel',
   '/hunt/:id/pause',


### PR DESCRIPTION
/hunt shouldn't be on the list of old apis

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
