### PR TITLE
Added macro %URIEncodedText% for URI encoded substitution

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -99,6 +99,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2521 add footerTemplate setting
   - #2525 add [config setting](https://arkime.com/settings#spiViewCategoryOrder) to set spiview category order
   - #2523 resize session detail field label/values
+  - #2552 added %URIEncodedText% for URI encoded substitution (thanks @vpiserchia)
 ## Parliament
   - #2377 dashboard-only mode removed, if you want users to just see the dashboard don't assign them the parliamentUser role
   - #2395 configuration is now stored in opensearch/elasticsearch

--- a/viewer/vueapp/src/components/sessions/SessionField.vue
+++ b/viewer/vueapp/src/components/sessions/SessionField.vue
@@ -549,6 +549,7 @@ export default {
             .replace('%FIELD%', info.field)
             .replace('%DBFIELD%', info.info.dbField)
             .replace('%TEXT%', text)
+            .replace('%URIEncodedText%', encodeURIComponent(text))
             .replace('%UCTEXT%', text.toUpperCase())
             .replace('%HOST%', host)
             .replace('%URL%', encodeURIComponent('http:' + url))


### PR DESCRIPTION
provide a new macro %URIEncodedText% for URL substitution in value-actions. The macro returns the text clicked on, URI encoded

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
