### PR TITLE
Add routing allocation exclusion in db.pl

### DIFF
--- a/db/db.pl
+++ b/db/db.pl
@@ -108,6 +108,7 @@ my $SHARDSPERNODE = 1;
 my $ESTIMEOUT=60;
 my $UPGRADEALLSESSIONS = 1;
 my $DOHOTWARM = 0;
+my $SESSIONSROUTINGALLOCATIONEXCLUDEKEY = 0;
 my $DOILM = 0;
 my $DOISM = 0;
 my $WARMAFTER = -1;
@@ -5221,6 +5222,12 @@ if ($DOHOTWARM) {
       "routing.allocation.require.molochtype": "hot"';
 }
 
+if ($SESSIONSROUTINGALLOCATIONEXCLUDEKEY) {
+  my ($key, $value) = split(/=/, $SESSIONSROUTINGALLOCATIONEXCLUDEKEY, 2);
+  $settings .= qq,
+      "index.routing.allocation.exclude.$key": "$value";
+}
+
 if ($DOILM) {
   $settings .= qq/,
       "lifecycle.name": "${PREFIX}molochsessions"/;
@@ -6301,6 +6308,9 @@ sub parseArgs {
             }
         } elsif ($ARGV[$pos] eq "--hotwarm") {
             $DOHOTWARM = 1;
+        } elsif ($ARGV[$pos] eq "--sessionsroutingallocationexcludekey") {
+            $pos++;
+            $SESSIONSROUTINGALLOCATIONEXCLUDEKEY = int($ARGV[$pos]);
         } elsif ($ARGV[$pos] eq "--ifneeded") {
             $IFNEEDED = 1;
         } elsif ($ARGV[$pos] eq "--ilm") {


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**

We're using an ES cluster where we dedicate/isolate nodes for storing sessions. Our rational doing that is that metadata indices (especially files) should not be lost even if nodes storing the sessions are overloaded: loosing 1 file means loosing all the sessions stored in the file).
ES provides a mechanism called index routing allocation, and in our case, we tag _metadata_ nodes as such and exclude sessions indices from these metadata nodes.

ES template contains something like: `index.routing.allocation.exclude.arkimeNodeType = metadata`, `arkimeNodeType = metadata` being the tag of the _metadata_ nodes.

This PR provides a way to initialise the sessions template with a specific `index.routing.allocation.exclude` value using the parameter `--sessionsroutingallocationexcludekey key1=value1`

**Relevant issue number(s) if applicable**

n/a

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
