### PR TITLE
Grep more explicitly

### DIFF
--- a/release/arkime_config_interfaces.sh
+++ b/release/arkime_config_interfaces.sh
@@ -29,11 +29,11 @@ if [ ! -f $file ]; then
 fi
 
 # Extract list of interfaces
-interfaces=$(sed -n "/^\[$node\]\s*$/,/^\[.*\]\s*$/ {p;}" $file | grep "interface" | awk -F "=" '{print $2}' | sed 's/;/ /g')
+interfaces=$(sed -n "/^\[$node\]\s*$/,/^\[.*\]\s*$/ {p;}" $file | grep "^interface[ =]" | awk -F "=" '{print $2}' | sed 's/;/ /g')
 
 # Check interfaces, force to default if no interface.
 if [ -z "$interfaces" ]; then
-	interfaces=$(sed -n -e "/^\[default\]\s*$/,/^\[.*\]\s*$/ {p;}" $file | grep "interface" | awk -F "=" '{print $2}' | sed 's/;/ /g')
+	interfaces=$(sed -n -e "/^\[default\]\s*$/,/^\[.*\]\s*$/ {p;}" $file | grep "^interface[ =]" | awk -F "=" '{print $2}' | sed 's/;/ /g')
 fi
 
 # Apply settings


### PR DESCRIPTION


With this change we will only grep for lines that *begin* with `interface`, and is immediately followed by either a space or `=`.

This means we won't match lines with the setting `interfaceOps`, or lines that contain `interface` and `=` in a comment.

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**

See #2831

**Relevant issue number(s) if applicable**

Resolves #2831

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

no

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

no

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.