### PR TITLE
make localhost not require --insecure

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,11 +32,15 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 5.2.0 2024/05/xx
+## Release
+  - #2779 Using https://localhost or https://127.0.0.1 no longer requires --insecure
+  - #2779 Configure now prompts for OpenSearch/Elasticserch user/password
+## All
+  - #2772 fix OIDC login crash
+  - #2773 Users tab saves automatically on change
 ## Capture
   - #2748 icmp community id support
   - #2766 VLAN or VNI can be used in session ids, controlled by sessionIdTracking
-## Viewer
-  - #2772 fix OIDC login crash
 
 5.1.2 2024/04/23
 ## Release

--- a/capture/http.c
+++ b/capture/http.c
@@ -102,6 +102,7 @@ struct arkimehttpserver_t {
     int                      snamesPos;
     char                     compress;
     char                     printErrors;
+    char                     insecure;
     uint16_t                 maxConns;
     uint16_t                 maxOutstandingRequests;
     uint16_t                 outstanding;
@@ -203,7 +204,7 @@ uint8_t *arkime_http_send_sync(void *serverV, const char *method, const char *ke
         easy = server->syncRequest.easy;
     }
 
-    if (config.insecure) {
+    if (server->insecure) {
         curl_easy_setopt(easy, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(easy, CURLOPT_SSL_VERIFYHOST, 0L);
     }
@@ -839,7 +840,7 @@ gboolean arkime_http_schedule2(void *serverV, const char *method, const char *ke
         curl_easy_setopt(request->easy, CURLOPT_VERBOSE, 1);
     }
 
-    if (config.insecure) {
+    if (server->insecure) {
         curl_easy_setopt(request->easy, CURLOPT_SSL_VERIFYPEER, 0L);
         curl_easy_setopt(request->easy, CURLOPT_SSL_VERIFYHOST, 0L);
     }
@@ -1059,6 +1060,16 @@ void *arkime_http_create_server(const char *hostnames, int maxConns, int maxOuts
 
     if (server->snamesCnt == 0) {
         LOGEXIT("ERROR - No valid endpoints in string '%s'", hostnames);
+    }
+
+    server->insecure = config.insecure; // Default to global setting
+
+    // If https to localhost or 127.0.0.1 we don't check the cert
+    if (config.insecure &&
+        (strncmp("https://localhost", server->snames[0].name, 17) == 0 ||
+         strncmp("https://127.0.0.1", server->snames[0].name, 17) == 0)) {
+        LOG("WARNING - Using insecure mode for %s", server->snames[0].name);
+        server->insecure = 1;
     }
 
     server->multi = curl_multi_init();

--- a/capture/http.c
+++ b/capture/http.c
@@ -1065,7 +1065,7 @@ void *arkime_http_create_server(const char *hostnames, int maxConns, int maxOuts
     server->insecure = config.insecure; // Default to global setting
 
     // If https to localhost or 127.0.0.1 we don't check the cert
-    if (config.insecure &&
+    if (!config.insecure &&
         (strncmp("https://localhost", server->snames[0].name, 17) == 0 ||
          strncmp("https://127.0.0.1", server->snames[0].name, 17) == 0)) {
         LOG("WARNING - Using insecure mode for %s", server->snames[0].name);

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -117,6 +117,31 @@ class ArkimeConfig {
   }
 
   // ----------------------------------------------------------------------------
+  static isInsecure (urls) {
+    if (ArkimeConfig.insecure) {
+      return true;
+    }
+
+    if (!urls) {
+      return false;
+    }
+
+    for (let url of urls) {
+      if (!url) {
+        continue;
+      }
+      if (Array.isArray(url)) {
+        url = url[0];
+      }
+      if (url.startsWith('https://localhost') || url.startsWith('https://127.0.0.1')) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  // ----------------------------------------------------------------------------
   /**
    * Reload the config file
    */

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -463,7 +463,7 @@ async function setupAuth () {
   const usersEs = ArkimeConfig.getArray('usersElasticsearch') ?? es;
 
   await Db.initialize({
-    insecure: ArkimeConfig.insecure,
+    insecure: ArkimeConfig.isInsecure([dbUrl, es]),
     url: dbUrl,
     node: es,
     caTrustFile: ArkimeConfig.get('caTrustFile'),
@@ -472,7 +472,7 @@ async function setupAuth () {
   });
 
   User.initialize({
-    insecure: ArkimeConfig.insecure,
+    insecure: ArkimeConfig.isInsecure([usersUrl, usersEs]),
     requestTimeout: ArkimeConfig.get('elasticsearchTimeout', 300),
     url: usersUrl,
     node: usersEs,

--- a/db/db.pl
+++ b/db/db.pl
@@ -6442,6 +6442,10 @@ if ($ARGV[0] =~ /^urlinfile:\/\//) {
     $main::elasticsearch = "http://$ARGV[0]";
 }
 
+if ($SECURE && $main::elasticsearch =~ /^https:\/\/(localhost|127.0.0.1)/) {
+    $SECURE=0;
+}
+
 if ($ARGV[1] =~ /^(users-?import|import)$/) {
     my $fh;
     if ($ARGV[2] =~ /\.gz$/) {

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1876,7 +1876,7 @@ async function setupAuth () {
   });
 
   User.initialize({
-    insecure: ArkimeConfig.insecure,
+    insecure: ArkimeConfig.isInsecure([ArkimeConfig.getArray('usersElasticsearch', 'http://localhost:9200')]),
     node: ArkimeConfig.getArray('usersElasticsearch', 'http://localhost:9200'),
     prefix: ArkimeConfig.get('usersPrefix'),
     apiKey: ArkimeConfig.get('usersElasticsearchAPIKey'),

--- a/release/Configure
+++ b/release/Configure
@@ -115,14 +115,22 @@ if [ "$ARKIME_INSTALLELASTICSEARCH" == "yes" ]; then
     fi
 else
     if [ -z "$ARKIME_ELASTICSEARCH" ]; then
-        echo -n "Elasticsearch server URL [http://localhost:9200] "
+        echo -n "OpenSearch/Elasticsearch server URL [http://localhost:9200] "
         read -r ARKIME_ELASTICSEARCH
     fi
     if [ -z "$ARKIME_ELASTICSEARCH" ]; then ARKIME_ELASTICSEARCH="http://localhost:9200"; fi
 fi
 
+echo -n "OpenSearch/Elasticsearch user [empty is no user] "
+read -r ARKIME_ELASTICSEARCH_USER
+
+if [ ! -z "$ARKIME_ELASTICSEARCH_USER" ]; then
+    echo -n "OpenSearch/Elasticsearch password [empty is no password] "
+    read -r ARKIME_ELASTICSEARCH_PASSWORD
+fi
+
 while [ -z "$ARKIME_PASSWORD" ]; do
-    echo -n "Password to encrypt S2S and other things, don't use spaces [no-default] "
+    echo -n "Password to encrypt S2S and other things, don't use spaces [must create one] "
     read -r ARKIME_PASSWORD
 done
 ARKIME_PASSWORD=${ARKIME_PASSWORD//\//\\/}
@@ -133,6 +141,10 @@ if [ ! -f "$ARKIME_INSTALL_DIR/etc/config.ini" ]; then
     echo "Installing sample $ARKIME_INSTALL_DIR/etc/config.ini"
     echo sed -e "s/ARKIME_INTERFACE/${ARKIME_INTERFACE}/g" -e "s,ARKIME_ELASTICSEARCH,${ARKIME_ELASTICSEARCH},g" -e "s/ARKIME_PASSWORD/${ARKIME_PASSWORD}/g" -e "s,ARKIME_INSTALL_DIR,${ARKIME_INSTALL_DIR},g" < $ARKIME_INSTALL_DIR/etc/config.ini.sample > $ARKIME_INSTALL_DIR/etc/config.ini
     sed -e "s/ARKIME_INTERFACE/${ARKIME_INTERFACE}/g" -e "s,ARKIME_ELASTICSEARCH,${ARKIME_ELASTICSEARCH},g" -e "s/ARKIME_PASSWORD/${ARKIME_PASSWORD}/g" -e "s,ARKIME_INSTALL_DIR,${ARKIME_INSTALL_DIR},g" < $ARKIME_INSTALL_DIR/etc/config.ini.sample > $ARKIME_INSTALL_DIR/etc/config.ini
+
+    if [ ! -z "$ARKIME_ELASTICSEARCH_USER" ]; then
+        sed -I "" -e "s/# elasticsearchBasicAuth=/elasticsearchBasicAuth=${ARKIME_ELASTICSEARCH_USER}:${ARKIME_ELASTICSEARCH_PASSWORD}/g" $ARKIME_INSTALL_DIR/etc/config.ini
+    fi
 else
     echo "Not overwriting $ARKIME_INSTALL_DIR/etc/config.ini, delete and run again if update required (usually not), or edit by hand"
     sleep 2

--- a/viewer/addUser.js
+++ b/viewer/addUser.js
@@ -158,7 +158,7 @@ async function premain () {
     const usersUrl = Config.get('usersUrl');
     const usersEs = Config.getArray('usersElasticsearch', Config.get('elasticsearch', 'http://localhost:9200'));
     User.initialize({
-      insecure: ArkimeConfig.insecure,
+      insecure: ArkimeConfig.isInsecure([usersUrl, usersEs]),
       requestTimeout: Config.get('elasticsearchTimeout', 300),
       url: usersUrl,
       node: usersEs,
@@ -180,7 +180,7 @@ async function premain () {
       esClientKey: Config.get('esClientKey', null),
       esClientCert: Config.get('esClientCert', null),
       esClientKeyPass: Config.get('esClientKeyPass', null),
-      insecure: ArkimeConfig.insecure,
+      insecure: ArkimeConfig.isInsecure([escInfo, Config.getArray('usersElasticsearch')]),
       caTrustFile: Config.getFull(Config.nodeName(), 'caTrustFile'),
       usersHost: Config.getArray('usersElasticsearch'),
       usersPrefix: Config.get('usersPrefix'),

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2171,7 +2171,7 @@ async function premain () {
     esClientCert: Config.get('esClientCert', null),
     esClientKeyPass: Config.get('esClientKeyPass', null),
     multiES: internals.multiES,
-    insecure: ArkimeConfig.insecure,
+    insecure: ArkimeConfig.isInsecure([internals.elasticBase, Config.getArray('usersElasticsearch')]),
     caTrustFile: Config.get('caTrustFile', null),
     requestTimeout: Config.get('elasticsearchTimeout', 300),
     esProfile: Config.esProfile,

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -195,7 +195,7 @@ function setupAuth () {
   const es = ArkimeConfig.getArray('usersElasticsearch', 'http://localhost:9200');
 
   User.initialize({
-    insecure: ArkimeConfig.insecure,
+    insecure: ArkimeConfig.isInsecure([es]),
     node: es,
     caTrustFile: ArkimeConfig.get('caTrustFile'),
     prefix: ArkimeConfig.get('usersPrefix'),


### PR DESCRIPTION
* If using https://localhost or https://127.0.0.1 we now turn off host/peer cert verification automatically since you can't have certs for those. That means other urls can still have verification turned on
* Configure script now asks for OpenSearch/Elasticsearch user/pass and fills in config file

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
