### PR TITLE
Command op support and scheme improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2875 New --command-wait option to use when no offline files on command line
   - #2877 command-socket add-dir now has options to override command line
   - #2891 fix JA4 when num extensions or ciphers is > 99
+  - #2893 support deleting pcaps when ignoreErrors set (thanks @vpiserchia)
+  - #2894 support --op/--delete with scheme commands
 ## Cont3xt
   - #2879 Added skipChildren query string parameter
   - #2880 Only focus on search if no search parameter

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -907,6 +907,7 @@ typedef void (* ArkimeCommandFunc) (int argc, char **argv, gpointer cc);
 
 void arkime_command_init();
 void arkime_command_register(const char *name, ArkimeCommandFunc func, const char *help);
+void arkime_command_register_opts(const char *name, ArkimeCommandFunc func, const char *help, ...);
 void arkime_command_respond(gpointer cc, const char *data, int len);
 
 /******************************************************************************/
@@ -1347,6 +1348,7 @@ int  arkime_field_define(const char *group, const char *kind, const char *expres
 
 int  arkime_field_by_db(const char *dbField);
 int  arkime_field_by_exp(const char *exp);
+int  arkime_field_by_exp_ignore_error(const char *exp);
 const char *arkime_field_string_add(int pos, ArkimeSession_t *session, const char *string, int len, gboolean copy);
 gboolean arkime_field_string_add_lower(int pos, ArkimeSession_t *session, const char *string, int len);
 gboolean arkime_field_string_add_host(int pos, ArkimeSession_t *session, char *string, int len);
@@ -1367,6 +1369,7 @@ int arkime_field_by_exp_add_internal(const char *exp, ArkimeFieldType type, Arki
 
 void arkime_field_ops_init(ArkimeFieldOps_t *ops, int numOps, uint16_t flags);
 void arkime_field_ops_free(ArkimeFieldOps_t *ops);
+char *arkime_field_ops_parse(ArkimeFieldOps_t *ops, uint16_t flags, gchar **strs);
 void arkime_field_ops_add(ArkimeFieldOps_t *ops, int fieldPos, char *value, int valuelen);
 void arkime_field_ops_add_match(ArkimeFieldOps_t *ops, int fieldPos, char *value, int valuelen, int matchPos);
 void arkime_field_ops_run(ArkimeSession_t *session, ArkimeFieldOps_t *ops);
@@ -1443,15 +1446,21 @@ typedef enum {
     ARKIME_SCHEME_FLAG_DIRHINT   = 0x0001,
     ARKIME_SCHEME_FLAG_MONITOR   = 0x0002,
     ARKIME_SCHEME_FLAG_RECURSIVE = 0x0004,
-    ARKIME_SCHEME_FLAG_SKIP      = 0x0008
+    ARKIME_SCHEME_FLAG_SKIP      = 0x0008,
+    ARKIME_SCHEME_FLAG_DELETE    = 0x0010
 } ArkimeSchemeFlags;
 
-typedef int  (*ArkimeSchemeLoad)(const char *uri, ArkimeSchemeFlags flags);
+typedef struct {
+    int refs;
+    ArkimeFieldOps_t ops;
+} ArkimeSchemeAction_t;
+
+typedef int  (*ArkimeSchemeLoad)(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions);
 typedef void (*ArkimeSchemeExit)();
 
 void arkime_reader_scheme_register(char *name, ArkimeSchemeLoad load, ArkimeSchemeExit exit);
-int arkime_reader_scheme_process(const char *uri, uint8_t *data, int len, const char *extraInfo);
-void arkime_reader_scheme_load(const char *uri, ArkimeSchemeFlags flags);
+int arkime_reader_scheme_process(const char *uri, uint8_t *data, int len, const char *extraInfo, ArkimeSchemeAction_t *actions);
+void arkime_reader_scheme_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions);
 
 /******************************************************************************/
 /*

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -58,6 +58,7 @@ LOCAL patricia_tree_t       *newipTree4 = 0;
 LOCAL patricia_tree_t       *newipTree6 = 0;
 
 extern ArkimeFieldOps_t      readerFieldOps[256];
+extern ArkimeSchemeAction_t *schemeActions[256];
 
 LOCAL ArkimePacketEnqueue_cb udpPortCbs[0x10000];
 LOCAL ArkimePacketEnqueue_cb ethernetCbs[0x10000];
@@ -247,6 +248,10 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
         arkime_parsers_initial_tag(session);
         if (readerFieldOps[packet->readerPos].num)
             arkime_field_ops_run(session, &readerFieldOps[packet->readerPos]);
+
+        if (schemeActions[packet->readerPos] && schemeActions[packet->readerPos]->ops.num) {
+            arkime_field_ops_run(session, &schemeActions[packet->readerPos]->ops);
+        }
 
         if (pluginsCbs & ARKIME_PLUGIN_NEW)
             arkime_plugins_cb_new(session);

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -823,24 +823,9 @@ void arkime_parsers_init()
 
 
     if (config.extraOps) {
-        for (i = 0; config.extraOps[i]; i++) { }
-        arkime_field_ops_init(&config.ops, i, 0);
-        for (i = 0; config.extraOps[i]; i++) {
-            char *equal = strchr(config.extraOps[i], '=');
-            if (!equal) {
-                CONFIGEXIT("Must be FieldExpr=value, missing equal '%s'", config.extraOps[i]);
-            }
-            int len = strlen(equal + 1);
-            if (!len) {
-                CONFIGEXIT("Must be FieldExpr=value, empty value for '%s'", config.extraOps[i]);
-            }
-            *equal = 0;
-            int fieldPos = arkime_field_by_exp(config.extraOps[i]);
-            if (fieldPos == -1) {
-                CONFIGEXIT("Must be FieldExpr=value, Unknown field expression '%s'", config.extraOps[i]);
-            }
-            arkime_field_ops_add(&config.ops, fieldPos, equal + 1, len);
-        }
+        char *error = arkime_field_ops_parse(&config.ops, 0, config.extraOps);
+        if (error)
+            CONFIGEXIT("%s", error);
     } else {
         arkime_field_ops_init(&config.ops, 0, 0);
     }

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -823,7 +823,7 @@ void arkime_parsers_init()
 
 
     if (config.extraOps) {
-        char *error = arkime_field_ops_parse(&config.ops, 0, config.extraOps);
+        const char *error = arkime_field_ops_parse(&config.ops, 0, config.extraOps);
         if (error)
             CONFIGEXIT("%s", error);
     } else {

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -139,7 +139,7 @@ LOCAL void scheme_file_monitor_dir(const char *dirname, ArkimeSchemeFlags flags,
     g_dir_close(dir);
 }
 #else
-LOCAL void scheme_file_monitor_dir(const char UNUSED(*dirname), ArkimeSchemeFlags UNUSED(flags))
+LOCAL void scheme_file_monitor_dir(const char UNUSED(*dirname), ArkimeSchemeFlags UNUSED(flags), ArkimeSchemeAction_t UNUSED(*actions))
 {
     if (config.commandSocket)
         LOG_RATE(30, "ERROR - Monitoring not supporting on this OS - %s", dirname);

--- a/capture/reader-scheme-http.c
+++ b/capture/reader-scheme-http.c
@@ -25,10 +25,10 @@ LOCAL void scheme_http_done(int UNUSED(code), uint8_t UNUSED(*data), int UNUSED(
 /******************************************************************************/
 LOCAL int scheme_http_read(uint8_t *data, int data_len, gpointer uw)
 {
-    return arkime_reader_scheme_process((char *)uw, data, data_len, NULL);
+    return arkime_reader_scheme_process((char *)uw, data, data_len, NULL, NULL); /* ALW - FIX ACTIONS */
 }
 /******************************************************************************/
-int scheme_http_load(const char *uri, ArkimeSchemeFlags flags)
+int scheme_http_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions)
 {
     if ((flags & ARKIME_SCHEME_FLAG_SKIP) && arkime_db_file_exists(uri, NULL)) {
         if (config.debug)

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -183,7 +183,7 @@ LOCAL void sqs_done(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
 // sqs://sqs.us-east-1.amazonaws.com/80398EXAMPLE/MyQueue
 // sqshttps://sqs.us-east-1.amazonaws.com/80398EXAMPLE/MyQueue
 // sqshttp://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/my-queue
-int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags)
+int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions)
 {
     if (!inited)
         sqs_init();
@@ -290,7 +290,7 @@ int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags)
             }
             if (config.debug)
                 LOG("SQS S3 URL: %s", s3url);
