### PR TITLE
Log pcap_dispatch errors

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2866 for s3/sqs scheme support standard AWS credentials methods including
           env vars, --profile ~/.aws/credentials or config, and meta data service
   - #2869 scheme mode for local files support monitor mode
+  - #2870 log error with pcap_dispatch (thanks @vpiserchia)
 ## Multies
   - #2865 form or oidc require usersElasticsearch to be set for multiES
 

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -486,6 +486,8 @@ LOCAL gboolean reader_libpcapfile_read()
             int rc = unlink(offlinePcapFilename);
             if (rc != 0)
                 LOG("Failed to delete file %s %s (%d)", offlinePcapFilename, strerror(errno), errno);
+        } else if (r < 0) {
+            LOG("Failed pcap_dispatch on file %s %s", offlinePcapFilename, pcap_geterr(pcap));
         }
         if (!config.dryRun && !config.copyPcap) {
             // Make sure the output file has been opened otherwise we can't update the entry


### PR DESCRIPTION
report pcap_dispatch errors with the LOG facility

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**

No log message is reported to the user when the ```pcap_dispatch``` call fails

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
