### PR TITLE
disable curl timeout on s3 download fixes #2698

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Capture
   - #2674 Fix filelist not working in scheme mode
   - #2679 Cert.alt can be used in rules
+  - #2699 Disable reader s3 download timeout
 ## Cont3xt
   - #2683 lock integration settings
 ## Viewer

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1025,6 +1025,7 @@ uint64_t arkime_http_dropped_count(void *server);
 
 void *arkime_http_create_server(const char *hostnames, int maxConns, int maxOutstandingRequests, int compress);
 void arkime_http_set_retries(void *server, uint16_t retries);
+void arkime_http_set_timeout(void *serverV, uint64_t timeout);
 void arkime_http_set_client_cert(void *serverV, char *clientCert, char *clientKey, char *clientKeyPass);
 void arkime_http_set_print_errors(void *server);
 void arkime_http_set_headers(void *server, char **headers);

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -256,6 +256,7 @@ int scheme_s3_load(const char *uri)
         void *server = g_hash_table_lookup(servers, schemehostport);
         if (!server) {
             server = arkime_http_create_server(schemehostport, 2, 2, TRUE);
+            arkime_http_set_timeout(server, 0);
             g_hash_table_insert(servers, g_strdup(schemehostport), server);
         }
 
@@ -326,6 +327,7 @@ int scheme_s3_load_full(const char *uri)
     void *server = g_hash_table_lookup(servers, schemehostport);
     if (!server) {
         server = arkime_http_create_server(schemehostport, 2, 2, TRUE);
+        arkime_http_set_timeout(server, 0);
         g_hash_table_insert(servers, g_strdup(schemehostport), server);
     }
 


### PR DESCRIPTION
Can now override default 120s timeout for each server.
S3 downloads disable timeout
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
