### PR TITLE
Env vars improvements and DASH, COLON, DOT, SLASH are now replaced

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,12 +32,13 @@ NOTICE: Restart wiseService before capture when upgrading
 NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at once after upgrading
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
-5.5.2 2025/01/xx
+5.6.0 2025/01/xx
 ## Release
   - #3051 arkime_config_interfaces.sh doesn't try and set up "dummy" interface
   - #3081 afterinstall.sh uses prefix correctly
 ## All
   - #3037 remove babel
+  - #3087 Env vars improvements and DASH, COLON, PERIOD are now replaced
 ## Capture
   - #3046 added packet-stats command
   - #3052 add ARKIME_default__ support for env vars

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,12 +33,14 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 5.6.0 2025/01/xx
+## BREAKING
+  - Unknown config variables that start with tpacketv3 or simple will now cause an error
 ## Release
   - #3051 arkime_config_interfaces.sh doesn't try and set up "dummy" interface
   - #3081 afterinstall.sh uses prefix correctly
 ## All
   - #3037 remove babel
-  - #3087 Env vars improvements and DASH, COLON, PERIOD are now replaced
+  - #3087 Env vars improvements and DASH, COLON, DOT, SLASH are now replaced
 ## Capture
   - #3046 added packet-stats command
   - #3052 add ARKIME_default__ support for env vars

--- a/capture/config.c
+++ b/capture/config.c
@@ -669,13 +669,13 @@ void arkime_config_load()
 
         g_string_replace(key, "DASH", "-", 0);
         g_string_replace(key, "COLON", ":", 0);
