### PR TITLE
Generic object field type

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -187,6 +187,9 @@ typedef struct {
 typedef HASH_VAR(o_, ArkimeFieldObjectHash_t, ArkimeFieldObjectHead_t, 1);
 typedef HASH_VAR(o_, ArkimeFieldObjectHashStd_t, ArkimeFieldObjectHead_t, 13);
 
+// forward declaration of ArkimeSession_t
+typedef struct arkime_session ArkimeSession_t;
+
 typedef void (* ArkimeFieldObjectSaveFunc) (BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session);
 typedef void (* ArkimeFieldObjectFreeFunc) (ArkimeFieldObject_t *object);
 typedef uint32_t (* ArkimeFieldObjectHashFunc) (const void *key);

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -167,6 +167,30 @@ typedef struct {
 typedef HASH_VAR(s_, ArkimeCertsInfoHash_t, ArkimeCertsInfoHead_t, 1);
 typedef HASH_VAR(s_, ArkimeCertsInfoHashStd_t, ArkimeCertsInfoHead_t, 5);
 
+/******************************************************************************/
+/*
+ * Generic object field type
+ */
+
+typedef struct arkime_field_object {
+    struct arkime_field_object      *o_next, *o_prev;
+    uint32_t                         o_hash;
+    short                            o_bucket;
+    void                            *object;
+} ArkimeFieldObject_t;
+
+typedef struct {
+    struct arkime_field_object      *o_next, *o_prev;
+    short                            o_count;
+} ArkimeFieldObjectHead_t;
+
+typedef HASH_VAR(o_, ArkimeFieldObjectHash_t, ArkimeFieldObjectHead_t, 1);
+typedef HASH_VAR(o_, ArkimeFieldObjectHashStd_t, ArkimeFieldObjectHead_t, 13);
+
+typedef void (* ArkimeFieldObjectSaveFunc) (BSB *jbsb, ArkimeFieldObject_t *object);
+typedef void (* ArkimeFieldObjectFreeFunc) (ArkimeFieldObject_t *object);
+typedef uint32_t (* ArkimeFieldObjectHashFunc) (const void *key);
+typedef int (* ArkimeFieldObjectCmpFunc) (const void *keyv, const void *elementv);
 
 /******************************************************************************/
 /*
@@ -187,7 +211,8 @@ typedef enum {
     ARKIME_FIELD_TYPE_CERTSINFO,
     ARKIME_FIELD_TYPE_FLOAT,
     ARKIME_FIELD_TYPE_FLOAT_ARRAY,
-    ARKIME_FIELD_TYPE_FLOAT_GHASH
+    ARKIME_FIELD_TYPE_FLOAT_GHASH,
+    ARKIME_FIELD_TYPE_OBJECT
 } ArkimeFieldType;
 
 #define ARKIME_FIELD_TYPE_IS_INT(t) (t >= ARKIME_FIELD_TYPE_INT && t <= ARKIME_FIELD_TYPE_INT_GHASH)
@@ -244,21 +269,27 @@ typedef struct arkime_field_info {
     char                      ruleEnabled;
     char                     *transform;
     char                     *aliases;
+
+    ArkimeFieldObjectSaveFunc object_save;
+    ArkimeFieldObjectFreeFunc object_free;
+    ArkimeFieldObjectHashFunc object_hash;
+    ArkimeFieldObjectCmpFunc  object_cmp;
 } ArkimeFieldInfo_t;
 
 typedef struct {
     union {
-        char                     *str;
-        GPtrArray                *sarray;
-        ArkimeStringHashStd_t    *shash;
-        int                       i;
-        GArray                   *iarray;
-        ArkimeIntHashStd_t       *ihash;
-        float                     f;
-        GArray                   *farray;
-        ArkimeCertsInfoHashStd_t *cihash;
-        GHashTable               *ghash;
-        struct in6_addr          *ip;
+        char                       *str;
+        GPtrArray                  *sarray;
+        ArkimeStringHashStd_t      *shash;
+        int                         i;
+        GArray                     *iarray;
+        ArkimeIntHashStd_t         *ihash;
+        float                       f;
+        GArray                     *farray;
+        ArkimeCertsInfoHashStd_t   *cihash;
+        GHashTable                 *ghash;
+        struct in6_addr            *ip;
+        ArkimeFieldObjectHashStd_t *ohash;
     };
     uint32_t                   jsonSize;
 } ArkimeField_t;
@@ -1341,6 +1372,8 @@ void *arkime_field_parse_ip(const char *str);
 gboolean arkime_field_ip_equal (gconstpointer v1, gconstpointer v2);
 guint arkime_field_ip_hash (gconstpointer v);
 
+int arkime_field_object_register(const char *name, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp);
+gboolean arkime_field_object_add(int pos, ArkimeSession_t *session, ArkimeFieldObject_t *object, int len);
 
 /******************************************************************************/
 /*

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1375,7 +1375,7 @@ void *arkime_field_parse_ip(const char *str);
 gboolean arkime_field_ip_equal (gconstpointer v1, gconstpointer v2);
 guint arkime_field_ip_hash (gconstpointer v);
 
-int arkime_field_object_register(const char *name, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp);
+int arkime_field_object_register(const char *name, const char *help, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp);
 gboolean arkime_field_object_add(int pos, ArkimeSession_t *session, ArkimeFieldObject_t *object, int len);
 
 /******************************************************************************/

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -187,7 +187,7 @@ typedef struct {
 typedef HASH_VAR(o_, ArkimeFieldObjectHash_t, ArkimeFieldObjectHead_t, 1);
 typedef HASH_VAR(o_, ArkimeFieldObjectHashStd_t, ArkimeFieldObjectHead_t, 13);
 
-typedef void (* ArkimeFieldObjectSaveFunc) (BSB *jbsb, ArkimeFieldObject_t *object);
+typedef void (* ArkimeFieldObjectSaveFunc) (BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session);
 typedef void (* ArkimeFieldObjectFreeFunc) (ArkimeFieldObject_t *object);
 typedef uint32_t (* ArkimeFieldObjectHashFunc) (const void *key);
 typedef int (* ArkimeFieldObjectCmpFunc) (const void *keyv, const void *elementv);

--- a/capture/db.c
+++ b/capture/db.c
@@ -1337,7 +1337,7 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
             ArkimeFieldObject_t *object;
 
             HASH_FORALL_POP_HEAD2(o_, *ohash, object) {
-                saveCB(&jbsb, object);
+                saveCB(&jbsb, object, session);
                 freeCB(object);
                 BSB_EXPORT_u08(jbsb, ',');
             }

--- a/capture/db.c
+++ b/capture/db.c
@@ -1323,6 +1323,25 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
 
             BSB_EXPORT_rewind(jbsb, 1); // Remove last comma
             BSB_EXPORT_cstr(jbsb, "],");
+
+            break;
+        }
+        case ARKIME_FIELD_TYPE_OBJECT: {
+            ArkimeFieldObjectHashStd_t *ohash = session->fields[pos]->ohash;
+            ArkimeFieldObjectSaveFunc saveCB = config.fields[pos]->object_save;
+            ArkimeFieldObjectFreeFunc freeCB = config.fields[pos]->object_free;
+
+            BSB_EXPORT_sprintf(jbsb, "\"%sCnt\":%d,", config.fields[pos]->dbField, HASH_COUNT(o_, *ohash));
+            BSB_EXPORT_sprintf(jbsb, "\"%s\":[", config.fields[pos]->dbField);
+
+            ArkimeFieldObject_t *object;
+
+            HASH_FORALL_POP_HEAD2(o_, *ohash, object) {
+                saveCB(&jbsb, object);
+                freeCB(object);
+                BSB_EXPORT_u08(jbsb, ',');
+            }
+            ARKIME_TYPE_FREE(ArkimeFieldObjectHashStd_t, ohash);
         }
         } /* switch */
         if (freeField) {

--- a/capture/db.c
+++ b/capture/db.c
@@ -1338,10 +1338,14 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
 
             HASH_FORALL_POP_HEAD2(o_, *ohash, object) {
                 saveCB(&jbsb, object, session);
-                freeCB(object);
+                if (freeField) {
+                    freeCB(object);
+                }
                 BSB_EXPORT_u08(jbsb, ',');
             }
-            ARKIME_TYPE_FREE(ArkimeFieldObjectHashStd_t, ohash);
+            if (freeField) {
+                ARKIME_TYPE_FREE(ArkimeFieldObjectHashStd_t, ohash);
+            }
 
             BSB_EXPORT_rewind(jbsb, 1); // Remove last comma
             BSB_EXPORT_cstr(jbsb, "],");

--- a/capture/db.c
+++ b/capture/db.c
@@ -1342,6 +1342,9 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
                 BSB_EXPORT_u08(jbsb, ',');
             }
             ARKIME_TYPE_FREE(ArkimeFieldObjectHashStd_t, ohash);
+
+            BSB_EXPORT_rewind(jbsb, 1); // Remove last comma
+            BSB_EXPORT_cstr(jbsb, "],");
         }
         } /* switch */
         if (freeField) {

--- a/capture/field.c
+++ b/capture/field.c
@@ -1329,6 +1329,7 @@ void arkime_field_free(ArkimeSession_t *session)
     ArkimeCertsInfoHashStd_t   *cihash;
     ArkimeFieldObject_t        *ho;
     ArkimeFieldObjectHashStd_t *ohash;
+    ArkimeFieldObjectFreeFunc   freeCB;
 
     for (pos = 0; pos < session->maxFields; pos++) {
         ArkimeField_t        *field;
@@ -1384,14 +1385,15 @@ void arkime_field_free(ArkimeSession_t *session)
             }
             ARKIME_TYPE_FREE(ArkimeCertsInfoHashStd_t, cihash);
             break;
-        case ARKIME_FIELD_TYPE_OBJECT:
-            ArkimeFieldObjectFreeFunc freeCB = config.fields[pos]->object_free;
+        case ARKIME_FIELD_TYPE_OBJECT: {
+            freeCB = config.fields[pos]->object_free;
             ohash = session->fields[pos]->ohash;
             HASH_FORALL_POP_HEAD2(o_, *ohash, ho) {
                 freeCB(ho);
             }
             ARKIME_TYPE_FREE(ArkimeFieldObjectHashStd_t, ohash);
-            break;
+        }
+        break;
         } // switch
         ARKIME_TYPE_FREE(ArkimeField_t, session->fields[pos]);
     }

