### PR TITLE
Command socket 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           env vars, --profile ~/.aws/credentials or config, and meta data service
   - #2869 scheme mode for local files support monitor mode
   - #2870 log error with pcap_dispatch (thanks @vpiserchia)
+  - #2873 New --command option to enable a unix domain control port for
+          controlling capture
 ## Multies
   - #2865 form or oidc require usersElasticsearch to be set for multiES
 

--- a/capture/Makefile.in
+++ b/capture/Makefile.in
@@ -30,7 +30,7 @@ LIB_OTHER     = @GLIB2_LIBS@ \
 	        thirdparty/patricia.o \
 		@DL_LIB@ -lssl -lcrypto -lyaml
 
-C_FILES         = main.c db.c yara.c http.c config.c parsers.c plugins.c field.c writers.c writer-inplace.c writer-null.c writer-simple.c readers.c reader-libpcap-file.c reader-libpcap.c reader-tpacketv3.c reader-null.c reader-pcapoverip.c reader-tzsp.c reader-scheme.c reader-scheme-file.c reader-scheme-http.c reader-scheme-s3.c reader-scheme-sqs.c packet.c session.c rules.c drophash.c pq.c dedup.c cloud.c
+C_FILES         = main.c db.c yara.c http.c config.c parsers.c plugins.c field.c writers.c writer-inplace.c writer-null.c writer-simple.c readers.c reader-libpcap-file.c reader-libpcap.c reader-tpacketv3.c reader-null.c reader-pcapoverip.c reader-tzsp.c reader-scheme.c reader-scheme-file.c reader-scheme-http.c reader-scheme-s3.c reader-scheme-sqs.c packet.c session.c rules.c drophash.c pq.c dedup.c cloud.c command.c
 O_FILES         = $(C_FILES:.c=.o)
 
 INSTALL         = @INSTALL@

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -895,7 +895,7 @@ void arkime_config_monitor_file(const char *desc, char *name, ArkimeFileChange_c
 void arkime_config_monitor_files(const char *desc, char **names, ArkimeFilesChange_cb cb);
 
 #define ARKIME_CONFIG_CMD_VAR_STR_PTR 16
-void arkime_config_register_cmd_var(char *name, void *var, size_t typelen);
+void arkime_config_register_cmd_var(const char *name, void *var, size_t typelen);
 
 /******************************************************************************/
 /*
@@ -905,8 +905,8 @@ void arkime_config_register_cmd_var(char *name, void *var, size_t typelen);
 typedef void (* ArkimeCommandFunc) (int argc, char **argv, gpointer cc);
 
 void arkime_command_init();
-void arkime_command_register(char *name, ArkimeCommandFunc func, char *help);
-void arkime_command_respond(gpointer cc, char *data, int len);
+void arkime_command_register(const char *name, ArkimeCommandFunc func, const char *help);
+void arkime_command_respond(gpointer cc, const char *data, int len);
 
 /******************************************************************************/
 /*

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -488,6 +488,7 @@ typedef struct arkime_config {
     char      sessionIdMode;
     char     *provider;
     char     *profile;
+    char     *command;
 } ArkimeConfig_t;
 
 typedef struct {
@@ -892,6 +893,20 @@ typedef void (*ArkimeFilesChange_cb)(char **names);
 void arkime_config_monitor_file_msg(const char *desc, char *name, ArkimeFileChange_cb cb, const char *msg);
 void arkime_config_monitor_file(const char *desc, char *name, ArkimeFileChange_cb cb);
 void arkime_config_monitor_files(const char *desc, char **names, ArkimeFilesChange_cb cb);
+
+#define ARKIME_CONFIG_CMD_VAR_STR_PTR 16
+void arkime_config_register_cmd_var(char *name, void *var, size_t typelen);
+
+/******************************************************************************/
+/*
+ * command.c
+ */
+
+typedef void (* ArkimeCommandFunc) (int argc, char **argv, gpointer cc);
+
+void arkime_command_init();
+void arkime_command_register(char *name, ArkimeCommandFunc func, char *help);
+void arkime_command_respond(gpointer cc, char *data, int len);
 
 /******************************************************************************/
 /*

--- a/capture/command.c
+++ b/capture/command.c
@@ -1,0 +1,224 @@
+/******************************************************************************/
+/* command.c
+ *
+ * Copyright 2024 All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "gio/gio.h"
+#include "glib-object.h"
+#include "arkime.h"
+extern ArkimeConfig_t        config;
+
+typedef struct {
+    char                    *name;
+    ArkimeCommandFunc        func;
+    char                    *help;
+} Command_t;
+
+LOCAL int         maxCommandLen = 0;
+LOCAL Command_t  *commandsArray[1000];
+LOCAL int         commandArrayLen;
+LOCAL gboolean    commandsArraySorted = FALSE;
+LOCAL GHashTable *commandsHash;
+
+typedef struct {
+    GSocket                *socket;
+    char                    data[1024];
+    uint32_t                len;
+    int                     readWatch;
+} CommandClient_t;
+
+
+/******************************************************************************/
+LOCAL void arkime_command_client_free(CommandClient_t *cc)
+{
+    g_source_remove(cc->readWatch);
+    g_object_unref (cc->socket);
+
+    ARKIME_TYPE_FREE(CommandClient_t, cc);
+}
+/******************************************************************************/
+LOCAL void arkime_command_run(char *line, gpointer cc)
+{
+    gint    argcp;
+    gchar **argvp = NULL;
+    GError *error = NULL;
+
+    if (!g_shell_parse_argv(line, &argcp, &argvp, &error)) {
+        arkime_command_respond(cc, "No command sent\n", -1);
+        return;
+    }
+
+    Command_t *cmd = g_hash_table_lookup(commandsHash, argvp[0]);
+    if (cmd) {
+        cmd->func(argcp, argvp, cc);
+    } else {
+        char error[1024];
+        snprintf(error, sizeof(error), "Unknown command %s\n", argvp[0]);
+        arkime_command_respond(cc, error, -1);
+    }
+    g_strfreev(argvp);
+}
+/******************************************************************************/
+SUPPRESS_ALIGNMENT
+LOCAL gboolean arkime_command_data_read_cb(gint UNUSED(fd), GIOCondition cond, gpointer data)
+{
+    CommandClient_t *cc = (CommandClient_t *)data;
+    // LOG("fd: %d cond: %x data: %p", fd, cond, data);
+
+    GError              *error = 0;
+
+    int len = g_socket_receive(cc->socket, cc->data + cc->len, sizeof(cc->data) - cc->len, NULL, &error);
+
+    if (error || cond & (G_IO_HUP | G_IO_ERR) || len <= 0) {
+        if (error) {
+            LOG("ERROR: Receive Error: %s", error->message);
+            g_error_free(error);
+        }
+        arkime_command_client_free(cc);
+        return FALSE;
+    }
+    cc->len += len;
+
+    while (1) {
+        char *pos = memchr(cc->data, '\n', cc->len);
+        if (!pos)
+            break;
+        *pos = 0;
+        arkime_command_run(cc->data, cc);
+        memmove(cc->data, pos + 1, cc->len - (pos - cc->data + 1));
+        cc->len -= pos - cc->data + 1;
+    }
+
+    return TRUE;
+}
+/******************************************************************************/
+LOCAL gboolean arkime_command_server_read_cb(gint UNUSED(fd), GIOCondition UNUSED(cond), gpointer data)
+{
+    GError                   *error = NULL;
+
+    //LOG("fd: %d cond: %x data: %p", fd, cond, data);
+
+    GSocket *client = g_socket_accept((GSocket *)data, NULL, &error);
+    if (!client || error) {
+        LOGEXIT("ERROR - Error accepting command: %s", error->message);
+    }
+
+    CommandClient_t *cc = ARKIME_TYPE_ALLOC0(CommandClient_t);
+    cc->socket = client;
+
+    int cfd = g_socket_get_fd(client);
+    cc->readWatch = arkime_watch_fd(cfd, ARKIME_GIO_READ_COND, arkime_command_data_read_cb, cc);
+    return TRUE;
+}
+/******************************************************************************/
+LOCAL void arkime_command_free(gpointer data)
+{
+    Command_t *cmd = (Command_t *)data;
+
+    g_free(cmd->name);
+    g_free(cmd->help);
+    ARKIME_TYPE_FREE(Command_t, cmd);
+}
+/******************************************************************************/
+void arkime_command_register(char *name, ArkimeCommandFunc func, char *help)
+{
+    if (!config.command) {
+        return;
+    }
+
+    if (!commandsHash) {
+        commandsHash = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, arkime_command_free);
+    }
+
+    Command_t *cmd = ARKIME_TYPE_ALLOC0(Command_t);
+    cmd->name = g_strdup(name);
+    cmd->func = func;
+    cmd->help = g_strdup(help);
+    g_hash_table_insert(commandsHash, cmd->name, cmd);
+    maxCommandLen = MIN(60, MAX(maxCommandLen, (int)strlen(name)));
+    commandsArray[commandArrayLen++] = cmd;
+    commandsArraySorted = FALSE;
+}
+/******************************************************************************/
+void arkime_command_respond(gpointer cc, char *data, int len)
+{
+    CommandClient_t *client = (CommandClient_t *)cc;
+    GError *error = NULL;
+
+    if (len == -1) {
+        len = strlen(data);
+    }
+
+    if (g_socket_send(client->socket, data, len, NULL, &error) != len) {
+        LOG("ERROR - Sending response: %s", error->message);
+    }
+}
+/******************************************************************************/
+LOCAL int arkime_command_cmp(const void *a, const void *b)
+{
+    return strcmp((*(Command_t **)a)->name, (*(Command_t **)b)->name);
+}
+/******************************************************************************/
+void arkime_command_help(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
+{
+    static const char indent[] = "                                                             ";
+    char help[10000];
+    BSB bsb;
+    BSB_INIT(bsb, help, sizeof(help));
+
+    if (!commandsArraySorted) {
+        qsort(commandsArray, commandArrayLen, sizeof(Command_t *), arkime_command_cmp);
+        commandsArraySorted = TRUE;
+    }
+
+    for (int i = 0; i < commandArrayLen; i++) {
+        Command_t *cmd = commandsArray[i];
+        int len = maxCommandLen - MIN(60, strlen(cmd->name));
+        BSB_EXPORT_sprintf(bsb, "%s %.*s - %s\n", cmd->name, len, indent, cmd->help);
+    }
+
+    arkime_command_respond(cc, help, BSB_LENGTH(bsb));
+}
+/******************************************************************************/
+void arkime_command_version(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
+{
+    arkime_command_respond(cc, "Version 1.0\n", 12);
+}
+/******************************************************************************/
+void arkime_command_init()
+{
+    if (!config.command) {
+        return;
+    }
+
+    GError                   *error = NULL;
+    GSocket                  *socket;
+    GSocketAddress           *addr;
+
+    socket = g_socket_new (G_SOCKET_FAMILY_UNIX, G_SOCKET_TYPE_STREAM, 0, &error);
+
+    if (!socket || error) {
+        CONFIGEXIT("Error creating command: %s", error->message);
+    }
+
+    unlink(config.command);
+    addr = g_unix_socket_address_new (config.command);
+
+    if (!g_socket_bind (socket, addr, TRUE, &error)) {
+        CONFIGEXIT("Error binding command socket: %s", error->message);
+    }
+    g_object_unref (addr);
+
+    if (!g_socket_listen (socket, &error)) {
+        CONFIGEXIT("Error listening command socket: %s", error->message);
+    }
+
+    int fd = g_socket_get_fd(socket);
+
+    arkime_watch_fd(fd, ARKIME_GIO_READ_COND, arkime_command_server_read_cb, socket);
+    arkime_command_register("help", arkime_command_help, "This help");
+}
+/******************************************************************************/

--- a/capture/command.c
+++ b/capture/command.c
@@ -99,7 +99,7 @@ LOCAL gboolean arkime_command_server_read_cb(gint UNUSED(fd), GIOCondition UNUSE
 {
     GError                   *error = NULL;
 
-    //LOG("fd: %d cond: %x data: %p", fd, cond, data);
+    // LOG("fd: %d cond: %x data: %p", fd, cond, data);
 
     GSocket *client = g_socket_accept((GSocket *)data, NULL, &error);
     if (!client || error) {
@@ -183,9 +183,9 @@ void arkime_command_help(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
     arkime_command_respond(cc, help, BSB_LENGTH(bsb));
 }
 /******************************************************************************/
-void arkime_command_version(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
+void arkime_command_exit(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
 {
-    arkime_command_respond(cc, "Version 1.0\n", 12);
+    arkime_command_client_free(cc);
 }
 /******************************************************************************/
 void arkime_command_init()
@@ -220,5 +220,6 @@ void arkime_command_init()
 
     arkime_watch_fd(fd, ARKIME_GIO_READ_COND, arkime_command_server_read_cb, socket);
     arkime_command_register("help", arkime_command_help, "This help");
+    arkime_command_register("exit", arkime_command_exit, "Close the connection, can also use Ctrl-D");
 }
 /******************************************************************************/

--- a/capture/command.c
+++ b/capture/command.c
@@ -40,7 +40,7 @@ LOCAL void arkime_command_client_free(CommandClient_t *cc)
     ARKIME_TYPE_FREE(CommandClient_t, cc);
 }
 /******************************************************************************/
-LOCAL void arkime_command_run(char *line, gpointer cc)
+LOCAL void arkime_command_run(const char *line, gpointer cc)
 {
     gint    argcp;
     gchar **argvp = NULL;
@@ -55,9 +55,9 @@ LOCAL void arkime_command_run(char *line, gpointer cc)
     if (cmd) {
         cmd->func(argcp, argvp, cc);
     } else {
-        char error[1024];
-        snprintf(error, sizeof(error), "Unknown command %s\n", argvp[0]);
-        arkime_command_respond(cc, error, -1);
+        char msg[1024];
+        snprintf(msg, sizeof(msg), "Unknown command %s\n", argvp[0]);
+        arkime_command_respond(cc, msg, -1);
     }
     g_strfreev(argvp);
 }
@@ -123,7 +123,7 @@ LOCAL void arkime_command_free(gpointer data)
     ARKIME_TYPE_FREE(Command_t, cmd);
 }
 /******************************************************************************/
-void arkime_command_register(char *name, ArkimeCommandFunc func, char *help)
+void arkime_command_register(const char *name, ArkimeCommandFunc func, const char *help)
 {
     if (!config.command) {
         return;
@@ -143,7 +143,7 @@ void arkime_command_register(char *name, ArkimeCommandFunc func, char *help)
     commandsArraySorted = FALSE;
 }
 /******************************************************************************/
-void arkime_command_respond(gpointer cc, char *data, int len)
+void arkime_command_respond(gpointer cc, const char *data, int len)
 {
     CommandClient_t *client = (CommandClient_t *)cc;
     GError *error = NULL;
@@ -175,7 +175,7 @@ void arkime_command_help(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
     }
 
     for (int i = 0; i < commandArrayLen; i++) {
-        Command_t *cmd = commandsArray[i];
+        const Command_t *cmd = commandsArray[i];
         int len = maxCommandLen - MIN(60, strlen(cmd->name));
         BSB_EXPORT_sprintf(bsb, "%s %.*s - %s\n", cmd->name, len, indent, cmd->help);
     }
@@ -188,10 +188,9 @@ void arkime_command_exit(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
     arkime_command_client_free(cc);
 }
 /******************************************************************************/
+GSocketAddress *g_unix_socket_address_new (const gchar * path);
 void arkime_command_init()
 {
-    GSocketAddress *g_unix_socket_address_new (const gchar * path);
-
     if (!config.command) {
         return;
     }

--- a/capture/command.c
+++ b/capture/command.c
@@ -103,7 +103,8 @@ LOCAL gboolean arkime_command_server_read_cb(gint UNUSED(fd), GIOCondition UNUSE
 
     GSocket *client = g_socket_accept((GSocket *)data, NULL, &error);
     if (!client || error) {
-        LOGEXIT("ERROR - Error accepting command: %s", error->message);
+        LOG("ERROR - Error accepting command: %s", error->message);
+        return FALSE;
     }
 
     CommandClient_t *cc = ARKIME_TYPE_ALLOC0(CommandClient_t);

--- a/capture/command.c
+++ b/capture/command.c
@@ -7,6 +7,7 @@
  */
 
 #include "gio/gio.h"
+#include "gio/gunixsocketaddress.h"
 #include "glib-object.h"
 #include "arkime.h"
 extern ArkimeConfig_t        config;

--- a/capture/command.c
+++ b/capture/command.c
@@ -7,7 +7,6 @@
  */
 
 #include "gio/gio.h"
-#include "gio/gunixsocketaddress.h"
 #include "glib-object.h"
 #include "arkime.h"
 extern ArkimeConfig_t        config;
@@ -191,6 +190,8 @@ void arkime_command_exit(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
 /******************************************************************************/
 void arkime_command_init()
 {
+    GSocketAddress *g_unix_socket_address_new (const gchar * path);
+
     if (!config.command) {
         return;
     }

--- a/capture/config.c
+++ b/capture/config.c
@@ -1267,7 +1267,7 @@ LOCAL ArkimeConfigVar_t *arkimeConfigVarsArray[100];
 LOCAL int                arkimeConfigVarsLen;
 LOCAL gboolean           arkimeConfigVarsSorted = FALSE;
 /******************************************************************************/
-void arkime_config_register_cmd_var(char *name, void *var, size_t typelen)
+void arkime_config_register_cmd_var(const char *name, void *var, size_t typelen)
 {
     if (!config.command)
         return;
@@ -1326,7 +1326,7 @@ LOCAL void arkime_config_cmd_set(int argc, char **argv, gpointer cc)
         arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
         return;
     } else if (argc == 2) {
-        ArkimeConfigVar_t *acv = g_hash_table_lookup(arkimeConfigVarsHash, argv[1]);
+        const ArkimeConfigVar_t *acv = g_hash_table_lookup(arkimeConfigVarsHash, argv[1]);
         if (!acv) {
             BSB_EXPORT_sprintf(bsb, "Unknown variable: %s\n", argv[1]);
             arkime_command_respond(cc, buf, BSB_LENGTH(bsb));

--- a/capture/config.c
+++ b/capture/config.c
@@ -1257,8 +1257,167 @@ gboolean arkime_config_reload_files (gpointer UNUSED(user_data))
     return G_SOURCE_CONTINUE;
 }
 /******************************************************************************/
+typedef struct {
+    char     *name;
+    gpointer  var;
+    int       typelen;
+} ArkimeConfigVar_t;
+LOCAL GHashTable        *arkimeConfigVarsHash = NULL;
+LOCAL ArkimeConfigVar_t *arkimeConfigVarsArray[100];
+LOCAL int                arkimeConfigVarsLen;
+LOCAL gboolean           arkimeConfigVarsSorted = FALSE;
+/******************************************************************************/
+void arkime_config_register_cmd_var(char *name, void *var, size_t typelen)
+{
+    if (!config.command)
+        return;
+
+    ArkimeConfigVar_t *acv = ARKIME_TYPE_ALLOC0(ArkimeConfigVar_t);
+    acv->name = g_strdup(name);
+    acv->var = var;
+    acv->typelen = (int)typelen;
+
+    g_hash_table_insert(arkimeConfigVarsHash, acv->name, acv);
+    arkimeConfigVarsArray[arkimeConfigVarsLen++] = acv;
+    arkimeConfigVarsSorted = FALSE;
+}
+/******************************************************************************/
+LOCAL int arkime_config_vars_cmp(const void *a, const void *b)
+{
+    return strcmp((*(ArkimeConfigVar_t **)a)->name, (*(ArkimeConfigVar_t **)b)->name);
+}
+/******************************************************************************/
+LOCAL void arkime_config_cmd_set(int argc, char **argv, gpointer cc)
+{
+    char buf[10000];
+    BSB bsb;
+    BSB_INIT(bsb, buf, sizeof(buf));
+
+    if (!arkimeConfigVarsSorted) {
+        qsort(arkimeConfigVarsArray, arkimeConfigVarsLen, sizeof(ArkimeConfigVar_t *), arkime_config_vars_cmp);
+        arkimeConfigVarsSorted = TRUE;
+    }
+
+    if (argc == 1) {
+        for (int i = 0; i < arkimeConfigVarsLen; i++) {
+            switch (arkimeConfigVarsArray[i]->typelen) {
+            case 1:
+                BSB_EXPORT_sprintf(bsb, "%s=%d\n", arkimeConfigVarsArray[i]->name, *(char *)arkimeConfigVarsArray[i]->var);
+                break;
+            case 2:
+                BSB_EXPORT_sprintf(bsb, "%s=%d\n", arkimeConfigVarsArray[i]->name, *(short *)arkimeConfigVarsArray[i]->var);
+                break;
+            case 4:
+                BSB_EXPORT_sprintf(bsb, "%s=%d\n", arkimeConfigVarsArray[i]->name, *(int *)arkimeConfigVarsArray[i]->var);
+                break;
+            case 8:
+                BSB_EXPORT_sprintf(bsb, "%s=%" PRId64 "\n", arkimeConfigVarsArray[i]->name, *(int64_t *)arkimeConfigVarsArray[i]->var);
+                break;
+            case ARKIME_CONFIG_CMD_VAR_STR_PTR:
+                BSB_EXPORT_sprintf(bsb, "%s=%s\n", arkimeConfigVarsArray[i]->name, (char *)arkimeConfigVarsArray[i]->var);
+                break;
+            default:
+                BSB_EXPORT_sprintf(bsb, "%s=unknown\n", arkimeConfigVarsArray[i]->name);
+            }
+        }
+        arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
+        return;
+    } else if (argc == 2) {
+        ArkimeConfigVar_t *acv = g_hash_table_lookup(arkimeConfigVarsHash, argv[1]);
+        if (!acv) {
+            BSB_EXPORT_sprintf(bsb, "Unknown variable: %s\n", argv[1]);
+            arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
+            return;
+        }
+        switch (acv->typelen) {
+        case 1:
+            BSB_EXPORT_sprintf(bsb, "%d\n",  *(char *)acv->var);
+            break;
+        case 2:
+            BSB_EXPORT_sprintf(bsb, "%d\n", *(short *)acv->var);
+            break;
+        case 4:
+            BSB_EXPORT_sprintf(bsb, "%d\n", *(int *)acv->var);
+            break;
+        case 8:
+            BSB_EXPORT_sprintf(bsb, "%" PRId64 "\n", *(int64_t *)acv->var);
+            break;
+        case ARKIME_CONFIG_CMD_VAR_STR_PTR:
+            BSB_EXPORT_sprintf(bsb, "%s\n", (char *)acv->var);
+            break;
+        default:
+            BSB_EXPORT_sprintf(bsb, "unknown\n");
+        }
+        arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
+        return;
+    } else if (argc == 3) {
+        ArkimeConfigVar_t *acv = g_hash_table_lookup(arkimeConfigVarsHash, argv[1]);
+        if (!acv) {
+            BSB_EXPORT_sprintf(bsb, "Unknown variable: %s\n", argv[1]);
+            arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
+            return;
+        }
+
+        switch (acv->typelen) {
+        case 1:
+            *(char *)acv->var = atoi(argv[2]);
+            BSB_EXPORT_sprintf(bsb, "%s=%d\n", acv->name, *(char *)acv->var);
+            break;
+        case 2:
+            *(short *)acv->var = atoi(argv[2]);
+            BSB_EXPORT_sprintf(bsb, "%s=%d\n", acv->name, *(short *)acv->var);
+            break;
+        case 4:
+            *(int *)acv->var = atoi(argv[2]);
+            BSB_EXPORT_sprintf(bsb, "%s=%d\n", acv->name, *(int *)acv->var);
+            break;
+        case 8:
+            *(int64_t *)acv->var = atoi(argv[2]);
+            BSB_EXPORT_sprintf(bsb, "%s=%" PRId64 "\n", acv->name, *(int64_t *)acv->var);
+            break;
+        case ARKIME_CONFIG_CMD_VAR_STR_PTR:
+            g_free(acv->var);
+            acv->var = g_strdup(argv[2]);
+            BSB_EXPORT_sprintf(bsb, "%s\n", (char *)acv->var);
+            break;
+        default:
+            BSB_EXPORT_sprintf(bsb, "Unknown variable: %s\n", argv[1]);
+        }
+
+        arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
+    }
+}
+/******************************************************************************/
+LOCAL void arkime_config_cmd_override_print(gpointer key, gpointer value, gpointer cc)
+{
+    char buf[1000];
+    snprintf(buf, sizeof(buf), "%s=%s\n", (char *)key, (char *)value);
+    arkime_command_respond(cc, buf, -1);
+}
+/******************************************************************************/
+LOCAL void arkime_config_cmd_list(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
+{
+    if (config.override) {
+        arkime_command_respond(cc, "[OVERRIDE]\n", -1);
+        g_hash_table_foreach(config.override, arkime_config_cmd_override_print, cc);
+        arkime_command_respond(cc, "\n", -1);
+    }
+    char *data = g_key_file_to_data(arkimeKeyFile, NULL, NULL);
+    arkime_command_respond(cc, data, -1);
+    g_free(data);
+}
+/******************************************************************************/
 void arkime_config_init()
 {
+    if (config.command) {
+        arkimeConfigVarsHash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+        arkime_config_register_cmd_var("debug", &config.debug, sizeof(config.debug));
+        arkime_config_register_cmd_var("quiet", &config.quiet, sizeof(config.quiet));
+        arkime_config_register_cmd_var("recursive", &config.pcapRecursive, sizeof(config.pcapRecursive));
+        arkime_config_register_cmd_var("skip", &config.pcapSkip, sizeof(config.pcapSkip));
+        arkime_config_register_cmd_var("reprocess", &config.pcapReprocess, sizeof(config.pcapReprocess));
+    }
+
     HASH_INIT(s_, config.dontSaveTags, arkime_string_hash, arkime_string_cmp);
 
     arkime_config_load();
@@ -1282,6 +1441,9 @@ void arkime_config_init()
     if (!config.dryRun) {
         g_timeout_add_seconds( 10, arkime_config_reload_files, 0);
     }
+
+    arkime_command_register("set", arkime_config_cmd_set, "Set/Get a config value - set [<name> [<value>]]");
+    arkime_command_register("config-list", arkime_config_cmd_list, "List raw config");
 }
 /******************************************************************************/
 void arkime_config_exit()

--- a/capture/main.c
+++ b/capture/main.c
@@ -1079,23 +1079,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     return 0;
 }
 #else
-void arkime_commands_init1()
-{
-
-    gint    argcp;
-    gchar **argvp;
-    GError *error = NULL;
-
-    if (!g_shell_parse_argv("hi there, \"quoted string\", \"quoted \\\"with\\\" quotes\"", &argcp, &argvp, &error)) {
-        LOGEXIT("ERROR - Couldn't parse commandLine - %s", error->message);
-    }
-
-    for (int i = 0; i < argcp; i++) {
-        printf("ALW >%s<\n", argvp[i]);
-    }
-    g_strfreev(argvp);
-}
-
 int main(int argc, char **argv)
 {
     signal(SIGHUP, reload);

--- a/capture/main.c
+++ b/capture/main.c
@@ -86,6 +86,7 @@ LOCAL  GOptionEntry entries[] = {
     { "config",    'c',                    0, G_OPTION_ARG_FILENAME,       &config.configFile,    "Config file name, default '" CONFIG_PREFIX "/etc/config.ini'", NULL },
     { "pcapfile",  'r',                    0, G_OPTION_ARG_FILENAME_ARRAY, &config.pcapReadFiles, "Offline pcap file", NULL },
     { "pcapdir",   'R',                    0, G_OPTION_ARG_FILENAME_ARRAY, &config.pcapReadDirs,  "Offline pcap directory, all *.pcap files will be processed", NULL },
+    { "command",     0,                    0, G_OPTION_ARG_FILENAME,       &config.command,       "File path of command socket", NULL },
     { "monitor",   'm',                    0, G_OPTION_ARG_NONE,           &config.pcapMonitor,   "Used with -R option monitors the directory for closed files", NULL },
     { "packetcnt",   0,                    0, G_OPTION_ARG_INT,            &config.pktsToRead,    "Number of packets to read from each offline file", NULL },
     { "delete",      0,                    0, G_OPTION_ARG_NONE,           &config.pcapDelete,    "In offline mode delete files once processed, requires --copy", NULL },
@@ -136,6 +137,45 @@ void free_args()
         g_strfreev(config.extraTags);
     if (config.extraOps)
         g_strfreev(config.extraOps);
+}
+/******************************************************************************/
+LOCAL void arkime_cmd_version(int UNUSED(argc), char UNUSED( * *argv), gpointer cc)
+{
+    extern char *curl_version(void);
+    extern char *pcre_version(void);
+    extern const char *MMDB_lib_version(void);
+    extern const char *zlibVersion(void);
+    extern const char *yaml_get_version_string(void);
+
+    char buf[1024];
+    BSB  bsb;
+
+    BSB_INIT(bsb, buf, sizeof(buf));
+
+    BSB_EXPORT_sprintf(bsb, "arkime-capture %s/%s session size=%d packet size=%d api=%d\n", PACKAGE_VERSION, BUILD_VERSION, (int)sizeof(ArkimeSession_t), (int)sizeof(ArkimePacket_t), ARKIME_API_VERSION);
+
+    BSB_EXPORT_sprintf(bsb, "curl: %s\n", curl_version());
+    BSB_EXPORT_sprintf(bsb, "glib2: %u.%u.%u\n", glib_major_version, glib_minor_version, glib_micro_version);
+    BSB_EXPORT_sprintf(bsb, "libpcap: %s\n", pcap_lib_version());
+    BSB_EXPORT_sprintf(bsb, "maxminddb: %s\n", MMDB_lib_version());
+    BSB_EXPORT_sprintf(bsb, "pcre: %s\n", pcre_version());
+    BSB_EXPORT_sprintf(bsb, "yaml: %s\n", yaml_get_version_string());
+    BSB_EXPORT_sprintf(bsb, "yara: %s\n", arkime_yara_version());
+    BSB_EXPORT_sprintf(bsb, "zlib: %s\n", zlibVersion());
+#ifdef HAVE_ZSTD
+    extern unsigned ZSTD_versionNumber(void);
+    unsigned zver = ZSTD_versionNumber();
+    BSB_EXPORT_sprintf(bsb, "zstd: %u.%u.%u\n", zver / (100 * 100), (zver / 100) % 100, zver % 100);
+#endif
+    const nghttp2_info *ngver = nghttp2_version(0);
+    BSB_EXPORT_sprintf(bsb, "nghttp2: %s\n", ngver->version_str);
+
+    arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
+}
+/******************************************************************************/
+LOCAL void arkime_cmd_shutdown(int UNUSED(argc), char UNUSED( * *argv), gpointer UNUSED(cc))
+{
+    arkime_quit();
 }
 /******************************************************************************/
 void parse_args(int argc, char **argv)
@@ -249,7 +289,11 @@ void parse_args(int argc, char **argv)
         exit(1);
     }
 
-    if (config.pcapMonitor && !config.pcapReadDirs) {
+    if (config.pcapMonitor && config.command) {
+        config.pcapReadOffline = 1;
+    }
+
+    if (config.pcapMonitor && !config.pcapReadDirs && !config.command) {
         printf("Must specify directories to monitor with -R\n");
         exit(1);
     }
@@ -1035,6 +1079,23 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     return 0;
 }
 #else
+void arkime_commands_init1()
+{
+
+    gint    argcp;
+    gchar **argvp;
+    GError *error = NULL;
+
+    if (!g_shell_parse_argv("hi there, \"quoted string\", \"quoted \\\"with\\\" quotes\"", &argcp, &argvp, &error)) {
+        LOGEXIT("ERROR - Couldn't parse commandLine - %s", error->message);
+    }
+
+    for (int i = 0; i < argcp; i++) {
+        printf("ALW >%s<\n", argvp[i]);
+    }
+    g_strfreev(argvp);
+}
+
 int main(int argc, char **argv)
 {
     signal(SIGHUP, reload);
@@ -1057,7 +1118,10 @@ int main(int argc, char **argv)
     arkime_free_later_init();
     arkime_hex_init();
     arkime_http_init();
+    arkime_command_init();
     arkime_config_init();
+    arkime_command_register("version", arkime_cmd_version, "Arkime Version");
+    arkime_command_register("shutdown", arkime_cmd_shutdown, "Shutdown Arkime");
     arkime_dedup_init();
     arkime_cloud_init();
     arkime_writers_init();

--- a/capture/plugins.c
+++ b/capture/plugins.c
@@ -50,9 +50,27 @@ typedef struct arkime_plugin {
 
 HASH_VAR(p_, plugins, ArkimePlugin_t, 11);
 /******************************************************************************/
+LOCAL void arkime_plugins_cmd_list(int UNUSED(argc), char UNUSED( * *argv), gpointer cc)
+{
+    char buf[10000];
+    BSB bsb;
+    BSB_INIT(bsb, buf, sizeof(buf));
+
+    ArkimePlugin_t *plugin;
+
+    if (HASH_COUNT(p_, plugins) == 0) {
+        BSB_EXPORT_sprintf(bsb, "No plugins loaded\n");
+    }
+    HASH_FORALL2(p_, plugins, plugin) {
+        BSB_EXPORT_sprintf(bsb, "%s\n", plugin->name);
+    }
+    arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
+}
+/******************************************************************************/
 void arkime_plugins_init()
 {
     HASH_INIT(p_, plugins, arkime_string_hash, arkime_string_cmp);
+    arkime_command_register("plugins-list", arkime_plugins_cmd_list, "List loaded plugins");
 }
 
 /******************************************************************************/

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -167,7 +167,10 @@ LOCAL void reader_libpcapfile_init_monitor()
 #else
 LOCAL void reader_libpcapfile_init_monitor()
 {
-    LOGEXIT("ERROR - Monitoring not supporting on this OS");
+    if (config.command)
+        LOG("ERROR - Monitoring not supporting on this OS");
+    else
+        LOGEXIT("ERROR - Monitoring not supporting on this OS");
 }
 #endif
 /******************************************************************************/

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -131,7 +131,10 @@ LOCAL void scheme_file_monitor_dir(const char *dirname)
 #else
 LOCAL void scheme_file_monitor_dir(const char UNUSED(*dirname))
 {
-    LOGEXIT("ERROR - Monitoring not supporting on this OS");
+    if (config.command)
+        LOG_RATE(30, "ERROR - Monitoring not supporting on this OS - %s", dirname);
+    else
+        LOGEXIT("ERROR - Monitoring not supporting on this OS - %s", dirname);
 }
 #endif
 /******************************************************************************/

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -493,6 +493,24 @@ void arkime_reader_scheme_register(char *name, ArkimeSchemeLoad load, ArkimeSche
     }
 }
 /******************************************************************************/
+void arkime_scheme_cmd_add_file(int argc, char **argv, gpointer cc)
+{
+    if (argc < 2) {
+        arkime_command_respond(cc, "Usage: add-file <file>\n", -1);
+        return;
+    }
+    arkime_reader_scheme_load(argv[1], FALSE);
+}
+/******************************************************************************/
+void arkime_scheme_cmd_add_dir(int argc, char **argv, gpointer cc)
+{
+    if (argc < 2) {
+        arkime_command_respond(cc, "Usage: add-dir <dir>\n", -1);
+        return;
+    }
+    arkime_reader_scheme_load(argv[1], FALSE);
+}
+/******************************************************************************/
 void arkime_reader_scheme_init()
 {
     HASH_INIT(s_, schemesHash, arkime_string_hash, arkime_string_cmp);
@@ -517,4 +535,7 @@ void arkime_reader_scheme_init()
 
     void arkime_reader_scheme_sqs_init();
     arkime_reader_scheme_sqs_init();
+
+    arkime_command_register("add-file", arkime_scheme_cmd_add_file, "Add a file to process");
+    arkime_command_register("add-dir", arkime_scheme_cmd_add_dir, "Add a directory to process");
 }


### PR DESCRIPTION
First version of a command socket, enabled with --command PATH-TO-UNIX-DOMAIN

Main goal is to allow the user to add new files/directories to process in scheme mode.

example: `/opt/arkime/bin/capture -m --scheme --command /var/run/arkime.socket`

```
nc -U /var/run/arkime.socket
help
exit
```



## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
