### PR TITLE
Set OIDC redirect_uri dynamically if needed

### DIFF
--- a/common/auth.js
+++ b/common/auth.js
@@ -197,7 +197,6 @@ class Auth {
       check('discoverURL', 'authDiscoverURL');
       check('clientId', 'authClientId');
       check('clientSecret', 'authClientSecret');
-      check('redirectURIs', 'authRedirectURIs');
       Auth.#strategies = ['oidc'];
       Auth.#passportAuthOptions = { session: true, failureRedirect: `${Auth.#basePath}api/login`, scope: Auth.#authConfig.oidcScope };
       sessionAuth = true;
@@ -769,7 +768,12 @@ class Auth {
       req.session.ogurl = Buffer.from(Auth.obj2authNext(req.originalUrl)).toString('base64');
     }
 
-    passport.authenticate(Auth.#strategies, Auth.#passportAuthOptions)(req, res, function (err) {
+    const passportAuthOptionsExtra = {};
+    if (Auth.#strategies.includes('oidc') && (Auth.#authConfig.redirectURIs === undefined || Auth.#authConfig.redirectURIs.split(',').length > 1)) {
+      passportAuthOptionsExtra.redirect_uri = req.protocol + '://' + req.hostname + `${Auth.#basePath}auth/login/callback`;
+    }
+
+    passport.authenticate(Auth.#strategies, { ...Auth.#passportAuthOptions, ...passportAuthOptionsExtra })(req, res, function (err) {
       if (Auth.#basePath !== '/') {
         req.url = req.url.replace(Auth.#basePath, '/');
       }

--- a/common/auth.js
+++ b/common/auth.js
@@ -538,7 +538,7 @@ class Auth {
       const client = new issuer.Client({
         client_id: Auth.#authConfig.clientId,
         client_secret: Auth.#authConfig.clientSecret,
-        redirect_uris: Auth.#authConfig.redirectURIs.split(','),
+        redirect_uris: Auth.#authConfig.redirectURIs ? Auth.#authConfig.redirectURIs.split(',') : undefined,
         token_endpoint_auth_method: 'client_secret_post'
       });
 


### PR DESCRIPTION
Setting authRedirectURIs to more than one URL (comma separated), results in no redirect_uri being used. This is because the redirect_uri has to be specified if client.redirect_uris isn't set to a single uri.

This commit sets the redirect_uri dynamically based on the hostname and path.

Fixes #2949

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
