### PR TITLE
Scheme file monitor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Capture
   - #2866 for s3/sqs scheme support standard AWS credentials methods including
           env vars, --profile ~/.aws/credentials or config, and meta data service
+  - #2869 scheme mode for local files support monitor mode
 ## Multies
   - #2865 form or oidc require usersElasticsearch to be set for multiES
 

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -8,14 +8,141 @@
 
 #include <fcntl.h>
 #include "arkime.h"
+#include "arkimeconfig.h"
 
 extern ArkimeConfig_t        config;
 
+#ifdef HAVE_SYS_INOTIFY_H
+#include <sys/inotify.h>
+LOCAL int         monitorFd;
+LOCAL GHashTable *wdHashTable;
+
+LOCAL void scheme_file_monitor_dir(const char *dirname);
+
+LOCAL void scheme_file_monitor_do(struct inotify_event *event)
+{
+    gchar *dirname = g_hash_table_lookup(wdHashTable, (void *)(long)event->wd);
+    gchar *fullfilename = g_build_filename (dirname, event->name, NULL);
+
+    if (config.pcapRecursive &&
+        (event->mask & IN_CREATE) &&
+        g_file_test(fullfilename, G_FILE_TEST_IS_DIR)) {
+
+        scheme_file_monitor_dir(fullfilename);
+        g_free(fullfilename);
+        return;
+    }
+
+    if ((event->mask & IN_CLOSE_WRITE) == 0) {
+        g_free(fullfilename);
+        return;
+    }
+
+    if (!g_regex_match(config.offlineRegex, fullfilename, 0, NULL)) {
+        g_free(fullfilename);
+        return;
+    }
+
+    if (config.debug)
+        LOG("Monitor enqueing %s", fullfilename);
+    arkime_reader_scheme_load(fullfilename, FALSE);
+}
+/******************************************************************************/
+LOCAL gboolean scheme_file_monitor_read()
+{
+    char buf[20 * (sizeof(struct inotify_event) + NAME_MAX + 1)] __attribute__ ((aligned(8)));
+
+    int rc = read (monitorFd, buf, sizeof(buf));
+    if (rc == 0)
+        return TRUE;
+    if (rc == -1)
+        LOGEXIT("ERROR - Monitor read failed - %s", strerror(errno));
+    buf[rc] = 0;
+
+    char *p;
+    for (p = buf; p < buf + rc; ) {
+        struct inotify_event *event = (struct inotify_event *) p;
+        scheme_file_monitor_do(event);
+        p += sizeof(struct inotify_event) + event->len;
+    }
+    return TRUE;
+}
+/******************************************************************************/
+LOCAL void scheme_file_init_monitor()
+{
+    monitorFd = inotify_init1(IN_NONBLOCK);
+
+    if (monitorFd < 0)
+        LOGEXIT("ERROR - Couldn't init inotify %s", strerror(errno));
+
+    wdHashTable = g_hash_table_new (g_direct_hash, g_direct_equal);
+    arkime_watch_fd(monitorFd, ARKIME_GIO_READ_COND, scheme_file_monitor_read, NULL);
+}
+/******************************************************************************/
+LOCAL void scheme_file_monitor_dir(const char *dirname)
+{
+    static char inited = 0;
+    if (!inited) {
+        inited = 1;
+        scheme_file_init_monitor();
+    }
+
+    if (config.debug)
+        LOG("Monitoring %s", dirname);
+
+    int rc = inotify_add_watch(monitorFd, dirname, IN_CLOSE_WRITE | IN_CREATE);
+    if (rc == -1) {
+        LOG ("WARNING - Couldn't watch %s %s", dirname, strerror(errno));
+        return;
+    } else {
+        g_hash_table_insert(wdHashTable, (void *)(long)rc, g_strdup(dirname));
+    }
+
+    if (!config.pcapRecursive)
+        return;
+
+    GError   *error = NULL;
+    GDir     *dir = g_dir_open(dirname, 0, &error);
+
+    if (error)
+        LOGEXIT("ERROR - Couldn't open pcap directory %s: Receive Error: %s", dirname, error->message);
+
+    while (1) {
+        const gchar *filename = g_dir_read_name(dir);
+
+        // No more files, stop processing this directory
+        if (!filename) {
+            break;
+        }
+
+        // Skip hidden files/directories
+        if (filename[0] == '.')
+            continue;
+
+        gchar *fullfilename = g_build_filename (dirname, filename, NULL);
+
+        if (g_file_test(fullfilename, G_FILE_TEST_IS_DIR)) {
+            scheme_file_monitor_dir(fullfilename);
+        }
+        g_free(fullfilename);
+    }
+    g_dir_close(dir);
+}
+#else
+LOCAL void scheme_file_monitor_dir(const char UNUSED(*dirname))
+{
+    LOGEXIT("ERROR - Monitoring not supporting on this OS");
+}
+#endif
 /******************************************************************************/
 int scheme_file_dir(const char *dirname)
 {
     GDir   *pcapGDir;
     GError *error = 0;
+
+    if (config.pcapMonitor) {
+        scheme_file_monitor_dir(dirname);
+    }
 
     pcapGDir = g_dir_open(dirname, 0, &error);
     while (1) {

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -84,7 +84,7 @@ LOCAL ArkimeScheme_t *uri2scheme(const char *uri)
     return str ? str->uw : NULL;
 }
 /******************************************************************************/
-void arkime_reader_scheme_load_thread(const char *uri, gboolean dirHint)
+LOCAL void arkime_reader_scheme_load_thread(const char *uri, gboolean dirHint)
 {
     LOG ("Processing %s", uri);
     ArkimeScheme_t *readerScheme = uri2scheme(uri);


### PR DESCRIPTION
monitor mode (-m) now works with file schemes.

Also make sure scheme processing is now always done on scheme thread, and if not add to Q
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
