### PR TITLE
add ability to use usersElasticsearch in url

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,7 +42,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 	  exist if specified.
   - #3107 ARKIME__ envs now use cont3xt,wiseService,... instead of default for
           section name for those respective applications
-  - #3109 can now use https://usersElasticsearch in url/config and Arkime will
+  - #3110 can now use https://usersElasticsearch in url/config and Arkime will
           fill in from the env/config
 ## Capture
   - #3100 fix SSLv2 constants and misidentify DTLS 0 (thanks @droe)
@@ -53,7 +53,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3095 Show Arkime version in the UI
 ## WISE
   - #3107, #3108 Support webBasePath
-  - #3109 if usersElasticsearch isn't set will use elasticsearch config
+  - #3110 if usersElasticsearch isn't set will use elasticsearch config
 
 5.6.0 2025/01/15
 ## BREAKING

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 	  exist if specified.
   - #3107 ARKIME__ envs now use cont3xt,wiseService,... instead of default for
           section name for those respective applications
+  - #3109 can now use https://usersElasticsearch in url/config and Arkime will
+          fill in from the env/config
 ## Capture
   - #3100 fix SSLv2 constants and misidentify DTLS 0 (thanks @droe)
 ## db.pl
@@ -51,6 +53,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3095 Show Arkime version in the UI
 ## WISE
   - #3107, #3108 Support webBasePath
+  - #3109 if usersElasticsearch isn't set will use elasticsearch config
 
 5.6.0 2025/01/15
 ## BREAKING

--- a/cont3xt/integrations/elasticsearch/index.js
+++ b/cont3xt/integrations/elasticsearch/index.js
@@ -21,7 +21,6 @@ class ElasticsearchIntegration extends Integration {
   #method;
   #queryField;
   #timestampField;
-  #url;
   #client;
   #maxResults;
   #includeId;
@@ -69,7 +68,9 @@ class ElasticsearchIntegration extends Integration {
     itypes.forEach(itype => {
       this.itypes[itype] = imethod;
     });
-    this.#url = ArkimeConfig.getFull(section, 'url', ArkimeConfig.exit);
+
+    const info = ArkimeUtil.createElasticsearchInfo(ArkimeConfig.getFull(section, 'url', ArkimeConfig.exit));
+
     this.#timestampField = ArkimeConfig.getFull(section, 'timestampField');
 
     this.#maxResults = ArkimeConfig.getFull(section, 'maxResults', 20);
@@ -77,7 +78,8 @@ class ElasticsearchIntegration extends Integration {
     this.#includeIndex = ArkimeConfig.getFull(section, 'includeIndex', false);
 
     const options = {
-      node: this.#url.split(',')[0],
+      node: info.url,
+      auth: info.auth,
       requestTimeout: 300000,
       maxRetries: 2,
       ssl: {

--- a/wiseService/source.elasticsearch.js
+++ b/wiseService/source.elasticsearch.js
@@ -7,6 +7,7 @@
  */
 'use strict';
 
+const ArkimeUtil = require('../common/arkimeUtil');
 const WISESource = require('./wiseSource.js');
 const { Client } = require('@elastic/elasticsearch');
 
@@ -31,10 +32,11 @@ class ElasticsearchSource extends WISESource {
     this[this.api.funcName(this.type)] = this.sendResult;
 
     try {
-      let nodeName = this.elasticsearch.split(',')[0];
-      nodeName = nodeName.startsWith('http') ? nodeName : `http://${nodeName}`;
+      const info = ArkimeUtil.createElasticsearchInfo(this.elasticsearch);
+
       this.client = new Client({
-        node: nodeName,
+        node: info.url,
+        auth: info.auth,
         requestTimeout: 300000,
         maxRetries: 2
       });

--- a/wiseService/source.elasticsearchfile.js
+++ b/wiseService/source.elasticsearchfile.js
@@ -7,6 +7,7 @@
  */
 'use strict';
 
+const ArkimeUtil = require('../common/arkimeUtil');
 const SimpleSource = require('./simpleSource.js');
 const axios = require('axios');
 
@@ -35,7 +36,9 @@ class ElasticsearchFileSource extends SimpleSource {
       return cb('no url specified in config file');
     }
 
-    axios.get(this.url, { validateStatus: (code) => { return code < 500; } })
+    const info = ArkimeUtil.createElasticsearchInfo(this.url);
+
+    axios.get(info.url, { validateStatus: (code) => { return code < 500; }, auth: info.auth })
       .then((response) => {
         if (response.status === 404 || response?.data?._source === undefined) {
           return cb(null, '{}', null, 2);
@@ -53,7 +56,9 @@ class ElasticsearchFileSource extends SimpleSource {
       return cb('no url specified in config file');
     }
 
-    axios.post(this.url, file, { headers: { 'Content-Type': 'application/json' } })
+    const info = ArkimeUtil.createElasticsearchInfo(this.url);
+
+    axios.post(info.url, file, { headers: { 'Content-Type': 'application/json' }, auth: info.auth })
       .then((response) => {
         this.load();
         return cb();

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -123,6 +123,7 @@ function processArgs (argv) {
       console.log('  -o <section>.<key>=<value>  Override the config file');
       console.log('  --debug                     Increase debug level, multiple are supported');
       console.log('  --webconfig                 Allow the config to be edited from web page');
+      console.log('  --webcode <code>            Set the web config code instead of random');
       console.log('  --workers <b>               Number of worker processes to create');
       console.log('  --insecure                  Disable certificate verification for https calls');
 
@@ -195,16 +196,27 @@ function setupAuth () {
     return;
   }
 
-  const es = ArkimeConfig.getArray('usersElasticsearch', 'http://localhost:9200');
-
-  User.initialize({
-    insecure: ArkimeConfig.isInsecure([es]),
-    node: es,
-    caTrustFile: ArkimeConfig.get('caTrustFile'),
-    prefix: ArkimeConfig.get('usersPrefix'),
-    apiKey: ArkimeConfig.get('usersElasticsearchAPIKey'),
-    basicAuth: ArkimeConfig.get('usersElasticsearchBasicAuth')
-  });
+  if (ArkimeConfig.get('usersElasticsearch')) {
+    const es = ArkimeConfig.getArray('usersElasticsearch');
+    User.initialize({
+      insecure: ArkimeConfig.isInsecure([es]),
+      node: ArkimeConfig.getArray('usersElasticsearch'),
+      caTrustFile: ArkimeConfig.get('caTrustFile'),
+      prefix: ArkimeConfig.get('usersPrefix'),
+      apiKey: ArkimeConfig.get('usersElasticsearchAPIKey'),
+      basicAuth: ArkimeConfig.get('usersElasticsearchBasicAuth')
+    });
+  } else {
+    const es = ArkimeConfig.getArray('usersElasticsearch', 'http://localhost:9200');
+    User.initialize({
+      insecure: ArkimeConfig.isInsecure([es]),
+      node: es,
+      caTrustFile: ArkimeConfig.get('caTrustFile'),
+      prefix: ArkimeConfig.get('prefix'),
+      apiKey: ArkimeConfig.get('elasticsearchAPIKey'),
+      basicAuth: ArkimeConfig.get('elasticsearchBasicAuth')
+    });
+  }
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
You can now use urls like https://usersElasticsearch and Arkime will automatically use the usersElasticserch and usersElasticsearchBasicAuth variables, and if those aren't set will fall back to elasticsearch and elasticsearchBasicAuth. If you set the ARKIME__usersElasticsearch env that makes even the command line config can use that.

Also wiseService will now fall back to
elasticsearch/elasticsearchBasicAuth if usersElasticsearch isn't set

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