--- a/capture/field.c
+++ b/capture/field.c
@@ -1455,13 +1455,13 @@ void arkime_field_certsinfo_free (ArkimeCertsInfo_t *certs)
     ARKIME_TYPE_FREE(ArkimeCertsInfo_t, certs);
 }
 /******************************************************************************/
-int arkime_field_object_register(const char *name, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp) {
+int arkime_field_object_register(const char *name, const char *help, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp) {
     int object_pos;
     ArkimeFieldInfo_t *object_info;
 
     object_pos = arkime_field_define(name, "notreal",
                                      name, name, name,
-                                     "Object Info", /*TODO: Improve the help string to contain object name*/
+                                     help,
                                      ARKIME_FIELD_TYPE_OBJECT, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_NODB,
                                      (char *)NULL);
 

--- a/capture/field.c
+++ b/capture/field.c
@@ -1467,14 +1467,14 @@ int arkime_field_object_register(const char *name, ArkimeFieldObjectSaveFunc sav
 
     // This should never be the case but better safe than sorry
     if (object_pos == -1) {
-        return -1;
+        LOGEXIT("ERROR - Field object position is %d", object_pos);
     }
 
     object_info = config.fields[object_pos];
 
     // This shouldn't happen but lets be sure
-    if (object_info) {
-        return -1;
+    if (!object_info) {
+        LOGEXIT("ERROR - Field object info is null");
     }
 
     object_info->object_save = save;

--- a/capture/field.c
+++ b/capture/field.c
@@ -1486,7 +1486,7 @@ int arkime_field_object_register(const char *name, ArkimeFieldObjectSaveFunc sav
 }
 gboolean arkime_field_object_add(int pos, ArkimeSession_t *session, ArkimeFieldObject_t *object, int len) {
     ArkimeField_t               *field;
-    ArkimeFieldObjectdHashStd_t *hash;
+    ArkimeFieldObjectHashStd_t  *hash;
     ArkimeFieldObject_t         *ho;
 
     if (!session->fields[pos]) {

--- a/capture/field.c
+++ b/capture/field.c
@@ -1320,13 +1320,15 @@ void arkime_field_macoui_add(ArkimeSession_t *session, int macField, int ouiFiel
 /******************************************************************************/
 void arkime_field_free(ArkimeSession_t *session)
 {
-    int                       pos;
-    ArkimeString_t           *hstring;
-    ArkimeStringHashStd_t    *shash;
-    ArkimeInt_t              *hint;
-    ArkimeIntHashStd_t       *ihash;
-    ArkimeCertsInfo_t        *hci;
-    ArkimeCertsInfoHashStd_t *cihash;
+    int                         pos;
+    ArkimeString_t             *hstring;
+    ArkimeStringHashStd_t      *shash;
+    ArkimeInt_t                *hint;
+    ArkimeIntHashStd_t         *ihash;
+    ArkimeCertsInfo_t          *hci;
+    ArkimeCertsInfoHashStd_t   *cihash;
+    ArkimeFieldObject_t        *ho;
+    ArkimeFieldObjectHashStd_t *ohash;
 
     for (pos = 0; pos < session->maxFields; pos++) {
         ArkimeField_t        *field;
@@ -1381,6 +1383,14 @@ void arkime_field_free(ArkimeSession_t *session)
                 arkime_field_certsinfo_free(hci);
             }
             ARKIME_TYPE_FREE(ArkimeCertsInfoHashStd_t, cihash);
+            break;
+        case ARKIME_FIELD_TYPE_OBJECT:
+            ArkimeFieldObjectFreeFunc freeCB = config.fields[pos]->object_free;
+            ohash = session->fields[pos]->ohash;
+            HASH_FORALL_POP_HEAD2(o_, *ohash, ho) {
+                freeCB(ho);
+            }
+            ARKIME_TYPE_FREE(ArkimeFieldObjectHashStd_t, ohash);
             break;
         } // switch
         ARKIME_TYPE_FREE(ArkimeField_t, session->fields[pos]);
@@ -1445,6 +1455,78 @@ void arkime_field_certsinfo_free (ArkimeCertsInfo_t *certs)
     ARKIME_TYPE_FREE(ArkimeCertsInfo_t, certs);
 }
 /******************************************************************************/
+int arkime_field_object_register(const char *name, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp) {
+    int object_pos;
+    ArkimeFieldInfo_t *object_info;
+
+    object_pos = arkime_field_define(name, "notreal",
+                                     name, name, name,
+                                     "Object Info", /*TODO: Improve the help string to contain object name*/
+                                     ARKIME_FIELD_TYPE_OBJECT, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_NODB,
+                                     (char *)NULL);
+
+    // This should never be the case but better safe than sorry
+    if (object_pos == -1) {
+        return -1;
+    }
+
+    object_info = config.fields[object_pos];
+
+    // This shouldn't happen but lets be sure
+    if (object_info) {
+        return -1;
+    }
+
+    object_info->object_save = save;
+    object_info->object_free = free;
+    object_info->object_hash = hash;
+    object_info->object_cmp = cmp;
+
+    return object_info->pos;
+}
+gboolean arkime_field_object_add(int pos, ArkimeSession_t *session, ArkimeFieldObject_t *object, int len) {
+    ArkimeField_t               *field;
+    ArkimeFieldObjectdHashStd_t *hash;
+    ArkimeFieldObject_t         *ho;
+
+    if (!session->fields[pos]) {
+        field = ARKIME_TYPE_ALLOC(ArkimeField_t);
+        session->fields[pos] = field;
+        // 3 for the quotes and colon
+        // length of the object name
+        // 4 for the brackets and braces
+        // len should be the length of the contents of the object
+        field->jsonSize = 3 + config.fields[pos]->dbFieldLen + 4 + len;
+        switch (config.fields[pos]->type) {
+        case ARKIME_FIELD_TYPE_OBJECT:
+            hash = ARKIME_TYPE_ALLOC(ArkimeFieldObjectHashStd_t);
+            HASH_INIT(o_, *hash, config.fields[pos]->object_hash, config.fields[pos]->object_cmp);
+            field->ohash = hash;
+            HASH_ADD(o_, *hash, object, object);
+            return TRUE;
+        default:
+            LOGEXIT("ERROR - Not a field object %s field", config.fields[pos]->dbField);
+        }
+    }
+
+    field = session->fields[pos];
+    switch (config.fields[pos]->type) {
+    case ARKIME_FIELD_TYPE_OBJECT:
+        HASH_FIND(o_, *(field->ohash), object, ho);
+        if (ho) {
+            return FALSE;
+        }
+        // 3 for braces and comma
+        // len should be the length of contents of the object
+        field->jsonSize += 3 + len;
+        HASH_ADD(o_, *(field->ohash), object, object);
+        return TRUE;
+    default:
+        LOGEXIT("ERROR - Not a field object %s field", config.fields[pos]->dbField);
+    }
+}
+
+/******************************************************************************/
 int arkime_field_count(int pos, ArkimeSession_t *session)
 {
     ArkimeField_t         *field;
@@ -1476,6 +1558,8 @@ int arkime_field_count(int pos, ArkimeSession_t *session)
         return g_hash_table_size(field->ghash);
     case ARKIME_FIELD_TYPE_CERTSINFO:
         return HASH_COUNT(s_, *(field->cihash));
+    case ARKIME_FIELD_TYPE_OBJECT:
+        return HASH_COUNT(o_, *(field->ohash));
     default:
         LOGEXIT("ERROR - Unknown field type for counting %s %d", config.fields[pos]->dbField, config.fields[pos]->type);
     }
@@ -1603,6 +1687,7 @@ void arkime_field_ops_run_match(ArkimeSession_t *session, ArkimeFieldOps_t *ops,
             arkime_field_string_add(fieldPos, session, op->str, op->strLenOrInt, TRUE);
             break;
         case ARKIME_FIELD_TYPE_CERTSINFO:
+        case ARKIME_FIELD_TYPE_OBJECT:
             // Unsupported
             break;
         }

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -153,6 +153,7 @@ void http_common_add_header_value(ArkimeSession_t *session, int pos, const char 
         break;
     }
     case ARKIME_FIELD_TYPE_CERTSINFO:
+    case ARKIME_FIELD_TYPE_OBJECT:
         // Unsupported
         break;
     } /* SWITCH */

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -136,6 +136,7 @@ LOCAL void smtp_email_add_value(ArkimeSession_t *session, int pos, char *s, int 
         break;
     }
     case ARKIME_FIELD_TYPE_CERTSINFO:
+    case ARKIME_FIELD_TYPE_OBJECT:
         // Unsupported
         break;
     } /* SWITCH */

--- a/capture/plugins/scrubspi.c
+++ b/capture/plugins/scrubspi.c
@@ -102,6 +102,7 @@ LOCAL void scrubspi_plugin_save(ArkimeSession_t *session, int UNUSED(final))
         case ARKIME_FIELD_TYPE_IP:
         case ARKIME_FIELD_TYPE_IP_GHASH:
         case ARKIME_FIELD_TYPE_CERTSINFO:
+        case ARKIME_FIELD_TYPE_OBJECT:
             // Unsupported
             break;
         } /* switch */

--- a/capture/plugins/wise.c
+++ b/capture/plugins/wise.c
@@ -800,6 +800,7 @@ void wise_plugin_pre_save(ArkimeSession_t *session, int UNUSED(final))
                         wise_lookup(session, iRequest, ikey, type, pos);
                 }
             case ARKIME_FIELD_TYPE_CERTSINFO:
+            case ARKIME_FIELD_TYPE_OBJECT:
                 // Unsupported
                 break;
             } /* switch */

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -386,6 +386,7 @@ LOCAL void arkime_rules_load_add_field(ArkimeRule_t *rule, int pos, char *key)
         }
         break;
     case ARKIME_FIELD_TYPE_CERTSINFO:
