### PR TITLE
Fix use of incorrect length when checking for punycode in DNS parser

### DIFF
--- a/capture/parsers/dns.c
+++ b/capture/parsers/dns.c
@@ -606,7 +606,7 @@ LOCAL void dns_parser(ArkimeSession_t *session, int kind, const uint8_t *data, i
                     jsonLen += HOST_IP_JSON_LEN;
                 }
             }
-            if (arkime_memstr((const char *)name, len, "xn--", 4)) {
+            if (arkime_memstr((const char *)name, namelen, "xn--", 4)) {
                 ArkimeString_t *hstring;
                 HASH_FIND(s_, *(dns->punyHosts), name, hstring);
                 if (!hstring) {
@@ -665,7 +665,7 @@ LOCAL void dns_parser(ArkimeSession_t *session, int kind, const uint8_t *data, i
                 answer->name = g_hostname_to_unicode(name);
                 if (!answer->name)
                     answer->name = g_strndup(name, namelen);
-                if (arkime_memstr((const char *)name, len, "xn--", 4)) {
+                if (arkime_memstr((const char *)name, namelen, "xn--", 4)) {
                     ArkimeString_t *hstring;
                     HASH_FIND(s_, *(dns->punyHosts), name, hstring);
                     if (!hstring) {


### PR DESCRIPTION
**Clearly describe the problem and solution**

In the DNS parser when checking if the hostname is a punycode, we check if the string contains `xn--` but the wrong length is passed to the `arkime_memstr` function and therefore reads past the hostname string and corrupts the data and can cause segfaults in the worst case

**Relevant issue number(s) if applicable**

None

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

No changes to viewer or parliament

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

Yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
