### PR TITLE
fix form auth not styling correctly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Cont3xt
   - #2823 added "Add Field" button to top of overview form
   - #2829 new DNS integration card
+## Parliament
+  - #2849 fix form auth not styling correctly
 ## Viewer
   - #2817 new maxSessionsQueried setting, default 2MM
   - #2819 hide noFacet fields from being columns

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -145,7 +145,6 @@ if (process.env.NODE_ENV === 'development') {
 const cspHeader = helmet.contentSecurityPolicy({
   directives: cspDirectives
 });
-app.use(cspHeader);
 
 function setCookie (req, res, next) {
   const cookieOptions = {
@@ -203,6 +202,7 @@ app.use(favicon(path.join(__dirname, '/favicon.ico')));
 
 // Set up auth, all APIs registered below will use passport
 Auth.app(app);
+app.use(cspHeader);
 
 app.use(ArkimeUtil.jsonParser);
 app.use(bp.urlencoded({ extended: true }));
@@ -1975,7 +1975,7 @@ async function main () {
 
   // construct the issues file name
   let issuesFilename = 'issues.json';
-  if (ArkimeConfig.get('file').indexOf('.json') > -1) {
+  if (ArkimeConfig.get('file')?.indexOf('.json') > -1) {
     const filename = ArkimeConfig.get('file').replace(/\.json/g, '');
     issuesFilename = `${filename}.issues.json`;
   }


### PR DESCRIPTION
Moved the csp header below the Auth.app stuff

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
