### PR TITLE
support multiple EOL for JA4T and JA4TS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2784 Added DTLS JA4 support
   - #2791 udp databytes was too large when padded
   - #2796 Added DTLS JA4S support, requires new ja4plus plugin also
+  - #2799 support multiple EOL for JA4T and JA4TS
 ## Cont3xt
   - #2795 support adding clickhouse integrations
 ## db.pl


### PR DESCRIPTION
Actually implemented in arkime/ja4@65431d650b3b7068eeb3afb24775faa0511d5478


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
