### PR TITLE
Scheme s3 dir 2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Capture
   - #2820 fix puny dns entries missing from all list sometimes
   - #2833 support processing a directory from s3
+  - #2834 fix crash with bgp parsing and shifting time
+  - #2834 create pcap files with at least config snapLen
+  - #2834 fix files with no processed packets hanging capture
 ## Cont3xt
   - #2823 added "Add Field" button to top of overview form
   - #2829 new DNS integration card

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1441,8 +1441,8 @@ typedef void (*ArkimePQ_cb)(ArkimeSession_t *session, gpointer uw);
 struct ArkimePQ_t;
 typedef struct ArkimePQ_t ArkimePQ_t;
 
-ArkimePQ_t *arkime_pq_alloc(int maxSeconds, ArkimePQ_cb cb);
-void arkime_pq_upsert(ArkimePQ_t *pq, ArkimeSession_t *session, uint32_t seconds,  void *uw);
+ArkimePQ_t *arkime_pq_alloc(int timeout, ArkimePQ_cb cb);
+void arkime_pq_upsert(ArkimePQ_t *pq, ArkimeSession_t *session, void *uw);
 void arkime_pq_remove(ArkimePQ_t *pq, ArkimeSession_t *session);
 void arkime_pq_run(int thread, int max);
 void arkime_pq_free(ArkimeSession_t *session);

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1832,7 +1832,9 @@ void arkime_packet_install_packet_ip()
 void arkime_packet_set_dltsnap(int dlt, int snaplen)
 {
     pcapFileHeader.dlt = dlt;
-    pcapFileHeader.snaplen = snaplen;
+    // Turns out libpcap actually truncates packets to near snaplen if used to
+    // read back in the packets,  so we need to make sure large enough.
+    pcapFileHeader.snaplen = MAX(snaplen, (int)config.snapLen);
     arkime_rules_recompile();
 }
 /******************************************************************************/

--- a/capture/parsers/arp.c
+++ b/capture/parsers/arp.c
@@ -8,8 +8,6 @@
 
 extern ArkimeConfig_t        config;
 
-LOCAL ArkimePQ_t *arpPq;
-
 LOCAL int arpMProtocol;
 
 /******************************************************************************/
@@ -61,15 +59,9 @@ LOCAL ArkimePacketRC arp_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), Arki
     return ARKIME_PACKET_DO_PROCESS;
 }
 /******************************************************************************/
-LOCAL void arp_pq_cb(ArkimeSession_t *session, void UNUSED(*uw))
-{
-    session->midSave = 1;
-}
-/******************************************************************************/
 void arkime_parser_init()
 {
     arkime_packet_set_ethernet_cb(0x0806, arp_packet_enqueue);
-    arpPq = arkime_pq_alloc(10, arp_pq_cb);
     arpMProtocol = arkime_mprotocol_register("arp",
                                              SESSION_OTHER,
                                              arp_create_sessionid,

--- a/capture/parsers/bgp.c
+++ b/capture/parsers/bgp.c
@@ -23,7 +23,7 @@ LOCAL int bgp_parser(ArkimeSession_t *session, void *UNUSED(uw), const uint8_t *
         arkime_field_string_add(typeField, session, types[data[18]], -1, TRUE);
     }
 
-    arkime_pq_upsert(bgpPq, session, 5, NULL);
+    arkime_pq_upsert(bgpPq, session, NULL);
     return 0;
 }
 /******************************************************************************/

--- a/capture/parsers/igmp.c
+++ b/capture/parsers/igmp.c
@@ -8,8 +8,6 @@
 
 extern ArkimeConfig_t        config;
 
-LOCAL ArkimePQ_t *igmpPq;
-
 LOCAL int igmpMProtocol;
 
 /******************************************************************************/
@@ -53,15 +51,9 @@ LOCAL ArkimePacketRC igmp_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), Ark
     return ARKIME_PACKET_DO_PROCESS;
 }
 /******************************************************************************/
