### PR TITLE
remove print-line in `db.pl sync-files`

### DIFF
--- a/db/db.pl
+++ b/db/db.pl
@@ -7230,7 +7230,6 @@ if ($ARGV[1] =~ /^(users-?import|import)$/) {
         next if ($file !~ /\/([^\/]*)-(\d+)-(\d+).(pcap|arkime)/);
         my @stat = stat("$file");
         if (!exists $remotefileshash{$file}) {
-            print $file;
             my $node = $1;
             my $filenum = int($3);
             progress("Adding $file $node $filenum $stat[7]\n");


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
When running `db.pl sync-files`, `db.pl` outputs all missing files on one long continous line. This strikes me as wrong behaviour.

User can use verbose flag to make the script print the filenames.

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
N/A

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
N/A

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.