### PR TITLE
Init cont3xt Db before Auth

### DIFF
--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -451,12 +451,6 @@ User.prototype.setCont3xtKeys = function (v) {
 // Initialize stuff
 // ----------------------------------------------------------------------------
 async function setupAuth () {
-  Auth.initialize({
-    appAdminRole: 'cont3xtAdmin',
-    passwordSecretSection: 'cont3xt',
-    basePath: internals.webBasePath
-  });
-
   const dbUrl = ArkimeConfig.get('dbUrl');
   const es = ArkimeConfig.getArray('elasticsearch', 'http://localhost:9200');
   const usersUrl = ArkimeConfig.get('usersUrl');
@@ -469,6 +463,12 @@ async function setupAuth () {
     caTrustFile: ArkimeConfig.get('caTrustFile'),
     apiKey: ArkimeConfig.get('elasticsearchAPIKey'),
     basicAuth: ArkimeConfig.get('elasticsearchBasicAuth')
+  });
+
+  Auth.initialize({
+    appAdminRole: 'cont3xtAdmin',
+    passwordSecretSection: 'cont3xt',
+    basePath: internals.webBasePath
   });
 
   User.initialize({


### PR DESCRIPTION
Move auth init until after Db init since it can take a while and mess up timing.
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
