### PR TITLE
Improvements to no git/internet builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = . capture db viewer parliament release tests
+SUBDIRS = . capture db viewer
 
 if BUILD_CONT3XT
 SUBDIRS += cont3xt
@@ -7,6 +7,16 @@ endif
 if BUILD_WISE
 SUBDIRS += wiseService
 endif
+
+if BUILD_PARLIAMENT
+SUBDIRS += parliament
+endif
+
+if BUILD_RELEASE
+SUBDIRS += release
+endif
+
+SUBDIRS += tests
 
 install-exec-local:
 	npm ci

--- a/capture/Makefile.in
+++ b/capture/Makefile.in
@@ -1,6 +1,12 @@
 INSTALL_DIR   = @INSTALL_DIR@
 
-BUILD_VERSION := $(shell @GIT@ describe --tags)
+# If ARKIME_BUILD_FULL_VERSION is set, use it
+BUILD_VERSION := $(ARKIME_BUILD_FULL_VERSION)
+
+# If BUILD_VERSION is still empty, use git
+ifeq ($(strip $(BUILD_VERSION)),)
+    BUILD_VERSION := $(shell git describe --tags)
+endif
 
 CC            = @CC@
 

--- a/common/git.js
+++ b/common/git.js
@@ -4,6 +4,12 @@
 const child_process = require('child_process');
 
 function git (command) {
+  if (command === 'describe --tags' && process.env.ARKIME_BUILD_FULL_VERSION) {
+    return process.env.ARKIME_BUILD_FULL_VERSION;
+  } else if (command === 'log -1 --format=%aI' && process.env.ARKIME_BUILD_DATE) {
+    return process.env.ARKIME_BUILD_DATE;
+  }
+
   // eslint-disable-next-line camelcase
   return child_process.execSync(`git ${command}`, { encoding: 'utf8' }).trim();
 }

--- a/configure.ac
+++ b/configure.ac
@@ -49,6 +49,18 @@ AC_ARG_WITH([wise],
     [with_wise=yes])
 AM_CONDITIONAL([BUILD_WISE], [test "x$with_wise" != "xno"])
 
+AC_ARG_WITH([release],
+    AS_HELP_STRING([--without-release], [Build without release]),
+    [],
+    [with_release=yes])
+AM_CONDITIONAL([BUILD_RELEASE], [test "x$with_release" != "xno"])
+
+AC_ARG_WITH([parliament],
+    AS_HELP_STRING([--without-parliament], [Build without parliament]),
+    [],
+    [with_parliament=yes])
+AM_CONDITIONAL([BUILD_PARLIAMENT], [test "x$with_parliament" != "xno"])
+
 
 dnl OS Stuff
 AC_CANONICAL_HOST

--- a/release/new_cyber_chef.pl
+++ b/release/new_cyber_chef.pl
@@ -94,7 +94,7 @@ close $fh;
 
 unlink "CyberChef_v$VERSION.html";
 
-system "perl -pi -e 's/v.*\\/CyberChef_v.*.zip/v$VERSION\\/CyberChef_v$VERSION.zip/g' ../Makefile.in";
+system "perl -pi -e 's/^CYBERCHEF_VERSION.*/CYBERCHEF_VERSION=$VERSION/g' ../Makefile.in";
 system qq{perl -pi -e "s/CYBERCHEFVERSION.*,/CYBERCHEFVERSION: '$VERSION',/g" ../internals.js};
 
 system "vim ../../CHANGELOG";

--- a/viewer/Makefile.in
+++ b/viewer/Makefile.in
@@ -4,6 +4,7 @@ INSTALL = @INSTALL@
 VIEWERDIR = @prefix@/viewer
 CP = /bin/cp
 INSTALL_BUNDLE ?= "bundle:min"
+CYBERCHEF_VERSION=10.19.2
 
 
 all: arkimeparser.js
@@ -15,13 +16,15 @@ check:
 	npm ci
 	npm run bundle
 
-install:
+cyberchef:
+	(cd public ; if [ ! -f CyberChef_v$(CYBERCHEF_VERSION).zip ]; then wget -nv -N https://github.com/gchq/CyberChef/releases/download/v$(CYBERCHEF_VERSION)/CyberChef_v$(CYBERCHEF_VERSION).zip; fi)
+
+install: cyberchef
 	@mkdir -p "$(VIEWERDIR)" "$(VIEWERDIR)/vueapp"
 	/bin/rm -f $(VIEWERDIR)/public/style.css
 	$(INSTALL) *.js package.json package-lock.json $(VIEWERDIR)
 	npm ci
 	npm run $(INSTALL_BUNDLE)
-	(cd public ; wget -nv -N https://github.com/gchq/CyberChef/releases/download/v10.19.2/CyberChef_v10.19.2.zip)
 	$(CP) -pr views public $(VIEWERDIR)
 	$(CP) -pr vueapp/dist "$(VIEWERDIR)/vueapp"
 	(cd $(VIEWERDIR) ; npm ci --production)


### PR DESCRIPTION
Can now set 2 envs and install cyberchef manually
ARKIME_BUILD_FULL_VERSION - git describe --tags
ARKIME_BUILD_DATE = git log -1 --format=%aI

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
