### PR TITLE
Cont3xt insecure integration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Cont3xt
   - #2683 lock integration settings
   - #2240 snap to dates
+  - #2730 Arkime/OpenSearch/Elasticsearch integration had insecure logic backwards
 ## Viewer
   - #2668 fix pcap export with only default time range and no date param in url
   - #2680 add default user settings to viewer config

--- a/cont3xt/integrations/arkime/index.js
+++ b/cont3xt/integrations/arkime/index.js
@@ -177,7 +177,7 @@ class ArkimeIntegration extends Integration {
       requestTimeout: 300000,
       maxRetries: 2,
       ssl: {
-        rejectUnauthorized: !!ArkimeConfig.getFull(section, 'insecure', true)
+        rejectUnauthorized: !ArkimeConfig.getFull(section, 'insecure', true)
       }
     };
 

--- a/cont3xt/integrations/arkime/index.js
+++ b/cont3xt/integrations/arkime/index.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 const Integration = require('../../integration.js');
 const ArkimeConfig = require('../../../common/arkimeConfig');
 const ArkimeUtil = require('../../../common/arkimeUtil');
@@ -177,7 +178,7 @@ class ArkimeIntegration extends Integration {
       requestTimeout: 300000,
       maxRetries: 2,
       ssl: {
-        rejectUnauthorized: !ArkimeConfig.getFull(section, 'insecure', true)
+        rejectUnauthorized: !ArkimeConfig.getFull(section, 'insecure', false)
       }
     };
 

--- a/cont3xt/integrations/elasticsearch/index.js
+++ b/cont3xt/integrations/elasticsearch/index.js
@@ -80,7 +80,7 @@ class ElasticsearchIntegration extends Integration {
       requestTimeout: 300000,
       maxRetries: 2,
       ssl: {
-        rejectUnauthorized: !!ArkimeConfig.getFull(section, 'insecure', true)
+        rejectUnauthorized: !ArkimeConfig.getFull(section, 'insecure', true)
       }
     };
 

--- a/cont3xt/integrations/elasticsearch/index.js
+++ b/cont3xt/integrations/elasticsearch/index.js
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
 const Integration = require('../../integration.js');
 const ArkimeConfig = require('../../../common/arkimeConfig');
 const ArkimeUtil = require('../../../common/arkimeUtil');
@@ -80,7 +81,7 @@ class ElasticsearchIntegration extends Integration {
       requestTimeout: 300000,
       maxRetries: 2,
       ssl: {
-        rejectUnauthorized: !ArkimeConfig.getFull(section, 'insecure', true)
+        rejectUnauthorized: !ArkimeConfig.getFull(section, 'insecure', false)
       }
     };
 


### PR DESCRIPTION
Had the insecure for Arkime and OpenSearch/Elasticsearch integration backwards
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
