### PR TITLE
fix for issue #2594, allow plugins to receive zero length TCP packets

### DIFF
--- a/capture/parsers/tcp.c
+++ b/capture/parsers/tcp.c
@@ -182,6 +182,9 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
             session->tcpSeq[packet->direction] = seq + 1;
             session->synSet |= (1 << packet->direction);
         }
+	// Send only the header up with a length 0, useful for tools like JA4Plus
+        if (pluginsCbs & ARKIME_PLUGIN_TCP)
+            arkime_plugins_cb_tcp(session, packet, 0, packet->direction);
         return 1;
     }
 
@@ -213,6 +216,9 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
             session->ackTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000000 +
                                (packet->ts.tv_usec - session->firstPacket.tv_usec) + 1;
         }
+	// Send only the header up with a length 0, useful for tools like JA4Plus
+        if (pluginsCbs & ARKIME_PLUGIN_TCP)
+            arkime_plugins_cb_tcp(session, packet, 0, packet->direction);
     }
 
     if (tcphdr->th_flags & TH_PUSH) {

--- a/capture/parsers/tcp.c
+++ b/capture/parsers/tcp.c
@@ -216,9 +216,6 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
             session->ackTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000000 +
                                (packet->ts.tv_usec - session->firstPacket.tv_usec) + 1;
         }
-	// Send only the header up with a length 0, useful for tools like JA4Plus
-        if (pluginsCbs & ARKIME_PLUGIN_TCP)
-            arkime_plugins_cb_tcp(session, packet, 0, packet->direction);
     }
 
     if (tcphdr->th_flags & TH_PUSH) {
@@ -271,8 +268,12 @@ int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const pac
     }
 
     // Empty packet, drop from tcp processing
-    if (len <= 0 || tcphdr->th_flags & TH_RST)
+    if (len <= 0 || tcphdr->th_flags & TH_RST) {
+	// Send only the header up with a length 0, useful for tools like JA4Plus
+        if (pluginsCbs & ARKIME_PLUGIN_TCP)
+            arkime_plugins_cb_tcp(session, packet, 0, packet->direction);
         return 1;
+    }
 
     // This packet is before what we are processing
     int64_t diff = tcp_sequence_diff(session->tcpSeq[packet->direction], seq + len);


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
This feature request has been submitted to allow Arkime to send TCP packets that do not have any payload to TCP callbacks.
The current code does not send TCP packets without a payload to callbacks registered by plugins.
In case of the new Ja4Plus plugin, we want to be able to access TCP packets to record and create fingerprints based on the below criteria and fields.

- SYN packet timestamp
- SYN-ACK packet timestamps along with re-trasmitted SYN-ACKs
- ACK pacet timestamp
- TCP options
- TCP window size
- IP time to live

Instead of adding the above fields to the Arkime session, we thought it would be cleaner to just send the entire ArkimePacket to plugins that have registered for TCP. The length of the packet will be zero in this case. It is upto the plugin to peek into the packet to decipher the TCP headers, IP headers or any other data that it requires.

**Relevant issue number(s) if applicable**
2594

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
No changes were made to either viewer or parliament

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
Yes, successfully ran tests. Observed failures but not related to these changes.
[arkime-test-out.txt](https://github.com/arkime/arkime/files/13979153/arkime-test-out.txt)


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
