### PR TITLE
support fieldSet rules on tcpflags.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -74,6 +74,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2528 new oui.txt location, some names have changes, fixes #2347
   - #2539 new tls:has_esni tag if the client hello has esni
   - #2553 fix rules range matching not working always
+  - #2554 support fieldSet tcpflag rules
 ## Cont3xt
   - #2121 new bulk UI and support for bulk queries
   - #2271 lots of keyboard shortcut improvements

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -215,7 +215,6 @@ typedef enum {
 /* prepend ip stuff - dont use*/
 #define ARKIME_FIELD_FLAG_IPPRE              0x4000
 
-
 typedef struct arkime_field_info {
     struct arkime_field_info *d_next, *d_prev; /* Must be first */
     char                     *dbFieldFull;     /* Must be second - this is the full version example:mysql.user-term */
@@ -1388,6 +1387,7 @@ typedef enum {
 
 void arkime_rules_init();
 void arkime_rules_recompile();
+#define ARKIME_RULES_RUN_FIELD_SET(session, pos, value) do { if (config.fields[pos]->ruleEnabled) arkime_rules_run_field_set(session, pos, value); } while (0)
 void arkime_rules_run_field_set(ArkimeSession_t *session, int pos, const gpointer value);
 int arkime_rules_run_every_packet(ArkimePacket_t *packet);
 void arkime_rules_session_create(ArkimeSession_t *session);

--- a/capture/parsers/tcp.c
+++ b/capture/parsers/tcp.c
@@ -146,6 +146,7 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
 
     if (tcphdr->th_flags & TH_URG) {
         session->tcpFlagCnt[ARKIME_TCPFLAG_URG]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, ARKIME_FIELD_EXSPECIAL_TCPFLAGS_URG, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_URG]);
     }
 
     // add to the long open
@@ -156,6 +157,7 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
     if (tcphdr->th_flags & TH_SYN) {
         if (tcphdr->th_flags & TH_ACK) {
             session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]++;
+            ARKIME_RULES_RUN_FIELD_SET(session, ARKIME_FIELD_EXSPECIAL_TCPFLAGS_SYN_ACK, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]);
 
             if (!session->haveTcpSession) {
 #ifdef DEBUG_TCP
@@ -165,6 +167,7 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
             }
         } else {
             session->tcpFlagCnt[ARKIME_TCPFLAG_SYN]++;
+            ARKIME_RULES_RUN_FIELD_SET(session, ARKIME_FIELD_EXSPECIAL_TCPFLAGS_SYN, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_SYN]);
             if (session->synTime == 0) {
                 session->synTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000000 +
                                    (packet->ts.tv_usec - session->firstPacket.tv_usec) + 1;
@@ -184,6 +187,7 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
 
     if (tcphdr->th_flags & TH_RST) {
         session->tcpFlagCnt[ARKIME_TCPFLAG_RST]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, ARKIME_FIELD_EXSPECIAL_TCPFLAGS_RST, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_RST]);
         int64_t diff = tcp_sequence_diff(seq, session->tcpSeq[packet->direction]);
         if (diff  <= 0) {
             if (diff == 0 && !session->closingQ) {
@@ -197,11 +201,13 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
 
     if (tcphdr->th_flags & TH_FIN) {
         session->tcpFlagCnt[ARKIME_TCPFLAG_FIN]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, ARKIME_FIELD_EXSPECIAL_TCPFLAGS_FIN, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_FIN]);
         session->tcpState[packet->direction] = ARKIME_TCP_STATE_FIN;
     }
 
     if ((tcphdr->th_flags & (TH_FIN | TH_RST | TH_PUSH | TH_SYN | TH_ACK)) == TH_ACK) {
         session->tcpFlagCnt[ARKIME_TCPFLAG_ACK]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, ARKIME_FIELD_EXSPECIAL_TCPFLAGS_ACK, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_ACK]);
         if (session->ackTime == 0) {
             session->ackTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000000 +
                                (packet->ts.tv_usec - session->firstPacket.tv_usec) + 1;
@@ -210,6 +216,7 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
 
     if (tcphdr->th_flags & TH_PUSH) {
         session->tcpFlagCnt[ARKIME_TCPFLAG_PSH]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, ARKIME_FIELD_EXSPECIAL_TCPFLAGS_PSH, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_PSH]);
     }
 
     if (session->stopTCP)


### PR DESCRIPTION
Previously they only worked with other fields being set after
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
