### PR TITLE
add has_ech tag for tls sessions with encrypted_client_hello extension

### DIFF
--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -808,6 +808,9 @@ uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uint8_t *
                 } else if (etype == 0xffce) { // esni
                     arkime_session_add_tag(session, "tls:has_esni");
                     BSB_IMPORT_skip (ebsb, elen);
+                } else if (etype == 0xfe0d) { // encrypted_client_hello
+                    arkime_session_add_tag(session, "tls:has_ech");
+                    BSB_IMPORT_skip (ebsb, elen);
                 } else {
                     BSB_IMPORT_skip (ebsb, elen);
                 }


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**This adds the tag for encrypted_client_hello extension in tls sessions tls:has_ech**

#1508 was for tagging sessions with the esni extension, for which support was added with #2539. The TLS extension and draft evolved over time, which is now: https://tools.ietf.org/html/draft-ietf-tls-esni-17 and there is another extension type, with id: 0xfe0d.

```
       enum {
          encrypted_client_hello(0xfe0d), (65535)
       } ExtensionTyp
```

Which is currently in use at domains from cloudflare, like https://1.1.1.1 or https://cloudflare.com, and many many others. This adds support for the new tag tls:has_ech, which stands for has_encrypted_client_hello, and makes it easy to spot and search for sessions that have this client extension in the handshake.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
