### PR TITLE
check if easybutton is run from .git dir fixes #3098

### DIFF
--- a/easybutton-build.sh
+++ b/easybutton-build.sh
@@ -162,6 +162,9 @@ command -v sudo >/dev/null 2>&1 || { echo >&2 "ARKIME: sudo is required to be in
 # Check if in right directory
 [ -f "./easybutton-build.sh" ] || { echo >&2 "ARKIME: must run from arkime directory"; exit 1; }
 
+# Check if git
+[[ -d .git || "$ARKIME_BUILD_FULL_VERSION" != "" ]] || { echo >&2 "ARKIME: must run from 'git clone' directory or use something like 'export ARKIME_BUILD_FULL_VERSION=vVERSION_STRING'"; exit 1; }
+
 MAKE=make
 UNAME="$(uname)"
 


### PR DESCRIPTION
Make sure when building arkime with easybutton we
warn if not in .git dir or ARKIME_BUILD_FULL_VERSION isn't set

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
