### PR TITLE
TLS certs using new generic object type field instead of ARKIME_FIELD_TYPE_CERTSINFO

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -131,6 +131,32 @@ typedef struct arkime_trie {
 
 /******************************************************************************/
 /*
+ * Certs Info
+ */
+
+typedef struct {
+    ArkimeStringHead_t  commonName; // 2.5.4.3
+    ArkimeStringHead_t  orgName;    // 2.5.4.10
+    ArkimeStringHead_t  orgUnit;    // 2.5.4.11
+    char                orgUtf8;
+} ArkimeCertInfo_t;
+
+typedef struct arkime_certsinfo {
+    uint64_t                 notBefore;
+    uint64_t                 notAfter;
+    ArkimeCertInfo_t         issuer;
+    ArkimeCertInfo_t         subject;
+    ArkimeStringHead_t       alt;
+    uint8_t                 *serialNumber;
+    short                    serialNumberLen;
+    uint8_t                  hash[60];
+    char                     isCA;
+    const char              *publicAlgorithm;
+    const char              *curve;
+    GHashTable              *extra;
+} ArkimeCertsInfo_t;
+/******************************************************************************/
+/*
  * Generic object field type
  */
 
@@ -1315,6 +1341,7 @@ gboolean arkime_field_float_add(int pos, ArkimeSession_t *session, float f);
 void arkime_field_macoui_add(ArkimeSession_t *session, int macField, int ouiField, const uint8_t *mac);
 
 int  arkime_field_count(int pos, ArkimeSession_t *session);
+void arkime_field_certsinfo_update_extra (ArkimeCertsInfo_t *certs, char *key, char *value);
 void arkime_field_free(ArkimeSession_t *session);
 void arkime_field_exit();
 

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -131,44 +131,6 @@ typedef struct arkime_trie {
 
 /******************************************************************************/
 /*
- * Certs Info
- */
-
-typedef struct {
-    ArkimeStringHead_t  commonName; // 2.5.4.3
-    ArkimeStringHead_t  orgName;    // 2.5.4.10
-    ArkimeStringHead_t  orgUnit;    // 2.5.4.11
-    char                orgUtf8;
-} ArkimeCertInfo_t;
-
-typedef struct arkime_certsinfo {
-    struct arkime_certsinfo *t_next, *t_prev;
-    uint32_t                 t_hash;
-    uint64_t                 notBefore;
-    uint64_t                 notAfter;
-    ArkimeCertInfo_t         issuer;
-    ArkimeCertInfo_t         subject;
-    ArkimeStringHead_t       alt;
-    uint8_t                 *serialNumber;
-    short                    serialNumberLen;
-    short                    t_bucket;
-    uint8_t                  hash[60];
-    char                     isCA;
-    const char              *publicAlgorithm;
-    const char              *curve;
-    GHashTable              *extra;
-} ArkimeCertsInfo_t;
-
-typedef struct {
-    struct arkime_certsinfo *t_next, *t_prev;
-    int                      t_count;
-} ArkimeCertsInfoHead_t;
-
-typedef HASH_VAR(s_, ArkimeCertsInfoHash_t, ArkimeCertsInfoHead_t, 1);
-typedef HASH_VAR(s_, ArkimeCertsInfoHashStd_t, ArkimeCertsInfoHead_t, 5);
-
-/******************************************************************************/
-/*
  * Generic object field type
  */
 
@@ -210,7 +172,6 @@ typedef enum {
     ARKIME_FIELD_TYPE_STR_GHASH,
     ARKIME_FIELD_TYPE_IP,
     ARKIME_FIELD_TYPE_IP_GHASH,
-    ARKIME_FIELD_TYPE_CERTSINFO,
     ARKIME_FIELD_TYPE_FLOAT,
     ARKIME_FIELD_TYPE_FLOAT_ARRAY,
     ARKIME_FIELD_TYPE_FLOAT_GHASH,
@@ -288,7 +249,6 @@ typedef struct {
         ArkimeIntHashStd_t         *ihash;
         float                       f;
         GArray                     *farray;
-        ArkimeCertsInfoHashStd_t   *cihash;
         GHashTable                 *ghash;
         struct in6_addr            *ip;
         ArkimeFieldObjectHashStd_t *ohash;
@@ -1351,13 +1311,10 @@ gboolean arkime_field_int_add(int pos, ArkimeSession_t *session, int i);
 gboolean arkime_field_ip4_add(int pos, ArkimeSession_t *session, uint32_t i);
 gboolean arkime_field_ip6_add(int pos, ArkimeSession_t *session, const uint8_t *val);
 gboolean arkime_field_ip_add_str(int pos, ArkimeSession_t *session, const char *str);
-gboolean arkime_field_certsinfo_add(int pos, ArkimeSession_t *session, ArkimeCertsInfo_t *certs, int len);
 gboolean arkime_field_float_add(int pos, ArkimeSession_t *session, float f);
 void arkime_field_macoui_add(ArkimeSession_t *session, int macField, int ouiField, const uint8_t *mac);
 
 int  arkime_field_count(int pos, ArkimeSession_t *session);
-void arkime_field_certsinfo_update_extra (ArkimeCertsInfo_t *certs, char *key, char *value);
-void arkime_field_certsinfo_free (ArkimeCertsInfo_t *certs);
 void arkime_field_free(ArkimeSession_t *session);
 void arkime_field_exit();
 

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -131,32 +131,6 @@ typedef struct arkime_trie {
 
 /******************************************************************************/
 /*
- * Certs Info
- */
-
-typedef struct {
-    ArkimeStringHead_t  commonName; // 2.5.4.3
-    ArkimeStringHead_t  orgName;    // 2.5.4.10
-    ArkimeStringHead_t  orgUnit;    // 2.5.4.11
-    char                orgUtf8;
-} ArkimeCertInfo_t;
-
-typedef struct arkime_certsinfo {
-    uint64_t                 notBefore;
-    uint64_t                 notAfter;
-    ArkimeCertInfo_t         issuer;
-    ArkimeCertInfo_t         subject;
-    ArkimeStringHead_t       alt;
-    uint8_t                 *serialNumber;
-    short                    serialNumberLen;
-    uint8_t                  hash[60];
-    char                     isCA;
-    const char              *publicAlgorithm;
-    const char              *curve;
-    GHashTable              *extra;
-} ArkimeCertsInfo_t;
-/******************************************************************************/
-/*
  * Generic object field type
  */
 
@@ -918,6 +892,7 @@ gboolean arkime_db_file_exists(const char *filename, uint32_t *outputId);
 void     arkime_db_exit();
 void     arkime_db_oui_lookup(int field, ArkimeSession_t *session, const uint8_t *mac);
 gchar   *arkime_db_community_id(ArkimeSession_t *session);
+void     arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8);
 
 
 // Replace how SPI data is sent to ES.
@@ -1341,7 +1316,7 @@ gboolean arkime_field_float_add(int pos, ArkimeSession_t *session, float f);
 void arkime_field_macoui_add(ArkimeSession_t *session, int macField, int ouiField, const uint8_t *mac);
 
 int  arkime_field_count(int pos, ArkimeSession_t *session);
-void arkime_field_certsinfo_update_extra (ArkimeCertsInfo_t *certs, char *key, char *value);
+void arkime_field_certsinfo_update_extra (void *cert, char *key, char *value);
 void arkime_field_free(ArkimeSession_t *session);
 void arkime_field_exit();
 

--- a/capture/db.c
+++ b/capture/db.c
@@ -477,7 +477,7 @@ if (HEAD.s_count > 0) { \
 
 #define SAVE_STRING_HEAD_CNT(HEAD, CNT) \
 if (HEAD.s_count > 0) { \
-    BSB_EXPORT_sprintf(jbsb, "\"" CNT "\":%d,", certs->alt.s_count); \
+    BSB_EXPORT_sprintf(jbsb, "\"" CNT "\":%d,", HEAD.s_count); \
 }
 
 #define SAVE_FIELD_STR_HASH(POS, FLAGS) \
@@ -1250,79 +1250,6 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
             if (freeField) {
                 g_hash_table_destroy(ghash);
             }
-
-            break;
-        }
-        case ARKIME_FIELD_TYPE_CERTSINFO: {
-            ArkimeCertsInfoHashStd_t *cihash = session->fields[pos]->cihash;
-
-            BSB_EXPORT_sprintf(jbsb, "\"certCnt\":%d,", HASH_COUNT(t_, *cihash));
-            BSB_EXPORT_cstr(jbsb, "\"cert\":[");
-
-            ArkimeCertsInfo_t *certs;
-            ArkimeString_t *string;
-
-            HASH_FORALL_POP_HEAD2(t_, *cihash, certs) {
-                BSB_EXPORT_u08(jbsb, '{');
-
-                BSB_EXPORT_sprintf(jbsb, "\"hash\":\"%s\",", certs->hash);
-
-                if (certs->publicAlgorithm)
-                    BSB_EXPORT_sprintf(jbsb, "\"publicAlgorithm\":\"%s\",", certs->publicAlgorithm);
-                if (certs->curve)
-                    BSB_EXPORT_sprintf(jbsb, "\"curve\":\"%s\",", certs->curve);
-
-                SAVE_STRING_HEAD(certs->issuer.commonName, "issuerCN");
-                SAVE_STRING_HEAD(certs->issuer.orgName, "issuerON");
-                SAVE_STRING_HEAD(certs->issuer.orgUnit, "issuerOU");
-                SAVE_STRING_HEAD(certs->subject.commonName, "subjectCN");
-                SAVE_STRING_HEAD(certs->subject.orgName, "subjectON");
-                SAVE_STRING_HEAD(certs->subject.orgUnit, "subjectOU");
-
-                if (certs->serialNumber) {
-                    int k;
-                    BSB_EXPORT_cstr(jbsb, "\"serial\":\"");
-                    for (k = 0; k < certs->serialNumberLen; k++) {
-                        BSB_EXPORT_sprintf(jbsb, "%02x", certs->serialNumber[k]);
-                    }
-                    BSB_EXPORT_u08(jbsb, '"');
-                    BSB_EXPORT_u08(jbsb, ',');
-                }
-
-                SAVE_STRING_HEAD_CNT(certs->alt, "altCnt");
-                SAVE_STRING_HEAD(certs->alt, "alt");
-
-                BSB_EXPORT_sprintf(jbsb, "\"notBefore\":%" PRId64 ",", certs->notBefore * 1000);
-                BSB_EXPORT_sprintf(jbsb, "\"notAfter\":%" PRId64 ",", certs->notAfter * 1000);
-                if (certs->notAfter < ((uint64_t)session->firstPacket.tv_sec)) {
-                    BSB_EXPORT_sprintf(jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)0));
-                    BSB_EXPORT_sprintf(jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)0));
-                } else {
-                    BSB_EXPORT_sprintf(jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)certs->notAfter - ((uint64_t)session->firstPacket.tv_sec)) / (60 * 60 * 24));
-                    BSB_EXPORT_sprintf(jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)certs->notAfter - ((uint64_t)session->firstPacket.tv_sec)));
-                }
-                BSB_EXPORT_sprintf(jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)certs->notAfter - (int64_t)certs->notBefore) / (60 * 60 * 24));
-                BSB_EXPORT_sprintf(jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)certs->notAfter - (int64_t)certs->notBefore));
-
-                if (certs->extra) {
-                    g_hash_table_iter_init (&iter, certs->extra);
-                    while (g_hash_table_iter_next (&iter, &ikey, &ival)) {
-                        BSB_EXPORT_sprintf(jbsb, "\"%s\":\"%s\",", (char *)ikey, (char *)ival);
-                    }
-                }
-
-                BSB_EXPORT_rewind(jbsb, 1); // Remove last comma
-
-                arkime_field_certsinfo_free(certs);
-                i++;
-
-                BSB_EXPORT_u08(jbsb, '}');
-                BSB_EXPORT_u08(jbsb, ',');
-            }
-            ARKIME_TYPE_FREE(ArkimeCertsInfoHashStd_t, cihash);
-
-            BSB_EXPORT_rewind(jbsb, 1); // Remove last comma
-            BSB_EXPORT_cstr(jbsb, "],");
 
             break;
         }

