### PR TITLE
Support viewurl path

### DIFF
--- a/common/auth.js
+++ b/common/auth.js
@@ -650,8 +650,11 @@ class Auth {
         return done('Can not authenticate with role');
       }
 
-      obj.path = obj.path.replace(Auth.#basePath, '/');
-      if (obj.path !== req.url) {
+      let objPath = obj.path;
+      if (Auth.#basePath.length > 1 && obj.path.startsWith(Auth.#basePath)) {
+        objPath = obj.path.substring(Auth.#basePath.length);
+      }
+      if (obj.path !== req.url && objPath !== req.url) {
         console.log('ERROR - mismatch url', obj.path, ArkimeUtil.sanitizeStr(req.url));
         return done('Unauthorized based on bad url');
       }

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -1601,8 +1601,8 @@ class SessionAPIs {
         agent: client === http ? internals.httpAgent : internals.httpsAgent
       };
 
-      const path = url.pathname + (url.search ?? '');
-      Auth.addS2SAuth(options, req.user, req.params.nodeName, path);
+      const urlPath = url.pathname + (url.search ?? '');
+      Auth.addS2SAuth(options, req.user, req.params.nodeName, urlPath);
       ViewerUtils.addCaTrust(options, req.params.nodeName);
 
       const preq = client.request(url, options, (pres) => {

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -1590,13 +1590,19 @@ class SessionAPIs {
         return res.send(`Can't find view url for '${ArkimeUtil.safeStr(req.params.nodeName)}' check viewer logs on '${Config.hostName()}'`);
       }
 
-      const url = new URL(req.url, viewUrl);
+      let url;
+      if (req.url.startsWith('/')) {
+        url = new URL(req.url.substring(1), viewUrl);
+      } else {
+        url = new URL(req.url, viewUrl);
+      }
       const options = {
         timeout: 20 * 60 * 1000,
         agent: client === http ? internals.httpAgent : internals.httpsAgent
       };
 
-      Auth.addS2SAuth(options, req.user, req.params.nodeName, req.url);
+      const path = url.pathname + (url.search ?? '');
+      Auth.addS2SAuth(options, req.user, req.params.nodeName, path);
       ViewerUtils.addCaTrust(options, req.params.nodeName);
 
       const preq = client.request(url, options, (pres) => {


### PR DESCRIPTION
previously when using a viewUrl if it has a path in it, it was ignored.
This allows a non standard method of accessing sensor viewers that
have a webBasePath now.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