-LOCAL void igmp_pq_cb(ArkimeSession_t *session, void UNUSED(*uw))
-{
-    session->midSave = 1;
-}
-/******************************************************************************/
 void arkime_parser_init()
 {
     arkime_packet_set_ip_cb(IPPROTO_IGMP, igmp_packet_enqueue);
-    igmpPq = arkime_pq_alloc(10, igmp_pq_cb);
     igmpMProtocol = arkime_mprotocol_register("igmp",
                                               SESSION_OTHER,
                                               igmp_create_sessionid,

--- a/capture/parsers/isis.c
+++ b/capture/parsers/isis.c
@@ -8,8 +8,6 @@
 
 extern ArkimeConfig_t        config;
 
-LOCAL ArkimePQ_t *isisPq;
-
 LOCAL int isisMProtocol;
 LOCAL int typeField;
 
@@ -99,15 +97,9 @@ LOCAL ArkimePacketRC isis_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), Ark
     return ARKIME_PACKET_DO_PROCESS;
 }
 /******************************************************************************/
-LOCAL void isis_pq_cb(ArkimeSession_t *session, void UNUSED(*uw))
-{
-    session->midSave = 1;
-}
-/******************************************************************************/
 void arkime_parser_init()
 {
     arkime_packet_set_ethernet_cb(0x83, isis_packet_enqueue);
-    isisPq = arkime_pq_alloc(10, isis_pq_cb);
     isisMProtocol = arkime_mprotocol_register("isis",
                                               SESSION_OTHER,
                                               isis_create_sessionid,

--- a/capture/parsers/lldp.c
+++ b/capture/parsers/lldp.c
@@ -8,8 +8,6 @@
 
 extern ArkimeConfig_t        config;
 
-LOCAL ArkimePQ_t *lldpPq;
-
 LOCAL int lldpMProtocol;
 
 /******************************************************************************/
@@ -59,15 +57,9 @@ LOCAL ArkimePacketRC lldp_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), Ark
     return ARKIME_PACKET_DO_PROCESS;
 }
 /******************************************************************************/
-LOCAL void lldp_pq_cb(ArkimeSession_t *session, void UNUSED(*uw))
-{
-    session->midSave = 1;
-}
-/******************************************************************************/
 void arkime_parser_init()
 {
     arkime_packet_set_ethernet_cb(0x88cc, lldp_packet_enqueue);
-    lldpPq = arkime_pq_alloc(10, lldp_pq_cb);
     lldpMProtocol = arkime_mprotocol_register("lldp",
                                               SESSION_OTHER,
                                               lldp_create_sessionid,

--- a/capture/parsers/ospf.c
+++ b/capture/parsers/ospf.c
@@ -8,8 +8,6 @@
 
 extern ArkimeConfig_t        config;
 
-LOCAL ArkimePQ_t *ospfPq;
-
 LOCAL int ospfMProtocol;
 
 /******************************************************************************/
@@ -55,15 +53,9 @@ LOCAL ArkimePacketRC ospf_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), Ark
     return ARKIME_PACKET_DO_PROCESS;
 }
 /******************************************************************************/
-LOCAL void ospf_pq_cb(ArkimeSession_t *session, void UNUSED(*uw))
-{
-    session->midSave = 1;
-}
-/******************************************************************************/
 void arkime_parser_init()
 {
     arkime_packet_set_ip_cb(89, ospf_packet_enqueue);
-    ospfPq = arkime_pq_alloc(10, ospf_pq_cb);
     ospfMProtocol = arkime_mprotocol_register("ospf",
                                               SESSION_OTHER,
                                               ospf_create_sessionid,

--- a/capture/parsers/pim.c
+++ b/capture/parsers/pim.c
@@ -8,8 +8,6 @@
 
 extern ArkimeConfig_t        config;
 
-LOCAL ArkimePQ_t *pimPq;
-
 LOCAL int pimMProtocol;
 
 /******************************************************************************/
@@ -53,15 +51,9 @@ LOCAL ArkimePacketRC pim_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), Arki
     return ARKIME_PACKET_DO_PROCESS;
 }
 /******************************************************************************/
