### PR TITLE
support for plugin/parser extensions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,15 @@ NOTICE: Restart wiseService before capture when upgrading
 NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at once after upgrading
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
+6.0.0 2025/11/01
+## BREAKING
+  - #3138 settings parseSMTP & parseSMB removed, use disableParsers instead
+  - #3138 plugins must end with supported extension, e.g. .so, .lua
+  - #3138 setting luaFiles now defaults to no files
+
+## Capture
+  - #3138 lua plugin now autoloads *.lua scripts in parsers and plugins directory
+
 5.6.2 2025/03/xx
 ## db.pl
   - #3135 Support passwords > 55 characters (thanks @GhostNaix)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,7 +40,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3138 setting luaFiles now defaults to no files
 
 ## Capture
-  - #3138 lua plugin now autoloads *.lua scripts in parsers and plugins directory
+  - #3138 lua plugin now autoloads *.lua scripts in parsers directory
+          if lua plugin is used
 
 5.6.2 2025/03/xx
 ## db.pl

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -48,7 +48,7 @@
 #define SUPPRESS_INT_CONVERSION
 #endif
 
-#define ARKIME_API_VERSION 542
+#define ARKIME_API_VERSION 600
 
 #define ARKIME_SESSIONID_LEN  40
 #define ARKIME_SESSIONID6_LEN 40
@@ -469,9 +469,7 @@ typedef struct arkime_config {
     char      logESRequests;
     char      logFileCreation;
     char      logHTTPConnections;
-    char      parseSMTP;
     char      parseSMTPHeaderAll;
-    char      parseSMB;
     char      ja3Strings;
     char      parseQSValue;
     char      parseCookieValue;

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1046,6 +1046,9 @@ uint32_t arkime_parsers_add_named_func(const char *name, ArkimeParsersNamedFunc 
 uint32_t arkime_parsers_get_named_func(const char *name);
 void arkime_parsers_call_named_func(uint32_t id, ArkimeSession_t *session, const uint8_t *data, int len, void *uw);
 
+typedef int (* ArkimeParserLoadFunc) (const char *path);
+void arkime_parsers_register_load_extension(const char *extension, ArkimeParserLoadFunc loadFunc);
+
 /******************************************************************************/
 /*
  * http.c
@@ -1337,6 +1340,9 @@ void arkime_plugins_cb_smtp_oh(ArkimeSession_t *session, const char *field, size
 void arkime_plugins_cb_smtp_ohc(ArkimeSession_t *session);
 
 void arkime_plugins_exit();
+
+typedef int (* ArkimePluginLoadFunc) (const char *path);
+void arkime_plugins_register_load_extension(const char *extension, ArkimePluginLoadFunc loadFunc);
 
 /******************************************************************************/
 /*

--- a/capture/config.c
+++ b/capture/config.c
@@ -871,9 +871,7 @@ void arkime_config_load()
     config.logESRequests         = arkime_config_boolean(keyfile, "logESRequests", config.debug);
     config.logFileCreation       = arkime_config_boolean(keyfile, "logFileCreation", config.debug);
     config.logHTTPConnections    = arkime_config_boolean(keyfile, "logHTTPConnections", config.debug || !config.pcapReadOffline);
-    config.parseSMTP             = arkime_config_boolean(keyfile, "parseSMTP", TRUE);
     config.parseSMTPHeaderAll    = arkime_config_boolean(keyfile, "parseSMTPHeaderAll", FALSE);
-    config.parseSMB              = arkime_config_boolean(keyfile, "parseSMB", TRUE);
     config.ja3Strings            = arkime_config_boolean(keyfile, "ja3Strings", FALSE);
     config.parseQSValue          = arkime_config_boolean(keyfile, "parseQSValue", FALSE);
     config.parseCookieValue      = arkime_config_boolean(keyfile, "parseCookieValue", FALSE);

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -39,6 +39,20 @@ LOCAL uint16_t           namedFuncsMax = 0;
 LOCAL ArkimeNamedInfo_t *namedFuncsArr[MAX_NAMED_FUNCS];
 LOCAL GHashTable        *namedFuncsHash;
 /******************************************************************************/
+typedef struct {
+    char *filename;
+    int   extension;
+} ArkimeFileWithExtension_t;
+
+typedef struct {
+    const char           *extension;
+    ArkimeParserLoadFunc  loadFunc;
+} ArkimeExtensions_t;
+
+#define MAX_EXTENSIONS  8
+LOCAL uint16_t            extensionsMax = 0;
+LOCAL ArkimeExtensions_t  extensionsArr[MAX_EXTENSIONS];
+/******************************************************************************/
 #define MAGIC_MATCH(offset, needle) memcmp(data+offset, needle, sizeof(needle)-1) == 0
 #define MAGIC_MATCH_LEN(offset, needle) ((len > (int)sizeof(needle)-1+offset) && (memcmp(data+offset, needle, sizeof(needle)-1) == 0))
 
@@ -597,9 +611,39 @@ gtdone:
     return 0;
 }
 /******************************************************************************/
-LOCAL int cstring_cmp(const void *a, const void *b)
+LOCAL int filewext_cmp(const void *a, const void *b)
 {
-    return strcmp(*(char **)a, *(char **)b);
+    return strcmp(((ArkimeFileWithExtension_t *)a)->filename, ((ArkimeFileWithExtension_t *)b)->filename);
+}
+/******************************************************************************/
+LOCAL int arkime_parsers_load_so(const char *path)
+{
+    GModule *parser = g_module_open (path, 0); /*G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);*/
+
+    if (!parser) {
+        LOG("ERROR - Couldn't load parser from '%s'\n%s", path, g_module_error());
+        return 1;
+    }
+
+    ArkimePluginInitFunc parser_init;
+
+    if (!g_module_symbol(parser, "arkime_parser_init", (gpointer *)(char * )&parser_init) || parser_init == NULL) {
+        LOG("ERROR - Module %s doesn't have a arkime_parser_init", path);
+        return 1;
+    }
+
+    parser_init();
+    return 0;
+}
+/******************************************************************************/
+void arkime_parsers_register_load_extension(const char *extension, ArkimeParserLoadFunc loadFunc)
+{
+    if (extension[0] != '.') {
+        LOGEXIT("ERROR - Extension '%s'must start with a .", extension);
+    }
+    extensionsArr[extensionsMax].extension = extension;
+    extensionsArr[extensionsMax].loadFunc = loadFunc;
+    extensionsMax++;
 }
 /******************************************************************************/
 void arkime_parsers_init()
@@ -675,6 +719,8 @@ void arkime_parsers_init()
         }
     }
 
