### PR TITLE
patch cyberchef xss vuln

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -108,6 +108,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2525 add [config setting](https://arkime.com/settings#spiViewCategoryOrder) to set spiview category order
   - #2523 resize session detail field label/values
   - #2552 added %URIEncodedText% for URI encoded substitution (thanks @vpiserchia)
+  - #2601 patch cyberchef xss vuln (https://github.com/gchq/CyberChef/issues/1468)
 ## Parliament
   - #2377 dashboard-only mode removed, if you want users to just see the dashboard don't assign them the parliamentUser role
   - #2395 configuration is now stored in opensearch/elasticsearch

--- a/release/new_cyber_chef.pl
+++ b/release/new_cyber_chef.pl
@@ -48,6 +48,26 @@ my $script = q|
       .then((result) => {
         interval = setInterval(() => {
           if (typeof app !== 'undefined') {
+            // THIS IS A HACK TO GET AROUND A CYBERCHEF BUG
+            // https://github.com/gchq/CyberChef/issues/1468
+            // https://github.com/gchq/CyberChef/pull/1549
+            app.manager.recipe.addOperation = (name) => {
+              const item = document.createElement('li');
+
+              item.classList.add('operation');
+
+              if (app.operations[name] != null) {
+                item.innerHTML = name;
+              }
+
+              app.manager.recipe.buildRecipeOperation(item);
+              document.getElementById('rec-list').appendChild(item);
+
+              $(item).find("[data-toggle='tooltip']").tooltip();
+              item.dispatchEvent(app.manager.operationadd);
+              return item;
+            };
+
             app.manager.recipe.addOperation('From Hex');
             app.setInput(result.data);
             clearInterval(interval);

--- a/viewer/public/cyberchef.html
+++ b/viewer/public/cyberchef.html
@@ -36,6 +36,7 @@
       }
     }
 
+    let data;
     let interval;
 
     // fetch the data to populate the input
@@ -48,17 +49,23 @@
         }
       })
       .then((result) => {
+        data = result.data;
+      })
+      .catch((error) => {
+        console.log('error', error);
+      }).finally(() => {
         interval = setInterval(() => {
           if (typeof app !== 'undefined') {
             // THIS IS A HACK TO GET AROUND A CYBERCHEF BUG
             // https://github.com/gchq/CyberChef/issues/1468
             // https://github.com/gchq/CyberChef/pull/1549
+            // replaces the addOperation function
             app.manager.recipe.addOperation = (name) => {
               const item = document.createElement('li');
 
               item.classList.add('operation');
 
-              if (app.operations[name] != null) {
+              if (app.operations[name] != null) { // THIS is the fix
                 item.innerHTML = name;
               }
 
@@ -70,14 +77,14 @@
               return item;
             };
 
-            app.manager.recipe.addOperation('From Hex');
-            app.setInput(result.data);
+            if (data) {
+              app.manager.recipe.addOperation('From Hex');
+              app.setInput(data);
+            }
+
             clearInterval(interval);
           }
         }, 100);
-      })
-      .catch((error) => {
-        console.log('error', error);
       });
 
     setTimeout(() => {

--- a/viewer/public/cyberchef.html
+++ b/viewer/public/cyberchef.html
@@ -50,6 +50,26 @@
       .then((result) => {
         interval = setInterval(() => {
           if (typeof app !== 'undefined') {
+            // THIS IS A HACK TO GET AROUND A CYBERCHEF BUG
+            // https://github.com/gchq/CyberChef/issues/1468
+            // https://github.com/gchq/CyberChef/pull/1549
+            app.manager.recipe.addOperation = (name) => {
+              const item = document.createElement('li');
+
+              item.classList.add('operation');
+
+              if (app.operations[name] != null) {
+                item.innerHTML = name;
+              }
+
+              app.manager.recipe.buildRecipeOperation(item);
+              document.getElementById('rec-list').appendChild(item);
+
+              $(item).find("[data-toggle='tooltip']").tooltip();
+              item.dispatchEvent(app.manager.operationadd);
+              return item;
+            };
+
             app.manager.recipe.addOperation('From Hex');
             app.setInput(result.data);
             clearInterval(interval);


### PR DESCRIPTION
vuln: https://github.com/gchq/CyberChef/issues/1468
patch: https://github.com/gchq/CyberChef/pull/1549/files

appending `recipe=%3Cimg_src%3dx_onerror%3d'alert%601%60'/%3E('Space',false)Generate_all_hashes()&input=MzA1MTczMTA5` to the query params, should not display a browser alert with the value "1"

example Arkime url: `http://localhost:8123/arkime/cyberchef.html?nodeId=test&sessionId=3@220824:js0UFI0BtGIErXJqmoR_&type=src&recipe=%3Cimg_src%3dx_onerror%3d%27alert%601%60%27/%3E(%27Space%27,false)Generate_all_hashes()&input=MzA1MTczMTA5`

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