-LOCAL void pim_pq_cb(ArkimeSession_t *session, void UNUSED(*uw))
-{
-    session->midSave = 1;
-}
-/******************************************************************************/
 void arkime_parser_init()
 {
     arkime_packet_set_ip_cb(IPPROTO_PIM, pim_packet_enqueue);
-    pimPq = arkime_pq_alloc(10, pim_pq_cb);
     pimMProtocol = arkime_mprotocol_register("pim",
                                              SESSION_OTHER,
                                              pim_create_sessionid,

--- a/capture/pq.c
+++ b/capture/pq.c
@@ -23,7 +23,7 @@ typedef struct arkimepqitem {
 
     ArkimeSession_t     *session;
     void                *uw;
-    time_t               expire;
+    uint32_t             expire;
     uint32_t             pqh_hash;
     uint32_t             pqh_bucket;
 } ArkimePQItem_t;
@@ -38,11 +38,10 @@ typedef struct {
 typedef HASH_VAR(s_, ArkimePQHash_t, ArkimePQHead_t, 51);
 
 struct ArkimePQ_t {
-    ArkimePQHead_t     *buckets[ARKIME_MAX_PACKET_THREADS];
+    ArkimePQHead_t      lists[ARKIME_MAX_PACKET_THREADS];
     ArkimePQHash_t      keys[ARKIME_MAX_PACKET_THREADS];
     ArkimePQ_cb         cb;
-    time_t              bucket0[ARKIME_MAX_PACKET_THREADS];
-    uint32_t            maxSeconds;
+    uint32_t            timeout;
 };
 
 /******************************************************************************/
@@ -51,18 +50,15 @@ LOCAL int arkime_pq_cmp(const void *keyv, const ArkimePQItem_t *item)
     return memcmp(keyv, item->session->sessionId, MIN(((uint8_t *)keyv)[0], item->session->sessionId[0])) == 0;
 }
 /******************************************************************************/
-ArkimePQ_t *arkime_pq_alloc(int maxSeconds, ArkimePQ_cb cb)
+ArkimePQ_t *arkime_pq_alloc(int timeout, ArkimePQ_cb cb)
 {
     ArkimePQ_t *pq = ARKIME_TYPE_ALLOC0(ArkimePQ_t);
 
-    pq->maxSeconds = maxSeconds;
-    int t, i;
+    pq->timeout = timeout;
+    int t;
     for (t = 0; t < config.packetThreads; t++) {
-        pq->bucket0[t] = 0;
-        pq->buckets[t] = malloc(sizeof(ArkimePQHead_t) * (maxSeconds + 1));
         HASH_INIT(pqh_, pq->keys[t], arkime_string_hash, (HASH_CMP_FUNC)arkime_pq_cmp);
-        for (i = 0; i <= maxSeconds; i++)
-            DLL_INIT(pql_, &pq->buckets[t][i]);
+        DLL_INIT(pql_, &pq->lists[t]);
     }
     pq->cb = cb;
     pqs[numPQs] = pq;
@@ -71,66 +67,22 @@ ArkimePQ_t *arkime_pq_alloc(int maxSeconds, ArkimePQ_cb cb)
     return pq;
 }
 /******************************************************************************/
-LOCAL void arkime_pq_shift(ArkimePQ_t *pq, int thread)
-{
-    uint32_t shift = lastPacketSecs[thread] - pq->bucket0[thread];
-
-    if (shift > pq->maxSeconds)
-        shift = pq->maxSeconds;
-
-    for (uint32_t i = 1; i <= pq->maxSeconds; i++) {
-        if (i <= shift) {
-            DLL_PUSH_TAIL_DLL(pql_, &pq->buckets[thread][0], &pq->buckets[thread][i]);
-        }
-        if (i + shift <= pq->maxSeconds) {
-            DLL_PUSH_TAIL_DLL(pql_, &pq->buckets[thread][i], &pq->buckets[thread][i + shift]);
-        }
-    }
-    pq->bucket0[thread] = lastPacketSecs[thread];
-}
-/******************************************************************************/
-void arkime_pq_upsert(ArkimePQ_t *pq, ArkimeSession_t *session, uint32_t timeout, void *uw)
+void arkime_pq_upsert(ArkimePQ_t *pq, ArkimeSession_t *session, void *uw)
 {
     // timeout is relative to lastPacketSecs, figure out time
-    time_t expire = lastPacketSecs[session->thread] + timeout;
-
-    // Now recalculate bucket0 if we need to
-    if (lastPacketSecs[session->thread] > pq->bucket0[session->thread])
-        arkime_pq_shift(pq, session->thread);
-
-    // In the past, just run now
-    if (expire < pq->bucket0[session->thread])
-        timeout = 0;
-    else {
-        timeout = expire - pq->bucket0[session->thread];
-
-        // To far in the future for this PQ
-        if (timeout > pq->maxSeconds)
-            timeout = pq->maxSeconds;
-    }
+    uint32_t expire = lastPacketSecs[session->thread] + pq->timeout;
 
     ArkimePQItem_t *item;
     HASH_FIND(pqh_, (pq->keys[session->thread]), session->sessionId, item);
     if (item) {
-        uint32_t bucket = item->expire - pq->bucket0[session->thread];
-        if (bucket > pq->maxSeconds)
-            bucket = pq->maxSeconds;
-
-        // Same bucket
-        if (bucket == timeout) {
-            return;
-        }
-
-        // Move the item from 1 bucket to another
-        DLL_REMOVE(pql_, &pq->buckets[session->thread][bucket], item);
-        DLL_PUSH_TAIL(pql_, &pq->buckets[session->thread][timeout], item);
+        DLL_MOVE_TAIL(pql_, &pq->lists[session->thread], item);
         item->expire = expire;
         return;
     }
 
     // This is a new item
     item = ARKIME_TYPE_ALLOC(ArkimePQItem_t);
-    DLL_PUSH_TAIL(pql_, &pq->buckets[session->thread][timeout], item);
+    DLL_PUSH_TAIL(pql_, &pq->lists[session->thread], item);
     HASH_ADD(pqh_, pq->keys[session->thread], session->sessionId, item);
     item->expire = expire;
     item->session = session;
@@ -146,9 +98,7 @@ void arkime_pq_remove(ArkimePQ_t *pq, ArkimeSession_t *session)
     if (!item)
         return;
 
-    int bucket = item->expire - pq->bucket0[session->thread];
-    if (bucket < 0) bucket = 0;
-    DLL_REMOVE(pql_, &pq->buckets[session->thread][bucket], item);
+    DLL_REMOVE(pql_, &pq->lists[session->thread], item);
     HASH_REMOVE(pqh_, pq->keys[session->thread], item);
     ARKIME_TYPE_FREE(ArkimePQItem_t, item);
     pqEntries--;
@@ -161,12 +111,13 @@ void arkime_pq_run(int thread, int max)
 
     int i;
     for (i = 0; i < numPQs; i++) {
-        if (lastPacketSecs[thread] > pqs[i]->bucket0[thread])
-            arkime_pq_shift(pqs[i], thread);
-
         int cnt = max;
         ArkimePQItem_t *item = 0;
-        while (cnt > 0 && DLL_POP_HEAD(pql_, &pqs[i]->buckets[thread][0], item)) {
+        while (cnt > 0 && (item = DLL_PEEK_HEAD(pql_, &pqs[i]->lists[thread]))) {
+            if (item->expire >= (uint64_t)lastPacketSecs[thread])
+                break;
+
+            DLL_REMOVE(pql_, &pqs[i]->lists[thread], item);
             HASH_REMOVE(pqh_, pqs[i]->keys[thread], item);
             pqs[i]->cb(item->session, item->uw);
             ARKIME_TYPE_FREE(ArkimePQItem_t, item);
@@ -184,157 +135,14 @@ void arkime_pq_free(ArkimeSession_t *session)
     }
 }
 /******************************************************************************/
-/* Reset the bucket0 time */
 void arkime_pq_flush(int thread)
 {
     for (int i = 0; i < numPQs; i++) {
-        for (uint32_t b = 0; b < pqs[i]->maxSeconds; b++) {
-            ArkimePQItem_t *item = 0;
-            while (DLL_POP_HEAD(pql_, &pqs[i]->buckets[thread][b], item)) {
-                HASH_REMOVE(pqh_, pqs[i]->keys[thread], item);
-                ARKIME_TYPE_FREE(ArkimePQItem_t, item);
-            }
+        ArkimePQItem_t *item = 0;
+        while (DLL_POP_HEAD(pql_, &pqs[i]->lists[thread], item)) {
+            HASH_REMOVE(pqh_, pqs[i]->keys[thread], item);
+            ARKIME_TYPE_FREE(ArkimePQItem_t, item);
         }
-        pqs[i]->bucket0[thread] = 0;
     }
 }
 /******************************************************************************/
-
-#ifdef TESTPQ
-#include <assert.h>
-
-SUPPRESS_UNSIGNED_INTEGER_OVERFLOW
-uint32_t arkime_string_hash(const void *key)
-{
-    uint8_t *p = (uint8_t *)key;
-    uint32_t n = 0;
-    while (*p) {
-        n = (n << 5) - n + *p;
-        p++;
-    }
-    return n;
-}
-int callbacks;
-LOCAL void pq_cb(ArkimeSession_t *session, void UNUSED(*uw))
-{
-    callbacks++;
-}
-ARKIME_LOCK_DEFINE(LOG);
-ArkimeConfig_t         config;
-time_t                 lastPacketSecs[ARKIME_MAX_PACKET_THREADS];
-int main()
-{
-    ArkimePQ_t pq;
-    ArkimeSession_t session1;
-    session1.sessionId[0] = 2;
-    session1.sessionId[1] = 'A';
-    session1.thread = 0;
-    config.packetThreads = 1;
-
-    // Big jump
-    LOG("**TEST1");
-    arkime_pq_init(&pq, 1, pq_cb);
-    lastPacketSecs[0] = 0;
-    arkime_pq_run(0, 10);
-    lastPacketSecs[0] = 1259261324;
-    arkime_pq_run(0, 10);
-    lastPacketSecs[0] = 1259261324;
-    arkime_pq_upsert(&pq, &session1, 5, NULL);
-    lastPacketSecs[0] = 1259261384;
-    arkime_pq_upsert(&pq, &session1, 5, NULL);
-    lastPacketSecs[0] = 1259261384;
-    arkime_pq_upsert(&pq, &session1, 5, NULL);
-    lastPacketSecs[0] = 1259261384;
-    arkime_pq_run(0, 10);
-    lastPacketSecs[0] = 1259261385;
-    arkime_pq_run(0, 10);
-    assert(callbacks == 1);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 0);
-
-    // Move from 1 to 0 and run
-    LOG("**TEST2");
-    callbacks = 0;
-    pq.bucket0[0] = lastPacketSecs[0] = 100;
-    arkime_pq_upsert(&pq, &session1, 1, NULL);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][0]) == 0);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][1]) == 1);
-    arkime_pq_upsert(&pq, &session1, 0, NULL);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][0]) == 1);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][1]) == 0);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 1);
-    arkime_pq_run(0, 10);
-    assert(callbacks == 1);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 0);
-
-    // Move from 0 to 1 and run
-    LOG("**TEST3");
-    callbacks = 0;
-    pq.bucket0[0] = lastPacketSecs[0] = 100;
-    arkime_pq_upsert(&pq, &session1, 0, NULL);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][0]) == 1);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][1]) == 0);
-    arkime_pq_upsert(&pq, &session1, 1, NULL);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][0]) == 0);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][1]) == 1);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 1);
-    arkime_pq_run(0, 10);
-    assert(callbacks == 0);
-    lastPacketSecs[0] = 101;
-    arkime_pq_run(0, 10);
-    assert(callbacks == 1);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 0);
-
-
-    // Keep moving 0 ahead
-    LOG("**TEST4");
-    callbacks = 0;
-    pq.bucket0[0] = lastPacketSecs[0] = 100;
-    arkime_pq_upsert(&pq, &session1, 0, NULL);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 0, NULL);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 0, NULL);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 0, NULL);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 0, NULL);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 0, NULL);
-    assert(callbacks == 0);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 1);
-    arkime_pq_run(0, 10);
-    assert(callbacks == 1);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 0);
-
-    // Keep re adding
-    LOG("**TEST5");
-    callbacks = 0;
-    lastPacketSecs[0] = 100;
-    arkime_pq_upsert(&pq, &session1, 1, NULL);
-    assert(callbacks == 0);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][0]) == 0);
-    assert(DLL_COUNT(pql_, &pq.buckets[0][1]) == 1);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 1);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 1, NULL);
-    arkime_pq_run(0, 10);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 1, NULL);
-    arkime_pq_run(0, 10);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 1, NULL);
-    arkime_pq_run(0, 10);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 1, NULL);
-    arkime_pq_run(0, 10);
-    lastPacketSecs[0]++;
-    arkime_pq_upsert(&pq, &session1, 1, NULL);
-    arkime_pq_run(0, 10);
-    assert(callbacks == 0);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 1);
-    lastPacketSecs[0]++;
-    arkime_pq_run(0, 10);
-    assert(callbacks == 1);
-    assert(HASH_COUNT(pqh_, pq.keys[0]) == 0);
-}
-#endif


### PR DESCRIPTION
* s3 dir list no longer streaming
* rewrote pq to work like tcpWriteQ since old version was buggy and crashy
* pcap file caplen is at least config.snapLen long, libpcap actualy uses this
* don't hang if no packets are processed

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
