### PR TITLE
fix JA4 when num extensions or ciphers is > 99

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,7 +33,6 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 5.4.0 2024/07/xx
-## BREAKING
 ## Release
   - #2885 Node 20.15.1
 ## Capture
@@ -45,6 +44,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           controlling capture
   - #2875 New --command-wait option to use when no offline files on command line
   - #2877 command-socket add-dir now has options to override command line
+  - #2891 fix JA4 when num extensions or ciphers is > 99
 ## Cont3xt
   - #2879 Added skipChildren query string parameter
   - #2880 Only focus on search if no search parameter

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Another way to view the data is the SPI View page, which allows the user to see 
 Most users should use the prebuilt binaries available at our [Downloads page](https://arkime.com/downloads) and follow the simple install instructions on that page.
 
 For advanced users, you can build Arkime yourself:
-* Make sure `node` is in your path, currently main supports Node version 18.x (18.15 or higher) or 20.x
+* Make sure `node` is in your path, currently main supports Node version 20.x
 * `git clone https://github.com/arkime/arkime` - latest version on github
 * `./easybutton-build.sh --install` - downloads all the prerequisites, build, and install
 * `make config` - performs an initial Arkime configuration

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -279,6 +279,17 @@ LOCAL int compare_uint16_t(const void *a, const void *b)
     return (*(const uint16_t *)a < * (const uint16_t *)b ? -1 : * (const uint16_t *)a > *(const uint16_t *)b);
 }
 /******************************************************************************/
+LOCAL void tls_2digit_to_string(int val, char *str)
+{
+    if (val >= 99) {
+        str[0] = '9';
+        str[1] = '9';
+        return;
+    }
+    str[0] = (val / 10) + '0';
+    str[1] = (val % 10) + '0';
+}
+/******************************************************************************/
 uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uint8_t *data, int len, void UNUSED(*uw))
 {
     if (len < 7)
@@ -522,10 +533,8 @@ uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uint8_t *
     ja4[1] = vstr[0];
     ja4[2] = vstr[1];
     ja4[3] = ja4HasSNI;
-    ja4[4] = (ja4NumCiphers / 10) + '0';
-    ja4[5] = (ja4NumCiphers % 10) + '0';
-    ja4[6] = (ja4NumExtensions / 10) + '0';
-    ja4[7] = (ja4NumExtensions % 10) + '0';
+    tls_2digit_to_string(ja4NumCiphers, ja4 + 4);
+    tls_2digit_to_string(ja4NumExtensions, ja4 + 6);
     ja4[8] = ja4ALPN[0];
     ja4[9] = ja4ALPN[1];
     ja4[10] = '_';


### PR DESCRIPTION
When more then 99 extensions or ciphers output 99 in JA4

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
