### PR TITLE
cronQueries=auto now uses the node name in the unique key

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #2925 Node 20.17.0
 ## Capture
   - #2924 _closeNow rule operator
+## Viewer
+  - #2926 cronQueries=auto now uses the node name in the unique key
 
 5.4.0 2024/08/05
 ## Release

--- a/viewer/db.js
+++ b/viewer/db.js
@@ -1950,7 +1950,7 @@ Db.putTemplate = async (templateName, body, cluster) => {
 };
 
 Db.setQueriesNode = async (node, force) => {
-  const namePid = `node-${process.pid}`;
+  const namePid = `${node}-${process.pid}`;
 
   // force is true we just rewrite the primary-viewer entry everytime
   if (force) {


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
