### PR TITLE
lua plugin & cmd_thread improvements

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1062,6 +1062,7 @@ gboolean arkime_http_schedule2(void *serverV, const char *method, const char *ke
 uint8_t *arkime_http_get(void *server, const char *key, int key_len, size_t *mlen);
 #define arkime_http_get_buffer(size) ARKIME_SIZE_ALLOC(buffer, size)
 #define arkime_http_free_buffer(b) ARKIME_SIZE_FREE(buffer, b)
+#define arkime_http_free_response(b) free(b)
 void arkime_http_exit();
 int arkime_http_queue_length(void *server);
 int arkime_http_queue_length_best(void *server);
@@ -1074,6 +1075,7 @@ void arkime_http_set_retries(void *server, uint16_t retries);
 void arkime_http_set_timeout(void *serverV, uint64_t timeout);
 void arkime_http_set_client_cert(void *serverV, char *clientCert, char *clientKey, char *clientKeyPass);
 void arkime_http_set_print_errors(void *server);
+void arkime_http_set_dont_free_response(void *server);
 void arkime_http_set_headers(void *server, char **headers);
 void arkime_http_set_header_cb(void *server, ArkimeHttpHeader_cb cb);
 void arkime_http_set_userpwd(void *server, const char *userpwd);

--- a/capture/http.c
+++ b/capture/http.c
@@ -105,6 +105,7 @@ struct arkimehttpserver_t {
     char                     compress;
     char                     printErrors;
     char                     insecure;
+    char                     dontFreeResponse;
     uint16_t                 maxConns;
     uint16_t                 maxOutstandingRequests;
     uint16_t                 outstanding;
@@ -444,7 +445,8 @@ LOCAL void arkime_http_curlm_check_multi_info(ArkimeHttpServer_t *server)
                     request->func(responseCode, request->dataIn, request->used, request->uw);
                 }
                 if (request->dataIn) {
-                    free(request->dataIn);
+                    if (!server->dontFreeResponse)
+                        free(request->dataIn);
                     request->dataIn = 0;
                 }
                 if (request->dataOut) {
@@ -1052,6 +1054,13 @@ void arkime_http_set_aws_sigv4(void *serverV, const char *aws_sigv4)
     ArkimeHttpServer_t        *server = serverV;
 
     server->aws_sigv4 = strdup(aws_sigv4);
+}
+/******************************************************************************/
+void arkime_http_set_dont_free_response(void *serverV)
+{
+    ArkimeHttpServer_t        *server = serverV;
+
+    server->dontFreeResponse = 1;
 }
 /******************************************************************************/
 gboolean arkime_http_is_arkime(uint32_t hash, uint8_t *sessionId)

--- a/capture/plugins/lua/molua.c
+++ b/capture/plugins/lua/molua.c
@@ -12,7 +12,6 @@
 extern ArkimeConfig_t        config;
 
 lua_State *Ls[ARKIME_MAX_PACKET_THREADS];
-ArkimeSession_t moluaFakeSessions[ARKIME_MAX_PACKET_THREADS];
 
 int molua_pluginIndex;
 
@@ -96,6 +95,10 @@ void arkime_plugin_init()
     int thread;
     char **names = arkime_config_str_list(NULL, "luaFiles", "moloch.lua");
 
+    if (!*names || *names[0] == 0) {
+        return;
+    }
+
     molua_pluginIndex = arkime_plugins_register("lua", TRUE);
 
     arkime_plugins_set_cb("lua", NULL, NULL, NULL, NULL, molua_session_save, NULL, NULL, NULL);
@@ -104,11 +107,9 @@ void arkime_plugin_init()
     for (thread = 0; thread < config.packetThreads; thread++) {
         lua_State *L = Ls[thread] = luaL_newstate();
         luaL_openlibs(L);
-        moluaFakeSessions[thread].thread = thread;
 
         int i;
         for (i = 0; names[i]; i++) {
-
             luaopen_arkime(L);
             luaopen_arkimehttpservice(L);
             luaopen_arkimesession(L);


### PR DESCRIPTION
* lua plugin doesn't register if luaFiles is empty fixes #2932
* lua doesn't need to copy http response data
* arkime_session_add_cmd_thread no longer uses fake session so if thread is needed must be passed along
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
