### PR TITLE
switch to using LOG_RATE everywhere

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,7 +38,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2779 Using https://localhost or https://127.0.0.1 no longer requires --insecure
   - #2779 Configure now prompts for OpenSearch/Elasticserch user/password
   - #2783 New debian 12 package
-  - #2790 CyberChef 10.18.3
+  - CyberChef 10.18.3
 ## All
   - #2772 fix OIDC login crash
   - #2773 Users tab saves automatically on change

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -787,11 +787,12 @@ extern ARKIME_LOCK_EXTERN(LOG);
 #define REMOVEDCONFIG(_var,_help) do { if (arkime_config_str(NULL, _var, NULL) != NULL) CONFIGEXIT("Setting '" _var "' removed - " _help); } while (0) /* no trailing ; */
 
 #define LOG_RATE(rate, ...) do { \
+    struct timespec ts_current; \
+    clock_gettime(CLOCK_MONOTONIC, &ts_current); \
     static time_t last_time = 0; \
-    time_t current_time = time(NULL); \
-    if (config.debug || current_time - last_time >= rate) { \
+    if (config.debug > 1 || ts_current.tv_sec - last_time >= rate) { \
         LOG(__VA_ARGS__); \
-        last_time = current_time; \
+        last_time = ts_current.tv_sec; \
     } \
 } while (0) /* no trailing ; */
 

--- a/capture/parsers/smb.c
+++ b/capture/parsers/smb.c
@@ -500,7 +500,7 @@ LOCAL int smb2_parse(ArkimeSession_t *session, SMBInfo_t *smb, BSB *bsb, char *s
         uint16_t  dialect = 0;
         BSB_LIMPORT_u16(*bsb, dialect);
         if (dialect != 0 && dialect != 0x02FF) {
-            char str[11];
+            char str[13];
             snprintf(str, sizeof(str), "SMB %d.%d.%d", (dialect >> 8) & 0xf, (dialect >> 4) & 0xf, dialect & 0xf);
             arkime_field_string_add(dialectField, session, str, -1, TRUE);
         }

--- a/capture/session.c
+++ b/capture/session.c
@@ -720,15 +720,8 @@ ArkimeSession_t *arkime_session_find_or_create(int mProtocol, uint32_t hash, uin
     DLL_PUSH_TAIL(q_, &sessionsQ[thread][ses], session);
 
     if (HASH_BUCKET_COUNT(h_, sessions[thread][ses], hash) > 15) {
-        struct timeval  currentTime;
-        static uint32_t lastError;
-
-        gettimeofday(&currentTime, NULL);
-        if (currentTime.tv_sec - lastError > 30) {
-            lastError = currentTime.tv_sec;
-            char buf[100];
-            LOG("ERROR - Large number of chains: id:%s hash:%u bucket:%u thread:%d ses:%d count:%d size:%d maxStreams[ses]:%u - might want to increase maxStreams see https://arkime.com/settings#maxstreams", arkime_session_id_string(sessionId, buf), hash, hash % sessions[thread][ses].size, thread, ses, HASH_BUCKET_COUNT(h_, sessions[thread][ses], hash), sessions[thread][ses].size, config.maxStreams[ses]);
-        }
+        char buf[100];
+        LOG_RATE(30, "ERROR - Large number of chains: id:%s hash:%u bucket:%u thread:%d ses:%d count:%d size:%d maxStreams[ses]:%u - might want to increase maxStreams see https://arkime.com/settings#maxstreams", arkime_session_id_string(sessionId, buf), hash, hash % sessions[thread][ses].size, thread, ses, HASH_BUCKET_COUNT(h_, sessions[thread][ses], hash), sessions[thread][ses].size, config.maxStreams[ses]);
     }
 
     session->filePosArray = g_array_sized_new(FALSE, FALSE, sizeof(uint64_t), 100);


### PR DESCRIPTION
* Use LOG_RATE everywhere for consistency
* LOG_RATE uses clock_gettime now instead of time
* LOG_RATE now prints out all for debug > 1 instead of debug > 0

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
