### PR TITLE
Fix missing HTTP content in the UI's packet data section

### DIFF
--- a/viewer/decode.js
+++ b/viewer/decode.js
@@ -612,6 +612,9 @@ class ItemHTTPStream extends ItemTransform {
         if (this.code / 100 === 1 || this.code === 204 || this.code === 304) {
           this.states[item.client] = ItemHTTPStream.STATES.start;
         } else if (this.method === undefined) {
+          if (this.contentLength[item.client] > 0) {
+            this.states[item.client] = ItemHTTPStream.STATES.res_body;
+          }
         } else if (this.method.match(/^(CONNECT)$/)) {
           this.states[item.client] = ItemHTTPStream.STATES.pass;
         } else if (this.transferEncoding[item.client] === 'CHUNKED') {


### PR DESCRIPTION
<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**
For the following query `http.reqbody == EXISTS! && http.statuscode == EXISTS! && http.method != EXISTS! `, it was noticed that the HTTP content of the packets were not showing up in the packet data section of the UI, even though the content-length was greater than zero. Currently, the HTTP content can only be seen by opening up the packet using CyberChef.

**Relevant issue number(s) if applicable**
N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
Yes.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
Yes.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
