### PR TITLE
new creds system s3/sqs, move s3 to curl aws sig

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,11 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 5.3.1 2024/07/xx
+## Capture
+  - #2866 for s3/sqs scheme support standard AWS credentials methods including
+          env vars, --profile ~/.aws/credentials or config, and meta data service
+## Multies
+  - #2865 form or oidc require usersElasticsearch to be set for multiES
 
 5.3.0 2024/06/27
 ## Release

--- a/capture/Makefile.in
+++ b/capture/Makefile.in
@@ -30,7 +30,7 @@ LIB_OTHER     = @GLIB2_LIBS@ \
 	        thirdparty/patricia.o \
 		@DL_LIB@ -lssl -lcrypto -lyaml
 
-C_FILES         = main.c db.c yara.c http.c config.c parsers.c plugins.c field.c writers.c writer-inplace.c writer-null.c writer-simple.c readers.c reader-libpcap-file.c reader-libpcap.c reader-tpacketv3.c reader-null.c reader-pcapoverip.c reader-tzsp.c reader-scheme.c reader-scheme-file.c reader-scheme-http.c reader-scheme-s3.c reader-scheme-sqs.c packet.c session.c rules.c drophash.c pq.c dedup.c
+C_FILES         = main.c db.c yara.c http.c config.c parsers.c plugins.c field.c writers.c writer-inplace.c writer-null.c writer-simple.c readers.c reader-libpcap-file.c reader-libpcap.c reader-tpacketv3.c reader-null.c reader-pcapoverip.c reader-tzsp.c reader-scheme.c reader-scheme-file.c reader-scheme-http.c reader-scheme-s3.c reader-scheme-sqs.c packet.c session.c rules.c drophash.c pq.c dedup.c cloud.c
 O_FILES         = $(C_FILES:.c=.o)
 
 INSTALL         = @INSTALL@

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -486,6 +486,8 @@ typedef struct arkime_config {
     char      gapPacketPos;
     char      enablePacketDedup;
     char      sessionIdMode;
+    char     *provider;
+    char     *profile;
 } ArkimeConfig_t;
 
 typedef struct {
@@ -713,6 +715,12 @@ typedef struct arkime_session_head {
     int                    h_count;
 } ArkimeSessionHead_t;
 
+typedef struct {
+    char                  *id;
+    char                  *key;
+    char                  *token;
+} ArkimeCredentials_t;
+
 
 #ifdef ARKIME_USE_GSLICE
 #define ARKIME_TYPE_ALLOC(type) (type *)(g_slice_alloc(sizeof(type)))
@@ -845,6 +853,16 @@ uint32_t arkime_get_next_prime(uint32_t v);
 uint32_t arkime_get_next_powerof2(uint32_t v);
 void arkime_check_file_permissions(const char *filename);
 
+typedef void (*ArkimeCredentialsGet)(const char *service);
+void arkime_credentials_register(char *name, ArkimeCredentialsGet func);
+void arkime_credentials_set(char *id, char *key, char *token);
+ArkimeCredentials_t *arkime_credentials_get(const char *service, const char *idName, const char *keyName);
+
+/******************************************************************************/
+/*
+ * cloud.c
+ */
+void arkime_cloud_init();
 
 /******************************************************************************/
 /*

--- a/capture/cloud.c
+++ b/capture/cloud.c
@@ -1,0 +1,203 @@
+/******************************************************************************/
+/* cloud-aws.c
+ *
+ * Common AWS code
+ *
+ * Copyright 2024 All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <fcntl.h>
+#include <curl/curl.h>
+#include "arkime.h"
+
+extern ArkimeConfig_t        config;
+
+LOCAL  void                 *metadataServer = 0;
+
+LOCAL  char                  awsUseTokenForMetadata;
+
+/******************************************************************************/
+uint8_t *aws_get_instance_metadata(const char *key, int key_len, size_t *mlen)
+{
+    char *requestHeaders[2];
+    char  tokenHeader[200];
+    requestHeaders[1] = NULL;
+    if (awsUseTokenForMetadata) {
+        char *tokenRequestHeaders[2] = {"X-aws-ec2-metadata-token-ttl-seconds: 30", NULL};
+        if (config.debug)
+            LOG("Requesting IMDSv2 metadata token");
+        const uint8_t *token = arkime_http_send_sync(metadataServer, "PUT", "/latest/api/token", -1, NULL, 0, tokenRequestHeaders, mlen, NULL);
+        if (config.debug)
+            LOG("IMDSv2 metadata token received");
+        snprintf(tokenHeader, sizeof(tokenHeader), "X-aws-ec2-metadata-token: %s", token);
+        requestHeaders[0] = tokenHeader;
+    } else {
+        if (config.debug)
+            LOG("Using IMDSv1");
+        requestHeaders[0] = NULL;
+    }
+    return arkime_http_send_sync(metadataServer, "GET", key, key_len, NULL, 0, requestHeaders, mlen, NULL);
+}
+/******************************************************************************/
+static char credURL[1024];
+LOCAL gboolean aws_refresh_creds(gpointer UNUSED(user_data))
+{
+    size_t clen;
+
+    uint8_t *credentials = aws_get_instance_metadata(credURL, -1, &clen);
+
+    if (credentials && clen) {
+        // Now need to extract access key, secret key and token
+        char *id = arkime_js0n_get_str(credentials, clen, "AccessKeyId");
+        char *key = arkime_js0n_get_str(credentials, clen, "SecretAccessKey");
+        char *token = arkime_js0n_get_str(credentials, clen, "Token");
+        if (config.debug)
+            LOG("Found AccessKeyId %s", id);
+
+        if (id && key) {
+            arkime_credentials_set(id, key, token);
+        }
+    }
+
+    return G_SOURCE_CONTINUE;
+}
+/******************************************************************************/
+int aws_get_credentials_metadata(const char UNUSED(*service))
+{
+    if (!metadataServer) {
+        char *uri = getenv("ECS_CONTAINER_METADATA_URI_V4");
+        char *relativeURI = getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI");
+        if (uri && relativeURI) {
+            uri = g_strdup(uri);
+            char *slash = strchr(uri + 8, '/');
+            if (slash) {
+                *slash = 0;
+            }
+            g_strlcpy(credURL, relativeURI, sizeof(credURL));
+            metadataServer = arkime_http_create_server(uri, 2, 2, FALSE);
+        } else {
+            size_t rlen;
+
+            metadataServer = arkime_http_create_server("http://169.254.169.254", 2, 2, FALSE);
+            uint8_t *rolename = aws_get_instance_metadata("/latest/meta-data/iam/security-credentials/", -1, &rlen);
+            if (!rolename || !rlen || rolename[0] == '<') {
+                if (config.debug)
+                    LOG("ERROR - Cannot retrieve role name from metadata service\n");
+                return 0;
+            }
+
+            snprintf(credURL, sizeof(credURL), "/latest/meta-data/iam/security-credentials/%.*s", (int)rlen, rolename);
+            free(rolename);
+        }
+        arkime_http_set_print_errors(metadataServer);
+        g_timeout_add_seconds( 280, aws_refresh_creds, 0);
+    }
+    aws_refresh_creds(NULL);
+    return 1;
+}
+/******************************************************************************/
+int aws_get_credentials_env(const char UNUSED(*service))
+{
+    char *id = getenv("AWS_ACCESS_KEY_ID");;
+    char *key = getenv("AWS_SECRET_ACCESS_KEY");
+    char *token = getenv("AWS_SESSION_TOKEN");
+
+    if (id && key) {
+        arkime_credentials_set(id, key, token);
+        return 1;
+    }
+    return 0;
+}
+/******************************************************************************/
+int aws_get_credentials_file(const char UNUSED(*service), char *envName, char *fileName, gboolean leadingProfile)
+{
+    char *credFileEnv = getenv(envName);
+
+    char *credFilename;
+    if (credFileEnv)
+        credFilename = g_strdup(credFileEnv);
+    else
+        credFilename = g_build_filename(g_get_home_dir(), ".aws", fileName, NULL);
+
+    if (!g_file_test(credFilename, G_FILE_TEST_EXISTS)) {
+        g_free(credFilename);
+        return 0;
+    }
+
+    GKeyFile *keyFile = g_key_file_new();
+
+    // Load the credentials file
+    GError *error = NULL;
+    if (!g_key_file_load_from_file(keyFile, credFilename, G_KEY_FILE_NONE, &error)) {
+        g_free(credFilename);
+        g_printerr("Error loading credentials file: %s\n", error->message);
+        g_error_free(error);
+        return 0;
+    }
+    g_free(credFilename);
+
+    int good = 0;
+
+    // Get the credentials
+    if (config.profile) {
+        char profileSection[200];
+        if (leadingProfile)
+            snprintf(profileSection, sizeof(profileSection), "%s %s", "profile", config.profile);
+        else
+            snprintf(profileSection, sizeof(profileSection), "%s", config.profile);
+        gchar *idp = g_key_file_get_string(keyFile, profileSection, "aws_access_key_id", NULL);
+        gchar *keyp = g_key_file_get_string(keyFile, profileSection, "aws_secret_access_key", NULL);
+        gchar *tokenp = g_key_file_get_string(keyFile, profileSection, "aws_session_token", NULL);
+        if (idp && keyp) {
+            arkime_credentials_set(idp, keyp, tokenp);
+            good = 1;
+        }
+
+        g_free(idp);
+        g_free(keyp);
+        g_free(tokenp);
+        if (good) {
+            g_key_file_free(keyFile);
+            return 1;
+        }
+    }
+
+    gchar *id = g_key_file_get_string(keyFile, "default", "aws_access_key_id", NULL);
+    gchar *key = g_key_file_get_string(keyFile, "default", "aws_secret_access_key", NULL);
+    gchar *token = g_key_file_get_string(keyFile, "default", "aws_session_token", NULL);
+    if (id && key) {
+        arkime_credentials_set(id, key, token);
+        good = 1;
+    }
+    g_free(id);
+    g_free(key);
+    g_free(token);
+    g_key_file_free(keyFile);
+    return good;
+}
+
+/******************************************************************************/
+void aws_get_credentials(const char *service)
+{
+    if (aws_get_credentials_env(service))
+        return;
+
+    if (aws_get_credentials_file(service, "AWS_SHARED_CREDENTIALS_FILE", "credentials", FALSE))
+        return;
+
+    if (aws_get_credentials_file(service, "AWS_CONFIG_FILE", "config", TRUE))
+        return;
+
+    if (aws_get_credentials_metadata(service))
+        return;
+
+    LOGEXIT("No AWS credentials found, try --profile\n");
+}
+/******************************************************************************/
+void arkime_cloud_init()
+{
+    arkime_credentials_register("aws", aws_get_credentials);
+}
+/******************************************************************************/

--- a/capture/cloud.c
+++ b/capture/cloud.c
@@ -1,7 +1,7 @@
 /******************************************************************************/
-/* cloud-aws.c
+/* cloud.c
  *
- * Common AWS code
+ * Common cloud code
  *
  * Copyright 2024 All rights reserved.
  *

--- a/capture/dedup.c
+++ b/capture/dedup.c
@@ -17,6 +17,7 @@
  */
 
 #include "arkime.h"
+#define OPENSSL_SUPPRESS_DEPRECATED
 #include <openssl/md5.h>
 
 extern ArkimeConfig_t       config;


### PR DESCRIPTION
* For s3/sqs scheme support --profile option that can use the standard env vars, ~/.aws/credential or config files or fall back to metadata service
* s3 scheme now uses curl to do the aws sig

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
