### PR TITLE
Don't starve viewer when tcp reassembling pcap fixes #2697

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2680 add default user settings to viewer config
           https://arkime.com/settings#user-setting-defaults
   - #2681 fix unique of numerical fields
+  - #2700 Make sure pcap reassembly doesn't starve viewer
 
 5.0.1 2024/02/20
 ## Release


### PR DESCRIPTION
Previously had a tight for loop which would hang viewer when processing large amounts of tcp packets.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
