### PR TITLE
add-dir now has options

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1438,12 +1438,20 @@ void arkime_readers_exit();
  * reader-scheme.c
  */
 
-typedef int  (*ArkimeSchemeLoad)(const char *uri, gboolean dirHint);
+typedef enum {
+    ARKIME_SCHEME_FLAG_NONE      = 0x0000,
+    ARKIME_SCHEME_FLAG_DIRHINT   = 0x0001,
+    ARKIME_SCHEME_FLAG_MONITOR   = 0x0002,
+    ARKIME_SCHEME_FLAG_RECURSIVE = 0x0004,
+    ARKIME_SCHEME_FLAG_SKIP      = 0x0008
+} ArkimeSchemeFlags;
+
+typedef int  (*ArkimeSchemeLoad)(const char *uri, ArkimeSchemeFlags flags);
 typedef void (*ArkimeSchemeExit)();
 
 void arkime_reader_scheme_register(char *name, ArkimeSchemeLoad load, ArkimeSchemeExit exit);
 int arkime_reader_scheme_process(const char *uri, uint8_t *data, int len, const char *extraInfo);
-void arkime_reader_scheme_load(const char *uri, gboolean dirHint);
+void arkime_reader_scheme_load(const char *uri, ArkimeSchemeFlags flags);
 
 /******************************************************************************/
 /*

--- a/capture/main.c
+++ b/capture/main.c
@@ -290,7 +290,7 @@ void parse_args(int argc, char **argv)
         exit(1);
     }
 
-    if (config.pcapMonitor && config.commandSocket) {
+    if ((config.pcapMonitor || config.commandWait) && config.commandSocket) {
         config.pcapReadOffline = 1;
     }
 

--- a/capture/reader-scheme-http.c
+++ b/capture/reader-scheme-http.c
@@ -28,9 +28,9 @@ LOCAL int scheme_http_read(uint8_t *data, int data_len, gpointer uw)
     return arkime_reader_scheme_process((char *)uw, data, data_len, NULL);
 }
 /******************************************************************************/
