### PR TITLE
use SEARCHTERM for named params in databricks integration

### DIFF
--- a/cont3xt/integrations/databricks/index.js
+++ b/cont3xt/integrations/databricks/index.js
@@ -72,7 +72,7 @@ class DatabricksIntegration extends Integration {
   }
 
   async search (user, item) {
-    const queryOperation = await this.#session.executeStatement(this.#statement, { namedParameters: { value: item } });
+    const queryOperation = await this.#session.executeStatement(this.#statement, { namedParameters: { SEARCHTERM: item } });
     const resultSet = await queryOperation.fetchAll();
     await queryOperation.close();
 


### PR DESCRIPTION
fixed this in dev6 but not main 🤦 

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
