### PR TITLE
new --command option instead of command-socket

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3052 add ARKIME_default__ support for env vars
   - #3062 only refresh Arkime indices on exit
   - #3063 use suricata vlan when using sessionIdTracking
+  - #3070 new --command option instead of having to use command-socket
 ## Viewer
   - #3055 fix missing session.network section error
   - #3059 fix losing custom theme setting

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -495,6 +495,7 @@ typedef struct arkime_config {
     char     *commandSocket;
     char      commandWait;
     char      noRefresh;
+    char    **commandList;
 } ArkimeConfig_t;
 
 typedef struct {
@@ -912,6 +913,7 @@ void arkime_config_register_cmd_var(const char *name, void *var, size_t typelen)
 typedef void (* ArkimeCommandFunc) (int argc, char **argv, gpointer cc);
 
 void arkime_command_init();
+void arkime_command_start();
 void arkime_command_register(const char *name, ArkimeCommandFunc func, const char *help);
 void arkime_command_register_opts(const char *name, ArkimeCommandFunc func, const char *help, ...);
 void arkime_command_respond(gpointer cc, const char *data, int len);

--- a/capture/command.c
+++ b/capture/command.c
@@ -129,7 +129,7 @@ LOCAL void arkime_command_free(gpointer data)
 /******************************************************************************/
 void arkime_command_register(const char *name, ArkimeCommandFunc func, const char *help)
 {
-    if (!config.commandSocket) {
+    if (!config.commandSocket && !config.commandList) {
         return;
     }
 
@@ -149,7 +149,7 @@ void arkime_command_register(const char *name, ArkimeCommandFunc func, const cha
 /******************************************************************************/
 void arkime_command_register_opts(const char *name, ArkimeCommandFunc func, const char *help, ...)
 {
-    if (!config.commandSocket) {
+    if (!config.commandSocket && !config.commandList) {
         return;
     }
 
@@ -193,6 +193,11 @@ void arkime_command_respond(gpointer cc, const char *data, int len)
 
     if (len == -1) {
         len = strlen(data);
+    }
+
+    if (!cc) {
+        LOG("%.*s", len, data);
+        return;
     }
 
     if (g_socket_send(client->socket, data, len, NULL, &error) != len) {
@@ -256,6 +261,9 @@ void arkime_command_exit(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
 GSocketAddress *g_unix_socket_address_new (const gchar *path);
 void arkime_command_init()
 {
+    arkime_command_register("help", arkime_command_help, "This help");
+    arkime_command_register("exit", arkime_command_exit, "Close the connection, can also use Ctrl-D");
+
     if (!config.commandSocket) {
         return;
     }
@@ -285,7 +293,12 @@ void arkime_command_init()
     int fd = g_socket_get_fd(socket);
 
     arkime_watch_fd(fd, ARKIME_GIO_READ_COND, arkime_command_server_read_cb, socket);
-    arkime_command_register("help", arkime_command_help, "This help");
-    arkime_command_register("exit", arkime_command_exit, "Close the connection, can also use Ctrl-D");
 }
 /******************************************************************************/
+void arkime_command_start()
+{
+    // Run Commands
+    for (int i = 0; config.commandList && config.commandList[i]; i++) {
+        arkime_command_run(config.commandList[i], NULL);
+    }
+}

--- a/capture/config.c
+++ b/capture/config.c
@@ -1269,7 +1269,7 @@ LOCAL gboolean           arkimeConfigVarsSorted = FALSE;
 /******************************************************************************/
 void arkime_config_register_cmd_var(const char *name, void *var, size_t typelen)
 {
-    if (!config.commandSocket)
+    if (!config.commandSocket && !config.commandList)
         return;
 
     ArkimeConfigVar_t *acv = ARKIME_TYPE_ALLOC0(ArkimeConfigVar_t);
@@ -1443,7 +1443,7 @@ void arkime_config_init()
         }
     }
 
-    if (config.commandSocket) {
+    if (config.commandSocket || config.commandList) {
         arkimeConfigVarsHash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
         arkime_config_register_cmd_var("debug", &config.debug, sizeof(config.debug));
         arkime_config_register_cmd_var("quiet", &config.quiet, sizeof(config.quiet));

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -168,7 +168,7 @@ LOCAL void reader_libpcapfile_init_monitor()
 #else
 LOCAL void reader_libpcapfile_init_monitor()
 {
-    if (config.commandSocket)
+    if (config.commandSocket || config.commandList)
         LOG("ERROR - Monitoring not supporting on this OS");
     else
         LOGEXIT("ERROR - Monitoring not supporting on this OS");

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -141,7 +141,7 @@ LOCAL void scheme_file_monitor_dir(const char *dirname, ArkimeSchemeFlags flags,
 #else
 LOCAL void scheme_file_monitor_dir(const char UNUSED(*dirname), ArkimeSchemeFlags UNUSED(flags), ArkimeSchemeAction_t UNUSED(*actions))
 {
-    if (config.commandSocket)
+    if (config.commandSocket || config.commandList)
         LOG_RATE(30, "ERROR - Monitoring not supporting on this OS - %s", dirname);
     else
         LOGEXIT("ERROR - Monitoring not supporting on this OS - %s", dirname);


### PR DESCRIPTION
This allows you to run the same commands as command-socket

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
