### PR TITLE
fix the detail grip

### DIFF
--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -520,7 +520,8 @@ SPDX-License-Identifier: Apache-2.0
                   :session="session"
                   :session-index="index"
                   @toggleColVis="toggleColVis"
-                  @toggleInfoVis="toggleInfoVis">
+                  @toggleInfoVis="toggleInfoVis"
+                  :session-detail-dl-width="dlWidth">
                 </arkime-session-detail>
               </td>
             </tr> <!-- /session detail -->
@@ -764,6 +765,10 @@ export default {
     window.addEventListener('resize', windowResizeEvent, { passive: true });
     this.$root.$on('bv::dropdown::show', this.dropdownShowListener);
     this.$root.$on('bv::dropdown::hide', this.dropdownHideListener);
+
+    UserService.getState('sessionDetailDLWidth').then((response) => {
+      this.$store.commit('setSessionDetailDLWidth', response.data.width ?? 160);
+    });
   },
   computed: {
     query: function () {
@@ -814,6 +819,14 @@ export default {
     },
     hideViz: function () {
       return this.$store.state.hideViz;
+    },
+    dlWidth: {
+      get: function () {
+        return this.$store.state.sessionDetailDLWidth || 160;
+      },
+      set: function (newValue) {
+        this.$store.commit('setSessionDetailDLWidth', newValue);
+      }
     }
   },
   watch: {

--- a/viewer/vueapp/src/store.js
+++ b/viewer/vueapp/src/store.js
@@ -55,7 +55,8 @@ const store = new Vuex.Store({
     capStartTimes: [{ nodeName: 'none', startTime: 1 }],
     roles: [],
     fieldActions: {},
-    notifiers: []
+    notifiers: [],
+    sessionDetailDLWidth: 160
   },
   getters: {
     sessionsTableState (state) {
@@ -250,6 +251,9 @@ const store = new Vuex.Store({
     },
     setNotifiers (state, value) {
       state.notifiers = value;
+    },
+    setSessionDetailDLWidth (state, value) {
+      state.sessionDetailDLWidth = value;
     }
   }
 });


### PR DESCRIPTION
was on far left side sometimes
don't use document selector, use sessionDetailSelection selector so we're not cycling through ALL the session details, just the one toggled
update all of the dl and button widths on every dragend save the dlWidth in the store
only get it once and update it on save
also fix packet options looking at every packet section, not just the one opened

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
