### PR TITLE
cpp check errors and fix scheme COND/LOCK init

### DIFF
--- a/capture/command.c
+++ b/capture/command.c
@@ -224,7 +224,7 @@ LOCAL void arkime_command_help(int argc, char **argv, gpointer cc)
     BSB_INIT(bsb, help, sizeof(help));
 
     if (argc == 2) {
-        Command_t *cmd = g_hash_table_lookup(commandsHash, argv[1]);
+        const Command_t *cmd = g_hash_table_lookup(commandsHash, argv[1]);
         if (!cmd) {
             arkime_command_respond(cc, "Unknown command\n", -1);
             return;

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -100,7 +100,6 @@ typedef struct arkimefrags_t {
 typedef struct {
     struct arkimefrags_t  *fragh_next, *fragh_prev;
     struct arkimefrags_t  *fragl_next, *fragl_prev;
-    short                  fragh_bucket;
     uint32_t               fragh_count;
     uint32_t               fragl_count;
 } ArkimeFragsHead_t;

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -253,9 +253,8 @@ int scheme_file_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeActio
                 }
                 return 1;
             }
-        } else if (bytesRead == 0) {
+        } else {
             break;
-        } else if (bytesRead < 0) {
         }
     } while (bytesRead > 0);
 

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -31,8 +31,8 @@ typedef struct ArkimeSchemeLater {
 
 LOCAL ArkimeSchemeLater_t *laterHead;
 LOCAL ArkimeSchemeLater_t *laterTail;
-ARKIME_COND_EXTERN(laterLock);
-ARKIME_LOCK_EXTERN(laterLock);
+ARKIME_COND_DEFINE(laterLock);
+ARKIME_LOCK_DEFINE(laterLock);
 LOCAL GThread *schemeThread;
 
 LOCAL  ArkimeStringHashStd_t  schemesHash;


### PR DESCRIPTION
Fix CPU busy wait on mac because scheme/lock wasn't initialized correctly
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
