### PR TITLE
make sure to turn off dirhint when fetch s3 files after prefix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,8 +37,10 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           env vars, --profile ~/.aws/credentials or config, and meta data service
   - #2869 scheme mode for local files support monitor mode
   - #2870 log error with pcap_dispatch (thanks @vpiserchia)
-  - #2873 New --command option to enable a unix domain control port for
+  - #2873 New --command-socket option to enable a unix domain control port for
           controlling capture
+  - #2875 New --command-wait option to use when no offline files on command line
+  - #2877 command-socket add-dir now has options to override command line
 ## Multies
   - #2865 form or oidc require usersElasticsearch to be set for multiES
 

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -322,7 +322,7 @@ LOCAL int scheme_s3_load_dir(const char *dir, ArkimeSchemeFlags flags)
         S3Item *item;
         DLL_POP_HEAD(item_, s3Items, item);
         ARKIME_UNLOCK(s3Items->lock);
-        arkime_reader_scheme_load(item->url, flags);
+        arkime_reader_scheme_load(item->url, flags & ~ARKIME_SCHEME_FLAG_DIRHINT);
         g_free(item->url);
         ARKIME_TYPE_FREE(S3Item, item);
     }
@@ -426,7 +426,7 @@ LOCAL int scheme_s3_load_full_dir(const char *dir, ArkimeSchemeFlags flags)
         S3Item *item;
         DLL_POP_HEAD(item_, s3Items, item);
         ARKIME_UNLOCK(s3Items->lock);
-        arkime_reader_scheme_load(item->url, flags);
+        arkime_reader_scheme_load(item->url, flags & ~ARKIME_SCHEME_FLAG_DIRHINT);
         g_free(item->url);
         ARKIME_TYPE_FREE(S3Item, item);
     }

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -290,7 +290,7 @@ int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags)
             }
             if (config.debug)
                 LOG("SQS S3 URL: %s", s3url);
-            arkime_reader_scheme_load(s3url, flags);
+            arkime_reader_scheme_load(s3url, flags & ~ARKIME_SCHEME_FLAG_DIRHINT);
         }
 
         // Delete the message

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -125,9 +125,12 @@ LOCAL void arkime_reader_scheme_load_thread(const char *uri, ArkimeSchemeFlags f
 /******************************************************************************/
 void arkime_reader_scheme_load(const char *uri, ArkimeSchemeFlags flags)
 {
-    // if on the scheme thread just process right away
-    if (g_thread_self() == schemeThread) {
+    static int depth;
+    // if on the scheme thread and stack isn't too deep just process right away
+    if (g_thread_self() == schemeThread && depth < 20) {
+        depth++;
         arkime_reader_scheme_load_thread(uri, flags);
+        depth--;
         return;
     }
 
@@ -518,6 +521,7 @@ void arkime_scheme_cmd_add_file(int argc, char **argv, gpointer cc)
     }
 
     arkime_reader_scheme_load(argv[1], ARKIME_SCHEME_FLAG_NONE);
+    arkime_command_respond(cc, "Added file", -1);
 }
 /******************************************************************************/
 void arkime_scheme_cmd_add_dir(int argc, char **argv, gpointer cc)
@@ -565,6 +569,7 @@ void arkime_scheme_cmd_add_dir(int argc, char **argv, gpointer cc)
     }
 
     arkime_reader_scheme_load(argv[argc - 1], flags);
+    arkime_command_respond(cc, "Added directory", -1);
 }
 /******************************************************************************/
 void arkime_reader_scheme_init()


### PR DESCRIPTION
Forgot to turn off dirhint for s3 files which was causing stack blow out. Also added protecting to stop that hopefully.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
