### PR TITLE
Force removal of problematic pcap when configured

### DIFF
--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -468,7 +468,7 @@ LOCAL gboolean reader_libpcapfile_read()
 
     int r;
     if (pktsToRead > 0) {
-        r = pcap_dispatch(pcap, MIN(pktsToRead, offlineDispatchAfter), reader_libpcapfile_pcap_cb, (u_char *)pcap);
+        r = pcap_dispatch(pcap, MIN(pktsToRead, offlineDispatchAfter), reader_libpcapfile_pcap_cb, NULL);
 
         if (r > 0)
             pktsToRead -= r;
@@ -476,7 +476,7 @@ LOCAL gboolean reader_libpcapfile_read()
         if (pktsToRead == 0)
             r = 0;
     } else {
-        r = pcap_dispatch(pcap, offlineDispatchAfter, reader_libpcapfile_pcap_cb, (u_char *)pcap);
+        r = pcap_dispatch(pcap, offlineDispatchAfter, reader_libpcapfile_pcap_cb, NULL);
     }
     lastPacketsBatched += batch.count;
     arkime_packet_batch_flush(&batch);


### PR DESCRIPTION
When PCAP file deletion is chosen together with errors ignore, effectively remove files.

<!-- Provide a clear and descriptive title -->

**the problem and solution**
As of now Arkime does not respect the configuration parameter "deletePCAP" and "ignoreErrors" when it comes to problematic PCAP.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