+    arkime_parsers_register_load_extension(".so", arkime_parsers_load_so);
+
     ArkimeStringHashStd_t loaded;
     HASH_INIT(s_, loaded, arkime_string_hash, arkime_string_cmp);
 
@@ -686,20 +732,6 @@ void arkime_parsers_init()
         hstring = ARKIME_TYPE_ALLOC0(ArkimeString_t);
         hstring->str = disableParsers[d];
         hstring->len = strlen(disableParsers[d]);
-        HASH_ADD(s_, loaded, hstring->str, hstring);
-    }
-
-    if (!config.parseSMTP) {
-        hstring = ARKIME_TYPE_ALLOC0(ArkimeString_t);
-        hstring->str = g_strdup("smtp.so");
-        hstring->len = strlen(hstring->str);
-        HASH_ADD(s_, loaded, hstring->str, hstring);
-    }
-
-    if (!config.parseSMB) {
-        hstring = ARKIME_TYPE_ALLOC0(ArkimeString_t);
-        hstring->str = g_strdup("smb.so");
-        hstring->len = strlen(hstring->str);
         HASH_ADD(s_, loaded, hstring->str, hstring);
     }
 
@@ -718,17 +750,23 @@ void arkime_parsers_init()
         if (!dir)
             continue;
 
-        const gchar *filename;
-        gchar *filenames[100];
-        int    flen = 0;
+        const gchar               *filename;
+        ArkimeFileWithExtension_t  files[100];
+        int                        flen = 0;
 
         while ((filename = g_dir_read_name(dir)) && flen < 100) {
             // Skip hidden files/directories
             if (filename[0] == '.')
                 continue;
 
-            // If it doesn't end with .so we ignore it
-            if (strlen(filename) < 3 || strcasecmp(".so", filename + strlen(filename) - 3) != 0) {
+            int e;
+            for (e = 0; e < extensionsMax; e++) {
+                if (g_str_has_suffix(filename, extensionsArr[e].extension)) {
+                    break;
+                }
+            }
+
+            if (e == extensionsMax) {
                 continue;
             }
 
@@ -740,42 +778,28 @@ void arkime_parsers_init()
                 continue; /* Already loaded */
             }
 
-            filenames[flen] = g_strdup(filename);
+            files[flen].filename = g_strdup(filename);
+            files[flen].extension = e;
             flen++;
         }
 
