### PR TITLE
Added support for elasticsearch username and passwords that are more than 55 characters in db.pl.

### DIFF
--- a/db/db.pl
+++ b/db/db.pl
@@ -6444,7 +6444,7 @@ if ($ESAPIKEY ne "") {
     $main::userAgent->default_header('Authorization' => "ApiKey $ESAPIKEY");
 } elsif ($USERPASS ne "") {
     if ($USERPASS =~ ':') {
-        $USERPASS = encode_base64($USERPASS);
+        $USERPASS = encode_base64($USERPASS, "");
     }
     $main::userAgent->default_header('Authorization' => "Basic $USERPASS");
 }


### PR DESCRIPTION
[+] Added support for Elasticsearch passwords that are longer then 55 characters.

**TLDR:** A simple fix to the `db.pl` Perl script that fixes an issue with passwords use for Elasticsearch that are more than 55 characters long.

**Issue:** 
When `db.pl` encodes a password for requests to the Elasticsearch server it uses the function `encode_base64` to encode both the username and password to base64 in the authorization header, however if the username and password is above 55 characters, when encoded in base64 it will result in more than 76 characters. By default the `encode_base64`  returns an encoded string that is broken into lines of no more than 76 characters each and it will end with '\n' causing subsequent Elasticsearch requests to result in 401 errors due to the server perceiving the password as incorrect.

**Resolution:**
By changing `encode_base64($USERPASS);` to `encode_base64($USERPASS,"");` we tell Perl not to breakup the lines or at least breakup the lines in with nothing. thus allowing the script to use Elasticsearch accounts with username and password combinations that are higher than 55 characters.


References:
[MIME::Base64::Perl](https://metacpan.org/pod/MIME::Base64::Perl)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
