### PR TITLE
Fix the build failure caused by the global Python environment and Bro…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,9 +23,9 @@ capture/molochconfig.h
 capture/molochconfig.h.in
 capture/arkimeconfig.h
 capture/arkimeconfig.h.in
+capture/arkimeconfig.h.in~
 capture/moloch-capture
 capture/capture
-
 
 # tests
 tests/GeoLite2*
@@ -76,6 +76,7 @@ missing
 install-sh
 compile
 configure
+configure~
 GeoIP.dat
 GeoIPASNum.dat
 GeoIPASNumv6.dat
@@ -83,3 +84,8 @@ GeoIPv6.dat
 ipv4-address-space.csv
 autom4te.cache
 stamp-h1
+thirdparty
+release/afterinstall.sh
+*.log
+*-log
+*.tar.xz


### PR DESCRIPTION
…tli.

**Clearly describe the problem and solution**
When compiling with `easybutton-build.sh` on the `Ubuntu 24` system, the compilation of `glib` fails due to the absence of a global Python environment (https://github.com/arkime/arkime/issues/3152) when using virtual environments managed by tools like `pyenv` or `Poetry`. Additionally, the compilation of`curl` fails because of `brotli` (https://github.com/sysown/proxysql/issues/1458, https://github.com/xbmc/xbmc/issues/22494).

**Relevant issue number(s) if applicable**
https://github.com/arkime/arkime/issues/3152
https://github.com/sysown/proxysql/issues/1458
https://github.com/xbmc/xbmc/issues/22494

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