-        g_string_replace(key, "PERIOD", ".", 0);
+        g_string_replace(key, "DOT", ".", 0);
         g_string_replace(key, "SLASH", "/", 0);
 
         if (section) {
             g_string_replace(section, "DASH", "-", 0);
             g_string_replace(section, "COLON", ":", 0);
-            g_string_replace(section, "PERIOD", ".", 0);
+            g_string_replace(section, "DOT", ".", 0);
             g_string_replace(section, "SLASH", "/", 0);
             g_key_file_set_string(keyfile, section->str, key->str, equal + 1);
             g_string_free(section, TRUE);

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -150,7 +150,7 @@ class ArkimeConfig {
     /* Setup any environment variable
      * ARKIME__var - will convert to default var=value
      * ARKIME_section__var - convert to section var=value
-     * Replace DASH, COLON, PERIOD with -, :, .
+     * Replace DASH, COLON, PERIOD, SLASH with -, :, ., /
      */
     Object.keys(process.env).filter(e => e.startsWith('ARKIME_')).forEach(e => {
       let section, key;
@@ -159,11 +159,11 @@ class ArkimeConfig {
         key = e.substring(8);
       } else {
         const parts = e.substring(7).split('__');
-        section = parts[0].replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.');
+        section = parts[0].replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.').replace(/SLASH/g, '/');
         key = parts[1];
       }
       if (section === undefined || key === undefined) { return; }
-      key = key.replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.');
+      key = key.replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.').replace(/SLASH/g, '/');
 
       if (ArkimeConfig.#config[section] === undefined) {
         ArkimeConfig.#config[section] = {};

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -69,8 +69,7 @@ class ArkimeConfig {
         ArkimeConfig.#config = {};
 
         if (ArkimeConfig.#dumpConfig) {
-          console.error('OVERRIDE', ArkimeConfig.#override);
-          console.error('CONFIG', JSON.stringify(ArkimeConfig.#config));
+          console.error(JSON.stringify({ OVERRIDE: Object.fromEntries(ArkimeConfig.#override), CONFIG: ArkimeConfig.#config}, false, 2));
           if (ArkimeConfig.regressionTests) { process.exit(); }
         }
         return;
@@ -173,8 +172,7 @@ class ArkimeConfig {
     });
 
     if (ArkimeConfig.#dumpConfig) {
-      console.error('OVERRIDE', ArkimeConfig.#override);
-      console.error('CONFIG', JSON.parse(JSON.stringify(ArkimeConfig.#config)));
+      console.error(JSON.stringify({ OVERRIDE: Object.fromEntries(ArkimeConfig.#override), CONFIG: ArkimeConfig.#config}, false, 2));
       if (ArkimeConfig.regressionTests) { process.exit(); }
     }
   }

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -102,23 +102,6 @@ class ArkimeConfig {
       console.log('Debug Level', ArkimeConfig.debug);
     }
 
-    /* Setup any environment variable overrides.
-     * ARKIME__var - will convert to default.var=value
-     * ARKIME_section__var - convert to section.var=value
-     */
-    Object.keys(process.env).filter(e => e.startsWith('ARKIME_')).forEach(e => {
-      let key;
-      if (e.startsWith('ARKIME__')) {
-        key = 'default.' + e.substring(8);
-      } else {
-        key = e.substring(7).replace(/__/g, '.');
-      }
-
-      if (!ArkimeConfig.#override.has(key)) {
-        ArkimeConfig.#override.set(key, process.env[e]);
-      }
-    });
-
     // Tell everything waiting on config we are done
     const loadedCbs = ArkimeConfig.#loadedCbs;
     ArkimeConfig.#loadedCbs = undefined; // Mark as loaded
@@ -164,6 +147,30 @@ class ArkimeConfig {
    */
   static async reload () {
     ArkimeConfig.#config = await ArkimeConfig.#configImpl.load(ArkimeConfig.#uri);
+
+    /* Setup any environment variable
+     * ARKIME__var - will convert to default var=value
+     * ARKIME_section__var - convert to section var=value
+     * Replace DASH, COLON, PERIOD with -, :, .
+     */
+    Object.keys(process.env).filter(e => e.startsWith('ARKIME_')).forEach(e => {
+      let section, key;
+      if (e.startsWith('ARKIME__')) {
+        section = 'default';
+        key = e.substring(8);
+      } else {
+        const parts = e.substring(7).split('__');
+        section = parts[0].replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.');
+        key = parts[1];
+      }
+      key = key.replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.');
+
+      if (ArkimeConfig.#config[section] === undefined) {
+        ArkimeConfig.#config[section] = {};
+      }
+      ArkimeConfig.#config[section][key] = process.env[e];
+    });
+
     if (ArkimeConfig.#dumpConfig) {
       console.error('OVERRIDE', ArkimeConfig.#override);
       console.error('CONFIG', JSON.parse(JSON.stringify(ArkimeConfig.#config)));

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -150,7 +150,7 @@ class ArkimeConfig {
     /* Setup any environment variable
      * ARKIME__var - will convert to default var=value
      * ARKIME_section__var - convert to section var=value
-     * Replace DASH, COLON, PERIOD, SLASH with -, :, ., /
+     * Replace DASH, COLON, DOT, SLASH with -, :, ., /
      */
     Object.keys(process.env).filter(e => e.startsWith('ARKIME_')).forEach(e => {
       let section, key;
@@ -159,11 +159,11 @@ class ArkimeConfig {
         key = e.substring(8);
       } else {
         const parts = e.substring(7).split('__');
-        section = parts[0].replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.').replace(/SLASH/g, '/');
+        section = parts[0].replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/DOT/g, '.').replace(/SLASH/g, '/');
         key = parts[1];
       }
       if (section === undefined || key === undefined) { return; }
-      key = key.replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.').replace(/SLASH/g, '/');
+      key = key.replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/DOT/g, '.').replace(/SLASH/g, '/');
 
       if (ArkimeConfig.#config[section] === undefined) {
         ArkimeConfig.#config[section] = {};

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -69,7 +69,7 @@ class ArkimeConfig {
         ArkimeConfig.#config = {};
 
         if (ArkimeConfig.#dumpConfig) {
-          console.error(JSON.stringify({ OVERRIDE: Object.fromEntries(ArkimeConfig.#override), CONFIG: ArkimeConfig.#config}, false, 2));
+          console.error(JSON.stringify({ OVERRIDE: Object.fromEntries(ArkimeConfig.#override), CONFIG: ArkimeConfig.#config }, false, 2));
           if (ArkimeConfig.regressionTests) { process.exit(); }
         }
         return;
@@ -172,7 +172,7 @@ class ArkimeConfig {
     });
 
     if (ArkimeConfig.#dumpConfig) {
-      console.error(JSON.stringify({ OVERRIDE: Object.fromEntries(ArkimeConfig.#override), CONFIG: ArkimeConfig.#config}, false, 2));
+      console.error(JSON.stringify({ OVERRIDE: Object.fromEntries(ArkimeConfig.#override), CONFIG: ArkimeConfig.#config }, false, 2));
       if (ArkimeConfig.regressionTests) { process.exit(); }
     }
   }

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -163,6 +163,7 @@ class ArkimeConfig {
         section = parts[0].replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.');
         key = parts[1];
       }
+      if (section === undefined || key === undefined) { return; }
       key = key.replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/PERIOD/g, '.');
 
       if (ArkimeConfig.#config[section] === undefined) {

--- a/tests/config.t
+++ b/tests/config.t
@@ -31,7 +31,9 @@ esGet("/_refresh");
 my ($out, $es, $url);
 
 #### ENV
-$out = `ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 node ../viewer/viewer.js -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+my $testenv='ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 ARKIME_overrideDASHips__10PERIOD1PERIOD0PERIOD0SLASH16="tag:ny-office;country:USA;asn:AS0000 This is neat"';
+
+$out = `$testenv node__fooDASH4=4 node ../viewer/viewer.js -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff(from_json($out), from_json('{
    "OVERRIDE": {
      "default.foo": "bar",
@@ -49,11 +51,14 @@ eq_or_diff(from_json($out), from_json('{
      },
      "foo_foo.-:": {
        "foo3": "foo3"
+     },
+     "override-ips": {
+       "10.1.0.0/16": "tag:ny-office;country:USA;asn:AS0000 This is neat"
      }
    }
  }'));
 
-$out = `ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 node ../cont3xt/cont3xt.js -c testconfig.ini -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `$testenv node__fooDASH4=4 node ../cont3xt/cont3xt.js -c testconfig.ini -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff(from_json($out), from_json('{
    "OVERRIDE": {
      "cont3xt.foo": "bar"
@@ -70,11 +75,14 @@ eq_or_diff(from_json($out), from_json('{
      },
      "foo_foo.-:": {
        "foo3": "foo3"
+     },
+     "override-ips": {
+       "10.1.0.0/16": "tag:ny-office;country:USA;asn:AS0000 This is neat"
      }
    }
  }'));
 
-$out = `ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 node ../wiseService/wiseService.js -c testconfig.ini -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `$testenv node__fooDASH4=4 node ../wiseService/wiseService.js -c testconfig.ini -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff(from_json($out), from_json('{
    "OVERRIDE": {
@@ -92,25 +100,31 @@ eq_or_diff(from_json($out), from_json('{
      },
      "foo_foo.-:": {
        "foo3": "foo3"
+     },
+     "override-ips": {
+       "10.1.0.0/16": "tag:ny-office;country:USA;asn:AS0000 This is neat"
      }
    }
  }'));
 
-$out = `ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 ../capture/capture -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `$testenv node__fooDASH4=4 ARKIME_overrideDASHips__10PERIOD1PERIOD0PERIOD0SLASH16="tag:ny-office;country:USA;asn:AS0000 This is neat" ../capture/capture -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE:
 foo=bar
 CONFIG:
 [default]
-var=1
 foo1=foo1
 foo2=foo2
-
-[node]
-var=2
-foo-4=4
+var=1
 
 [foo_foo.-:]
 foo3=foo3
+
+[node]
+foo-4=4
+var=2
+
+[override-ips]
+10.1.0.0/16=tag:ny-office;country:USA;asn:AS0000 This is neat
 ");
 
 

--- a/tests/config.t
+++ b/tests/config.t
@@ -31,7 +31,7 @@ esGet("/_refresh");
 my ($out, $es, $url);
 
 #### ENV
-my $testenv='ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 ARKIME_overrideDASHips__10PERIOD1PERIOD0PERIOD0SLASH16="tag:ny-office;country:USA;asn:AS0000 This is neat"';
+my $testenv='ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooDOTDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 ARKIME_overrideDASHips__10DOT1DOT0DOT0SLASH16="tag:ny-office;country:USA;asn:AS0000 This is neat"';
 
 $out = `$testenv node__fooDASH4=4 node ../viewer/viewer.js -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff(from_json($out), from_json('{
@@ -107,7 +107,7 @@ eq_or_diff(from_json($out), from_json('{
    }
  }'));
 
-$out = `$testenv node__fooDASH4=4 ARKIME_overrideDASHips__10PERIOD1PERIOD0PERIOD0SLASH16="tag:ny-office;country:USA;asn:AS0000 This is neat" ../capture/capture -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `$testenv node__fooDASH4=4 ARKIME_overrideDASHips__10DOT1DOT0DOT0SLASH16="tag:ny-office;country:USA;asn:AS0000 This is neat" ../capture/capture -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE:
 foo=bar
 CONFIG:

--- a/tests/config.t
+++ b/tests/config.t
@@ -1,7 +1,7 @@
 # Test config
 use lib ".";
 use ArkimeTest;
-use Test::More tests => 34;
+use Test::More tests => 38;
 use Test::Differences;
 use Data::Dumper;
 use JSON;
@@ -30,6 +30,52 @@ esGet("/_refresh");
 
 my ($out, $es, $url);
 
+#### ENV
+$out = `ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 node ../viewer/viewer.js -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => \'bar\' }
+CONFIG {
+  default: { var: \'1\', foo1: \'foo1\', foo2: \'foo2\' },
+  node: { var: \'2\', \'foo-4\': \'4\' },
+  \'foo_foo.-:\': { foo3: \'foo3\' }
+}
+");
+
+$out = `ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 node ../cont3xt/cont3xt.js -c testconfig.ini -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
+CONFIG {
+  default: { var: \'1\', foo1: \'foo1\', foo2: \'foo2\' },
+  node: { var: \'2\', \'foo-4\': \'4\' },
+  \'foo_foo.-:\': { foo3: \'foo3\' }
+}
+");
+
+$out = `ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 node ../wiseService/wiseService.js -c testconfig.ini -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out =~ s/^\[.*\] //mg;
+eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
+CONFIG {
+  default: { var: \'1\', foo1: \'foo1\', foo2: \'foo2\' },
+  node: { var: \'2\', \'foo-4\': \'4\' },
+  \'foo_foo.-:\': { foo3: \'foo3\' }
+}
+");
+
+$out = `ARKIME__foo1=foo1 ARKIME_default__foo2=foo2 ARKIME_foo_fooPERIODDASHCOLON__foo3=foo3 ARKIME_node__fooDASH4=4 ../capture/capture -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+eq_or_diff($out, "OVERRIDE:
+foo=bar
+CONFIG:
+[default]
+var=1
+foo1=foo1
+foo2=foo2
+
+[node]
+var=2
+foo-4=4
+
+[foo_foo.-:]
+foo3=foo3
+");
+
 #### FILE INI
 
 $out = `node ../viewer/viewer.js -c testconfig.ini -o foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
@@ -37,12 +83,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c testconfig.ini -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c testconfig.ini -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../wiseService/wiseService.js -c testconfig.ini -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c testconfig.ini -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
@@ -66,12 +112,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG {}
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c notfound.ini -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c notfound.ini -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG {}
 ");
 
-$out = `node ../wiseService/wiseService.js -c notfound.ini -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c notfound.ini -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG {}
@@ -87,12 +133,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c testconfig.json -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c testconfig.json -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../wiseService/wiseService.js -c testconfig.json -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c testconfig.json -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
@@ -119,12 +165,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c $es -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c $es -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../wiseService/wiseService.js -c $es -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c $es -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
@@ -151,12 +197,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG {}
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c $es -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c $es -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG {}
 ");
 
-$out = `node ../wiseService/wiseService.js -c $es -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c $es -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG {}
@@ -174,12 +220,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c $url -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c $url -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../wiseService/wiseService.js -c $url -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c $url -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
@@ -205,12 +251,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG {}
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c $url -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c $url -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG {}
 ");
 
-$out = `node ../wiseService/wiseService.js -c $url -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c $url -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG {}
@@ -231,12 +277,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c $url -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c $url -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
 ");
 
-$out = `node ../wiseService/wiseService.js -c $url -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c $url -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG { default: { var: \'1\' }, node: { var: \'2\' } }
@@ -250,12 +296,12 @@ eq_or_diff($out, "OVERRIDE Map(2) { \'default.foo\' => \'bar\', \'test.foo\' => 
 CONFIG {}
 ");
 
-$out = `node ../cont3xt/cont3xt.js -c $url -o cont3xt.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../cont3xt/cont3xt.js -c $url -o cont3xt.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 eq_or_diff($out, "OVERRIDE Map(1) { \'cont3xt.foo\' => \'bar\' }
 CONFIG {}
 ");
 
-$out = `node ../wiseService/wiseService.js -c $url -o wiseService.foo=bar -n test --regressionTests --dumpConfig 2>&1 1>/dev/null`;
+$out = `node ../wiseService/wiseService.js -c $url -o wiseService.foo=bar --regressionTests --dumpConfig 2>&1 1>/dev/null`;
 $out =~ s/^\[.*\] //mg;
 eq_or_diff($out, "OVERRIDE Map(1) { \'wiseService.foo\' => \'bar\' }
 CONFIG {}


### PR DESCRIPTION
* Env vars now replace inside of ini table instead of overrides so all values should be settable

* Replace DASH, COLON, DOT, SLASH with -, :, ., / in sections and keys

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
