### PR TITLE
inital sqs support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2835 fix crash with bgp parsing and shifting time
   - #2835 create pcap files with at least config snapLen
   - #2835 fix files with no processed packets hanging capture
+  - #2856 suppport AWS SQS for notifications to process new S3 files
+  - #2856 fix scheme pcap processor with corrupt pcap files
 ## Cont3xt
   - #2823 added "Add Field" button to top of overview form
   - #2829 new DNS integration card

--- a/capture/Makefile.in
+++ b/capture/Makefile.in
@@ -30,7 +30,7 @@ LIB_OTHER     = @GLIB2_LIBS@ \
 	        thirdparty/patricia.o \
 		@DL_LIB@ -lssl -lcrypto -lyaml
 
-C_FILES         = main.c db.c yara.c http.c config.c parsers.c plugins.c field.c writers.c writer-inplace.c writer-null.c writer-simple.c readers.c reader-libpcap-file.c reader-libpcap.c reader-tpacketv3.c reader-null.c reader-pcapoverip.c reader-tzsp.c reader-scheme.c reader-scheme-file.c reader-scheme-http.c reader-scheme-s3.c packet.c session.c rules.c drophash.c pq.c dedup.c
+C_FILES         = main.c db.c yara.c http.c config.c parsers.c plugins.c field.c writers.c writer-inplace.c writer-null.c writer-simple.c readers.c reader-libpcap-file.c reader-libpcap.c reader-tpacketv3.c reader-null.c reader-pcapoverip.c reader-tzsp.c reader-scheme.c reader-scheme-file.c reader-scheme-http.c reader-scheme-s3.c reader-scheme-sqs.c packet.c session.c rules.c drophash.c pq.c dedup.c
 O_FILES         = $(C_FILES:.c=.o)
 
 INSTALL         = @INSTALL@

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -818,6 +818,7 @@ typedef int  (* ArkimeCanQuitFunc) ();
 
 gint arkime_watch_fd(gint fd, GIOCondition cond, ArkimeWatchFd_func func, gpointer data);
 const uint8_t *arkime_js0n_get(const uint8_t *data, uint32_t len, const char *key, uint32_t *olen);
+const uint8_t *arkime_js0n_get_path(const uint8_t *data, uint32_t len, const char **keys, uint32_t *olen);
 char *arkime_js0n_get_str(const uint8_t *data, uint32_t len, const char *key);
 
 gboolean arkime_string_add(void *hashv, char *string, gpointer uw, gboolean copy);
@@ -1032,7 +1033,7 @@ int arkime_http_queue_length_best(void *server);
 uint64_t arkime_http_dropped_count(void *server);
 
 void *arkime_http_create_server(const char *hostnames, int maxConns, int maxOutstandingRequests, int compress);
-void *arkime_http_get_or_create_server(const char *hostnames, int maxConns, int maxOutstandingRequests, int compress, int *isNew);
+void *arkime_http_get_or_create_server(const char *name, const char *hostnames, int maxConns, int maxOutstandingRequests, int compress, int *isNew);
 
 void arkime_http_set_retries(void *server, uint16_t retries);
 void arkime_http_set_timeout(void *serverV, uint64_t timeout);
