### PR TITLE
fix rules not always matching "0" for non array integer fields and add test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,7 +34,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 5.2.0 2024/05/xx
 ## Capture
   - #2756 parse SMB dialect
-  - #2757 fix rules not always matching "0" for non array integer fields
+  - #2758 fix rules not always matching "0" for non array integer fields
 
 5.1.1 2024/04/15
 ## Release

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -34,6 +34,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 5.2.0 2024/05/xx
 ## Capture
   - #2756 parse SMB dialect
+  - #2757 fix rules not always matching "0" for non array integer fields
 
 5.1.1 2024/04/15
 ## Release

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -1107,8 +1107,8 @@ LOCAL void arkime_rules_check_rule_fields(ArkimeSession_t *const session, Arkime
             if (config.fields[p]->getCb)
                 value = config.fields[p]->getCb(session, p);
 
-            // For NOT, missing fields means match
-            if (!value) {
+            // For NOT, missing fields means match, single int can be 0
+            if (!value && config.fields[p]->type != ARKIME_FIELD_TYPE_INT) {
                 continue;
             }
 
@@ -1314,7 +1314,8 @@ LOCAL void arkime_rules_check_rule_fields(ArkimeSession_t *const session, Arkime
             if (config.fields[p]->getCb)
                 value = config.fields[p]->getCb(session, p);
 
-            if (!value) {
+            // If the field is missing and not a single int (which could be 0), then it is a fail
+            if (!value && config.fields[p]->type != ARKIME_FIELD_TYPE_INT) {
                 good = 0;
                 continue;
             }

--- a/tests/pcap/gtp-iphone.test
+++ b/tests/pcap/gtp-iphone.test
@@ -780,6 +780,10 @@
             "srcOuterRIR" : [
                ""
             ],
+            "tags" : [
+               "src-2-dst-0"
+            ],
+            "tagsCnt" : 1,
             "totDataBytes" : 176
          },
          "header" : {

--- a/tests/rules.yaml
+++ b/tests/rules.yaml
@@ -77,6 +77,15 @@ rules:
       "protocols": "iprulztest"
       _maxPacketsToSave: ">100"
 
+  - name: "0 test"
+    when: "beforeFinalSave"
+    fields:
+      packets.src: 2
+      packets.dst: 0
+      databytes.src: 176
+    ops:
+      tags: "src-2-dst-0"
+
   - name: "only syn"
     when: "beforeFinalSave"
     fields:


### PR DESCRIPTION
internal non array integers were failing 0 test, for example packets.dst: 0

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
