### PR TITLE
Fix packets not showing up fixes #3155

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3148 Fix issuerCN not displaying in session detail
   - #3151 Fix cert.serial not displaying in session detail
   - #3158 Fix s3http/s scheme not caching blocks correctly
+  - #3159 Fix packets not showing up when using writer-s3 without compression
 
 5.6.1 2025/02/13
 ## BREAKING

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -149,8 +149,9 @@ async function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
 
     function doProcess (data, nextCb) {
       let haveAllCached = data.compressed;
+
       // See if we have all the required decompressed blocks
-      for (let i = 0; i < data.subPackets.length; i++) {
+      for (let i = 0; haveAllCached && i < data.subPackets.length; i++) {
         const sp = data.subPackets[i];
         const decompressedCacheKey = 'data:' + data.params.Bucket + ':' + data.params.Key + ':' + sp.rangeStart;
         const cachedDecompressed = lru.get(decompressedCacheKey);
@@ -185,7 +186,7 @@ async function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
         for (let i = 0; i < data.subPackets.length; i++) {
           const sp = data.subPackets[i];
           const decompressedCacheKey = 'data:' + data.params.Bucket + ':' + data.params.Key + ':' + sp.rangeStart;
-          if (!CacheInProgress[decompressedCacheKey]) {
+          if (data.compressed && !CacheInProgress[decompressedCacheKey]) {
             CacheInProgress[decompressedCacheKey] = true;
           }
         }

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -212,6 +212,21 @@ s3Region=us-west-2
 s3Bucket=andywick-testbucket-1
 packetThreads=1
 
+[minio]
+prefix=tests
+plugins=writer-s3.so
+pcapWriteMethod=s3
+viewerPlugins=writer-s3/index.js
+s3AccessKeyId=admin
+s3SecretAccessKey=password
+s3Region=us-east-1
+s3Bucket=arkime
+s3Host=localhost:9000
+s3UseHttp=true
+s3PathAccessStyle=true
+packetThreads=1
+s3Compression=none
+
 [lua]
 pcapWriteMethod=simple
 plugins=lua.so


### PR DESCRIPTION
Packets weren't showing up when not using compression with writer-s3. Right now this doesn't use caching if not compressing, should fix someday.
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
