### PR TITLE
Use a painless script to do integer autocomplete

### DIFF
--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2517,7 +2517,7 @@ class SessionAPIs {
         query.query.bool.filter.push({
           script: {
             script: {
-              source: `doc["${req.query.field}"].value.toString().startsWith("${req.query.autocomplete}")`
+              source: `doc["${req.query.field}"].size() > 0 && doc["${req.query.field}"].value.toString().startsWith("${req.query.autocomplete}")`
             }
           }
         });
@@ -2565,6 +2565,7 @@ class SessionAPIs {
 
       const options = ViewerUtils.addCluster(req.query.cluster);
       Db.searchSessions(indices, query, options, (err, result) => {
+
         if (err) {
           console.log(`ERROR - ${req.method} /api/unique`, query, util.inspect(err, false, 50));
           return doneCb ? doneCb() : res.end();

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2565,7 +2565,6 @@ class SessionAPIs {
 
       const options = ViewerUtils.addCluster(req.query.cluster);
       Db.searchSessions(indices, query, options, (err, result) => {
-
         if (err) {
           console.log(`ERROR - ${req.method} /api/unique`, query, util.inspect(err, false, 50));
           return doneCb ? doneCb() : res.end();

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2514,7 +2514,7 @@ class SessionAPIs {
 
       const fieldDef = Config.getFieldsMap()[req.query.field];
       if (fieldDef && fieldDef.type === 'integer') {
-        query.query.bool.filter.push ({
+        query.query.bool.filter.push({
           script: {
             script: {
               source: `doc["${req.query.field}"].value.toString().startsWith("${req.query.autocomplete}")`

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2479,6 +2479,7 @@ class SessionAPIs {
       doneCb = () => {
         res.send(items);
       };
+
       writeCb = (item) => {
         items.push(item.key);
       };
@@ -2509,6 +2510,17 @@ class SessionAPIs {
       if (err) {
         res.status(403);
         return res.end(err);
+      }
+
+      const fieldDef = Config.getFieldsMap()[req.query.field];
+      if (fieldDef && fieldDef.type === 'integer') {
+        query.query.bool.filter.push ({
+          script: {
+            script: {
+              source: `doc["${req.query.field}"].value.toString().startsWith("${req.query.autocomplete}")`
+            }
+          }
+        });
       }
 
       delete query.sort;

--- a/viewer/vueapp/src/components/search/ExpressionTypeahead.vue
+++ b/viewer/vueapp/src/components/search/ExpressionTypeahead.vue
@@ -648,7 +648,7 @@ export default {
       // autocomplete other values after 2 chars
       if (lastToken.trim().length >= 2) {
         const params = { // build parameters for getting value(s)
-          autocomplete: true,
+          autocomplete: lastToken,
           field: field.dbField
         };
 
@@ -660,7 +660,8 @@ export default {
           params.stopTime = this.$route.query.stopTime;
         }
 
-        if (field.type === 'ip') {
+        if (field.type === 'integer') {
+        } else if (field.type === 'ip') {
           params.expression = token + '==' + lastToken;
         } else {
           params.expression = token + '==' + lastToken + '*';


### PR DESCRIPTION
Support integer autocomplete by using a painless script that converts fields to strings an uses startsWith. This might be too slow. Also change the vueapp to send the value being autocompleted against as the autocomple query field.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