-int scheme_http_load(const char *uri, gboolean UNUSED(dirHint))
+int scheme_http_load(const char *uri, ArkimeSchemeFlags flags)
 {
-    if (config.pcapSkip && arkime_db_file_exists(uri, NULL)) {
+    if ((flags & ARKIME_SCHEME_FLAG_SKIP) && arkime_db_file_exists(uri, NULL)) {
         if (config.debug)
             LOG("Skipping %s", uri);
         return 1;

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -183,7 +183,7 @@ LOCAL void sqs_done(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
 // sqs://sqs.us-east-1.amazonaws.com/80398EXAMPLE/MyQueue
 // sqshttps://sqs.us-east-1.amazonaws.com/80398EXAMPLE/MyQueue
 // sqshttp://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/my-queue
-int scheme_sqs_load(const char *uri, gboolean UNUSED(dirHint))
+int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags)
 {
     if (!inited)
         sqs_init();
@@ -290,7 +290,7 @@ int scheme_sqs_load(const char *uri, gboolean UNUSED(dirHint))
             }
             if (config.debug)
                 LOG("SQS S3 URL: %s", s3url);
-            arkime_reader_scheme_load(s3url, FALSE);
+            arkime_reader_scheme_load(s3url, flags);
         }
 
         // Delete the message

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -25,7 +25,7 @@ typedef struct {
 typedef struct ArkimeSchemeLater {
     struct ArkimeSchemeLater *next;
     char                     *uri;
-    char                      dirHint;
+    ArkimeSchemeFlags         flags;
 } ArkimeSchemeLater_t;
 
 LOCAL ArkimeSchemeLater_t *laterHead;
@@ -84,7 +84,7 @@ LOCAL ArkimeScheme_t *uri2scheme(const char *uri)
     return str ? str->uw : NULL;
 }
 /******************************************************************************/
-LOCAL void arkime_reader_scheme_load_thread(const char *uri, gboolean dirHint)
+LOCAL void arkime_reader_scheme_load_thread(const char *uri, ArkimeSchemeFlags flags)
 {
     LOG ("Processing %s", uri);
     ArkimeScheme_t *readerScheme = uri2scheme(uri);
@@ -112,7 +112,7 @@ LOCAL void arkime_reader_scheme_load_thread(const char *uri, gboolean dirHint)
     lastPackets = 0;
     tmpBufferLen = 0;
 
-    int rc = readerScheme->load(uri, dirHint);
+    int rc = readerScheme->load(uri, flags);
 
     if (rc == 0 && !config.dryRun && !config.copyPcap && offlineInfo[readerPos].didBatch) {
         // Wait for the first packet to be processed so we have an outputId
@@ -123,11 +123,11 @@ LOCAL void arkime_reader_scheme_load_thread(const char *uri, gboolean dirHint)
     }
 }
 /******************************************************************************/
-void arkime_reader_scheme_load(const char *uri, gboolean dirHint)
+void arkime_reader_scheme_load(const char *uri, ArkimeSchemeFlags flags)
 {
     // if on the scheme thread just process right away
     if (g_thread_self() == schemeThread) {
-        arkime_reader_scheme_load_thread(uri, dirHint);
+        arkime_reader_scheme_load_thread(uri, flags);
         return;
     }
 
@@ -135,7 +135,7 @@ void arkime_reader_scheme_load(const char *uri, gboolean dirHint)
     ArkimeSchemeLater_t *item = ARKIME_TYPE_ALLOC(ArkimeSchemeLater_t);
     item->next = 0;
     item->uri = g_strdup(uri);
-    item->dirHint = dirHint;
+    item->flags = flags;
     ARKIME_LOCK(laterLock);
     if (laterHead) {
         laterTail->next = item;
@@ -234,10 +234,20 @@ LOCAL int reader_scheme_header(const char *uri, const uint8_t *header, const cha
 /******************************************************************************/
 LOCAL void *reader_scheme_thread(void *UNUSED(arg))
 {
+    ArkimeSchemeFlags flags = ARKIME_SCHEME_FLAG_NONE;
+    if (config.pcapMonitor) {
+        flags |= ARKIME_SCHEME_FLAG_MONITOR;
+    }
+    if (config.pcapRecursive) {
+        flags |= ARKIME_SCHEME_FLAG_RECURSIVE;
+    }
+    if (config.pcapSkip) {
+        flags |= ARKIME_SCHEME_FLAG_SKIP;
+    }
 
     // Load files
     for (int i = 0; config.pcapReadFiles && config.pcapReadFiles[i]; i++) {
-        arkime_reader_scheme_load_thread(config.pcapReadFiles[i], FALSE);
+        arkime_reader_scheme_load_thread(config.pcapReadFiles[i], flags);
     }
 
     // Load list of files
@@ -268,13 +278,13 @@ LOCAL void *reader_scheme_thread(void *UNUSED(arg))
             g_strstrip(line);
             if (!line[0] || line[0] == '#')
                 continue;
-            arkime_reader_scheme_load_thread(line, FALSE);
+            arkime_reader_scheme_load_thread(line, flags);
         }
         fclose(file);
     }
 
     for (int i = 0; config.pcapReadDirs && config.pcapReadDirs[i]; i++) {
-        arkime_reader_scheme_load_thread(config.pcapReadDirs[i], TRUE);
+        arkime_reader_scheme_load_thread(config.pcapReadDirs[i], flags | ARKIME_SCHEME_FLAG_DIRHINT);
     }
 
     while (config.commandWait || config.pcapMonitor || laterHead) {
@@ -286,7 +296,7 @@ LOCAL void *reader_scheme_thread(void *UNUSED(arg))
         item = laterHead;
         laterHead = item->next;
         ARKIME_UNLOCK(laterLock);
-        arkime_reader_scheme_load_thread(item->uri, item->dirHint);
+        arkime_reader_scheme_load_thread(item->uri, item->flags);
         g_free(item->uri);
         ARKIME_TYPE_FREE(ArkimeSchemeLater_t, item);
     }
@@ -506,16 +516,45 @@ void arkime_scheme_cmd_add_file(int argc, char **argv, gpointer cc)
         arkime_command_respond(cc, "Usage: add-file <file>\n", -1);
         return;
     }
-    arkime_reader_scheme_load(argv[1], FALSE);
+
+    arkime_reader_scheme_load(argv[1], ARKIME_SCHEME_FLAG_NONE);
 }
 /******************************************************************************/
 void arkime_scheme_cmd_add_dir(int argc, char **argv, gpointer cc)
 {
     if (argc < 2) {
-        arkime_command_respond(cc, "Usage: add-dir <dir>\n", -1);
+        arkime_command_respond(cc, "Usage: add-dir [-monitor] [-nomonitor] [-recursive] [-norecursive] [-skip] [-noskip] <dir>\n", -1);
         return;
     }
-    arkime_reader_scheme_load(argv[1], FALSE);
+
+    ArkimeSchemeFlags flags = ARKIME_SCHEME_FLAG_DIRHINT;
+    if (config.pcapMonitor) {
+        flags |= ARKIME_SCHEME_FLAG_MONITOR;
+    }
+    if (config.pcapRecursive) {
+        flags |= ARKIME_SCHEME_FLAG_RECURSIVE;
+    }
+    if (config.pcapSkip) {
+        flags |= ARKIME_SCHEME_FLAG_SKIP;
+    }
+
+    for (int i = 1; i < argc - 1; i++) {
+        if (strcmp(argv[i], "-monitor") == 0) {
+            flags |= ARKIME_SCHEME_FLAG_MONITOR;
+        } else if (strcmp(argv[i], "-nomonitor") == 0) {
+            flags &= ~ARKIME_SCHEME_FLAG_MONITOR;
+        } else if (strcmp(argv[i], "-recursive") == 0) {
+            flags |= ARKIME_SCHEME_FLAG_RECURSIVE;
+        } else if (strcmp(argv[i], "-norecursive") == 0) {
+            flags &= ~ARKIME_SCHEME_FLAG_RECURSIVE;
+        } else if (strcmp(argv[i], "-skip") == 0) {
+            flags |= ARKIME_SCHEME_FLAG_SKIP;
+        } else if (strcmp(argv[i], "-noskip") == 0) {
+            flags &= ~ARKIME_SCHEME_FLAG_SKIP;
+        }
+    }
+
+    arkime_reader_scheme_load(argv[argc - 1], flags);
 }
 /******************************************************************************/
 void arkime_reader_scheme_init()
@@ -544,5 +583,5 @@ void arkime_reader_scheme_init()
     arkime_reader_scheme_sqs_init();
 
     arkime_command_register("add-file", arkime_scheme_cmd_add_file, "Add a file to process");
-    arkime_command_register("add-dir", arkime_scheme_cmd_add_dir, "Add a directory to process");
+    arkime_command_register("add-dir", arkime_scheme_cmd_add_dir, "[-monitor] [-nomonitor] [-recursive] [-norecursive] [-skip] [-noskip] <dir> Add a directory to process");
 }

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -539,18 +539,28 @@ void arkime_scheme_cmd_add_dir(int argc, char **argv, gpointer cc)
     }
 
     for (int i = 1; i < argc - 1; i++) {
-        if (strcmp(argv[i], "-monitor") == 0) {
+        char *cmp = argv[i];
+        if (*cmp == '-' && cmp[1] == '-') {
+            cmp++;
+        }
+
+        if (strcmp(cmp, "-monitor") == 0) {
             flags |= ARKIME_SCHEME_FLAG_MONITOR;
-        } else if (strcmp(argv[i], "-nomonitor") == 0) {
+        } else if (strcmp(cmp, "-nomonitor") == 0) {
             flags &= ~ARKIME_SCHEME_FLAG_MONITOR;
-        } else if (strcmp(argv[i], "-recursive") == 0) {
+        } else if (strcmp(cmp, "-recursive") == 0) {
             flags |= ARKIME_SCHEME_FLAG_RECURSIVE;
-        } else if (strcmp(argv[i], "-norecursive") == 0) {
+        } else if (strcmp(cmp, "-norecursive") == 0) {
             flags &= ~ARKIME_SCHEME_FLAG_RECURSIVE;
-        } else if (strcmp(argv[i], "-skip") == 0) {
+        } else if (strcmp(cmp, "-skip") == 0) {
             flags |= ARKIME_SCHEME_FLAG_SKIP;
-        } else if (strcmp(argv[i], "-noskip") == 0) {
+        } else if (strcmp(cmp, "-noskip") == 0) {
             flags &= ~ARKIME_SCHEME_FLAG_SKIP;
+        } else if (cmp[0] == '-') {
+            char err[1000];
+            snprintf(err, sizeof(err), "Unknown option %s\n", argv[i]);
+            arkime_command_respond(cc, err, -1);
+            return;
         }
     }
 


### PR DESCRIPTION
For monitor/recursive/skip add-dir can override the command line settings which are treated as "defaults"

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
