### PR TITLE
Update easybutton-build.sh

### DIFF
--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -192,7 +192,7 @@ if [ -f "/etc/debian_version" ]; then
 
   # Just use OS packages, currently for Ubuntu 22
   if [ $DOTHIRDPARTY -eq 0 ]; then
-    apt-get -qq install libmaxminddb-dev libcurl4-openssl-dev libyara-dev libglib2.0-dev libpcap-dev libnghttp2-dev liblua5.4-dev librdkafka-dev libzstd-dev
+    sudo apt-get -qq install libmaxminddb-dev libcurl4-openssl-dev libyara-dev libglib2.0-dev libpcap-dev libnghttp2-dev liblua5.4-dev librdkafka-dev libzstd-dev
     if [ $? -ne 0 ]; then
       echo "ARKIME: apt-get failed"
       exit 1


### PR DESCRIPTION
Added missing sudo to the apt-get command

**Clearly describe the problem and solution**
apt-get requires root.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