@@ -1040,6 +1041,8 @@ void arkime_http_set_client_cert(void *serverV, char *clientCert, char *clientKe
 void arkime_http_set_print_errors(void *server);
 void arkime_http_set_headers(void *server, char **headers);
 void arkime_http_set_header_cb(void *server, ArkimeHttpHeader_cb cb);
+void arkime_http_set_userpwd(void *server, const char *userpwd);
+void arkime_http_set_aws_sigv4(void *server, const char *aws_sigv4);
 void arkime_http_free_server(void *server);
 
 gboolean arkime_http_is_arkime(uint32_t hash, uint8_t *sessionId);

--- a/capture/main.c
+++ b/capture/main.c
@@ -452,6 +452,21 @@ const uint8_t *arkime_js0n_get(const uint8_t *data, uint32_t len, const char *ke
     return 0;
 }
 /******************************************************************************/
+const uint8_t *arkime_js0n_get_path(const uint8_t *data, uint32_t len, const char **keys, uint32_t *olen)
+{
+    int k;
+    for (k = 0; keys[k]; k++) {
+        data = arkime_js0n_get(data, len, keys[k], &len);
+        if (!data) {
+            if (config.debug > 2)
+                LOG("Couldn't find key %s", keys[k]);
+            return 0;
+        }
+    }
+    *olen = len;
+    return data;
+}
+/******************************************************************************/
 char *arkime_js0n_get_str(const uint8_t *data, uint32_t len, const char *key)
 {
     uint32_t           value_len;

--- a/capture/main.c
+++ b/capture/main.c
@@ -1001,8 +1001,8 @@ int main(int argc, char **argv)
     arkime_plugins_load(config.rootPlugins);
     if (config.pcapReadOffline)
         if (useScheme ||
-                (config.pcapReadFiles && config.pcapReadFiles[0] && strstr(config.pcapReadFiles[0], "://")) ||
-                (config.pcapReadDirs && config.pcapReadDirs[0] && strstr(config.pcapReadDirs[0], "://")))
+            (config.pcapReadFiles && config.pcapReadFiles[0] && strstr(config.pcapReadFiles[0], "://")) ||
+            (config.pcapReadDirs && config.pcapReadDirs[0] && strstr(config.pcapReadDirs[0], "://")))
             arkime_readers_set("scheme");
         else
             arkime_readers_set("libpcap-file");

--- a/capture/main.c
+++ b/capture/main.c
@@ -1000,7 +1000,9 @@ int main(int argc, char **argv)
     arkime_plugins_init();
     arkime_plugins_load(config.rootPlugins);
     if (config.pcapReadOffline)
-        if (useScheme || (config.pcapReadFiles && config.pcapReadFiles[0] && strstr(config.pcapReadFiles[0], "://")))
+        if (useScheme ||
+                (config.pcapReadFiles && config.pcapReadFiles[0] && strstr(config.pcapReadFiles[0], "://")) ||
+                (config.pcapReadDirs && config.pcapReadDirs[0] && strstr(config.pcapReadDirs[0], "://")))
             arkime_readers_set("scheme");
         else
             arkime_readers_set("libpcap-file");

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -435,7 +435,7 @@ LOCAL int scheme_s3_load_dir(const char *dir)
         snprintf(schemehostport, sizeof(schemehostport), "https://%s", hostport);
 
         int isNew;
-        server = arkime_http_get_or_create_server(schemehostport, 2, 2, TRUE, &isNew);
+        server = arkime_http_get_or_create_server(schemehostport, schemehostport, 2, 2, TRUE, &isNew);
         if (isNew)
             arkime_http_set_timeout(server, 0);
 
@@ -509,7 +509,7 @@ LOCAL int scheme_s3_load_full_dir(const char *dir)
         snprintf(hostport, sizeof(hostport), "%s", host);
 
     int isNew;
-    void *server = arkime_http_get_or_create_server(schemehostport, 2, 2, TRUE, &isNew);
+    void *server = arkime_http_get_or_create_server(schemehostport, schemehostport, 2, 2, TRUE, &isNew);
     if (isNew)
         arkime_http_set_timeout(server, 0);
 
@@ -633,7 +633,7 @@ int scheme_s3_load(const char *uri, gboolean dirHint)
         snprintf(schemehostport, sizeof(schemehostport), "https://%s", hostport);
 
         int isNew;
-        void *server = arkime_http_get_or_create_server(schemehostport, 2, 2, TRUE, &isNew);
+        void *server = arkime_http_get_or_create_server(schemehostport, schemehostport, 2, 2, TRUE, &isNew);
         if (isNew)
             arkime_http_set_timeout(server, 0);
 
@@ -706,7 +706,7 @@ int scheme_s3_load_full(const char *uri, gboolean dirHint)
         snprintf(hostport, sizeof(hostport), "%s", host);
 
     int isNew;
-    void *server = arkime_http_get_or_create_server(schemehostport, 2, 2, TRUE, &isNew);
+    void *server = arkime_http_get_or_create_server(schemehostport, schemehostport, 2, 2, TRUE, &isNew);
     if (isNew)
         arkime_http_set_timeout(server, 0);
 

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -1,0 +1,287 @@
+/******************************************************************************/
+/* reader-scheme-sqs.c
+ *
+ * Copyright 2023 All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <fcntl.h>
+#include <curl/curl.h>
+#include "arkime.h"
+
+extern ArkimeConfig_t        config;
+
+
+LOCAL char                  *sqsAccessKeyId;
+LOCAL char                  *sqsSecretAccessKey;
+LOCAL char                  *s3Host;
+LOCAL gboolean               inited;
+
+typedef struct sqs_item {
+    struct sqs_item  *item_next, *item_prev;
+    char             *receiptHandle;
+    char             *bucket;
+    char             *key;
+} SQSItem;
+
+typedef struct sqs_item_head {
+    struct sqs_item  *item_next, *item_prev;
+    int               item_count;
+
+    ARKIME_COND_EXTERN(lock);
+    ARKIME_LOCK_EXTERN(lock);
+    int     done;
+} SQSItemHead;
+
+LOCAL ARKIME_LOCK_DEFINE(waitingsqs);
+
+typedef struct sqs_request {
+    SQSItemHead *items;
+    uint8_t      done : 1;
+} SQSRequest;
+
+
+/******************************************************************************/
+LOCAL SQSItemHead *sqs_alloc()
+{
+    SQSItemHead *head = ARKIME_TYPE_ALLOC0(SQSItemHead);
+    DLL_INIT(item_, head);
+    ARKIME_LOCK_INIT(head->lock);
+    ARKIME_COND_INIT(head->lock);
+    return head;
+}
+/******************************************************************************/
+LOCAL void sqs_enqueue(SQSItemHead *head, char *receiptHandle, char *bucket, char *key)
+{
+
+    ARKIME_LOCK(head->lock);
+    SQSItem *item = ARKIME_TYPE_ALLOC0(SQSItem);
+    item->receiptHandle = receiptHandle;
+    item->bucket = bucket;
+    item->key = key;
+    DLL_PUSH_TAIL(item_, head, item);
+
+    ARKIME_COND_SIGNAL(head->lock);
+    ARKIME_UNLOCK(head->lock);
+}
+/******************************************************************************/
+LOCAL void sqs_init()
+{
+    inited = TRUE;
+    sqsAccessKeyId = arkime_config_str(NULL, "sqsAccessKeyId", NULL);
+    sqsSecretAccessKey = arkime_config_str(NULL, "sqsSecretAccessKey", NULL);
+    s3Host = arkime_config_str(NULL, "s3Host", NULL);
+}
+/******************************************************************************/
+LOCAL void sqs_delete_done(int UNUSED(code), uint8_t *data, int data_len, gpointer UNUSED(uw))
+{
+    if (code != 200) {
+        LOG("Delete failed %d %.*s", code, data_len, data);
+    }
+}
+/******************************************************************************/
+LOCAL void sqs_done(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
+{
+    SQSRequest *req = (SQSRequest *)uw;
+
+    static const char *messagePath[] = {"ReceiveMessageResponse", "ReceiveMessageResult", "Message", NULL};
+    uint32_t messageLen = 0;
+    const uint8_t *message = arkime_js0n_get_path(data, data_len, messagePath, &messageLen);
+
+    if (!message) {
+        req->done = 1;
+        ARKIME_UNLOCK(waitingsqs);
+        ARKIME_COND_SIGNAL(req->items->lock);
+        return;
+    }
+
+    int      i;
+    uint32_t out[4 * 100]; // Can have up to 100 elements at any level
+
+    // Message will be an array if more than 1 message was REQUESTED
+    if (message[0] == '[') {
+        int rc;
+        if ((rc = js0n(message, messageLen, out, sizeof(out))) != 0) {
+            LOG("ERROR - Parse error %d in >%.*s<\n", rc, messageLen, message);
+            return;
+        }
+    } else {
+        // Fake array of 1
+        out[0] = 0;
+        out[1] = messageLen;
+        out[2] = 0;
+        out[3] = 0;
+    }
+
+    for (i = 0; out[i + 1]; i += 2) {
+        uint32_t receiptLen = 0;
+        uint8_t *receipt = (uint8_t *)arkime_js0n_get(message + out[i], out[i+1], "ReceiptHandle", &receiptLen);
+
+        uint32_t bodyLen = 0;
+        uint8_t *body = (uint8_t *)arkime_js0n_get(message + out[i], out[i+1], "Body", &bodyLen);
+        if (!body) {
+            LOG("No Body %.*s", out[i+1], message + out[i]);
+            continue;
+        }
+        body[bodyLen] = 0;
+        body = (uint8_t *)g_strcompress((char *)body);
+
+        uint32_t recordsLen = 0;
+        const uint8_t *records = arkime_js0n_get(body, strlen((char *)body), "Records", &recordsLen);
+        if (!records) {
+            LOG("No records %s", body);
+            sqs_enqueue(req->items, g_strndup((char *)receipt, receiptLen), NULL, NULL);
+            continue;
+        }
+
+        uint32_t s3Len = 0;
+        const uint8_t *s3 = arkime_js0n_get(records + 1, recordsLen - 2, "s3", &s3Len);
+        if (!s3) {
+            LOG("No s3 %.*s", recordsLen - 2, records + 1);
+            sqs_enqueue(req->items, g_strndup((char *)receipt, receiptLen), NULL, NULL);
+            continue;
+        }
+
+        static const char *bucketPath[] = {"bucket", "name", NULL};
+        uint32_t bucketLen = 0;
+        const uint8_t *bucket = arkime_js0n_get_path(s3, s3Len, bucketPath, &bucketLen);
+
+        static const char *keyPath[] = {"object", "key", NULL};
+        uint32_t keyLen = 0;
+        uint8_t *key = (uint8_t *)arkime_js0n_get_path(s3, s3Len, keyPath, &keyLen);
+
+        key[keyLen] = 0;
+        if (bucket && key && g_regex_match(config.offlineRegex, (char *)key, 0, NULL)) {
+            sqs_enqueue(req->items, g_strndup((char *)receipt, receiptLen), g_strndup((char *)bucket, bucketLen), g_strndup((char *)key, keyLen));
+        } else
+            sqs_enqueue(req->items, g_strndup((char *)receipt, receiptLen), NULL, NULL);
+    }
+
+    ARKIME_UNLOCK(waitingsqs);
+}
+/******************************************************************************/
+// sqs://sqs.us-east-1.amazonaws.com/80398EXAMPLE/MyQueue
+// sqshttps://sqs.us-east-1.amazonaws.com/80398EXAMPLE/MyQueue
+// sqshttp://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/my-queue
+int scheme_sqs_load(const char *uri, gboolean UNUSED(dirHint))
+{
+    if (!inited)
+        sqs_init();
+
+    SQSRequest *req = ARKIME_TYPE_ALLOC0(SQSRequest);
+    req->items = sqs_alloc();
+
+    char **uris = g_strsplit(uri, "/", 0);
+
+    if (!uris[2] || !uris[3] || !uris[4]) {
+        LOGEXIT("ERROR - Invalid SQS uri %s", uri);
+        return 1;
+    }
+
+    char **dots = g_strsplit(uris[2], ".", 0);
+
+    char *scheme;
+    if (strcmp(uris[0], "sqshttp") == 0)
+        scheme = "http";
+    else
+        scheme = "https";
+
+    char schemehostport[300];
+    snprintf(schemehostport, sizeof(schemehostport), "%s://%s", scheme, uris[2]);
+
+    char serverName[300];
+    snprintf(serverName, sizeof(serverName), "sqs:%s:%s", uris[3], uris[4]);
+
+    int isNew;
+    void *server = arkime_http_get_or_create_server(serverName, schemehostport, 2, 100, TRUE, &isNew);
+    if (isNew) {
+        arkime_http_set_timeout(server, 0);
+
+        char userpwd[100];
+        snprintf(userpwd, sizeof(userpwd), "%s:%s", sqsAccessKeyId, sqsSecretAccessKey);
+        arkime_http_set_userpwd(server, userpwd);
+
+        char aws_sigv4[100];
+        snprintf(aws_sigv4, sizeof(aws_sigv4), "aws:amz:%s:sqs", dots[1]);
+        arkime_http_set_aws_sigv4(server, aws_sigv4);
+    }
+
+    // Construct the request URL
+    char receiveFullPath[1000];
+    snprintf(receiveFullPath, sizeof(receiveFullPath), "/%s/%s?Action=ReceiveMessage&Version=2012-11-05&MaxNumberOfMessages=1&WaitTimeSeconds=10", uris[3], uris[4]);
+
+    if (config.debug)
+        LOG("receiveFullPath: %s", receiveFullPath);
+
+    static char *headers[4] = {"Content-Type: application/json", "Expect:", NULL, NULL};
+    arkime_http_schedule(server, "POST", receiveFullPath, -1, NULL, 0, headers, ARKIME_HTTP_PRIORITY_BEST, sqs_done, req);
+
+    ARKIME_LOCK(waitingsqs);
+    ARKIME_LOCK(waitingsqs);
+    ARKIME_UNLOCK(waitingsqs);
+
+    const gboolean isaws = g_str_has_suffix(uris[2], "amazonaws.com");
+
+    while (!req->done || DLL_COUNT(item_, req->items) > 0) {
+        if (!req->done && DLL_COUNT(item_, req->items) == 0) {
+            // request more items
+            arkime_http_schedule(server, "POST", receiveFullPath, -1, NULL, 0, headers, ARKIME_HTTP_PRIORITY_BEST, sqs_done, req);
+            ARKIME_LOCK(waitingsqs);
+            ARKIME_LOCK(waitingsqs);
+            ARKIME_UNLOCK(waitingsqs);
+            continue;
+        }
+
+        ARKIME_LOCK(req->items->lock);
+        while (DLL_COUNT(item_, req->items) == 0) {
+            ARKIME_COND_WAIT(req->items->lock);
+        }
+        SQSItem *item;
+        DLL_POP_HEAD(item_, req->items, item);
+        ARKIME_UNLOCK(req->items->lock);
+
+        if (item->bucket && item->key) {
+            char s3url[1000];
+            if (isaws) {
+                snprintf(s3url, sizeof(s3url), "s3://%s/%s", item->bucket, item->key);
+            } else if (s3Host) {
+                snprintf(s3url, sizeof(s3url), "s3https://%s/%s/%s", s3Host, item->bucket, item->key);
+            } else {
+                snprintf(s3url, sizeof(s3url), "s3%s/%s/%s", schemehostport, item->bucket, item->key);
+            }
+            if (config.debug)
+                LOG("SQS S3 URL: %s", s3url);
+            arkime_reader_scheme_load(s3url, FALSE);
+        }
+
+        // Delete the message
+        char deleteFullPath[1000];
+        snprintf(deleteFullPath, sizeof(deleteFullPath), "/%s/%s?Action=DeleteMessage&Version=2012-11-05&ReceiptHandle=%s", uris[3], uris[4], item->receiptHandle);
+
+        if (config.debug)
+            LOG("deleteFullPath: %s", deleteFullPath);
+
+        arkime_http_schedule(server, "POST", deleteFullPath, -1, NULL, 0, headers, ARKIME_HTTP_PRIORITY_DROPABLE, sqs_delete_done, NULL);
+
+        g_free(item->receiptHandle);
+        g_free(item->bucket);
+        g_free(item->key);
+        ARKIME_TYPE_FREE(SQSItem, item);
+    }
+
+    g_strfreev(uris);
+    g_strfreev(dots);
+    return 0;
+}
+/******************************************************************************/
+LOCAL void scheme_sqs_exit()
+{
+}
+/******************************************************************************/
+void arkime_reader_scheme_sqs_init()
+{
+    arkime_reader_scheme_register("sqs", scheme_sqs_load, scheme_sqs_exit);
+    arkime_reader_scheme_register("sqshttp", scheme_sqs_load, scheme_sqs_exit);
+    arkime_reader_scheme_register("sqshttps", scheme_sqs_load, scheme_sqs_exit);
+}

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -122,7 +122,10 @@ LOCAL void sqs_done(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
         }
     } else {
         // Fake array of 1
+        out[0] = 0;
         out[1] = messagesLen;
+        out[2] = 0;
+        out[3] = 0;
     }
 
     for (i = 0; out[i + 1]; i += 2) {

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -104,7 +104,8 @@ LOCAL void sqs_done(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
 
     // AWS returns "null" instead of removing key
     if (!messages || (messagesLen == 4 && memcmp(messages, "null", 4) == 0)) {
-        req->done = 1;
+        if (!config.pcapMonitor)
+            req->done = 1;
         ARKIME_UNLOCK(waitingsqs);
         ARKIME_COND_SIGNAL(req->items->lock);
         return;

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -464,4 +464,7 @@ void arkime_reader_scheme_init()
 
     void arkime_reader_scheme_s3_init();
     arkime_reader_scheme_s3_init();
+
+    void arkime_reader_scheme_sqs_init();
+    arkime_reader_scheme_sqs_init();
 }

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -98,6 +98,7 @@ void arkime_reader_scheme_load(const char *uri, gboolean dirHint)
     state = 0;
     lastBytes = 0;
     lastPackets = 0;
+    tmpBufferLen = 0;
 
     int rc = readerScheme->load(uri, dirHint);
 

--- a/capture/thirdparty/js0n.c
+++ b/capture/thirdparty/js0n.c
@@ -21,7 +21,7 @@ int js0n(const unsigned char *js, unsigned int len, unsigned int *out, unsigned 
 	const unsigned char *cur, *end;
 	int depth=0;
 	int utf8_remain=0;
-	static void *gostruct[] = 
+	static void *gostruct[] =
 	{
 		[0 ... 255] = &&l_bad,
 		['\t'] = &&l_loop, [' '] = &&l_loop, ['\r'] = &&l_loop, ['\n'] = &&l_loop,
@@ -32,7 +32,7 @@ int js0n(const unsigned char *js, unsigned int len, unsigned int *out, unsigned 
 		['-'] = &&l_bare, [48 ... 57] = &&l_bare, // 0-9
 		['t'] = &&l_bare, ['f'] = &&l_bare, ['n'] = &&l_bare // true, false, null
 	};
-	static void *gobare[] = 
+	static void *gobare[] =
 	{
 		[0 ... 31] = &&l_bad,
 		[32 ... 126] = &&l_loop, // could be more pedantic/validation-checking
@@ -40,7 +40,7 @@ int js0n(const unsigned char *js, unsigned int len, unsigned int *out, unsigned 
 		[','] = &&l_unbare, [']'] = &&l_unbare, ['}'] = &&l_unbare,
 		[127 ... 255] = &&l_bad
 	};
-	static void *gostring[] = 
+	static void *gostring[] =
 	{
 		[0 ... 31] = &&l_bad, // ALW - removed 127 logic
 		[32 ... 127] = &&l_loop, // ALW - changed to 127
@@ -57,26 +57,26 @@ int js0n(const unsigned char *js, unsigned int len, unsigned int *out, unsigned 
 		[128 ... 191] = &&l_utf_continue,
 		[192 ... 255] = &&l_bad
 	};
-	static void *goesc[] = 
+	static void *goesc[] =
 	{
 		[0 ... 255] = &&l_bad,
 		['"'] = &&l_unesc, ['\\'] = &&l_unesc, ['/'] = &&l_unesc, ['b'] = &&l_unesc,
 		['f'] = &&l_unesc, ['n'] = &&l_unesc, ['r'] = &&l_unesc, ['t'] = &&l_unesc, ['u'] = &&l_unesc
 	};
 	void **go = gostruct;
-	
+
 	for(cur=js,end=js+len,oend=out+olen; cur<end && out<oend; cur++)
 	{
 			goto *go[*cur];
 			l_loop:;
 	}
-	
-	if(out < oend) *out = 0;
+
+	if(out < oend) out[0] = out[1] = 0; // ALW - Set length to 0 also
 	return depth; // 0 if successful full parse, >0 for incomplete data
-	
+
 	l_bad:
 		return cur - js + 1; // ALW - Return where the error happen
-	
+
 	l_up:
 		PUSH(0);
 		++depth;
@@ -96,11 +96,11 @@ int js0n(const unsigned char *js, unsigned int len, unsigned int *out, unsigned 
 		CAP(-1);
 		go=gostruct;
 		goto l_loop;
-		
+
 	l_esc:
 		go = goesc;
 		goto l_loop;
-		
+
 	l_unesc:
 		go = gostring;
 		goto l_loop;


### PR DESCRIPTION
* Can process a sqs q for pcap files that have been added to s3. 
* Start to use libcurl sigv4 implementation.
* http server instances can be named now since they might have other data (such as sigv4 info) associated
* arkime_js0n_get_path, need to use in db.c to reduce js0n insanity.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
