### PR TITLE
node v22 is required since we use zstd from there - finally

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,7 +15,7 @@ Elasticsearch Versions:
   * Moloch >= 0.18.1 supports ES 2.4.x, >= 5.3.1 not 6.x or later
 
 Node Versions:
-  * Arkime >= 6.0.0 requires NodeJS >= 20.9.0 or < 23
+  * Arkime >= 6.0.0 requires NodeJS >= 22.15.0 or < 23
   * Arkime >= 5.4.0 requires NodeJS >= 20.0.0 or < 21
   * Arkime >= 5.0.2 requires NodeJS >= 18.15.0 or < 21
   * Arkime >= 5.0.0 requires NodeJS >= 18.0.0 and < 19

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -10,7 +10,6 @@
 const { S3 } = require('@aws-sdk/client-s3');
 const async = require('async');
 const zlib = require('zlib');
-const { decompressSync } = require('@skhaz/zstd');
 const S3s = {};
 const LRU = require('lru-cache');
 const CacheInProgress = {};
@@ -127,7 +126,7 @@ async function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
         if (params.Key.endsWith('.gz')) {
           header = zlib.gunzipSync(body, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
         } else if (params.Key.endsWith('.zst')) {
-          header = decompressSync(body);
+          header = zlib.zstdDecompressSync(body, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
         } else {
           header = body;
         }
@@ -212,7 +211,8 @@ async function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
                   decompressed[sp.rangeStart] = zlib.inflateRawSync(body.subarray(offset, offset + data.info.compressionBlockSize),
                     { finishFlush: zlib.constants.Z_SYNC_FLUSH });
                 } else if (data.compressed === COMPRESSED_ZSTD) {
-                  decompressed[sp.rangeStart] = decompressSync(body.subarray(offset, offset + data.info.compressionBlockSize));
+                  decompressed[sp.rangeStart] = zlib.zstdDecompressSync(body.subarray(offset, offset + data.info.compressionBlockSize),
+                    { finishFlush: zlib.constants.Z_SYNC_FLUSH });
                 }
                 const decompressedCacheKey = 'data:' + data.params.Bucket + ':' + data.params.Key + ':' + sp.rangeStart;
                 lru.set(decompressedCacheKey, decompressed[sp.rangeStart]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@clickhouse/client": "^1.0.2",
         "@databricks/sql": "^1.8.4",
         "@elastic/elasticsearch": "7.10.0",
-        "@skhaz/zstd": "^1.0.21",
         "arkime-iptrie": "^0.0.9",
         "arkime-notifme-sdk": "^1.11.4",
         "async": "^3.2.6",
@@ -120,7 +119,7 @@
         "webpack-merge": "^5.9.0"
       },
       "engines": {
-        "node": ">= 20.9.0 < 23",
+        "node": ">= 22.15.0 < 23",
         "npm": ">= 3.0.0"
       }
     },
@@ -3421,19 +3420,6 @@
         "darwin"
       ],
       "peer": true
-    },
-    "node_modules/@skhaz/zstd": {
-      "version": "1.0.21",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.6.1",
-        "pond": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/@smithy/abort-controller": {
       "version": "3.1.1",
@@ -11899,15 +11885,6 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.1",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
       "license": "MIT",
@@ -12742,27 +12719,6 @@
       "engines": {
         "node": ">=14.19.0"
       }
-    },
-    "node_modules/pond": {
-      "version": "2.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/pond/node_modules/debug": {
-      "version": "3.2.7",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/pond/node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
     },
     "node_modules/popper.js": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@clickhouse/client": "^1.0.2",
     "@databricks/sql": "^1.8.4",
     "@elastic/elasticsearch": "7.10.0",
-    "@skhaz/zstd": "^1.0.21",
     "arkime-iptrie": "^0.0.9",
     "arkime-notifme-sdk": "^1.11.4",
     "async": "^3.2.6",
@@ -175,7 +174,7 @@
     "webpack-merge": "^5.9.0"
   },
   "engines": {
-    "node": ">= 20.9.0 < 23",
+    "node": ">= 22.15.0 < 23",
     "npm": ">= 3.0.0"
   }
 }

--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -13,7 +13,6 @@ const cryptoLib = require('crypto');
 const ipaddr = require('ipaddr.js');
 const zlib = require('zlib');
 const async = require('async');
-const { decompressSync } = require('@skhaz/zstd');
 const ArkimeUtil = require('../common/arkimeUtil');
 
 const internals = {
@@ -216,7 +215,7 @@ class Pcap {
       if (this.compression === 'gzip') {
         this.headBuffer = zlib.gunzipSync(this.headBuffer, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
       } else if (this.compression === 'zstd') {
-        this.headBuffer = decompressSync(this.headBuffer);
+        this.headBuffer = zlib.zstdDecompressSync(this.headBuffer, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
       }
     }
 
@@ -332,7 +331,7 @@ class Pcap {
             if (this.compression === 'gzip') {
               readBuffer = zlib.inflateRawSync(readBuffer, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
             } else if (this.compression === 'zstd') {
-              readBuffer = decompressSync(readBuffer);
+              readBuffer = zlib.zstdDecompressSync(readBuffer, { finishFlush: zlib.constants.Z_SYNC_FLUSH });
             }
           } catch (e) {
             console.log('PCAP uncompress issue', this.key, pos, buffer.length, bytesRead, e);


### PR DESCRIPTION
node finally has zstd built in so lets use that instead of this old npm packages.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
