### PR TITLE
http --op works, command line --delete was ignored

### DIFF
--- a/capture/reader-scheme-http.c
+++ b/capture/reader-scheme-http.c
@@ -12,20 +12,26 @@
 
 extern ArkimeConfig_t        config;
 
+typedef struct {
+    const char              *uri;
+    ArkimeSchemeAction_t    *actions;
+} HTTPRequest_t;
 
 LOCAL GHashTable            *servers;
 
 LOCAL ARKIME_LOCK_DEFINE(waiting);
 
 /******************************************************************************/
-LOCAL void scheme_http_done(int UNUSED(code), uint8_t UNUSED(*data), int UNUSED(data_len), gpointer UNUSED(uw))
+LOCAL void scheme_http_done(int UNUSED(code), uint8_t UNUSED(*data), int UNUSED(data_len), gpointer uw)
 {
+    ARKIME_TYPE_FREE(HTTPRequest_t, uw);
     ARKIME_UNLOCK(waiting);
 }
 /******************************************************************************/
 LOCAL int scheme_http_read(uint8_t *data, int data_len, gpointer uw)
 {
-    return arkime_reader_scheme_process((char *)uw, data, data_len, NULL, NULL); /* ALW - FIX ACTIONS */
+    HTTPRequest_t *req = (HTTPRequest_t *)uw;
+    return arkime_reader_scheme_process(req->uri, data, data_len, NULL, req->actions);
 }
 /******************************************************************************/
 int scheme_http_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions)
@@ -62,7 +68,6 @@ int scheme_http_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeActio
         return 1;
     }
 
-
     char hostport[1000];
     snprintf(hostport, sizeof(hostport), "%s://%s:%s", scheme, host, port);
 
@@ -72,7 +77,10 @@ int scheme_http_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeActio
         g_hash_table_insert(servers, g_strdup(hostport), server);
     }
 
-    arkime_http_schedule2(server, "GET", path, -1, NULL, 0, NULL, ARKIME_HTTP_PRIORITY_NORMAL, scheme_http_done, scheme_http_read, (gpointer)uri);
+    HTTPRequest_t *req = ARKIME_TYPE_ALLOC(HTTPRequest_t);
+    req->uri = uri;
+    req->actions = actions;
+    arkime_http_schedule2(server, "GET", path, -1, NULL, 0, NULL, ARKIME_HTTP_PRIORITY_NORMAL, scheme_http_done, scheme_http_read, req);
 
     curl_free(scheme);
     curl_free(host);

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -21,12 +21,13 @@ LOCAL gboolean               s3PathAccessStyle;
 
 LOCAL char                   extraInfo[600];
 
+/* S3Item is used to get the list of files from the http thread into the scheme thread */
 typedef struct s3_item {
     struct s3_item  *item_next, *item_prev;
     char            *url;
 } S3Item;
 
-typedef struct s3_item_head {
+typedef struct {
     struct s3_item  *item_next, *item_prev;
     int              item_count;
 
@@ -40,14 +41,15 @@ S3ItemHead *s3Items;
 LOCAL ARKIME_LOCK_DEFINE(waiting);
 LOCAL ARKIME_LOCK_DEFINE(waitingdir);
 
+/* S3Request is used to pass information from the scheme thread to the http thread */
 typedef struct s3_request {
-    ArkimeSchemeAction_t *actions;
+    ArkimeSchemeAction_t  *actions;
     const char            *url;
-    char                  *continuation;
-    uint8_t                isDir : 1;
-    uint8_t                isS3 : 1;
-    uint8_t                tryAgain : 1;
-    uint8_t                first : 1;
+    char                  *continuation; // Continuation token, http thread -> scheme thread
+    uint8_t                isDir : 1;    // Doint a prefix match
+    uint8_t                isS3 : 1;     // Use S3 URL
+    uint8_t                tryAgain : 1; // Try again because wrong region
+    uint8_t                first : 1;    // The first attemp at url
 } S3Request;
 
 

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -279,6 +279,9 @@ LOCAL void *reader_scheme_thread(void *UNUSED(arg))
     if (config.pcapSkip) {
         flags |= ARKIME_SCHEME_FLAG_SKIP;
     }
+    if (config.pcapDelete) {
+        flags |= ARKIME_SCHEME_FLAG_DELETE;
+    }
 
     // Load files
     for (int i = 0; config.pcapReadFiles && config.pcapReadFiles[i]; i++) {


### PR DESCRIPTION
* http scheme now supports --op from command
* fixed pcapData command line option not working with scheme
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
