### PR TITLE
fix read out of bounds with wrap around, make format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Capture
   - #2748 icmp community id support
   - #2766 VLAN or VNI can be used in session ids, controlled by sessionIdTracking
+  - #2791 udp databytes was too large when padded
 ## Viewer
   - #2741 save session table info column fields
 

--- a/capture/parsers/udp.c
+++ b/capture/parsers/udp.c
@@ -61,10 +61,8 @@ int udp_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packet, int 
     packet->direction = (dir &&
                          session->port1 == ntohs(udphdr->uh_sport) &&
                          session->port2 == ntohs(udphdr->uh_dport)) ? 0 : 1;
-    session->databytes[packet->direction] += MIN(
-        ntohs(udphdr->uh_ulen) - 8,
-        (packet->pktlen - packet->payloadOffset - 8)
-    );
+    session->databytes[packet->direction] += MIN(ntohs(udphdr->uh_ulen),
+                                                 packet->pktlen - packet->payloadOffset) - 8;
 
     return 0;
 }
@@ -72,10 +70,8 @@ int udp_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packet, int 
 int udp_process(ArkimeSession_t *session, ArkimePacket_t *const packet)
 {
     const uint8_t *data = packet->pkt + packet->payloadOffset + 8;
-    uint16_t        len = MIN(
-        (packet->pkt[packet->payloadOffset + 4] << 8 | packet->pkt[packet->payloadOffset + 5]) - 8,
-        packet->payloadLen - 8
-    );
+    int            len = MIN((packet->pkt[packet->payloadOffset + 4] << 8 | packet->pkt[packet->payloadOffset + 5]),
+                             packet->payloadLen) - 8;
 
     if (len <= 0)
         return 1;


### PR DESCRIPTION
* The -8 would cause large values for the uint16_t, switch back to int.
* make format
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