-            arkime_reader_scheme_load(s3url, flags & ~ARKIME_SCHEME_FLAG_DIRHINT);
+            arkime_reader_scheme_load(s3url, flags & ~ARKIME_SCHEME_FLAG_DIRHINT, actions);
         }
 
         // Delete the message

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -72,7 +72,6 @@ LOCAL void reader_scheme_actions_ref(ArkimeSchemeAction_t *actions)
     if (!actions)
         return;
 
-    LOG("actions->ref %p %d", actions, actions->refs);
     actions->refs++;
 }
 /******************************************************************************/
@@ -81,7 +80,6 @@ LOCAL void reader_scheme_actions_deref(ArkimeSchemeAction_t *actions)
     if (!actions)
         return;
 
-    LOG("actions->deref %p %d", actions, actions->refs);
     actions->refs--;
 
     if (actions->refs)

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -123,9 +123,9 @@ LOCAL void arkime_reader_scheme_load_thread(const char *uri, ArkimeSchemeFlags f
     lastPackets = 0;
     tmpBufferLen = 0;
 
-    int rc = readerScheme->load(uri, flags, actions);
+    int rcl = readerScheme->load(uri, flags, actions);
 
-    if (rc == 0 && !config.dryRun && !config.copyPcap && offlineInfo[readerPos].didBatch) {
+    if (rcl == 0 && !config.dryRun && !config.copyPcap && offlineInfo[readerPos].didBatch) {
         // Wait for the first packet to be processed so we have an outputId
         while (offlineInfo[readerPos].outputId == 0 || arkime_http_queue_length_best(esServer) > 0) {
             usleep(5000);
@@ -607,7 +607,7 @@ int arkime_scheme_cmd_add(int argc, char **argv, gpointer cc, ArkimeSchemeFlags 
     if (opsNum > 0) {
         actions = ARKIME_TYPE_ALLOC0(ArkimeSchemeAction_t);
         ops[opsNum] = 0;
-        char *error = arkime_field_ops_parse(&actions->ops, ARKIME_FIELD_OPS_FLAGS_COPY, ops);
+        const char *error = arkime_field_ops_parse(&actions->ops, ARKIME_FIELD_OPS_FLAGS_COPY, ops);
         if (error) {
             ARKIME_TYPE_FREE(ArkimeSchemeAction_t, actions);
             arkime_command_respond(cc, error, -1);
@@ -669,17 +669,17 @@ void arkime_reader_scheme_init()
     arkime_reader_scheme_sqs_init();
 
     arkime_command_register_opts("add-file", arkime_scheme_cmd_add_file, "Add a file to process",
-            "[--delete|--nodelete]", "Override command line delete files after processing",
-            "[--op <field>=<value>]", "Can be multiple, override command line op option",
-            "[--skip|--noskip]", "Override command line skip files already processed",
-            "<file>", "File to process",
-            NULL);
+                                 "[--delete|--nodelete]", "Override command line delete files after processing",
+                                 "[--op <field>=<value>]", "Can be multiple, override command line op option",
+                                 "[--skip|--noskip]", "Override command line skip files already processed",
+                                 "<file>", "File to process",
+                                 NULL);
     arkime_command_register_opts("add-dir", arkime_scheme_cmd_add_dir, "Add a directory to process",
-            "[--delete|--nodelete]", "Override command line delete files after processing",
-            "[--op <field>=<value>]", "Can be multiple, override command line op option",
-            "[--skip|--noskip]", "Override command line skip files already processed",
-            "[--monitor|--nomonitor]", "Override command line monitor the directory for new files option",
-            "[--recursive|--norecursive]", "Override command line Recurse sub directories option",
-            "<dir>", "Directory to process",
-            NULL);
+                                 "[--delete|--nodelete]", "Override command line delete files after processing",
+                                 "[--op <field>=<value>]", "Can be multiple, override command line op option",
+                                 "[--skip|--noskip]", "Override command line skip files already processed",
+                                 "[--monitor|--nomonitor]", "Override command line monitor the directory for new files option",
+                                 "[--recursive|--norecursive]", "Override command line Recurse sub directories option",
+                                 "<dir>", "Directory to process",
+                                 NULL);
 }

--- a/capture/readers.c
+++ b/capture/readers.c
@@ -79,33 +79,17 @@ void arkime_readers_start()
     char **interfaceOps;
     interfaceOps = arkime_config_raw_str_list(NULL, "interfaceOps", "");
 
-    int i, j;
+    int i;
     for (i = 0; interfaceOps[i]; i++) {
         if (!interfaceOps[i][0])
             continue;
 
         char **opsstr = g_strsplit(interfaceOps[i], ",", 0);
-        for (j = 0; opsstr[j]; j++) { }
+        char *error = arkime_field_ops_parse(&readerFieldOps[i], ARKIME_FIELD_OPS_FLAGS_COPY, opsstr);
 
-        arkime_field_ops_init(&readerFieldOps[i], j, ARKIME_FIELD_OPS_FLAGS_COPY);
-
-        for (j = 0; opsstr[j]; j++) {
-            char *equal = strchr(opsstr[j], '=');
-            if (!equal) {
-                CONFIGEXIT("Must be FieldExpr=value, missing equal '%s'", opsstr[j]);
-            }
-            int len = strlen(equal + 1);
-            if (!len) {
-                CONFIGEXIT("Must be FieldExpr=value, empty value for '%s'", opsstr[j]);
-            }
-            *equal = 0;
-            int fieldPos = arkime_field_by_exp(opsstr[j]);
-            if (fieldPos == -1) {
-                CONFIGEXIT("Must be FieldExpr=value, Unknown field expression '%s'", opsstr[j]);
-            }
-            arkime_field_ops_add(&readerFieldOps[i], fieldPos, equal + 1, len);
+        if (error) {
+            CONFIGEXIT("%s", error);
         }
-        g_strfreev(opsstr);
     }
     g_strfreev(interfaceOps);
 

--- a/capture/readers.c
+++ b/capture/readers.c
@@ -85,7 +85,7 @@ void arkime_readers_start()
             continue;
 
         char **opsstr = g_strsplit(interfaceOps[i], ",", 0);
-        char *error = arkime_field_ops_parse(&readerFieldOps[i], ARKIME_FIELD_OPS_FLAGS_COPY, opsstr);
+        const char *error = arkime_field_ops_parse(&readerFieldOps[i], ARKIME_FIELD_OPS_FLAGS_COPY, opsstr);
 
         if (error) {
             CONFIGEXIT("%s", error);


### PR DESCRIPTION
* support --op for add-file and add-dir which required new SchemeActions all the way down
* support scheme DELETE flag
* --delete/--nodelete support for scheme add*
* combine 3 --op parsing to one place
* better help for options in commands

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