-        qsort((void *)filenames, (size_t)flen, sizeof(char *), cstring_cmp);
+        qsort((void *)files, (size_t)flen, sizeof(ArkimeFileWithExtension_t), filewext_cmp);
 
         int i;
         for (i = 0; i < flen; i++) {
-            gchar *path = g_build_filename (config.parsersDir[d], filenames[i], NULL);
-            GModule *parser = g_module_open (path, 0); /*G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);*/
+            gchar *path = g_build_filename (config.parsersDir[d], files[i].filename, NULL);
 
-            if (!parser) {
-                LOG("ERROR - Couldn't load parser %s from '%s'\n%s", filenames[i], path, g_module_error());
-                g_free(filenames[i]);
+            int rc = extensionsArr[files[i].extension].loadFunc(path);
+
+            if (rc != 0) {
+                g_free(files[i].filename);
                 g_free (path);
                 continue;
             }
-
-            ArkimePluginInitFunc parser_init;
-
-            if (!g_module_symbol(parser, "arkime_parser_init", (gpointer *)(char * )&parser_init) || parser_init == NULL) {
-                LOG("ERROR - Module %s doesn't have a arkime_parser_init", filenames[i]);
-                g_free(filenames[i]);
-                g_free (path);
-                continue;
-            }
-
-            if (config.debug > 1) {
-                LOG("Loaded %s", path);
-            }
-
-            parser_init();
 
             hstring = ARKIME_TYPE_ALLOC0(ArkimeString_t);
-            hstring->str = filenames[i];
-            hstring->len = strlen(filenames[i]);
+            hstring->str = files[i].filename;
+            hstring->len = strlen(files[i].filename);
             HASH_ADD(s_, loaded, hstring->str, hstring);
 
             if (config.debug)

--- a/capture/plugins.c
+++ b/capture/plugins.c
@@ -49,6 +49,15 @@ typedef struct arkime_plugin {
 } ArkimePlugin_t;
 
 HASH_VAR(p_, plugins, ArkimePlugin_t, 11);
+
+typedef struct {
+    const char           *extension;
+    ArkimePluginLoadFunc  loadFunc;
+} ArkimeExtensions_t;
+
+#define MAX_EXTENSIONS  8
+LOCAL uint16_t            extensionsMax = 0;
+LOCAL ArkimeExtensions_t  extensionsArr[MAX_EXTENSIONS];
 /******************************************************************************/
 LOCAL void arkime_plugins_cmd_list(int UNUSED(argc), char UNUSED( * *argv), gpointer cc)
 {
@@ -66,12 +75,6 @@ LOCAL void arkime_plugins_cmd_list(int UNUSED(argc), char UNUSED( * *argv), gpoi
     }
     arkime_command_respond(cc, buf, BSB_LENGTH(bsb));
 }
-/******************************************************************************/
-void arkime_plugins_init()
-{
-    HASH_INIT(p_, plugins, arkime_string_hash, arkime_string_cmp);
-    arkime_command_register("plugins-list", arkime_plugins_cmd_list, "List loaded plugins");
-}
 
 /******************************************************************************/
 void arkime_plugins_load(char **plugins)
@@ -83,11 +86,6 @@ void arkime_plugins_load(char **plugins)
     if (!plugins)
         return;
 
-    if (!g_module_supported ()) {
-        LOG("ERROR - glib compiled without module support");
-        return;
-    }
-
     arkime_add_can_quit((ArkimeCanQuitFunc)arkime_plugins_outstanding, "plugin outstanding");
 
     int         i;
@@ -95,9 +93,22 @@ void arkime_plugins_load(char **plugins)
     for (i = 0; plugins[i]; i++) {
         const char *name = plugins[i];
 
+        int e;
+        for (e = 0; e < extensionsMax; e++) {
+            if (g_str_has_suffix(name, extensionsArr[e].extension)) {
+                break;
+            }
+        }
+
+        if (e == extensionsMax) {
+            LOG("WARNING - plugin '%s' has unknown extension", name);
+            continue;
+        }
+
+
         int d;
-        GModule *plugin = 0;
         gchar   *path;
+        int      loaded = 0;
         for (d = 0; config.pluginsDir[d]; d++) {
             path = g_build_filename (config.pluginsDir[d], name, NULL);
 
@@ -106,35 +117,55 @@ void arkime_plugins_load(char **plugins)
                 continue;
             }
 
-            plugin = g_module_open (path, 0); /*G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);*/
 
-            if (!plugin) {
-                LOG("ERROR - Couldn't load plugin %s from '%s'\n%s", name, path, g_module_error());
-                g_free (path);
-                continue;
+            int rc = extensionsArr[e].loadFunc(path);
+
+            if (rc == 0) {
+                loaded = 1;
+                break;
             }
-            break;
         }
 
-        if (!plugin) {
+        if (!loaded) {
             LOG("WARNING - plugin '%s' not found", name);
             continue;
         }
-
-        ArkimePluginInitFunc plugin_init;
-
-        if (!g_module_symbol(plugin, "arkime_plugin_init", (gpointer *)(char * )&plugin_init) || plugin_init == NULL) {
-            LOG("ERROR - Module %s doesn't have a arkime_plugin_init", name);
-            continue;
-        }
-
-        plugin_init();
 
         if (config.debug)
             LOG("Loaded %s", path);
 
         g_free (path);
     }
+}
+/******************************************************************************/
+LOCAL int arkime_plugins_load_so(const char *path)
+{
+    GModule *plugin = g_module_open (path, 0); /*G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);*/
+
+    if (!plugin) {
+        LOG("ERROR - Couldn't load plugin from '%s'\n%s", path, g_module_error());
+        return 1;
+    }
+
+    ArkimePluginInitFunc plugin_init;
+
+    if (!g_module_symbol(plugin, "arkime_plugin_init", (gpointer *)(char * )&plugin_init) || plugin_init == NULL) {
+        LOG("ERROR - Module %s doesn't have a arkime_plugin_init", path);
+        return 1;
+    }
+
+    plugin_init();
+    return 0;
+}
+/******************************************************************************/
+void arkime_plugins_register_extension(const char *extension, ArkimeParserLoadFunc loadFunc)
+{
+    if (extension[0] != '.') {
+        LOGEXIT("ERROR - Extension '%s'must start with a .", extension);
+    }
+    extensionsArr[extensionsMax].extension = extension;
+    extensionsArr[extensionsMax].loadFunc = loadFunc;
+    extensionsMax++;
 }
 /******************************************************************************/
 int arkime_plugins_register_internal(const char             *name,
@@ -511,4 +542,11 @@ uint32_t arkime_plugins_outstanding()
             outstanding += plugin->outstandingFunc();
     }
     return outstanding;
+}
+/******************************************************************************/
+void arkime_plugins_init()
+{
+    HASH_INIT(p_, plugins, arkime_string_hash, arkime_string_cmp);
+    arkime_command_register("plugins-list", arkime_plugins_cmd_list, "List loaded plugins");
+    arkime_plugins_register_extension(".so", arkime_plugins_load_so);
 }

--- a/release/config.ini.sample
+++ b/release/config.ini.sample
@@ -174,12 +174,6 @@ dropGroup=daemon
 #requiredAuthHeaderVal="ARKIME_ACCESS"
 #userAutoCreateTmpl={"userId": "${this.arkime_user}", "userName": "${this.http_auth_mail}", "enabled": true, "webEnabled": true, "headerAuthEnabled": true, "emailSearch": true, "createEnabled": false, "removeEnabled": false, "packetSearch": true }
 
-# Should we parse extra smtp traffic info
-parseSMTP=true
-
-# Should we parse extra smb traffic info
-parseSMB=true
-
 # Should we parse HTTP QS Values
 parseQSValue=false
 


### PR DESCRIPTION
* Can now register extensions to load for plugins/parsers
* lua now will auto load .lua files in parsers directory or listed as a plugin
* parseSMTP & parseSMB removed, use disableParsers instead
* luaFiles now defaults to no files

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
