### PR TITLE
support using env vars for many config settings (thanks @Jc2k)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2885 Node 20.15.1
 ## All
   - #2892 backoff recurring health requests if they fail
+  - #2898 support using env vars for many config settings (thanks @Jc2k)
 ## Capture
   - #2866 for s3/sqs scheme support standard AWS credentials methods including
           env vars, --profile ~/.aws/credentials or config, and meta data service

--- a/capture/config.c
+++ b/capture/config.c
@@ -1422,6 +1422,26 @@ LOCAL void arkime_config_cmd_list(int UNUSED(argc), char UNUSED(**argv), gpointe
 /******************************************************************************/
 void arkime_config_init()
 {
+    extern char **environ;
+    for (int e = 0; environ[e]; e++) {
+        if (strncmp(environ[e], "ARKIME__", 8) == 0) {
+            char *equal = strchr(environ[e] + 8, '=');
+            if (!equal)
+                continue;
+
+            if (!config.override) {
+                config.override = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+            }
+
+            char *key = g_strndup(environ[e] + 8,  equal - environ[e] - 8);
+            if (g_hash_table_contains(config.override, key)) {
+                g_free(key);
+            } else {
+                g_hash_table_insert(config.override, key, g_strdup(equal + 1));
+            }
+        }
+    }
+
     if (config.commandSocket) {
         arkimeConfigVarsHash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
         arkime_config_register_cmd_var("debug", &config.debug, sizeof(config.debug));

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -93,7 +93,7 @@ class ArkimeConfig {
     // Load includes, currently must be ini
     ArkimeConfig.#loadIncludes(ArkimeConfig.get('includes'));
 
-    // Setup any deaults
+    // Setup any defaults
     //
     if (ArkimeConfig.debug === 0) {
       ArkimeConfig.debug = parseInt(ArkimeConfig.get('debug', 0));
@@ -102,6 +102,23 @@ class ArkimeConfig {
     if (ArkimeConfig.debug) {
       console.log('Debug Level', ArkimeConfig.debug);
     }
+
+    /* Setup any environment variable overrides.
+     * ARKIME__var - will convert to default.var=value
+     * ARKIME_section__var - convert to section.var=value
+     */
+    Object.keys(process.env).filter(e => e.startsWith("ARKIME_")).forEach(e => {
+      let key;
+      if (e.startsWith("ARKIME__")) {
+        key = 'default.' + e.substring(8);
+      } else {
+        key = e.substring(7).replace(/__/g, '.');
+      }
+
+      if (!ArkimeConfig.#override.has(key)) {
+        ArkimeConfig.#override.set(key, process.env[e]);
+      }
+    });
 
     // Tell everything waiting on config we are done
     const loadedCbs = ArkimeConfig.#loadedCbs;

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -107,9 +107,9 @@ class ArkimeConfig {
      * ARKIME__var - will convert to default.var=value
      * ARKIME_section__var - convert to section.var=value
      */
-    Object.keys(process.env).filter(e => e.startsWith("ARKIME_")).forEach(e => {
+    Object.keys(process.env).filter(e => e.startsWith('ARKIME_')).forEach(e => {
       let key;
-      if (e.startsWith("ARKIME__")) {
+      if (e.startsWith('ARKIME__')) {
         key = 'default.' + e.substring(8);
       } else {
         key = e.substring(7).replace(/__/g, '.');


### PR DESCRIPTION
Environment variables used after -o but before config file. Only took 4 years, sorry :(

* ARKIME__var - will convert to default.var=value
* ARKIME_section__var - convert to section.var=value

Idea: https://gist.github.com/Jc2k/eaf16b6fc9158da1bcbaee0a473725a8#environment-variables

Note: capture only supports the ARKIME__var form for now

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