--- a/capture/db.c
+++ b/capture/db.c
@@ -477,7 +477,7 @@ if (HEAD.s_count > 0) { \
 
 #define SAVE_STRING_HEAD_CNT(HEAD, CNT) \
 if (HEAD.s_count > 0) { \
-    BSB_EXPORT_sprintf(jbsb, "\"" CNT "\":%d,", HEAD.s_count); \
+    BSB_EXPORT_sprintf(jbsb, "\"" CNT "\":%d,", certs->alt.s_count); \
 }
 
 #define SAVE_FIELD_STR_HASH(POS, FLAGS) \
@@ -518,7 +518,6 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
     const uint8_t         *dataPtr;
     uint32_t               jsonSize;
     gpointer               ikey;
-    gpointer               ival;
     char                   ipsrc[INET6_ADDRSTRLEN];
     char                   ipdst[INET6_ADDRSTRLEN];
 

--- a/capture/db.c
+++ b/capture/db.c
@@ -150,7 +150,7 @@ LOCAL ArkimeIpInfo_t *arkime_db_get_override_ip6(ArkimeSession_t *session, struc
 }
 
 /******************************************************************************/
-LOCAL void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
+void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
 {
     BSB_EXPORT_u08(*bsb, '"');
     while (*in) {
@@ -1276,6 +1276,7 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
             BSB_EXPORT_rewind(jbsb, 1); // Remove last comma
             BSB_EXPORT_cstr(jbsb, "],");
         }
+        break;
         } /* switch */
         if (freeField) {
             ARKIME_TYPE_FREE(ArkimeField_t, session->fields[pos]);

--- a/capture/field.c
+++ b/capture/field.c
@@ -1260,6 +1260,13 @@ void arkime_field_free(ArkimeSession_t *session)
     session->fields = 0;
 }
 /******************************************************************************/
+void arkime_field_certsinfo_update_extra (ArkimeCertsInfo_t *certs, char *key, char *value)
+{
+    if (!certs->extra)
+        certs->extra = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+    g_hash_table_replace(certs->extra, key, value);
+}
 int arkime_field_object_register(const char *name, const char *help, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp) {
     int object_pos;
     ArkimeFieldInfo_t *object_info;

--- a/capture/field.c
+++ b/capture/field.c
@@ -1170,138 +1170,6 @@ added:
     return TRUE;
 }
 /******************************************************************************/
-SUPPRESS_UNSIGNED_INTEGER_OVERFLOW
-SUPPRESS_SHIFT
-SUPPRESS_INT_CONVERSION
-uint32_t arkime_field_certsinfo_hash(const void *key)
-{
-    ArkimeCertsInfo_t *ci = (ArkimeCertsInfo_t *)key;
-
-    if (ci->serialNumberLen == 0) {
-        return ((ci->issuer.commonName.s_count << 18) |
-                (ci->issuer.orgName.s_count << 12) |
-                (ci->subject.commonName.s_count << 6) |
-                (ci->subject.orgName.s_count));
-    }
-    return ((ci->serialNumber[0] << 28) |
-            (ci->serialNumber[ci->serialNumberLen - 1] << 24) |
-            (ci->issuer.commonName.s_count << 18) |
-            (ci->issuer.orgName.s_count << 12) |
-            (ci->subject.commonName.s_count << 6) |
-            (ci->subject.orgName.s_count));
-}
-
-/******************************************************************************/
-int arkime_field_certsinfo_cmp(const void *keyv, const void *elementv)
-{
-    ArkimeCertsInfo_t *key = (ArkimeCertsInfo_t *)keyv;
-    ArkimeCertsInfo_t *element = (ArkimeCertsInfo_t *)elementv;
-
-    // Make sure all the easy things to check are the same
-    if ( !((key->serialNumberLen == element->serialNumberLen) &&
-           (memcmp(key->serialNumber, element->serialNumber, element->serialNumberLen) == 0) &&
-           (key->issuer.commonName.s_count == element->issuer.commonName.s_count) &&
-           (key->issuer.orgName.s_count == element->issuer.orgName.s_count) &&
-           (key->issuer.orgUnit.s_count == element->issuer.orgUnit.s_count) &&
-           (key->subject.commonName.s_count == element->subject.commonName.s_count) &&
-           (key->subject.orgName.s_count == element->subject.orgName.s_count) &&
-           (key->subject.orgUnit.s_count == element->subject.orgUnit.s_count)
-          )
-       ) {
-
-        return 0;
-    }
-
-    // Now see if all the other items are the same
-
-    ArkimeString_t *kstr, *estr;
-    for (kstr = key->issuer.commonName.s_next, estr = element->issuer.commonName.s_next;
-         kstr != (void *) & (key->issuer.commonName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = key->issuer.orgName.s_next, estr = element->issuer.orgName.s_next;
-         kstr != (void *) & (key->issuer.orgName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = key->issuer.orgUnit.s_next, estr = element->issuer.orgUnit.s_next;
-         kstr != (void *) & (key->issuer.orgUnit);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = key->subject.commonName.s_next, estr = element->subject.commonName.s_next;
-         kstr != (void *) & (key->subject.commonName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = key->subject.orgName.s_next, estr = element->subject.orgName.s_next;
-         kstr != (void *) & (key->subject.orgName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = key->subject.orgUnit.s_next, estr = element->subject.orgUnit.s_next;
-         kstr != (void *) & (key->subject.orgUnit);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    return 1;
-}
-/******************************************************************************/
-gboolean arkime_field_certsinfo_add(int pos, ArkimeSession_t *session, ArkimeCertsInfo_t *certs, int len)
-{
-    ArkimeField_t             *field;
-    ArkimeCertsInfoHashStd_t   *hash;
-    ArkimeCertsInfo_t          *hci;
-
-    if (!session->fields[pos]) {
-        field = ARKIME_TYPE_ALLOC(ArkimeField_t);
-        session->fields[pos] = field;
-        field->jsonSize = 3 + config.fields[pos]->dbFieldLen + 120 + len;
-        switch (config.fields[pos]->type) {
-        case ARKIME_FIELD_TYPE_CERTSINFO:
-            hash = ARKIME_TYPE_ALLOC(ArkimeCertsInfoHashStd_t);
-            HASH_INIT(t_, *hash, arkime_field_certsinfo_hash, arkime_field_certsinfo_cmp);
-            field->cihash = hash;
-            HASH_ADD(t_, *hash, certs, certs);
-            return TRUE;
-        default:
-            LOGEXIT("ERROR - Not a certsinfo %s field", config.fields[pos]->dbField);
-        }
-    }
-
-    field = session->fields[pos];
-    switch (config.fields[pos]->type) {
-    case ARKIME_FIELD_TYPE_CERTSINFO:
-        HASH_FIND(t_, *(field->cihash), certs, hci);
-        if (hci)
-            return FALSE;
-        field->jsonSize += 3 + 120 + len;
-        HASH_ADD(t_, *(field->cihash), certs, certs);
-        return TRUE;
-    default:
-        LOGEXIT("ERROR - Not a certsinfo %s field", config.fields[pos]->dbField);
-    }
-}
-/******************************************************************************/
 void arkime_field_macoui_add(ArkimeSession_t *session, int macField, int ouiField, const uint8_t *mac)
 {
     char str[20];
@@ -1325,8 +1193,6 @@ void arkime_field_free(ArkimeSession_t *session)
     ArkimeStringHashStd_t      *shash;
     ArkimeInt_t                *hint;
     ArkimeIntHashStd_t         *ihash;
-    ArkimeCertsInfo_t          *hci;
-    ArkimeCertsInfoHashStd_t   *cihash;
     ArkimeFieldObject_t        *ho;
     ArkimeFieldObjectHashStd_t *ohash;
     ArkimeFieldObjectFreeFunc   freeCB;
@@ -1378,13 +1244,6 @@ void arkime_field_free(ArkimeSession_t *session)
         case ARKIME_FIELD_TYPE_FLOAT_GHASH:
             g_hash_table_destroy(session->fields[pos]->ghash);
             break;
-        case ARKIME_FIELD_TYPE_CERTSINFO:
-            cihash = session->fields[pos]->cihash;
-            HASH_FORALL_POP_HEAD2(t_, *cihash, hci) {
-                arkime_field_certsinfo_free(hci);
-            }
-            ARKIME_TYPE_FREE(ArkimeCertsInfoHashStd_t, cihash);
-            break;
         case ARKIME_FIELD_TYPE_OBJECT: {
             freeCB = config.fields[pos]->object_free;
             ohash = session->fields[pos]->ohash;
@@ -1399,62 +1258,6 @@ void arkime_field_free(ArkimeSession_t *session)
     }
     ARKIME_SIZE_FREE(fields, session->fields);
     session->fields = 0;
-}
-/******************************************************************************/
-void arkime_field_certsinfo_update_extra (ArkimeCertsInfo_t *certs, char *key, char *value)
-{
-    if (!certs->extra)
-        certs->extra = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
-
-    g_hash_table_replace(certs->extra, key, value);
-}
-/******************************************************************************/
-void arkime_field_certsinfo_free (ArkimeCertsInfo_t *certs)
-{
-    ArkimeString_t *string;
-
-    while (DLL_POP_HEAD(s_, &certs->alt, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &certs->issuer.commonName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &certs->issuer.orgName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &certs->issuer.orgUnit, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &certs->subject.commonName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &certs->subject.orgName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &certs->subject.orgUnit, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    if (certs->serialNumber)
-        free(certs->serialNumber);
-
-    if (certs->extra)
-        g_hash_table_destroy(certs->extra);
-
-    ARKIME_TYPE_FREE(ArkimeCertsInfo_t, certs);
 }
 /******************************************************************************/
 int arkime_field_object_register(const char *name, const char *help, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp) {
@@ -1558,8 +1361,6 @@ int arkime_field_count(int pos, ArkimeSession_t *session)
     case ARKIME_FIELD_TYPE_INT_GHASH:
     case ARKIME_FIELD_TYPE_STR_GHASH:
         return g_hash_table_size(field->ghash);
-    case ARKIME_FIELD_TYPE_CERTSINFO:
-        return HASH_COUNT(s_, *(field->cihash));
     case ARKIME_FIELD_TYPE_OBJECT:
         return HASH_COUNT(o_, *(field->ohash));
     default:
@@ -1688,7 +1489,6 @@ void arkime_field_ops_run_match(ArkimeSession_t *session, ArkimeFieldOps_t *ops,
         case ARKIME_FIELD_TYPE_STR_GHASH:
             arkime_field_string_add(fieldPos, session, op->str, op->strLenOrInt, TRUE);
             break;
-        case ARKIME_FIELD_TYPE_CERTSINFO:
         case ARKIME_FIELD_TYPE_OBJECT:
             // Unsupported
             break;

--- a/capture/field.c
+++ b/capture/field.c
@@ -1260,14 +1260,8 @@ void arkime_field_free(ArkimeSession_t *session)
     session->fields = 0;
 }
 /******************************************************************************/
-void arkime_field_certsinfo_update_extra (ArkimeCertsInfo_t *certs, char *key, char *value)
+int arkime_field_object_register(const char *name, const char *help, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp)
 {
-    if (!certs->extra)
-        certs->extra = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
-
-    g_hash_table_replace(certs->extra, key, value);
-}
-int arkime_field_object_register(const char *name, const char *help, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp) {
     int object_pos;
     ArkimeFieldInfo_t *object_info;
 
@@ -1296,7 +1290,9 @@ int arkime_field_object_register(const char *name, const char *help, ArkimeField
 
     return object_info->pos;
 }
-gboolean arkime_field_object_add(int pos, ArkimeSession_t *session, ArkimeFieldObject_t *object, int len) {
+/******************************************************************************/
+gboolean arkime_field_object_add(int pos, ArkimeSession_t *session, ArkimeFieldObject_t *object, int len)
+{
     ArkimeField_t               *field;
     ArkimeFieldObjectHashStd_t  *hash;
     ArkimeFieldObject_t         *ho;

--- a/capture/parsers/certs_internal.c
+++ b/capture/parsers/certs_internal.c
@@ -1,0 +1,311 @@
+#include "arkime.h"
+
+
+#define SAVE_STRING_HEAD(HEAD, STR) \
+if (HEAD.s_count > 0) { \
+    BSB_EXPORT_cstr(*jbsb, "\"" STR "\":["); \
+    while (HEAD.s_count > 0) { \
+	DLL_POP_HEAD(s_, &HEAD, string); \
+	arkime_db_js0n_str(&*jbsb, (uint8_t *)string->str, string->utf8); \
+	BSB_EXPORT_u08(*jbsb, ','); \
+	g_free(string->str); \
+	ARKIME_TYPE_FREE(ArkimeString_t, string); \
+    } \
+    BSB_EXPORT_rewind(*jbsb, 1); \
+    BSB_EXPORT_u08(*jbsb, ']'); \
+    BSB_EXPORT_u08(*jbsb, ','); \
+}
+/******************************************************************************/
+LOCAL void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
+{
+    BSB_EXPORT_u08(*bsb, '"');
+    while (*in) {
+        switch(*in) {
+        case '\b':
+            BSB_EXPORT_cstr(*bsb, "\\b");
+            break;
+        case '\n':
+            BSB_EXPORT_cstr(*bsb, "\\n");
+            break;
+        case '\r':
+            BSB_EXPORT_cstr(*bsb, "\\r");
+            break;
+        case '\f':
+            BSB_EXPORT_cstr(*bsb, "\\f");
+            break;
+        case '\t':
+            BSB_EXPORT_cstr(*bsb, "\\t");
+            break;
+        case '"':
+            BSB_EXPORT_cstr(*bsb, "\\\"");
+            break;
+        case '\\':
+            BSB_EXPORT_cstr(*bsb, "\\\\");
+            break;
+        case '/':
+            BSB_EXPORT_cstr(*bsb, "\\/");
+            break;
+        default:
+            if(*in < 32) {
+                BSB_EXPORT_sprintf(*bsb, "\\u%04x", *in);
+            } else if (utf8) {
+                if ((*in & 0xf0) == 0xf0) {
+                    if (!in[1] || !in[2] || !in[3]) goto end;
+                    BSB_EXPORT_ptr(*bsb, in, 4);
+                    in += 3;
+                } else if ((*in & 0xf0) == 0xe0) {
+                    if (!in[1] || !in[2]) goto end;
+                    BSB_EXPORT_ptr(*bsb, in, 3);
+                    in += 2;
+                } else if ((*in & 0xf0) == 0xd0) {
+                    if (!in[1]) goto end;
+                    BSB_EXPORT_ptr(*bsb, in, 2);
+                    in += 1;
+                } else {
+                    BSB_EXPORT_u08(*bsb, *in);
+                }
+            } else {
+                if(*in & 0x80) {
+                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
+                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
+                } else {
+                    BSB_EXPORT_u08(*bsb, *in);
+                }
+            }
+            break;
+        }
+        in++;
+    }
+
+end:
+    BSB_EXPORT_u08(*bsb, '"');
+}
+/******************************************************************************/
+void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session) {
+    if (object->object == NULL) {
+        return;
+    }
+
+    ArkimeCertsInfo_t *ci = (ArkimeCertsInfo_t *)object->object;
+
+    ArkimeString_t *string;
+
+    BSB_EXPORT_u08(*jbsb, '{');
+
+    BSB_EXPORT_sprintf(*jbsb, "\"hash\":\"%s\",", ci->hash);
+
+    if (ci->publicAlgorithm)
+        BSB_EXPORT_sprintf(*jbsb, "\"publicAlgorithm\":\"%s\",", ci->publicAlgorithm);
+    if (ci->curve)
+        BSB_EXPORT_sprintf(*jbsb, "\"curve\":\"%s\",", ci->curve);
+
+    SAVE_STRING_HEAD(ci->issuer.commonName, "issuerCN");
+    SAVE_STRING_HEAD(ci->issuer.orgName, "issuerON");
+    SAVE_STRING_HEAD(ci->issuer.orgUnit, "issuerOU");
+    SAVE_STRING_HEAD(ci->subject.commonName, "subjectCN");
+    SAVE_STRING_HEAD(ci->subject.orgName, "subjectON");
+    SAVE_STRING_HEAD(ci->subject.orgUnit, "subjectOU");
+
+    if (ci->serialNumber) {
+        int k;
+        BSB_EXPORT_cstr(*jbsb, "\"serial\":\"");
+        for (k = 0; k < ci->serialNumberLen; k++) {
+            BSB_EXPORT_sprintf(*jbsb, "%02x", ci->serialNumber[k]);
+        }
+        BSB_EXPORT_u08(*jbsb, '"');
+        BSB_EXPORT_u08(*jbsb, ',');
+    }
+
+    if (ci->alt.s_count > 0) { \
+        BSB_EXPORT_sprintf(*jbsb, "\"altCnt\":%d,", ci->alt.s_count); \
+    }
+    SAVE_STRING_HEAD(ci->alt, "alt");
+
+    BSB_EXPORT_sprintf(*jbsb, "\"notBefore\":%" PRId64 ",", ci->notBefore * 1000);
+    BSB_EXPORT_sprintf(*jbsb, "\"notAfter\":%" PRId64 ",", ci->notAfter * 1000);
+    if (ci->notAfter < ((uint64_t)session->firstPacket.tv_sec)) {
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)0));
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)0));
+    } else {
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)) / (60 * 60 * 24));
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)));
+    }
+    BSB_EXPORT_sprintf(*jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore) / (60 * 60 * 24));
+    BSB_EXPORT_sprintf(*jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore));
+
+    if (ci->extra) {
+        GHashTableIter         iter;
+        gpointer               ikey;
+        gpointer               ival;
+        g_hash_table_iter_init (&iter, ci->extra);
+        while (g_hash_table_iter_next (&iter, &ikey, &ival)) {
+            BSB_EXPORT_sprintf(*jbsb, "\"%s\":\"%s\",", (char *)ikey, (char *)ival);
+        }
+    }
+
+    BSB_EXPORT_rewind(*jbsb, 1); // Remove last comma
+
+    BSB_EXPORT_u08(*jbsb, '}');
+}
+
+void certinfo_free(ArkimeFieldObject_t *object) {
+    if (object->object == NULL) {
+        ARKIME_TYPE_FREE(ArkimeFieldObject_t, object);
+        return;
+    }
+
+    ArkimeCertsInfo_t *ci = (ArkimeCertsInfo_t *)object->object;
+
+    ArkimeString_t *string;
+
+    while (DLL_POP_HEAD(s_, &ci->alt, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.commonName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.orgName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.orgUnit, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.commonName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.orgName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.orgUnit, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    if (ci->serialNumber)
+        free(ci->serialNumber);
+
+    ARKIME_TYPE_FREE(ArkimeCertsInfo_t, ci);
+    ARKIME_TYPE_FREE(ArkimeFieldObject_t, object);
+}
+
+SUPPRESS_UNSIGNED_INTEGER_OVERFLOW
+SUPPRESS_SHIFT
+SUPPRESS_INT_CONVERSION
+uint32_t certinfo_hash(const void *key) {
+    ArkimeFieldObject_t *obj = (ArkimeFieldObject_t *)key;
+    
+    ArkimeCertsInfo_t *ci;
+
+    if (obj->object == NULL) {
+        return 0;
+    }
+    
+    ci = (ArkimeCertsInfo_t *)obj->object;
+
+    if (ci->serialNumberLen == 0) {
+        return ((ci->issuer.commonName.s_count << 18) |
+                (ci->issuer.orgName.s_count << 12) |
+                (ci->subject.commonName.s_count << 6) |
+                (ci->subject.orgName.s_count));
+    }
+    return ((ci->serialNumber[0] << 28) |
+            (ci->serialNumber[ci->serialNumberLen - 1] << 24) |
+            (ci->issuer.commonName.s_count << 18) |
+            (ci->issuer.orgName.s_count << 12) |
+            (ci->subject.commonName.s_count << 6) |
+            (ci->subject.orgName.s_count));
+}
+
+int certinfo_cmp(const void *keyv, const void *elementv) {
+    ArkimeFieldObject_t *key      = (ArkimeFieldObject_t *)keyv;
+    ArkimeFieldObject_t *element = (ArkimeFieldObject_t *)elementv;
+
+    ArkimeCertsInfo_t *keyCI, *elementCI;
+
+    if (key->object == NULL || element->object == NULL) {
+        return 0;
+    }
+
+    keyCI = (ArkimeCertsInfo_t *)key->object;
+    elementCI = (ArkimeCertsInfo_t *)element->object;
+
+    // Make sure all the easy things to check are the same
+    if ( !((keyCI->serialNumberLen == elementCI->serialNumberLen) &&
+           (memcmp(keyCI->serialNumber, elementCI->serialNumber, elementCI->serialNumberLen) == 0) &&
+           (keyCI->issuer.commonName.s_count == elementCI->issuer.commonName.s_count) &&
+           (keyCI->issuer.orgName.s_count == elementCI->issuer.orgName.s_count) &&
+           (keyCI->issuer.orgUnit.s_count == elementCI->issuer.orgUnit.s_count) &&
+           (keyCI->subject.commonName.s_count == elementCI->subject.commonName.s_count) &&
+           (keyCI->subject.orgName.s_count == elementCI->subject.orgName.s_count) &&
+           (keyCI->subject.orgUnit.s_count == elementCI->subject.orgUnit.s_count)
+          )
+       ) {
+
+        return 0;
+    }
+
+    // Now see if all the other items are the same
+
+    ArkimeString_t *kstr, *estr;
+    for (kstr = keyCI->issuer.commonName.s_next, estr = elementCI->issuer.commonName.s_next;
+         kstr != (void *) & (keyCI->issuer.commonName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->issuer.orgName.s_next, estr = elementCI->issuer.orgName.s_next;
+         kstr != (void *) & (keyCI->issuer.orgName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->issuer.orgUnit.s_next, estr = elementCI->issuer.orgUnit.s_next;
+         kstr != (void *) & (keyCI->issuer.orgUnit);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.commonName.s_next, estr = elementCI->subject.commonName.s_next;
+         kstr != (void *) & (keyCI->subject.commonName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.orgName.s_next, estr = elementCI->subject.orgName.s_next;
+         kstr != (void *) & (keyCI->subject.orgName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.orgUnit.s_next, estr = elementCI->subject.orgUnit.s_next;
+         kstr != (void *) & (keyCI->subject.orgUnit);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    return 1;
+}

--- a/capture/parsers/certs_internals.h
+++ b/capture/parsers/certs_internals.h
@@ -1,5 +1,36 @@
-#include "arkime.h"
+/* Copyright 2023 AOL Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
+/******************************************************************************/
+/*
+ * Certs Info
+ */
+
+typedef struct {
+    ArkimeStringHead_t  commonName; // 2.5.4.3
+    ArkimeStringHead_t  orgName;    // 2.5.4.10
+    ArkimeStringHead_t  orgUnit;    // 2.5.4.11
+    char                orgUtf8;
+} ArkimeCertInfo_t;
+
+typedef struct arkime_certsinfo {
+    uint64_t                 notBefore;
+    uint64_t                 notAfter;
+    ArkimeCertInfo_t         issuer;
+    ArkimeCertInfo_t         subject;
+    ArkimeStringHead_t       alt;
+    uint8_t                 *serialNumber;
+    short                    serialNumberLen;
+    uint8_t                  hash[60];
+    char                     isCA;
+    const char              *publicAlgorithm;
+    const char              *curve;
+    GHashTable              *extra;
+} ArkimeCertsInfo_t;
+
+/******************************************************************************/
 void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session);
 void certinfo_free(ArkimeFieldObject_t *object);
 uint32_t certinfo_hash(const void *key);

--- a/capture/parsers/certs_internals.h
+++ b/capture/parsers/certs_internals.h
@@ -1,0 +1,6 @@
+#include "arkime.h"
+
+void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session);
+void certinfo_free(ArkimeFieldObject_t *object);
+uint32_t certinfo_hash(const void *key);
+int certinfo_cmp(const void *keyv, const void *elementv);

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -2,7 +2,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "arkime.h"
 #include "certs_internals.h"
 
 //#define DTLSDEBUG 1

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -6,6 +6,27 @@
 
 //#define DTLSDEBUG 1
 
+typedef struct {
+    ArkimeStringHead_t  commonName; // 2.5.4.3
+    ArkimeStringHead_t  orgName;    // 2.5.4.10
+    ArkimeStringHead_t  orgUnit;    // 2.5.4.11
+    char                orgUtf8;
+} CertNames_t;
+
+typedef struct {
+    uint64_t           notBefore;
+    uint64_t           notAfter;
+    CertNames_t        issuer;
+    CertNames_t        subject;
+    ArkimeStringHead_t alt;
+    uint8_t           *serialNumber;
+    short              serialNumberLen;
+    uint8_t            hash[60];
+    char               isCA;
+    const char        *publicAlgorithm;
+    const char        *curve;
+} CertInfo_t;
+
 extern ArkimeConfig_t        config;
 LOCAL  int                   certsField;
 
@@ -354,6 +375,238 @@ LOCAL void dtls_udp_classify(ArkimeSession_t *session, const uint8_t *data, int 
         return;
     arkime_session_add_protocol(session, "dtls");
     arkime_parsers_register(session, dtls_udp_parser, uw, 0);
+}
+/******************************************************************************/
+#define SAVE_STRING_HEAD(HEAD, STR) \
+if (HEAD.s_count > 0) { \
+    BSB_EXPORT_cstr(*jbsb, "\"" STR "\":["); \
+    while (HEAD.s_count > 0) { \
+	DLL_POP_HEAD(s_, &HEAD, string); \
+	arkime_db_js0n_str(&*jbsb, (uint8_t *)string->str, string->utf8); \
+	BSB_EXPORT_u08(*jbsb, ','); \
+	g_free(string->str); \
+	ARKIME_TYPE_FREE(ArkimeString_t, string); \
+    } \
+    BSB_EXPORT_rewind(*jbsb, 1); \
+    BSB_EXPORT_u08(*jbsb, ']'); \
+    BSB_EXPORT_u08(*jbsb, ','); \
+}
+
+void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session) {
+    if (object->object == NULL) {
+        return;
+    }
+
+    CertInfo_t *ci = (CertInfo_t *)object->object;
+
+    ArkimeString_t *string;
+
+    BSB_EXPORT_u08(*jbsb, '{');
+
+    BSB_EXPORT_sprintf(*jbsb, "\"hash\":\"%s\",", ci->hash);
+
+    if (ci->publicAlgorithm)
+        BSB_EXPORT_sprintf(*jbsb, "\"publicAlgorithm\":\"%s\",", ci->publicAlgorithm);
+    if (ci->curve)
+        BSB_EXPORT_sprintf(*jbsb, "\"curve\":\"%s\",", ci->curve);
+
+    SAVE_STRING_HEAD(ci->issuer.commonName, "issuerCN");
+    SAVE_STRING_HEAD(ci->issuer.orgName, "issuerON");
+    SAVE_STRING_HEAD(ci->issuer.orgUnit, "issuerOU");
+    SAVE_STRING_HEAD(ci->subject.commonName, "subjectCN");
+    SAVE_STRING_HEAD(ci->subject.orgName, "subjectON");
+    SAVE_STRING_HEAD(ci->subject.orgUnit, "subjectOU");
+
+    if (ci->serialNumber) {
+        int k;
+        BSB_EXPORT_cstr(*jbsb, "\"serial\":\"");
+        for (k = 0; k < ci->serialNumberLen; k++) {
+            BSB_EXPORT_sprintf(*jbsb, "%02x", ci->serialNumber[k]);
+        }
+        BSB_EXPORT_u08(*jbsb, '"');
+        BSB_EXPORT_u08(*jbsb, ',');
+    }
+
+    if (ci->alt.s_count > 0) { \
+        BSB_EXPORT_sprintf(*jbsb, "\"altCnt\":%d,", ci->alt.s_count); \
+    }
+    SAVE_STRING_HEAD(ci->alt, "alt");
+
+    BSB_EXPORT_sprintf(*jbsb, "\"notBefore\":%" PRId64 ",", ci->notBefore * 1000);
+    BSB_EXPORT_sprintf(*jbsb, "\"notAfter\":%" PRId64 ",", ci->notAfter * 1000);
+    if (ci->notAfter < ((uint64_t)session->firstPacket.tv_sec)) {
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)0));
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)0));
+    } else {
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)) / (60 * 60 * 24));
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)));
+    }
+    BSB_EXPORT_sprintf(*jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore) / (60 * 60 * 24));
+    BSB_EXPORT_sprintf(*jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore));
+
+    BSB_EXPORT_rewind(*jbsb, 1); // Remove last comma
+
+    BSB_EXPORT_u08(jbsb, '}');
+}
+
+void certinfo_free(ArkimeFieldObject_t *object) {
+    if (object->object == NULL) {
+        return;
+    }
+
+    CertInfo_t *ci = (CertInfo_t *)object->object;
+
+    ArkimeString_t *string;
+
+    while (DLL_POP_HEAD(s_, &ci->alt, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.commonName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.orgName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.orgUnit, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.commonName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.orgName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.orgUnit, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    if (ci->serialNumber)
+        free(ci->serialNumber);
+
+    ARKIME_TYPE_FREE(CertInfo_t, ci);
+}
+
+SUPPRESS_UNSIGNED_INTEGER_OVERFLOW
+SUPPRESS_SHIFT
+SUPPRESS_INT_CONVERSION
+uint32_t certinfo_hash(const void *key) {
+    ArkimeFieldObject_t *obj = (ArkimeFieldObject_t *)key;
+    
+    CertInfo_t *ci;
+
+    if (obj->object == NULL) {
+        return 0;
+    }
+    
+    ci = (CertInfo_t *)obj->object;
+
+    if (ci->serialNumberLen == 0) {
+        return ((ci->issuer.commonName.s_count << 18) |
+                (ci->issuer.orgName.s_count << 12) |
+                (ci->subject.commonName.s_count << 6) |
+                (ci->subject.orgName.s_count));
+    }
+    return ((ci->serialNumber[0] << 28) |
+            (ci->serialNumber[ci->serialNumberLen - 1] << 24) |
+            (ci->issuer.commonName.s_count << 18) |
+            (ci->issuer.orgName.s_count << 12) |
+            (ci->subject.commonName.s_count << 6) |
+            (ci->subject.orgName.s_count));
+}
+
+int certinfo_cmp(const void *keyv, const void *elementv) {
+    ArkimeFieldObject_t *key      = (ArkimeFieldObject_t *)keyv;
+    ArkimeFieldObject_t *element = (ArkimeFieldObject_t *)elementv;
+
+    CertInfo_t *keyCI, elementCI;
+
+    if (key->object == NULL || element->object == NULL) {
+        return 0;
+    }
+
+    keyCI = (CertInfo_t *)key->object;
+    elementCI = (CertInfo_t *)element->object;
+
+    // Make sure all the easy things to check are the same
+    if ( !((keyCI->serialNumberLen == elementCI->serialNumberLen) &&
+           (memcmp(keyCI->serialNumber, elementCI->serialNumber, elementCI->serialNumberLen) == 0) &&
+           (keyCI->issuer.commonName.s_count == elementCI->issuer.commonName.s_count) &&
+           (keyCI->issuer.orgName.s_count == elementCI->issuer.orgName.s_count) &&
+           (keyCI->issuer.orgUnit.s_count == elementCI->issuer.orgUnit.s_count) &&
+           (keyCI->subject.commonName.s_count == elementCI->subject.commonName.s_count) &&
+           (keyCI->subject.orgName.s_count == elementCI->subject.orgName.s_count) &&
+           (keyCI->subject.orgUnit.s_count == elementCI->subject.orgUnit.s_count)
+          )
+       ) {
+
+        return 0;
+    }
+
+    // Now see if all the other items are the same
+
+    ArkimeString_t *kstr, *estr;
+    for (kstr = keyCI->issuer.commonName.s_next, estr = elementCI->issuer.commonName.s_next;
+         kstr != (void *) & (keyCI->issuer.commonName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->issuer.orgName.s_next, estr = elementCI->issuer.orgName.s_next;
+         kstr != (void *) & (keyCI->issuer.orgName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->issuer.orgUnit.s_next, estr = elementCI->issuer.orgUnit.s_next;
+         kstr != (void *) & (keyCI->issuer.orgUnit);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.commonName.s_next, estr = elementCI->subject.commonName.s_next;
+         kstr != (void *) & (keyCI->subject.commonName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.orgName.s_next, estr = elementCI->subject.orgName.s_next;
+         kstr != (void *) & (keyCI->subject.orgName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.orgUnit.s_next, estr = elementCI->subject.orgUnit.s_next;
+         kstr != (void *) & (keyCI->subject.orgUnit);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    return 1;
 }
 /******************************************************************************/
 void arkime_parser_init()

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -30,6 +30,11 @@ typedef struct {
 extern ArkimeConfig_t        config;
 LOCAL  int                   certsField;
 
+void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session);
+void certinfo_free(ArkimeFieldObject_t *object);
+uint32_t certinfo_hash(const void *key);
+int certinfo_cmp(const void *keyv, const void *elementv);
+
 /******************************************************************************/
 LOCAL void dtls_certinfo_process(CertNames_t *ci, BSB *bsb)
 {
@@ -76,7 +81,7 @@ LOCAL void dtls_certinfo_process(CertNames_t *ci, BSB *bsb)
     }
 }
 /******************************************************************************/
-LOCAL void dtls_key_usage (CertsInfo_t *certs, BSB *bsb)
+LOCAL void dtls_key_usage (CertInfo_t *certs, BSB *bsb)
 {
     uint32_t apc, atag, alen;
 
@@ -88,7 +93,7 @@ LOCAL void dtls_key_usage (CertsInfo_t *certs, BSB *bsb)
     }
 }
 /******************************************************************************/
-LOCAL void dtls_alt_names(CertsInfo_t *certs, BSB *bsb, char *lastOid)
+LOCAL void dtls_alt_names(CertInfo_t *certs, BSB *bsb, char *lastOid)
 {
     uint32_t apc, atag, alen;
 
@@ -377,6 +382,71 @@ LOCAL void dtls_udp_classify(ArkimeSession_t *session, const uint8_t *data, int 
     arkime_parsers_register(session, dtls_udp_parser, uw, 0);
 }
 /******************************************************************************/
+LOCAL void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
+{
+    BSB_EXPORT_u08(*bsb, '"');
+    while (*in) {
+        switch(*in) {
+        case '\b':
+            BSB_EXPORT_cstr(*bsb, "\\b");
+            break;
+        case '\n':
+            BSB_EXPORT_cstr(*bsb, "\\n");
+            break;
+        case '\r':
+            BSB_EXPORT_cstr(*bsb, "\\r");
+            break;
+        case '\f':
+            BSB_EXPORT_cstr(*bsb, "\\f");
+            break;
+        case '\t':
+            BSB_EXPORT_cstr(*bsb, "\\t");
+            break;
+        case '"':
+            BSB_EXPORT_cstr(*bsb, "\\\"");
+            break;
+        case '\\':
+            BSB_EXPORT_cstr(*bsb, "\\\\");
+            break;
+        case '/':
+            BSB_EXPORT_cstr(*bsb, "\\/");
+            break;
+        default:
+            if(*in < 32) {
+                BSB_EXPORT_sprintf(*bsb, "\\u%04x", *in);
+            } else if (utf8) {
+                if ((*in & 0xf0) == 0xf0) {
+                    if (!in[1] || !in[2] || !in[3]) goto end;
+                    BSB_EXPORT_ptr(*bsb, in, 4);
+                    in += 3;
+                } else if ((*in & 0xf0) == 0xe0) {
+                    if (!in[1] || !in[2]) goto end;
+                    BSB_EXPORT_ptr(*bsb, in, 3);
+                    in += 2;
+                } else if ((*in & 0xf0) == 0xd0) {
+                    if (!in[1]) goto end;
+                    BSB_EXPORT_ptr(*bsb, in, 2);
+                    in += 1;
+                } else {
+                    BSB_EXPORT_u08(*bsb, *in);
+                }
+            } else {
+                if(*in & 0x80) {
+                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
+                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
+                } else {
+                    BSB_EXPORT_u08(*bsb, *in);
+                }
+            }
+            break;
+        }
+        in++;
+    }
+
+end:
+    BSB_EXPORT_u08(*bsb, '"');
+}
+/******************************************************************************/
 #define SAVE_STRING_HEAD(HEAD, STR) \
 if (HEAD.s_count > 0) { \
     BSB_EXPORT_cstr(*jbsb, "\"" STR "\":["); \
@@ -446,11 +516,12 @@ void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *sess
 
     BSB_EXPORT_rewind(*jbsb, 1); // Remove last comma
 
-    BSB_EXPORT_u08(jbsb, '}');
+    BSB_EXPORT_u08(*jbsb, '}');
 }
 
 void certinfo_free(ArkimeFieldObject_t *object) {
     if (object->object == NULL) {
+        ARKIME_TYPE_FREE(ArkimeFieldObject_t, object);
         return;
     }
 
@@ -497,6 +568,7 @@ void certinfo_free(ArkimeFieldObject_t *object) {
         free(ci->serialNumber);
 
     ARKIME_TYPE_FREE(CertInfo_t, ci);
+    ARKIME_TYPE_FREE(ArkimeFieldObject_t, object);
 }
 
 SUPPRESS_UNSIGNED_INTEGER_OVERFLOW
@@ -531,7 +603,7 @@ int certinfo_cmp(const void *keyv, const void *elementv) {
     ArkimeFieldObject_t *key      = (ArkimeFieldObject_t *)keyv;
     ArkimeFieldObject_t *element = (ArkimeFieldObject_t *)elementv;
 
-    CertInfo_t *keyCI, elementCI;
+    CertInfo_t *keyCI, *elementCI;
 
     if (key->object == NULL || element->object == NULL) {
         return 0;

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -3,40 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "arkime.h"
+#include "certs_internals.h"
 
 //#define DTLSDEBUG 1
-
-typedef struct {
-    ArkimeStringHead_t  commonName; // 2.5.4.3
-    ArkimeStringHead_t  orgName;    // 2.5.4.10
-    ArkimeStringHead_t  orgUnit;    // 2.5.4.11
-    char                orgUtf8;
-} CertNames_t;
-
-typedef struct {
-    uint64_t           notBefore;
-    uint64_t           notAfter;
-    CertNames_t        issuer;
-    CertNames_t        subject;
-    ArkimeStringHead_t alt;
-    uint8_t           *serialNumber;
-    short              serialNumberLen;
-    uint8_t            hash[60];
-    char               isCA;
-    const char        *publicAlgorithm;
-    const char        *curve;
-} CertInfo_t;
 
 extern ArkimeConfig_t        config;
 LOCAL  int                   certsField;
 
-void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session);
-void certinfo_free(ArkimeFieldObject_t *object);
-uint32_t certinfo_hash(const void *key);
-int certinfo_cmp(const void *keyv, const void *elementv);
-
 /******************************************************************************/
-LOCAL void dtls_certinfo_process(CertNames_t *ci, BSB *bsb)
+LOCAL void dtls_certinfo_process(ArkimeCertInfo_t *ci, BSB *bsb)
 {
     uint32_t apc, atag, alen;
     char lastOid[1000];
@@ -81,7 +56,7 @@ LOCAL void dtls_certinfo_process(CertNames_t *ci, BSB *bsb)
     }
 }
 /******************************************************************************/
-LOCAL void dtls_key_usage (CertInfo_t *certs, BSB *bsb)
+LOCAL void dtls_key_usage (ArkimeCertsInfo_t *certs, BSB *bsb)
 {
     uint32_t apc, atag, alen;
 
@@ -93,7 +68,7 @@ LOCAL void dtls_key_usage (CertInfo_t *certs, BSB *bsb)
     }
 }
 /******************************************************************************/
-LOCAL void dtls_alt_names(CertInfo_t *certs, BSB *bsb, char *lastOid)
+LOCAL void dtls_alt_names(ArkimeCertsInfo_t *certs, BSB *bsb, char *lastOid)
 {
     uint32_t apc, atag, alen;
 
@@ -152,7 +127,7 @@ LOCAL void dtls_process_server_certificate(ArkimeSession_t *session, const uint8
 
         ArkimeFieldObject_t *fobject = ARKIME_TYPE_ALLOC0(ArkimeFieldObject_t);
 
-        CertInfo_t *certs = ARKIME_TYPE_ALLOC0(CertInfo_t);
+        ArkimeCertsInfo_t *certs = ARKIME_TYPE_ALLOC0(ArkimeCertsInfo_t);
         DLL_INIT(s_, &certs->alt);
         DLL_INIT(s_, &certs->subject.commonName);
         DLL_INIT(s_, &certs->subject.orgName);
@@ -380,305 +355,6 @@ LOCAL void dtls_udp_classify(ArkimeSession_t *session, const uint8_t *data, int 
         return;
     arkime_session_add_protocol(session, "dtls");
     arkime_parsers_register(session, dtls_udp_parser, uw, 0);
-}
-/******************************************************************************/
-LOCAL void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
-{
-    BSB_EXPORT_u08(*bsb, '"');
-    while (*in) {
-        switch(*in) {
-        case '\b':
-            BSB_EXPORT_cstr(*bsb, "\\b");
-            break;
-        case '\n':
-            BSB_EXPORT_cstr(*bsb, "\\n");
-            break;
-        case '\r':
-            BSB_EXPORT_cstr(*bsb, "\\r");
-            break;
-        case '\f':
-            BSB_EXPORT_cstr(*bsb, "\\f");
-            break;
-        case '\t':
-            BSB_EXPORT_cstr(*bsb, "\\t");
-            break;
-        case '"':
-            BSB_EXPORT_cstr(*bsb, "\\\"");
-            break;
-        case '\\':
-            BSB_EXPORT_cstr(*bsb, "\\\\");
-            break;
-        case '/':
-            BSB_EXPORT_cstr(*bsb, "\\/");
-            break;
-        default:
-            if(*in < 32) {
-                BSB_EXPORT_sprintf(*bsb, "\\u%04x", *in);
-            } else if (utf8) {
-                if ((*in & 0xf0) == 0xf0) {
-                    if (!in[1] || !in[2] || !in[3]) goto end;
-                    BSB_EXPORT_ptr(*bsb, in, 4);
-                    in += 3;
-                } else if ((*in & 0xf0) == 0xe0) {
-                    if (!in[1] || !in[2]) goto end;
-                    BSB_EXPORT_ptr(*bsb, in, 3);
-                    in += 2;
-                } else if ((*in & 0xf0) == 0xd0) {
-                    if (!in[1]) goto end;
-                    BSB_EXPORT_ptr(*bsb, in, 2);
-                    in += 1;
-                } else {
-                    BSB_EXPORT_u08(*bsb, *in);
-                }
-            } else {
-                if(*in & 0x80) {
-                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
-                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
-                } else {
-                    BSB_EXPORT_u08(*bsb, *in);
-                }
-            }
-            break;
-        }
-        in++;
-    }
-
-end:
-    BSB_EXPORT_u08(*bsb, '"');
-}
-/******************************************************************************/
-#define SAVE_STRING_HEAD(HEAD, STR) \
-if (HEAD.s_count > 0) { \
-    BSB_EXPORT_cstr(*jbsb, "\"" STR "\":["); \
-    while (HEAD.s_count > 0) { \
-	DLL_POP_HEAD(s_, &HEAD, string); \
-	arkime_db_js0n_str(&*jbsb, (uint8_t *)string->str, string->utf8); \
-	BSB_EXPORT_u08(*jbsb, ','); \
-	g_free(string->str); \
-	ARKIME_TYPE_FREE(ArkimeString_t, string); \
-    } \
-    BSB_EXPORT_rewind(*jbsb, 1); \
-    BSB_EXPORT_u08(*jbsb, ']'); \
-    BSB_EXPORT_u08(*jbsb, ','); \
-}
-
-void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session) {
-    if (object->object == NULL) {
-        return;
-    }
-
-    CertInfo_t *ci = (CertInfo_t *)object->object;
-
-    ArkimeString_t *string;
-
-    BSB_EXPORT_u08(*jbsb, '{');
-
-    BSB_EXPORT_sprintf(*jbsb, "\"hash\":\"%s\",", ci->hash);
-
-    if (ci->publicAlgorithm)
-        BSB_EXPORT_sprintf(*jbsb, "\"publicAlgorithm\":\"%s\",", ci->publicAlgorithm);
-    if (ci->curve)
-        BSB_EXPORT_sprintf(*jbsb, "\"curve\":\"%s\",", ci->curve);
-
-    SAVE_STRING_HEAD(ci->issuer.commonName, "issuerCN");
-    SAVE_STRING_HEAD(ci->issuer.orgName, "issuerON");
-    SAVE_STRING_HEAD(ci->issuer.orgUnit, "issuerOU");
-    SAVE_STRING_HEAD(ci->subject.commonName, "subjectCN");
-    SAVE_STRING_HEAD(ci->subject.orgName, "subjectON");
-    SAVE_STRING_HEAD(ci->subject.orgUnit, "subjectOU");
-
-    if (ci->serialNumber) {
-        int k;
-        BSB_EXPORT_cstr(*jbsb, "\"serial\":\"");
-        for (k = 0; k < ci->serialNumberLen; k++) {
-            BSB_EXPORT_sprintf(*jbsb, "%02x", ci->serialNumber[k]);
-        }
-        BSB_EXPORT_u08(*jbsb, '"');
-        BSB_EXPORT_u08(*jbsb, ',');
-    }
-
-    if (ci->alt.s_count > 0) { \
-        BSB_EXPORT_sprintf(*jbsb, "\"altCnt\":%d,", ci->alt.s_count); \
-    }
-    SAVE_STRING_HEAD(ci->alt, "alt");
-
-    BSB_EXPORT_sprintf(*jbsb, "\"notBefore\":%" PRId64 ",", ci->notBefore * 1000);
-    BSB_EXPORT_sprintf(*jbsb, "\"notAfter\":%" PRId64 ",", ci->notAfter * 1000);
-    if (ci->notAfter < ((uint64_t)session->firstPacket.tv_sec)) {
-        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)0));
-        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)0));
-    } else {
-        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)) / (60 * 60 * 24));
-        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)));
-    }
-    BSB_EXPORT_sprintf(*jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore) / (60 * 60 * 24));
-    BSB_EXPORT_sprintf(*jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore));
-
-    BSB_EXPORT_rewind(*jbsb, 1); // Remove last comma
-
-    BSB_EXPORT_u08(*jbsb, '}');
-}
-
-void certinfo_free(ArkimeFieldObject_t *object) {
-    if (object->object == NULL) {
-        ARKIME_TYPE_FREE(ArkimeFieldObject_t, object);
-        return;
-    }
-
-    CertInfo_t *ci = (CertInfo_t *)object->object;
-
-    ArkimeString_t *string;
-
-    while (DLL_POP_HEAD(s_, &ci->alt, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->issuer.commonName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->issuer.orgName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->issuer.orgUnit, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->subject.commonName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->subject.orgName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->subject.orgUnit, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    if (ci->serialNumber)
-        free(ci->serialNumber);
-
-    ARKIME_TYPE_FREE(CertInfo_t, ci);
-    ARKIME_TYPE_FREE(ArkimeFieldObject_t, object);
-}
-
-SUPPRESS_UNSIGNED_INTEGER_OVERFLOW
-SUPPRESS_SHIFT
-SUPPRESS_INT_CONVERSION
-uint32_t certinfo_hash(const void *key) {
-    ArkimeFieldObject_t *obj = (ArkimeFieldObject_t *)key;
-    
-    CertInfo_t *ci;
-
-    if (obj->object == NULL) {
-        return 0;
-    }
-    
-    ci = (CertInfo_t *)obj->object;
-
-    if (ci->serialNumberLen == 0) {
-        return ((ci->issuer.commonName.s_count << 18) |
-                (ci->issuer.orgName.s_count << 12) |
-                (ci->subject.commonName.s_count << 6) |
-                (ci->subject.orgName.s_count));
-    }
-    return ((ci->serialNumber[0] << 28) |
-            (ci->serialNumber[ci->serialNumberLen - 1] << 24) |
-            (ci->issuer.commonName.s_count << 18) |
-            (ci->issuer.orgName.s_count << 12) |
-            (ci->subject.commonName.s_count << 6) |
-            (ci->subject.orgName.s_count));
-}
-
-int certinfo_cmp(const void *keyv, const void *elementv) {
-    ArkimeFieldObject_t *key      = (ArkimeFieldObject_t *)keyv;
-    ArkimeFieldObject_t *element = (ArkimeFieldObject_t *)elementv;
-
-    CertInfo_t *keyCI, *elementCI;
-
-    if (key->object == NULL || element->object == NULL) {
-        return 0;
-    }
-
-    keyCI = (CertInfo_t *)key->object;
-    elementCI = (CertInfo_t *)element->object;
-
-    // Make sure all the easy things to check are the same
-    if ( !((keyCI->serialNumberLen == elementCI->serialNumberLen) &&
-           (memcmp(keyCI->serialNumber, elementCI->serialNumber, elementCI->serialNumberLen) == 0) &&
-           (keyCI->issuer.commonName.s_count == elementCI->issuer.commonName.s_count) &&
-           (keyCI->issuer.orgName.s_count == elementCI->issuer.orgName.s_count) &&
-           (keyCI->issuer.orgUnit.s_count == elementCI->issuer.orgUnit.s_count) &&
-           (keyCI->subject.commonName.s_count == elementCI->subject.commonName.s_count) &&
-           (keyCI->subject.orgName.s_count == elementCI->subject.orgName.s_count) &&
-           (keyCI->subject.orgUnit.s_count == elementCI->subject.orgUnit.s_count)
-          )
-       ) {
-
-        return 0;
-    }
-
-    // Now see if all the other items are the same
-
-    ArkimeString_t *kstr, *estr;
-    for (kstr = keyCI->issuer.commonName.s_next, estr = elementCI->issuer.commonName.s_next;
-         kstr != (void *) & (keyCI->issuer.commonName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->issuer.orgName.s_next, estr = elementCI->issuer.orgName.s_next;
-         kstr != (void *) & (keyCI->issuer.orgName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->issuer.orgUnit.s_next, estr = elementCI->issuer.orgUnit.s_next;
-         kstr != (void *) & (keyCI->issuer.orgUnit);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->subject.commonName.s_next, estr = elementCI->subject.commonName.s_next;
-         kstr != (void *) & (keyCI->subject.commonName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->subject.orgName.s_next, estr = elementCI->subject.orgName.s_next;
-         kstr != (void *) & (keyCI->subject.orgName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->subject.orgUnit.s_next, estr = elementCI->subject.orgUnit.s_next;
-         kstr != (void *) & (keyCI->subject.orgUnit);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    return 1;
 }
 /******************************************************************************/
 void arkime_parser_init()

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -688,5 +688,5 @@ void arkime_parser_init()
     arkime_parsers_classifier_register_udp("dtls", NULL, 0, (const uint8_t *)"\x16\xfe\xfe", 3, dtls_udp_classify);
     arkime_parsers_classifier_register_udp("dtls", NULL, 0, (const uint8_t *)"\x16\xfe\xfd", 3, dtls_udp_classify);
 
-    certsField = arkime_field_object_register("cert", certinfo_save, certinfo_free, certinfo_hash, certinfo_cmp);
+    certsField = arkime_field_object_register("cert", "Certificates info", certinfo_save, certinfo_free, certinfo_hash, certinfo_cmp);
 }

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "arkime.h"
 #include "certs_internals.h"
 
 //#define DTLSDEBUG 1

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -152,7 +152,6 @@ void http_common_add_header_value(ArkimeSession_t *session, int pos, const char 
         g_strfreev(parts);
         break;
     }
-    case ARKIME_FIELD_TYPE_CERTSINFO:
     case ARKIME_FIELD_TYPE_OBJECT:
         // Unsupported
         break;

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -135,7 +135,6 @@ LOCAL void smtp_email_add_value(ArkimeSession_t *session, int pos, char *s, int 
         g_strfreev(parts);
         break;
     }
-    case ARKIME_FIELD_TYPE_CERTSINFO:
     case ARKIME_FIELD_TYPE_OBJECT:
         // Unsupported
         break;

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include "arkime.h"
+#include "certs_internals.h"
 #include "tls-cipher.h"
 #include "openssl/objects.h"
 
@@ -28,27 +29,6 @@ typedef struct {
     char                which;
 } TLSInfo_t;
 
-typedef struct {
-    ArkimeStringHead_t  commonName; // 2.5.4.3
-    ArkimeStringHead_t  orgName;    // 2.5.4.10
-    ArkimeStringHead_t  orgUnit;    // 2.5.4.11
-    char                orgUtf8;
-} CertNames_t;
-
-typedef struct {
-    uint64_t           notBefore;
-    uint64_t           notAfter;
-    CertNames_t        issuer;
-    CertNames_t        subject;
-    ArkimeStringHead_t alt;
-    uint8_t           *serialNumber;
-    short              serialNumberLen;
-    uint8_t            hash[60];
-    char               isCA;
-    const char        *publicAlgorithm;
-    const char        *curve;
-} CertInfo_t;
-
 extern uint8_t    arkime_char_to_hexstr[256][3];
 
 LOCAL GChecksum *checksums[ARKIME_MAX_PACKET_THREADS];
@@ -59,13 +39,8 @@ LOCAL uint32_t tls_process_server_hello_func;
 LOCAL uint32_t tls_process_server_certificate_func;
 LOCAL uint32_t tls_process_certificate_wInfo_func;
 
-void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session);
-void certinfo_free(ArkimeFieldObject_t *object);
-uint32_t certinfo_hash(const void *key);
-int certinfo_cmp(const void *keyv, const void *elementv);
-
 /******************************************************************************/
-LOCAL void tls_certinfo_process(CertNames_t *ci, BSB *bsb)
+LOCAL void tls_certinfo_process(ArkimeCertInfo_t *ci, BSB *bsb)
 {
     uint32_t apc, atag, alen;
     char lastOid[1000];
@@ -110,7 +85,7 @@ LOCAL void tls_certinfo_process(CertNames_t *ci, BSB *bsb)
     }
 }
 /******************************************************************************/
-LOCAL void tls_certinfo_process_publickey(CertInfo_t *certs, uint8_t *data, uint32_t len)
+LOCAL void tls_certinfo_process_publickey(ArkimeCertsInfo_t *certs, uint8_t *data, uint32_t len)
 {
     BSB bsb, tbsb;
     BSB_INIT(bsb, data, len);
@@ -150,7 +125,7 @@ LOCAL void tls_certinfo_process_publickey(CertInfo_t *certs, uint8_t *data, uint
     }
 }
 /******************************************************************************/
-LOCAL void tls_key_usage (CertInfo_t *certs, BSB *bsb)
+LOCAL void tls_key_usage (ArkimeCertsInfo_t *certs, BSB *bsb)
 {
     uint32_t apc, atag, alen;
 
@@ -162,7 +137,7 @@ LOCAL void tls_key_usage (CertInfo_t *certs, BSB *bsb)
     }
 }
 /******************************************************************************/
-LOCAL void tls_alt_names(ArkimeSession_t *session, CertInfo_t *certs, BSB *bsb, char *lastOid)
+LOCAL void tls_alt_names(ArkimeSession_t *session, ArkimeCertsInfo_t *certs, BSB *bsb, char *lastOid)
 {
     uint32_t apc, atag, alen;
 
@@ -433,7 +408,7 @@ LOCAL uint32_t tls_process_server_certificate(ArkimeSession_t *session, const ui
 
         ArkimeFieldObject_t *fobject = ARKIME_TYPE_ALLOC0(ArkimeFieldObject_t);
 
-        CertInfo_t *certs = ARKIME_TYPE_ALLOC0(CertInfo_t);
+        ArkimeCertsInfo_t *certs = ARKIME_TYPE_ALLOC0(ArkimeCertsInfo_t);
         DLL_INIT(s_, &certs->alt);
         DLL_INIT(s_, &certs->subject.commonName);
         DLL_INIT(s_, &certs->subject.orgName);
@@ -589,6 +564,7 @@ LOCAL uint32_t tls_process_server_certificate(ArkimeSession_t *session, const ui
         if (!arkime_field_object_add(certsField, session, fobject, clen * 2)) {
             certinfo_free(fobject);
             fobject = 0;
+            certs = 0;
         }
 
         BSB_IMPORT_skip(cbsb, clen + 3);
@@ -1066,305 +1042,6 @@ LOCAL void tls_classify(ArkimeSession_t *session, const uint8_t *data, int len, 
             tls->which      = which;
         }
     }
-}
-/******************************************************************************/
-LOCAL void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
-{
-    BSB_EXPORT_u08(*bsb, '"');
-    while (*in) {
-        switch(*in) {
-        case '\b':
-            BSB_EXPORT_cstr(*bsb, "\\b");
-            break;
-        case '\n':
-            BSB_EXPORT_cstr(*bsb, "\\n");
-            break;
-        case '\r':
-            BSB_EXPORT_cstr(*bsb, "\\r");
-            break;
-        case '\f':
-            BSB_EXPORT_cstr(*bsb, "\\f");
-            break;
-        case '\t':
-            BSB_EXPORT_cstr(*bsb, "\\t");
-            break;
-        case '"':
-            BSB_EXPORT_cstr(*bsb, "\\\"");
-            break;
-        case '\\':
-            BSB_EXPORT_cstr(*bsb, "\\\\");
-            break;
-        case '/':
-            BSB_EXPORT_cstr(*bsb, "\\/");
-            break;
-        default:
-            if(*in < 32) {
-                BSB_EXPORT_sprintf(*bsb, "\\u%04x", *in);
-            } else if (utf8) {
-                if ((*in & 0xf0) == 0xf0) {
-                    if (!in[1] || !in[2] || !in[3]) goto end;
-                    BSB_EXPORT_ptr(*bsb, in, 4);
-                    in += 3;
-                } else if ((*in & 0xf0) == 0xe0) {
-                    if (!in[1] || !in[2]) goto end;
-                    BSB_EXPORT_ptr(*bsb, in, 3);
-                    in += 2;
-                } else if ((*in & 0xf0) == 0xd0) {
-                    if (!in[1]) goto end;
-                    BSB_EXPORT_ptr(*bsb, in, 2);
-                    in += 1;
-                } else {
-                    BSB_EXPORT_u08(*bsb, *in);
-                }
-            } else {
-                if(*in & 0x80) {
-                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
-                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
-                } else {
-                    BSB_EXPORT_u08(*bsb, *in);
-                }
-            }
-            break;
-        }
-        in++;
-    }
-
-end:
-    BSB_EXPORT_u08(*bsb, '"');
-}
-/******************************************************************************/
-#define SAVE_STRING_HEAD(HEAD, STR) \
-if (HEAD.s_count > 0) { \
-    BSB_EXPORT_cstr(*jbsb, "\"" STR "\":["); \
-    while (HEAD.s_count > 0) { \
-	DLL_POP_HEAD(s_, &HEAD, string); \
-	arkime_db_js0n_str(&*jbsb, (uint8_t *)string->str, string->utf8); \
-	BSB_EXPORT_u08(*jbsb, ','); \
-	g_free(string->str); \
-	ARKIME_TYPE_FREE(ArkimeString_t, string); \
-    } \
-    BSB_EXPORT_rewind(*jbsb, 1); \
-    BSB_EXPORT_u08(*jbsb, ']'); \
-    BSB_EXPORT_u08(*jbsb, ','); \
-}
-
-void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session) {
-    if (object->object == NULL) {
-        return;
-    }
-
-    CertInfo_t *ci = (CertInfo_t *)object->object;
-
-    ArkimeString_t *string;
-
-    BSB_EXPORT_u08(*jbsb, '{');
-
-    BSB_EXPORT_sprintf(*jbsb, "\"hash\":\"%s\",", ci->hash);
-
-    if (ci->publicAlgorithm)
-        BSB_EXPORT_sprintf(*jbsb, "\"publicAlgorithm\":\"%s\",", ci->publicAlgorithm);
-    if (ci->curve)
-        BSB_EXPORT_sprintf(*jbsb, "\"curve\":\"%s\",", ci->curve);
-
-    SAVE_STRING_HEAD(ci->issuer.commonName, "issuerCN");
-    SAVE_STRING_HEAD(ci->issuer.orgName, "issuerON");
-    SAVE_STRING_HEAD(ci->issuer.orgUnit, "issuerOU");
-    SAVE_STRING_HEAD(ci->subject.commonName, "subjectCN");
-    SAVE_STRING_HEAD(ci->subject.orgName, "subjectON");
-    SAVE_STRING_HEAD(ci->subject.orgUnit, "subjectOU");
-
-    if (ci->serialNumber) {
-        int k;
-        BSB_EXPORT_cstr(*jbsb, "\"serial\":\"");
-        for (k = 0; k < ci->serialNumberLen; k++) {
-            BSB_EXPORT_sprintf(*jbsb, "%02x", ci->serialNumber[k]);
-        }
-        BSB_EXPORT_u08(*jbsb, '"');
-        BSB_EXPORT_u08(*jbsb, ',');
-    }
-
-    if (ci->alt.s_count > 0) { \
-        BSB_EXPORT_sprintf(*jbsb, "\"altCnt\":%d,", ci->alt.s_count); \
-    }
-    SAVE_STRING_HEAD(ci->alt, "alt");
-
-    BSB_EXPORT_sprintf(*jbsb, "\"notBefore\":%" PRId64 ",", ci->notBefore * 1000);
-    BSB_EXPORT_sprintf(*jbsb, "\"notAfter\":%" PRId64 ",", ci->notAfter * 1000);
-    if (ci->notAfter < ((uint64_t)session->firstPacket.tv_sec)) {
-        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)0));
-        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)0));
-    } else {
-        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)) / (60 * 60 * 24));
-        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)));
-    }
-    BSB_EXPORT_sprintf(*jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore) / (60 * 60 * 24));
-    BSB_EXPORT_sprintf(*jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore));
-
-    BSB_EXPORT_rewind(*jbsb, 1); // Remove last comma
-
-    BSB_EXPORT_u08(*jbsb, '}');
-}
-
-void certinfo_free(ArkimeFieldObject_t *object) {
-    if (object->object == NULL) {
-        ARKIME_TYPE_FREE(ArkimeFieldObject_t, object);
-        return;
-    }
-
-    CertInfo_t *ci = (CertInfo_t *)object->object;
-
-    ArkimeString_t *string;
-
-    while (DLL_POP_HEAD(s_, &ci->alt, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->issuer.commonName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->issuer.orgName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->issuer.orgUnit, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->subject.commonName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->subject.orgName, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    while (DLL_POP_HEAD(s_, &ci->subject.orgUnit, string)) {
-        g_free(string->str);
-        ARKIME_TYPE_FREE(ArkimeString_t, string);
-    }
-
-    if (ci->serialNumber)
-        free(ci->serialNumber);
-
-    ARKIME_TYPE_FREE(CertInfo_t, ci);
-    ARKIME_TYPE_FREE(ArkimeFieldObject_t, object);
-}
-
-SUPPRESS_UNSIGNED_INTEGER_OVERFLOW
-SUPPRESS_SHIFT
-SUPPRESS_INT_CONVERSION
-uint32_t certinfo_hash(const void *key) {
-    ArkimeFieldObject_t *obj = (ArkimeFieldObject_t *)key;
-    
-    CertInfo_t *ci;
-
-    if (obj->object == NULL) {
-        return 0;
-    }
-    
-    ci = (CertInfo_t *)obj->object;
-
-    if (ci->serialNumberLen == 0) {
-        return ((ci->issuer.commonName.s_count << 18) |
-                (ci->issuer.orgName.s_count << 12) |
-                (ci->subject.commonName.s_count << 6) |
-                (ci->subject.orgName.s_count));
-    }
-    return ((ci->serialNumber[0] << 28) |
-            (ci->serialNumber[ci->serialNumberLen - 1] << 24) |
-            (ci->issuer.commonName.s_count << 18) |
-            (ci->issuer.orgName.s_count << 12) |
-            (ci->subject.commonName.s_count << 6) |
-            (ci->subject.orgName.s_count));
-}
-
-int certinfo_cmp(const void *keyv, const void *elementv) {
-    ArkimeFieldObject_t *key      = (ArkimeFieldObject_t *)keyv;
-    ArkimeFieldObject_t *element = (ArkimeFieldObject_t *)elementv;
-
-    CertInfo_t *keyCI, *elementCI;
-
-    if (key->object == NULL || element->object == NULL) {
-        return 0;
-    }
-
-    keyCI = (CertInfo_t *)key->object;
-    elementCI = (CertInfo_t *)element->object;
-
-    // Make sure all the easy things to check are the same
-    if ( !((keyCI->serialNumberLen == elementCI->serialNumberLen) &&
-           (memcmp(keyCI->serialNumber, elementCI->serialNumber, elementCI->serialNumberLen) == 0) &&
-           (keyCI->issuer.commonName.s_count == elementCI->issuer.commonName.s_count) &&
-           (keyCI->issuer.orgName.s_count == elementCI->issuer.orgName.s_count) &&
-           (keyCI->issuer.orgUnit.s_count == elementCI->issuer.orgUnit.s_count) &&
-           (keyCI->subject.commonName.s_count == elementCI->subject.commonName.s_count) &&
-           (keyCI->subject.orgName.s_count == elementCI->subject.orgName.s_count) &&
-           (keyCI->subject.orgUnit.s_count == elementCI->subject.orgUnit.s_count)
-          )
-       ) {
-
-        return 0;
-    }
-
-    // Now see if all the other items are the same
-
-    ArkimeString_t *kstr, *estr;
-    for (kstr = keyCI->issuer.commonName.s_next, estr = elementCI->issuer.commonName.s_next;
-         kstr != (void *) & (keyCI->issuer.commonName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->issuer.orgName.s_next, estr = elementCI->issuer.orgName.s_next;
-         kstr != (void *) & (keyCI->issuer.orgName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->issuer.orgUnit.s_next, estr = elementCI->issuer.orgUnit.s_next;
-         kstr != (void *) & (keyCI->issuer.orgUnit);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->subject.commonName.s_next, estr = elementCI->subject.commonName.s_next;
-         kstr != (void *) & (keyCI->subject.commonName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->subject.orgName.s_next, estr = elementCI->subject.orgName.s_next;
-         kstr != (void *) & (keyCI->subject.orgName);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    for (kstr = keyCI->subject.orgUnit.s_next, estr = elementCI->subject.orgUnit.s_next;
-         kstr != (void *) & (keyCI->subject.orgUnit);
-         kstr = kstr->s_next, estr = estr->s_next) {
-
-        if (strcmp(kstr->str, estr->str) != 0)
-            return 0;
-    }
-
-    return 1;
 }
 /******************************************************************************/
 void arkime_parser_init()

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -28,6 +28,27 @@ typedef struct {
     char                which;
 } TLSInfo_t;
 
+typedef struct {
+    ArkimeStringHead_t  commonName; // 2.5.4.3
+    ArkimeStringHead_t  orgName;    // 2.5.4.10
+    ArkimeStringHead_t  orgUnit;    // 2.5.4.11
+    char                orgUtf8;
+} CertNames_t;
+
+typedef struct {
+    uint64_t           notBefore;
+    uint64_t           notAfter;
+    CertNames_t        issuer;
+    CertNames_t        subject;
+    ArkimeStringHead_t alt;
+    uint8_t           *serialNumber;
+    short              serialNumberLen;
+    uint8_t            hash[60];
+    char               isCA;
+    const char        *publicAlgorithm;
+    const char        *curve;
+} CertInfo_t;
+
 extern uint8_t    arkime_char_to_hexstr[256][3];
 
 LOCAL GChecksum *checksums[ARKIME_MAX_PACKET_THREADS];
@@ -39,7 +60,7 @@ LOCAL uint32_t tls_process_server_certificate_func;
 LOCAL uint32_t tls_process_certificate_wInfo_func;
 
 /******************************************************************************/
-LOCAL void tls_certinfo_process(ArkimeCertInfo_t *ci, BSB *bsb)
+LOCAL void tls_certinfo_processCertNames_t *ci, BSB *bsb)
 {
     uint32_t apc, atag, alen;
     char lastOid[1000];
@@ -84,7 +105,7 @@ LOCAL void tls_certinfo_process(ArkimeCertInfo_t *ci, BSB *bsb)
     }
 }
 /******************************************************************************/
-LOCAL void tls_certinfo_process_publickey(ArkimeCertsInfo_t *certs, uint8_t *data, uint32_t len)
+LOCAL void tls_certinfo_process_publickey(CertInfo_t *certs, uint8_t *data, uint32_t len)
 {
     BSB bsb, tbsb;
     BSB_INIT(bsb, data, len);
@@ -124,7 +145,7 @@ LOCAL void tls_certinfo_process_publickey(ArkimeCertsInfo_t *certs, uint8_t *dat
     }
 }
 /******************************************************************************/
-LOCAL void tls_key_usage (ArkimeCertsInfo_t *certs, BSB *bsb)
+LOCAL void tls_key_usage (CertInfo_t *certs, BSB *bsb)
 {
     uint32_t apc, atag, alen;
 
@@ -136,7 +157,7 @@ LOCAL void tls_key_usage (ArkimeCertsInfo_t *certs, BSB *bsb)
     }
 }
 /******************************************************************************/
-LOCAL void tls_alt_names(ArkimeSession_t *session, ArkimeCertsInfo_t *certs, BSB *bsb, char *lastOid)
+LOCAL void tls_alt_names(ArkimeSession_t *session, CertInfo_t *certs, BSB *bsb, char *lastOid)
 {
     uint32_t apc, atag, alen;
 
@@ -405,8 +426,9 @@ LOCAL uint32_t tls_process_server_certificate(ArkimeSession_t *session, const ui
         uint8_t *cdata = BSB_WORK_PTR(cbsb);
         int            clen = MIN(BSB_REMAINING(cbsb) - 3, (cdata[0] << 16 | cdata[1] << 8 | cdata[2]));
 
+        ArkimeFieldObject_t *fobject = ARKIME_TYPE_ALLOC0(ArkimeFieldObject_t);
 
-        ArkimeCertsInfo_t *certs = ARKIME_TYPE_ALLOC0(ArkimeCertsInfo_t);
+        CertInfo_t *certs = ARKIME_TYPE_ALLOC0(CertInfo_t);
         DLL_INIT(s_, &certs->alt);
         DLL_INIT(s_, &certs->subject.commonName);
         DLL_INIT(s_, &certs->subject.orgName);
@@ -414,6 +436,8 @@ LOCAL uint32_t tls_process_server_certificate(ArkimeSession_t *session, const ui
         DLL_INIT(s_, &certs->issuer.commonName);
         DLL_INIT(s_, &certs->issuer.orgName);
         DLL_INIT(s_, &certs->issuer.orgUnit);
+
+        fobject->object = certs;
 
         uint32_t       atag, alen, apc;
         uint8_t *value;
@@ -557,9 +581,9 @@ LOCAL uint32_t tls_process_server_certificate(ArkimeSession_t *session, const ui
         }
 
 
-        if (!arkime_field_certsinfo_add(certsField, session, certs, clen * 2)) {
-            arkime_field_certsinfo_free(certs);
-            certs = 0;
+        if (!arkime_field_object_add(certsField, session, fobject, clen * 2)) {
+            certinfo_free(fobject);
+            fobject = 0;
         }
 
         BSB_IMPORT_skip(cbsb, clen + 3);
@@ -572,7 +596,7 @@ LOCAL uint32_t tls_process_server_certificate(ArkimeSession_t *session, const ui
 bad_cert:
         if (config.debug)
             LOG("bad cert %d - %d", badreason, clen);
-        arkime_field_certsinfo_free(certs);
+        certinfo_free(fobject);
         break;
     }
     return 0;
@@ -1039,15 +1063,243 @@ LOCAL void tls_classify(ArkimeSession_t *session, const uint8_t *data, int len, 
     }
 }
 /******************************************************************************/
+#define SAVE_STRING_HEAD(HEAD, STR) \
+if (HEAD.s_count > 0) { \
+    BSB_EXPORT_cstr(*jbsb, "\"" STR "\":["); \
+    while (HEAD.s_count > 0) { \
+	DLL_POP_HEAD(s_, &HEAD, string); \
+	arkime_db_js0n_str(&*jbsb, (uint8_t *)string->str, string->utf8); \
+	BSB_EXPORT_u08(*jbsb, ','); \
+	g_free(string->str); \
+	ARKIME_TYPE_FREE(ArkimeString_t, string); \
+    } \
+    BSB_EXPORT_rewind(*jbsb, 1); \
+    BSB_EXPORT_u08(*jbsb, ']'); \
+    BSB_EXPORT_u08(*jbsb, ','); \
+}
+
+void certinfo_save(BSB *jbsb, ArkimeFieldObject_t *object, ArkimeSession_t *session) {
+    if (object->object == NULL) {
+        return;
+    }
+
+    CertInfo_t *ci = (CertInfo_t *)object->object;
+
+    ArkimeString_t *string;
+
+    BSB_EXPORT_u08(*jbsb, '{');
+
+    BSB_EXPORT_sprintf(*jbsb, "\"hash\":\"%s\",", ci->hash);
+
+    if (ci->publicAlgorithm)
+        BSB_EXPORT_sprintf(*jbsb, "\"publicAlgorithm\":\"%s\",", ci->publicAlgorithm);
+    if (ci->curve)
+        BSB_EXPORT_sprintf(*jbsb, "\"curve\":\"%s\",", ci->curve);
+
+    SAVE_STRING_HEAD(ci->issuer.commonName, "issuerCN");
+    SAVE_STRING_HEAD(ci->issuer.orgName, "issuerON");
+    SAVE_STRING_HEAD(ci->issuer.orgUnit, "issuerOU");
+    SAVE_STRING_HEAD(ci->subject.commonName, "subjectCN");
+    SAVE_STRING_HEAD(ci->subject.orgName, "subjectON");
+    SAVE_STRING_HEAD(ci->subject.orgUnit, "subjectOU");
+
+    if (ci->serialNumber) {
+        int k;
+        BSB_EXPORT_cstr(*jbsb, "\"serial\":\"");
+        for (k = 0; k < ci->serialNumberLen; k++) {
+            BSB_EXPORT_sprintf(*jbsb, "%02x", ci->serialNumber[k]);
+        }
+        BSB_EXPORT_u08(*jbsb, '"');
+        BSB_EXPORT_u08(*jbsb, ',');
+    }
+
+    if (ci->alt.s_count > 0) { \
+        BSB_EXPORT_sprintf(*jbsb, "\"altCnt\":%d,", ci->alt.s_count); \
+    }
+    SAVE_STRING_HEAD(ci->alt, "alt");
+
+    BSB_EXPORT_sprintf(*jbsb, "\"notBefore\":%" PRId64 ",", ci->notBefore * 1000);
+    BSB_EXPORT_sprintf(*jbsb, "\"notAfter\":%" PRId64 ",", ci->notAfter * 1000);
+    if (ci->notAfter < ((uint64_t)session->firstPacket.tv_sec)) {
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)0));
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)0));
+    } else {
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingDays\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)) / (60 * 60 * 24));
+        BSB_EXPORT_sprintf(*jbsb, "\"remainingSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - ((uint64_t)session->firstPacket.tv_sec)));
+    }
+    BSB_EXPORT_sprintf(*jbsb, "\"validDays\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore) / (60 * 60 * 24));
+    BSB_EXPORT_sprintf(*jbsb, "\"validSeconds\":%" PRId64 ",", ((int64_t)ci->notAfter - (int64_t)ci->notBefore));
+
+    BSB_EXPORT_rewind(*jbsb, 1); // Remove last comma
+
+    BSB_EXPORT_u08(jbsb, '}');
+}
+
+void certinfo_free(ArkimeFieldObject_t *object) {
+    if (object->object == NULL) {
+        return;
+    }
+
+    CertInfo_t *ci = (CertInfo_t *)object->object;
+
+    ArkimeString_t *string;
+
+    while (DLL_POP_HEAD(s_, &ci->alt, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.commonName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.orgName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->issuer.orgUnit, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.commonName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.orgName, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    while (DLL_POP_HEAD(s_, &ci->subject.orgUnit, string)) {
+        g_free(string->str);
+        ARKIME_TYPE_FREE(ArkimeString_t, string);
+    }
+
+    if (ci->serialNumber)
+        free(ci->serialNumber);
+
+    ARKIME_TYPE_FREE(CertInfo_t, ci);
+}
+
+SUPPRESS_UNSIGNED_INTEGER_OVERFLOW
+SUPPRESS_SHIFT
+SUPPRESS_INT_CONVERSION
+uint32_t certinfo_hash(const void *key) {
+    ArkimeFieldObject_t *obj = (ArkimeFieldObject_t *)key;
+    
+    CertInfo_t *ci;
+
+    if (obj->object == NULL) {
+        return 0;
+    }
+    
+    ci = (CertInfo_t *)obj->object;
+
+    if (ci->serialNumberLen == 0) {
+        return ((ci->issuer.commonName.s_count << 18) |
+                (ci->issuer.orgName.s_count << 12) |
+                (ci->subject.commonName.s_count << 6) |
+                (ci->subject.orgName.s_count));
+    }
+    return ((ci->serialNumber[0] << 28) |
+            (ci->serialNumber[ci->serialNumberLen - 1] << 24) |
+            (ci->issuer.commonName.s_count << 18) |
+            (ci->issuer.orgName.s_count << 12) |
+            (ci->subject.commonName.s_count << 6) |
+            (ci->subject.orgName.s_count));
+}
+
+int certinfo_cmp(const void *keyv, const void *elementv) {
+    ArkimeFieldObject_t *key      = (ArkimeFieldObject_t *)keyv;
+    ArkimeFieldObject_t *element = (ArkimeFieldObject_t *)elementv;
+
+    CertInfo_t *keyCI, elementCI;
+
+    if (key->object == NULL || element->object == NULL) {
+        return 0;
+    }
+
+    keyCI = (CertInfo_t *)key->object;
+    elementCI = (CertInfo_t *)element->object;
+
+    // Make sure all the easy things to check are the same
+    if ( !((keyCI->serialNumberLen == elementCI->serialNumberLen) &&
+           (memcmp(keyCI->serialNumber, elementCI->serialNumber, elementCI->serialNumberLen) == 0) &&
+           (keyCI->issuer.commonName.s_count == elementCI->issuer.commonName.s_count) &&
+           (keyCI->issuer.orgName.s_count == elementCI->issuer.orgName.s_count) &&
+           (keyCI->issuer.orgUnit.s_count == elementCI->issuer.orgUnit.s_count) &&
+           (keyCI->subject.commonName.s_count == elementCI->subject.commonName.s_count) &&
+           (keyCI->subject.orgName.s_count == elementCI->subject.orgName.s_count) &&
+           (keyCI->subject.orgUnit.s_count == elementCI->subject.orgUnit.s_count)
+          )
+       ) {
+
+        return 0;
+    }
+
+    // Now see if all the other items are the same
+
+    ArkimeString_t *kstr, *estr;
+    for (kstr = keyCI->issuer.commonName.s_next, estr = elementCI->issuer.commonName.s_next;
+         kstr != (void *) & (keyCI->issuer.commonName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->issuer.orgName.s_next, estr = elementCI->issuer.orgName.s_next;
+         kstr != (void *) & (keyCI->issuer.orgName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->issuer.orgUnit.s_next, estr = elementCI->issuer.orgUnit.s_next;
+         kstr != (void *) & (keyCI->issuer.orgUnit);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.commonName.s_next, estr = elementCI->subject.commonName.s_next;
+         kstr != (void *) & (keyCI->subject.commonName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.orgName.s_next, estr = elementCI->subject.orgName.s_next;
+         kstr != (void *) & (keyCI->subject.orgName);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    for (kstr = keyCI->subject.orgUnit.s_next, estr = elementCI->subject.orgUnit.s_next;
+         kstr != (void *) & (keyCI->subject.orgUnit);
+         kstr = kstr->s_next, estr = estr->s_next) {
+
+        if (strcmp(kstr->str, estr->str) != 0)
+            return 0;
+    }
+
+    return 1;
+}
+/******************************************************************************/
 void arkime_parser_init()
 {
     ja4Raw = arkime_config_boolean(NULL, "ja4Raw", FALSE);
 
-    certsField = arkime_field_define("cert", "notreal",
-                                     "cert", "cert", "cert",
-                                     "CERT Info",
-                                     ARKIME_FIELD_TYPE_CERTSINFO,  ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_NODB,
-                                     (char *)NULL);
+    certsField = arkime_field_object_register("cert", certinfo_save, certinfo_free, certinfo_hash, certinfo_cmp);
 
     arkime_field_define("cert", "integer",
                         "cert.cnt", "Cert Cnt", "certCnt",

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -2,7 +2,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "arkime.h"
 #include "certs_internals.h"
 #include "tls-cipher.h"
 #include "openssl/objects.h"

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#include "arkime.h"
 #include "certs_internals.h"
 #include "tls-cipher.h"
 #include "openssl/objects.h"
@@ -614,7 +615,7 @@ LOCAL int tls_process_server_handshake_record(ArkimeSession_t *session, const ui
 // Comparison function for qsort
 LOCAL int compare_uint16_t(const void *a, const void *b)
 {
-    return (*(const uint16_t *)a < *(const uint16_t *)b ? -1 : *(const uint16_t *)a > *(const uint16_t *)b);
+    return (*(const uint16_t *)a < * (const uint16_t *)b ? -1 : * (const uint16_t *)a > *(const uint16_t *)b);
 }
 /******************************************************************************/
 uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uint8_t *data, int len, void UNUSED(*uw))

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -1371,7 +1371,7 @@ void arkime_parser_init()
 {
     ja4Raw = arkime_config_boolean(NULL, "ja4Raw", FALSE);
 
-    certsField = arkime_field_object_register("cert", certinfo_save, certinfo_free, certinfo_hash, certinfo_cmp);
+    certsField = arkime_field_object_register("cert", "Certificates info", certinfo_save, certinfo_free, certinfo_hash, certinfo_cmp);
 
     arkime_field_define("cert", "integer",
                         "cert.cnt", "Cert Cnt", "certCnt",

--- a/capture/plugins/lua/session.c
+++ b/capture/plugins/lua/session.c
@@ -635,49 +635,6 @@ LOCAL int MSP_get_port2(lua_State *L)
     return 1;
 }
 /******************************************************************************/
-LOCAL int MS_get_certs(lua_State *L, ArkimeSession_t *session, const char *exp)
-{
-    const ArkimeField_t *field = session->fields[certsField];
-
-    if (!field) {
-        lua_pushnil(L);
-        return 1;
-    }
-
-    const ArkimeCertsInfoHashStd_t *cihash = session->fields[certsField]->cihash;
-    ArkimeCertsInfo_t *certs;
-
-    int i = 0;
-    if (strcmp(exp, "cert.curve") == 0) {
-        lua_newtable(L);
-        HASH_FORALL2(t_, *cihash, certs) {
-            if (!certs->curve)
-                continue;
-            lua_pushinteger(L, i + 1);
-            lua_pushstring(L, certs->curve);
-            lua_settable(L, -3);
-            i++;
-        }
-        return 1;
-    }
-
-    if (strcmp(exp, "cert.publicAlgorithm") == 0) {
-        lua_newtable(L);
-        HASH_FORALL2(t_, *cihash, certs) {
-            if (!certs->publicAlgorithm)
-                continue;
-            lua_pushinteger(L, i + 1);
-            lua_pushstring(L, certs->publicAlgorithm);
-            lua_settable(L, -3);
-            i++;
-        }
-        return 1;
-    }
-
-    lua_pushnil(L);
-    return 1;
-}
-/******************************************************************************/
 LOCAL int MS_get(lua_State *L)
 {
     if (config.debug > 2)
@@ -694,11 +651,6 @@ LOCAL int MS_get(lua_State *L)
     } else {
         const char *exp = lua_tostring(L, 2);
         switch(exp[0]) {
-        case 'c':
-            if (strncmp(exp, "cert.", 5) == 0) {
-                return MS_get_certs(L, session, exp);
-            }
-            break;
         case 'd':
             if (strcmp(exp, "databytes.src") == 0) {
                 lua_pushinteger(L, session->databytes[0]);

--- a/capture/plugins/scrubspi.c
+++ b/capture/plugins/scrubspi.c
@@ -101,7 +101,6 @@ LOCAL void scrubspi_plugin_save(ArkimeSession_t *session, int UNUSED(final))
         case ARKIME_FIELD_TYPE_FLOAT_GHASH:
         case ARKIME_FIELD_TYPE_IP:
         case ARKIME_FIELD_TYPE_IP_GHASH:
-        case ARKIME_FIELD_TYPE_CERTSINFO:
         case ARKIME_FIELD_TYPE_OBJECT:
             // Unsupported
             break;

--- a/capture/plugins/wise.c
+++ b/capture/plugins/wise.c
@@ -799,7 +799,6 @@ void wise_plugin_pre_save(ArkimeSession_t *session, int UNUSED(final))
                     else
                         wise_lookup(session, iRequest, ikey, type, pos);
                 }
-            case ARKIME_FIELD_TYPE_CERTSINFO:
             case ARKIME_FIELD_TYPE_OBJECT:
                 // Unsupported
                 break;

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -385,7 +385,6 @@ LOCAL void arkime_rules_load_add_field(ArkimeRule_t *rule, int pos, char *key)
             g_ptr_array_add(rules, rule);
         }
         break;
-    case ARKIME_FIELD_TYPE_CERTSINFO:
     case ARKIME_FIELD_TYPE_OBJECT:
         // Unsupported
         break;
@@ -617,9 +616,6 @@ LOCAL void arkime_rules_parser_load_rule(char *filename, YamlNode_t *parent)
                 }
                 break;
 
-            case ARKIME_FIELD_TYPE_CERTSINFO:
-                CONFIGEXIT("%s: Currently don't support any certs fields", filename);
-                break;
             case ARKIME_FIELD_TYPE_OBJECT:
                 CONFIGEXIT("%s: Currently don't support any generic object fields", filename);
             }
@@ -1137,7 +1133,6 @@ LOCAL void arkime_rules_check_rule_fields(ArkimeSession_t *const session, Arkime
                 good = g_hash_table_contains(rule->hash[p], (gpointer)(long)HASH_COUNT(s_, *shash));
                 RULE_LOG_INT(HASH_COUNT(s_, *shash));
                 break;
-            case ARKIME_FIELD_TYPE_CERTSINFO:
             case ARKIME_FIELD_TYPE_OBJECT:
                 // Unsupported
                 break;
@@ -1263,7 +1258,6 @@ LOCAL void arkime_rules_check_rule_fields(ArkimeSession_t *const session, Arkime
                 }
             }
             break;
-        case ARKIME_FIELD_TYPE_CERTSINFO:
         case ARKIME_FIELD_TYPE_OBJECT:
             // Unsupported
             break;

--- a/tests/pcap/badcurveball.test
+++ b/tests/pcap/badcurveball.test
@@ -5,30 +5,6 @@
             "@timestamp" : "SET",
             "cert" : [
                {
-                  "curve" : "corrupt",
-                  "hash" : "f9:ce:21:f0:64:d4:99:f9:e9:95:e8:4d:c7:30:6d:19:62:e1:02:c4",
-                  "issuerCN" : [
-                     "infigo"
-                  ],
-                  "issuerON" : [
-                     "INFIGO IS"
-                  ],
-                  "notAfter" : 1581775250000,
-                  "notBefore" : 1579183250000,
-                  "publicAlgorithm" : "id-ecPublicKey",
-                  "remainingDays" : 28,
-                  "remainingSeconds" : 2481434,
-                  "serial" : "62344031f7ab03e6f9327cde33419cf7fb09df94",
-                  "subjectCN" : [
-                     "infigo"
-                  ],
-                  "subjectON" : [
-                     "INFIGO IS"
-                  ],
-                  "validDays" : 30,
-                  "validSeconds" : 2592000
-               },
-               {
                   "alt" : [
                      "bad.curveballtest.com"
                   ],
@@ -55,6 +31,30 @@
                   ],
                   "validDays" : 730,
                   "validSeconds" : 63072000
+               },
+               {
+                  "curve" : "corrupt",
+                  "hash" : "f9:ce:21:f0:64:d4:99:f9:e9:95:e8:4d:c7:30:6d:19:62:e1:02:c4",
+                  "issuerCN" : [
+                     "infigo"
+                  ],
+                  "issuerON" : [
+                     "INFIGO IS"
+                  ],
+                  "notAfter" : 1581775250000,
+                  "notBefore" : 1579183250000,
+                  "publicAlgorithm" : "id-ecPublicKey",
+                  "remainingDays" : 28,
+                  "remainingSeconds" : 2481434,
+                  "serial" : "62344031f7ab03e6f9327cde33419cf7fb09df94",
+                  "subjectCN" : [
+                     "infigo"
+                  ],
+                  "subjectON" : [
+                     "INFIGO IS"
+                  ],
+                  "validDays" : 30,
+                  "validSeconds" : 2592000
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/https-connect.test
+++ b/tests/pcap/https-connect.test
@@ -5,6 +5,35 @@
             "@timestamp" : "SET",
             "cert" : [
                {
+                  "hash" : "a0:31:c4:67:82:e6:e6:c6:62:c2:c8:7c:76:da:9a:a6:2c:ca:bd:8e",
+                  "issuerCN" : [
+                     "digicert high assurance ev root ca"
+                  ],
+                  "issuerON" : [
+                     "DigiCert Inc"
+                  ],
+                  "issuerOU" : [
+                     "www.digicert.com"
+                  ],
+                  "notAfter" : 1855828800000,
+                  "notBefore" : 1382443200000,
+                  "publicAlgorithm" : "rsaEncryption",
+                  "remainingDays" : 3337,
+                  "remainingSeconds" : 288378187,
+                  "serial" : "04e1e7a4dc5cf2f36dc02b42b85d159f",
+                  "subjectCN" : [
+                     "digicert sha2 high assurance server ca"
+                  ],
+                  "subjectON" : [
+                     "DigiCert Inc"
+                  ],
+                  "subjectOU" : [
+                     "www.digicert.com"
+                  ],
+                  "validDays" : 5479,
+                  "validSeconds" : 473385600
+               },
+               {
                   "alt" : [
                      "lfoup01-b.cloudsink.net",
                      "cloudsink.net",
@@ -36,35 +65,6 @@
                   ],
                   "validDays" : 1100,
                   "validSeconds" : 95083200
-               },
-               {
-                  "hash" : "a0:31:c4:67:82:e6:e6:c6:62:c2:c8:7c:76:da:9a:a6:2c:ca:bd:8e",
-                  "issuerCN" : [
-                     "digicert high assurance ev root ca"
-                  ],
-                  "issuerON" : [
-                     "DigiCert Inc"
-                  ],
-                  "issuerOU" : [
-                     "www.digicert.com"
-                  ],
-                  "notAfter" : 1855828800000,
-                  "notBefore" : 1382443200000,
-                  "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 3337,
-                  "remainingSeconds" : 288378187,
-                  "serial" : "04e1e7a4dc5cf2f36dc02b42b85d159f",
-                  "subjectCN" : [
-                     "digicert sha2 high assurance server ca"
-                  ],
-                  "subjectON" : [
-                     "DigiCert Inc"
-                  ],
-                  "subjectOU" : [
-                     "www.digicert.com"
-                  ],
-                  "validDays" : 5479,
-                  "validSeconds" : 473385600
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/openssl-ssl3.test
+++ b/tests/pcap/openssl-ssl3.test
@@ -5,6 +5,29 @@
             "@timestamp" : "SET",
             "cert" : [
                {
+                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
+                  "issuerCN" : [
+                     "geotrust global ca"
+                  ],
+                  "issuerON" : [
+                     "GeoTrust Inc."
+                  ],
+                  "notAfter" : 1483228799000,
+                  "notBefore" : 1365174955000,
+                  "publicAlgorithm" : "rsaEncryption",
+                  "remainingDays" : 808,
+                  "remainingSeconds" : 69891030,
+                  "serial" : "023a76",
+                  "subjectCN" : [
+                     "google internet authority g2"
+                  ],
+                  "subjectON" : [
+                     "Google Inc"
+                  ],
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
+               },
+               {
                   "hash" : "73:59:75:5c:6d:f9:a0:ab:c3:06:0b:ce:36:95:64:c8:ec:45:42:a3",
                   "issuerON" : [
                      "Equifax"
@@ -101,29 +124,6 @@
                   ],
                   "validDays" : 89,
                   "validSeconds" : 7739515
-               },
-               {
-                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
-                  "issuerCN" : [
-                     "geotrust global ca"
-                  ],
-                  "issuerON" : [
-                     "GeoTrust Inc."
-                  ],
-                  "notAfter" : 1483228799000,
-                  "notBefore" : 1365174955000,
-                  "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 808,
-                  "remainingSeconds" : 69891030,
-                  "serial" : "023a76",
-                  "subjectCN" : [
-                     "google internet authority g2"
-                  ],
-                  "subjectON" : [
-                     "Google Inc"
-                  ],
-                  "validDays" : 1366,
-                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/openssl-tls1-tls1_2.test
+++ b/tests/pcap/openssl-tls1-tls1_2.test
@@ -5,6 +5,29 @@
             "@timestamp" : "SET",
             "cert" : [
                {
+                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
+                  "issuerCN" : [
+                     "geotrust global ca"
+                  ],
+                  "issuerON" : [
+                     "GeoTrust Inc."
+                  ],
+                  "notAfter" : 1483228799000,
+                  "notBefore" : 1365174955000,
+                  "publicAlgorithm" : "rsaEncryption",
+                  "remainingDays" : 808,
+                  "remainingSeconds" : 69890592,
+                  "serial" : "023a76",
+                  "subjectCN" : [
+                     "google internet authority g2"
+                  ],
+                  "subjectON" : [
+                     "Google Inc"
+                  ],
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
+               },
+               {
                   "hash" : "73:59:75:5c:6d:f9:a0:ab:c3:06:0b:ce:36:95:64:c8:ec:45:42:a3",
                   "issuerON" : [
                      "Equifax"
@@ -101,29 +124,6 @@
                   ],
                   "validDays" : 89,
                   "validSeconds" : 7739515
-               },
-               {
-                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
-                  "issuerCN" : [
-                     "geotrust global ca"
-                  ],
-                  "issuerON" : [
-                     "GeoTrust Inc."
-                  ],
-                  "notAfter" : 1483228799000,
-                  "notBefore" : 1365174955000,
-                  "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 808,
-                  "remainingSeconds" : 69890592,
-                  "serial" : "023a76",
-                  "subjectCN" : [
-                     "google internet authority g2"
-                  ],
-                  "subjectON" : [
-                     "Google Inc"
-                  ],
-                  "validDays" : 1366,
-                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/openssl-tls1.test
+++ b/tests/pcap/openssl-tls1.test
@@ -5,6 +5,29 @@
             "@timestamp" : "SET",
             "cert" : [
                {
+                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
+                  "issuerCN" : [
+                     "geotrust global ca"
+                  ],
+                  "issuerON" : [
+                     "GeoTrust Inc."
+                  ],
+                  "notAfter" : 1483228799000,
+                  "notBefore" : 1365174955000,
+                  "publicAlgorithm" : "rsaEncryption",
+                  "remainingDays" : 808,
+                  "remainingSeconds" : 69890978,
+                  "serial" : "023a76",
+                  "subjectCN" : [
+                     "google internet authority g2"
+                  ],
+                  "subjectON" : [
+                     "Google Inc"
+                  ],
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
+               },
+               {
                   "hash" : "73:59:75:5c:6d:f9:a0:ab:c3:06:0b:ce:36:95:64:c8:ec:45:42:a3",
                   "issuerON" : [
                      "Equifax"
@@ -101,29 +124,6 @@
                   ],
                   "validDays" : 89,
                   "validSeconds" : 7739515
-               },
-               {
-                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
-                  "issuerCN" : [
-                     "geotrust global ca"
-                  ],
-                  "issuerON" : [
-                     "GeoTrust Inc."
-                  ],
-                  "notAfter" : 1483228799000,
-                  "notBefore" : 1365174955000,
-                  "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 808,
-                  "remainingSeconds" : 69890978,
-                  "serial" : "023a76",
-                  "subjectCN" : [
-                     "google internet authority g2"
-                  ],
-                  "subjectON" : [
-                     "Google Inc"
-                  ],
-                  "validDays" : 1366,
-                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/openssl-tls1_1.test
+++ b/tests/pcap/openssl-tls1_1.test
@@ -5,6 +5,29 @@
             "@timestamp" : "SET",
             "cert" : [
                {
+                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
+                  "issuerCN" : [
+                     "geotrust global ca"
+                  ],
+                  "issuerON" : [
+                     "GeoTrust Inc."
+                  ],
+                  "notAfter" : 1483228799000,
+                  "notBefore" : 1365174955000,
+                  "publicAlgorithm" : "rsaEncryption",
+                  "remainingDays" : 808,
+                  "remainingSeconds" : 69890962,
+                  "serial" : "023a76",
+                  "subjectCN" : [
+                     "google internet authority g2"
+                  ],
+                  "subjectON" : [
+                     "Google Inc"
+                  ],
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
+               },
+               {
                   "hash" : "73:59:75:5c:6d:f9:a0:ab:c3:06:0b:ce:36:95:64:c8:ec:45:42:a3",
                   "issuerON" : [
                      "Equifax"
@@ -101,29 +124,6 @@
                   ],
                   "validDays" : 89,
                   "validSeconds" : 7739515
-               },
-               {
-                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
-                  "issuerCN" : [
-                     "geotrust global ca"
-                  ],
-                  "issuerON" : [
-                     "GeoTrust Inc."
-                  ],
-                  "notAfter" : 1483228799000,
-                  "notBefore" : 1365174955000,
-                  "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 808,
-                  "remainingSeconds" : 69890962,
-                  "serial" : "023a76",
-                  "subjectCN" : [
-                     "google internet authority g2"
-                  ],
-                  "subjectON" : [
-                     "Google Inc"
-                  ],
-                  "validDays" : 1366,
-                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/openssl-tls1_2-tls1.test
+++ b/tests/pcap/openssl-tls1_2-tls1.test
@@ -5,6 +5,37 @@
             "@timestamp" : "SET",
             "cert" : [
                {
+                  "hash" : "c5:3e:73:07:3f:93:ce:78:95:de:74:84:12:6b:c3:03:da:b9:e6:57",
+                  "issuerCN" : [
+                     "entrust.net certification authority (2048)"
+                  ],
+                  "issuerON" : [
+                     "Entrust.net"
+                  ],
+                  "issuerOU" : [
+                     "www.entrust.net/CPS_2048 incorp. by ref. (limits liab.)",
+                     "(c) 1999 Entrust.net Limited"
+                  ],
+                  "notAfter" : 1636685477000,
+                  "notBefore" : 1321026040000,
+                  "publicAlgorithm" : "rsaEncryption",
+                  "remainingDays" : 2585,
+                  "remainingSeconds" : 223347403,
+                  "serial" : "4c0e8c39",
+                  "subjectCN" : [
+                     "entrust certification authority - l1c"
+                  ],
+                  "subjectON" : [
+                     "Entrust, Inc."
+                  ],
+                  "subjectOU" : [
+                     "www.entrust.net/rpa is incorporated by reference",
+                     "(c) 2009 Entrust, Inc."
+                  ],
+                  "validDays" : 3653,
+                  "validSeconds" : 315659437
+               },
+               {
                   "alt" : [
                      "toshiba.aol.ca",
                      "main-w.welcomescreen.aol.com",
@@ -98,37 +129,6 @@
                   ],
                   "validDays" : 1096,
                   "validSeconds" : 94731909
-               },
-               {
-                  "hash" : "c5:3e:73:07:3f:93:ce:78:95:de:74:84:12:6b:c3:03:da:b9:e6:57",
-                  "issuerCN" : [
-                     "entrust.net certification authority (2048)"
-                  ],
-                  "issuerON" : [
-                     "Entrust.net"
-                  ],
-                  "issuerOU" : [
-                     "www.entrust.net/CPS_2048 incorp. by ref. (limits liab.)",
-                     "(c) 1999 Entrust.net Limited"
-                  ],
-                  "notAfter" : 1636685477000,
-                  "notBefore" : 1321026040000,
-                  "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 2585,
-                  "remainingSeconds" : 223347403,
-                  "serial" : "4c0e8c39",
-                  "subjectCN" : [
-                     "entrust certification authority - l1c"
-                  ],
-                  "subjectON" : [
-                     "Entrust, Inc."
-                  ],
-                  "subjectOU" : [
-                     "www.entrust.net/rpa is incorporated by reference",
-                     "(c) 2009 Entrust, Inc."
-                  ],
-                  "validDays" : 3653,
-                  "validSeconds" : 315659437
                }
             ],
             "certCnt" : 2,

--- a/tests/pcap/openssl-tls1_2.test
+++ b/tests/pcap/openssl-tls1_2.test
@@ -5,6 +5,29 @@
             "@timestamp" : "SET",
             "cert" : [
                {
+                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
+                  "issuerCN" : [
+                     "geotrust global ca"
+                  ],
+                  "issuerON" : [
+                     "GeoTrust Inc."
+                  ],
+                  "notAfter" : 1483228799000,
+                  "notBefore" : 1365174955000,
+                  "publicAlgorithm" : "rsaEncryption",
+                  "remainingDays" : 808,
+                  "remainingSeconds" : 69890903,
+                  "serial" : "023a76",
+                  "subjectCN" : [
+                     "google internet authority g2"
+                  ],
+                  "subjectON" : [
+                     "Google Inc"
+                  ],
+                  "validDays" : 1366,
+                  "validSeconds" : 118053844
+               },
+               {
                   "hash" : "73:59:75:5c:6d:f9:a0:ab:c3:06:0b:ce:36:95:64:c8:ec:45:42:a3",
                   "issuerON" : [
                      "Equifax"
@@ -101,29 +124,6 @@
                   ],
                   "validDays" : 89,
                   "validSeconds" : 7739515
-               },
-               {
-                  "hash" : "bb:dc:e1:3e:9d:53:7a:52:29:91:5c:b1:23:c7:aa:b0:a8:55:e7:98",
-                  "issuerCN" : [
-                     "geotrust global ca"
-                  ],
-                  "issuerON" : [
-                     "GeoTrust Inc."
-                  ],
-                  "notAfter" : 1483228799000,
-                  "notBefore" : 1365174955000,
-                  "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 808,
-                  "remainingSeconds" : 69890903,
-                  "serial" : "023a76",
-                  "subjectCN" : [
-                     "google internet authority g2"
-                  ],
-                  "subjectON" : [
-                     "Google Inc"
-                  ],
-                  "validDays" : 1366,
-                  "validSeconds" : 118053844
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/pppoe.test
+++ b/tests/pcap/pppoe.test
@@ -5,30 +5,27 @@
             "@timestamp" : "SET",
             "cert" : [
                {
-                  "hash" : "cc:04:2e:48:2f:29:6a:3a:dc:a4:8b:fb:79:a6:cd:5f:67:8a:c1:e2",
+                  "hash" : "a1:44:6b:ce:0c:87:4d:f0:f2:c3:f6:1d:a5:c9:a2:bc:f9:da:b2:04",
                   "issuerCN" : [
-                     "aol member ca"
+                     "america online root certification authority 1"
                   ],
                   "issuerON" : [
                      "America Online Inc."
                   ],
-                  "notAfter" : 1231995540000,
-                  "notBefore" : 1168837200000,
+                  "notAfter" : 1875288399000,
+                  "notBefore" : 1086369999000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 443,
-                  "remainingSeconds" : 38319485,
-                  "serial" : "0119",
+                  "remainingDays" : 7889,
+                  "remainingSeconds" : 681612344,
+                  "serial" : "07",
                   "subjectCN" : [
-                     "kdc.uas.aol.com"
+                     "aol member ca"
                   ],
                   "subjectON" : [
-                     "AOL LLC"
+                     "America Online Inc."
                   ],
-                  "subjectOU" : [
-                     "Core Services"
-                  ],
-                  "validDays" : 730,
-                  "validSeconds" : 63158340
+                  "validDays" : 9131,
+                  "validSeconds" : 788918400
                },
                {
                   "hash" : "39:21:c1:15:c1:5d:0e:ca:5c:cb:5b:c4:f0:7d:21:d8:05:0b:56:6a",
@@ -54,27 +51,30 @@
                   "validSeconds" : 1119710580
                },
                {
-                  "hash" : "a1:44:6b:ce:0c:87:4d:f0:f2:c3:f6:1d:a5:c9:a2:bc:f9:da:b2:04",
+                  "hash" : "cc:04:2e:48:2f:29:6a:3a:dc:a4:8b:fb:79:a6:cd:5f:67:8a:c1:e2",
                   "issuerCN" : [
-                     "america online root certification authority 1"
+                     "aol member ca"
                   ],
                   "issuerON" : [
                      "America Online Inc."
                   ],
-                  "notAfter" : 1875288399000,
-                  "notBefore" : 1086369999000,
+                  "notAfter" : 1231995540000,
+                  "notBefore" : 1168837200000,
                   "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 7889,
-                  "remainingSeconds" : 681612344,
-                  "serial" : "07",
+                  "remainingDays" : 443,
+                  "remainingSeconds" : 38319485,
+                  "serial" : "0119",
                   "subjectCN" : [
-                     "aol member ca"
+                     "kdc.uas.aol.com"
                   ],
                   "subjectON" : [
-                     "America Online Inc."
+                     "AOL LLC"
                   ],
-                  "validDays" : 9131,
-                  "validSeconds" : 788918400
+                  "subjectOU" : [
+                     "Core Services"
+                  ],
+                  "validDays" : 730,
+                  "validSeconds" : 63158340
                }
             ],
             "certCnt" : 3,
@@ -164,11 +164,11 @@
             ],
             "srcOuiCnt" : 1,
             "srcPayload8" : "804c010300003300",
+            "srcRIR" : "ARIN",
             "tags" : [
                "cert:certificate-authority"
             ],
             "tagsCnt" : 1,
-            "srcRIR" : "ARIN",
             "tcpflags" : {
                "ack" : 4,
                "dstZero" : 0,

--- a/tests/pcap/smtp-starttls.test
+++ b/tests/pcap/smtp-starttls.test
@@ -28,29 +28,6 @@
                   "validSeconds" : 62985600
                },
                {
-                  "hash" : "73:59:75:5c:6d:f9:a0:ab:c3:06:0b:ce:36:95:64:c8:ec:45:42:a3",
-                  "issuerON" : [
-                     "Equifax"
-                  ],
-                  "issuerOU" : [
-                     "Equifax Secure Certificate Authority"
-                  ],
-                  "notAfter" : 1534824000000,
-                  "notBefore" : 1021953600000,
-                  "publicAlgorithm" : "rsaEncryption",
-                  "remainingDays" : 1699,
-                  "remainingSeconds" : 146806876,
-                  "serial" : "12bbe6",
-                  "subjectCN" : [
-                     "geotrust global ca"
-                  ],
-                  "subjectON" : [
-                     "GeoTrust Inc."
-                  ],
-                  "validDays" : 5936,
-                  "validSeconds" : 512870400
-               },
-               {
                   "alt" : [
                      "aspmx.l.google.com",
                      "alt1.aspmx.l.google.com",
@@ -95,6 +72,29 @@
                   ],
                   "validDays" : 365,
                   "validSeconds" : 31536000
+               },
+               {
+                  "hash" : "73:59:75:5c:6d:f9:a0:ab:c3:06:0b:ce:36:95:64:c8:ec:45:42:a3",
+                  "issuerON" : [
+                     "Equifax"
+                  ],
+                  "issuerOU" : [
+                     "Equifax Secure Certificate Authority"
+                  ],
+                  "notAfter" : 1534824000000,
+                  "notBefore" : 1021953600000,
+                  "publicAlgorithm" : "rsaEncryption",
+                  "remainingDays" : 1699,
+                  "remainingSeconds" : 146806876,
+                  "serial" : "12bbe6",
+                  "subjectCN" : [
+                     "geotrust global ca"
+                  ],
+                  "subjectON" : [
+                     "GeoTrust Inc."
+                  ],
+                  "validDays" : 5936,
+                  "validSeconds" : 512870400
                }
             ],
             "certCnt" : 3,

--- a/tests/pcap/tls-alpn-h2.test
+++ b/tests/pcap/tls-alpn-h2.test
@@ -5,6 +5,36 @@
             "@timestamp" : "SET",
             "cert" : [
                {
+                  "curve" : "secp384r1",
+                  "hash" : "fc:20:b6:0c:ad:ac:38:d1:ff:40:cf:1b:6e:ef:29:0f:10:b5:7a:bd",
+                  "issuerCN" : [
+                     "digicert high assurance ev root ca"
+                  ],
+                  "issuerON" : [
+                     "DigiCert Inc"
+                  ],
+                  "issuerOU" : [
+                     "www.digicert.com"
+                  ],
+                  "notAfter" : 1939812867000,
+                  "notBefore" : 1466513667000,
+                  "publicAlgorithm" : "id-ecPublicKey",
+                  "remainingDays" : 4002,
+                  "remainingSeconds" : 345832259,
+                  "serial" : "029707560cd4a9ebbfe272f1e096d882",
+                  "subjectCN" : [
+                     "digicert ecc extended validation server ca"
+                  ],
+                  "subjectON" : [
+                     "DigiCert Inc"
+                  ],
+                  "subjectOU" : [
+                     "www.digicert.com"
+                  ],
+                  "validDays" : 5478,
+                  "validSeconds" : 473299200
+               },
+               {
                   "alt" : [
                      "cloudflare.com",
                      "www.cloudflare.com"
@@ -35,36 +65,6 @@
                   ],
                   "validDays" : 735,
                   "validSeconds" : 63547200
-               },
-               {
-                  "curve" : "secp384r1",
-                  "hash" : "fc:20:b6:0c:ad:ac:38:d1:ff:40:cf:1b:6e:ef:29:0f:10:b5:7a:bd",
-                  "issuerCN" : [
-                     "digicert high assurance ev root ca"
-                  ],
-                  "issuerON" : [
-                     "DigiCert Inc"
-                  ],
-                  "issuerOU" : [
-                     "www.digicert.com"
-                  ],
-                  "notAfter" : 1939812867000,
-                  "notBefore" : 1466513667000,
-                  "publicAlgorithm" : "id-ecPublicKey",
-                  "remainingDays" : 4002,
-                  "remainingSeconds" : 345832259,
-                  "serial" : "029707560cd4a9ebbfe272f1e096d882",
-                  "subjectCN" : [
-                     "digicert ecc extended validation server ca"
-                  ],
-                  "subjectON" : [
-                     "DigiCert Inc"
-                  ],
-                  "subjectOU" : [
-                     "www.digicert.com"
-                  ],
-                  "validDays" : 5478,
-                  "validSeconds" : 473299200
                }
             ],
             "certCnt" : 2,


### PR DESCRIPTION
**Clearly describe the problem and solution**

The TLS certs parsed by the tls and dtls parser use the ARKIME_FIELD_TYPE_CERTSINFO but this should be changed to the ARKIME_FIELD_TYPE_OBJECT.

**Relevant issue number(s) if applicable**

No issue, but this PR depends and includes the PR #2671.

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

No, no changes to viewer.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Yes, but at the moment the cert array is sorted differently, this is still being investigated therefore this PR is still in draft.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
