### PR TITLE
fix scheme issues, fixes #2837

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,6 +48,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2819 hide noFacet fields from being columns
   - #2824 add ability to delete shards from ES Shards tab
   - #2834 improve forcedExpression help
+  - #2840 fix downloading pcap of scheme uploaded items
 ## WISE
   - #2834 fix azure ip link
 

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -331,7 +331,8 @@ function s3Expire () {
         must: [
           { range: { first: { lte: Math.floor(Date.now() / 1000 - (+Config.get('s3ExpireDays')) * 60 * 60 * 24) } } },
           { prefix: { name: 's3://' } }
-        ]
+        ],
+        must_not: { term: { locked: 1 } }
       }
     },
     sort: { first: { order: 'asc' } }

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -754,7 +754,7 @@ class SessionAPIs {
     }
 
     const block = await getBlock(info, 0);
-    obj = { info, header: block };
+    obj = { info, header: block.slice(0, 24) };
     headerlru.set(key, obj);
     return obj;
   }
@@ -798,7 +798,7 @@ class SessionAPIs {
       try {
         h = await SessionAPIs.#getHeader(fields.node, -pos, getBlock);
       } catch (e) {
-        console.log('Failure fetching header', e.response);
+        console.log('Failure fetching header', e.response ?? e);
         return endCb('Only have SPI data, PCAP file no longer available for ' + e.response?.config?.url);
       }
       pcap = Pcap.make(h.info.name, h.header);
@@ -1276,12 +1276,12 @@ class SessionAPIs {
           psid ??= SessionAPIs.#processSessionIdBlock;
           extra = scheme.getBlock;
         }
-      }
-
-      const pcapWriteMethod = Config.getFull(fields.node, 'pcapWriteMethod');
-      const writer = internals.writers.get(pcapWriteMethod);
-      if (writer && writer.processSessionId) {
-        psid ??= writer.processSessionId;
+      } else {
+        const pcapWriteMethod = Config.getFull(fields.node, 'pcapWriteMethod');
+        const writer = internals.writers.get(pcapWriteMethod);
+        if (writer && writer.processSessionId) {
+          psid ??= writer.processSessionId;
+        }
       }
 
       psid ??= SessionAPIs.#processSessionIdDisk;

--- a/viewer/schemes.js
+++ b/viewer/schemes.js
@@ -93,8 +93,10 @@ async function getBlockS3 (info, pos) {
       Key: parts[4],
       Range: `bytes=${blockStart}-${blockStart + blockSize}`
     };
-    const result = await s3.getObject(params).promise();
-    block = result.Body;
+
+    const command = new GetObjectCommand(params);
+    const response = await s3.send(command);
+    block = Buffer.from(await response.Body.transformToByteArray());
     blocklru.set(key, block);
   }
 


### PR DESCRIPTION
* s3:// scheme downloading was using old api
* all scheme downloads could have  too big a header
* use scheme before pcapWriteMethod
* s3-writer won't try and delete locked files

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