+    case ARKIME_FIELD_TYPE_OBJECT:
         // Unsupported
         break;
     }
@@ -618,6 +619,9 @@ LOCAL void arkime_rules_parser_load_rule(char *filename, YamlNode_t *parent)
 
             case ARKIME_FIELD_TYPE_CERTSINFO:
                 CONFIGEXIT("%s: Currently don't support any certs fields", filename);
+                break;
+            case ARKIME_FIELD_TYPE_OBJECT:
+                CONFIGEXIT("%s: Currently don't support any generic object fields", filename);
             }
 
             if (node->value) {
@@ -1134,6 +1138,7 @@ LOCAL void arkime_rules_check_rule_fields(ArkimeSession_t *const session, Arkime
                 RULE_LOG_INT(HASH_COUNT(s_, *shash));
                 break;
             case ARKIME_FIELD_TYPE_CERTSINFO:
+            case ARKIME_FIELD_TYPE_OBJECT:
                 // Unsupported
                 break;
             } /* switch */
@@ -1259,6 +1264,7 @@ LOCAL void arkime_rules_check_rule_fields(ArkimeSession_t *const session, Arkime
             }
             break;
         case ARKIME_FIELD_TYPE_CERTSINFO:
+        case ARKIME_FIELD_TYPE_OBJECT:
             // Unsupported
             break;
         } /* switch */


### PR DESCRIPTION
**Clearly describe the problem and solution**

Their currently isn't an easy way to define a generic object field, something akin to the TLS certs field which isn't generic at all.

The proposed solution is discussed in issue #2664.

**Relevant issue number(s) if applicable**

#2664 

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

No, since viewer or parliament aren't touched.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
