### PR TITLE
When fetching from s3: scheme don't use the endpoint that capture used

### DIFF
--- a/capture/plugins/taggerUpload.pl
+++ b/capture/plugins/taggerUpload.pl
@@ -32,6 +32,14 @@ if ($host !~ /(http:|https)/) {
     $host = "http://$ARGV[0]";
 }
 
+if (!$INSECURE && $host =~ /^https:\/\//) {
+    my $uri = URI->new($host);
+    my $hostname = $uri->host;
+    if ($hostname eq "localhost" || $hostname eq "127.0.0.1") {
+        $INSECURE=1;
+    }
+}
+
 showHelp("Missing arguments") if (@ARGV < 3); # Again because of INSECURE
 showHelp("Must be ip, host, or md5 for file type instead of $ARGV[1]") if ($ARGV[1] !~ /^(host|ip|md5|email|uri)$/);
 showHelp("file '$ARGV[2]' not found") if (! -f $ARGV[2]);

--- a/viewer/schemes.js
+++ b/viewer/schemes.js
@@ -53,6 +53,10 @@ function makeS3 (info) {
 
   const s3Params = { region: info.extra.region, endpoint: info.extra.endpoint };
 
+  if (s3Params.endpoint.endsWith('s3.amazonaws.com')) {
+    delete s3Params.endpoint;
+  }
+
   if (key) {
     const secret = Config.getFull(info.node, 's3SecretAccessKey') ?? Config.get('s3SecretAccessKey');
     if (!secret) {
@@ -103,8 +107,8 @@ async function getBlockS3 (info, pos) {
     const parts = splitRemain(info.name, '/', 4);
 
     const params = {
-      Bucket: parts[3],
-      Key: parts[4],
+      Bucket: parts[2],
+      Key: parts[3],
       Range: `bytes=${blockStart}-${blockStart + blockSize}`
     };
 

--- a/viewer/schemes.js
+++ b/viewer/schemes.js
@@ -53,7 +53,7 @@ function makeS3 (info) {
 
   const s3Params = { region: info.extra.region, endpoint: info.extra.endpoint };
 
-  if (s3Params.endpoint.endsWith('s3.amazonaws.com')) {
+  if (s3Params.endpoint.endsWith('amazonaws.com')) {
     delete s3Params.endpoint;
   }
 


### PR DESCRIPTION
The s3 scheme was failing to view packets because it was adding the bucket name twice.
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
