### PR TITLE
add ethertype to all sessions, unkEthernet now uses mac address to group

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -33,6 +33,13 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 5.7.1 2025/07/xx
+## Capture/Viewer
+  - #3258 Add new ethertype field
+## Capture/Viewer
+  - #3258 unkEthernet plugin now groups sessions by ethertype + macs
+  
+## Cont3xt
+  - #3253 IPQualityScore support (thanks @RamboV)
 
 5.7.0 2025/06/11
 ## BREAKING

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -687,6 +687,7 @@ typedef struct arkime_session {
         uint8_t                icmpInfo[2];
     };
     uint16_t               maxFields;
+    uint16_t               ethertype;
 
     uint8_t                consumed[2];
     uint8_t                ipProtocol;

--- a/capture/db.c
+++ b/capture/db.c
@@ -772,6 +772,9 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
                        ((uint64_t)session->lastPacket.tv_sec) * 1000 + ((uint64_t)session->lastPacket.tv_usec) / 1000,
                        timediff,
                        session->ipProtocol);
+    if (session->ethertype) {
+        BSB_EXPORT_sprintf(jbsb, "\"ethertype\":%u,", session->ethertype);
+    }
 
     if (sendIndexInDoc) {
         BSB_EXPORT_sprintf(jbsb, "\"index\":\"%ssessions3-%s\",", config.prefix, dbInfo[thread].prefix);

--- a/capture/field.c
+++ b/capture/field.c
@@ -587,7 +587,7 @@ int arkime_field_by_exp_ignore_error(const char *exp)
     return -1;
 }
 /******************************************************************************/
-void arkime_field_truncated(ArkimeSession_t *session, const ArkimeFieldInfo_t *info)
+LOCAL void arkime_field_truncated(ArkimeSession_t *session, const ArkimeFieldInfo_t *info)
 {
     char str[1024];
     snprintf(str, sizeof(str), "truncated-field-%s", info->dbField);

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -350,6 +350,10 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
                 arkime_field_int_add(vlanField, session, vlan);
                 n += 4;
             }
+
+            if (session->ethertype == 0) {
+                session->ethertype = (pcapData[n] << 8) | pcapData[n + 1];
+            }
         }
 
         if (packet->vlan)
@@ -405,8 +409,6 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
         if (packet->tunnel & ARKIME_PACKET_TUNNEL_GENEVE) {
             arkime_session_add_protocol(session, "geneve");
         }
-
-
     }
 
     if (mProtocols[packet->mProtocol].process) {
@@ -1848,6 +1850,12 @@ void arkime_packet_init()
     arkime_field_define("general", "integer",
                         "tcpseq.dst", "TCP Dst Seq", "tcpseq.dst",
                         "Destination SYN-ACK sequence number",
+                        0,  ARKIME_FIELD_FLAG_FAKE,
+                        (char *)NULL);
+
+    arkime_field_define("general", "integer",
+                        "ethertype", "Ethertype", "ethertype",
+                        "The ethernet protocol type",
                         0,  ARKIME_FIELD_FLAG_FAKE,
                         (char *)NULL);
 

--- a/capture/plugins/unkEthernet.c
+++ b/capture/plugins/unkEthernet.c
@@ -13,13 +13,8 @@ LOCAL int unkEthernetMProtocol;
 /******************************************************************************/
 LOCAL void unkEthernet_create_sessionid(uint8_t *sessionId, ArkimePacket_t *const UNUSED (packet))
 {
-    // uint8_t *data = packet->pkt + packet->payloadOffset;
-
-    sessionId[0] = 2;
-    sessionId[1] = 0x99;
-    sessionId[2] = 0x99;
-
-    // for now, lump all unkEthernet into the same session
+    sessionId[0] = 14;
+    memcpy(sessionId + 1, packet->pkt + packet->etherOffset, 14); // Copy macs and ether type
 }
 /******************************************************************************/
 LOCAL int unkEthernet_pre_process(ArkimeSession_t *session, ArkimePacket_t *const UNUSED(packet), int isNewSession)

--- a/tests/pcap/6-4-gre-ppp-udp-4-dns.test
+++ b/tests/pcap/6-4-gre-ppp-udp-4-dns.test
@@ -81,6 +81,7 @@
                50
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1417577703821,
             "ipProtocol" : 17,

--- a/tests/pcap/CVE-2018-6794.test
+++ b/tests/pcap/CVE-2018-6794.test
@@ -26,6 +26,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1516186786703,
             "http" : {
@@ -229,6 +230,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1516186788618,
             "http" : {
@@ -434,6 +436,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1516186789703,
             "http" : {

--- a/tests/pcap/SNMPv2c_get_requests.test
+++ b/tests/pcap/SNMPv2c_get_requests.test
@@ -25,6 +25,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1222366202157,
             "ipProtocol" : 17,
@@ -125,6 +126,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1222366202193,
             "ipProtocol" : 17,
@@ -224,6 +226,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1222366202225,
             "ipProtocol" : 17,
@@ -323,6 +326,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1222366202254,
             "ipProtocol" : 17,

--- a/tests/pcap/aerospike.test
+++ b/tests/pcap/aerospike.test
@@ -35,6 +35,7 @@
                61
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1466097898472,
             "initRTT" : 1,
@@ -197,6 +198,7 @@
                61
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1466101718441,
             "initRTT" : 1,

--- a/tests/pcap/badcurveball.test
+++ b/tests/pcap/badcurveball.test
@@ -91,6 +91,7 @@
                238
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1579293816559,
             "http" : {

--- a/tests/pcap/bigendian.test
+++ b/tests/pcap/bigendian.test
@@ -20,6 +20,7 @@
                "ICANN, IANA Department"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1335958313152,
             "icmp" : {

--- a/tests/pcap/bt-tcp.test
+++ b/tests/pcap/bt-tcp.test
@@ -37,6 +37,7 @@
                117
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387744084182,
             "initRTT" : 60,
@@ -171,6 +172,7 @@
                63
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1482553479723,
             "initRTT" : 10,

--- a/tests/pcap/bt-udp.test
+++ b/tests/pcap/bt-udp.test
@@ -30,6 +30,7 @@
                "Juniper Networks"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387253713030,
             "ipProtocol" : 17,
@@ -127,6 +128,7 @@
                "ICANN, IANA Department"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387253793904,
             "ipProtocol" : 17,
@@ -200,6 +202,7 @@
                "ICANN, IANA Department"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387257610963,
             "ipProtocol" : 17,

--- a/tests/pcap/cassandra1.test
+++ b/tests/pcap/cassandra1.test
@@ -24,6 +24,7 @@
                58
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1466085103886,
             "initRTT" : 5,

--- a/tests/pcap/cloudshark-arp.test
+++ b/tests/pcap/cloudshark-arp.test
@@ -19,6 +19,7 @@
                "Universal Global Scientific Industrial Co., Ltd."
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2054,
             "fileId" : [],
             "firstPacket" : 1352595620652,
             "ipProtocol" : 0,
@@ -91,6 +92,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1352595620652,
             "icmp" : {
@@ -173,6 +175,7 @@
                "Universal Global Scientific Industrial Co., Ltd."
             ],
             "dstOuiCnt" : 2,
+            "ethertype" : 2054,
             "fileId" : [],
             "firstPacket" : 1352595625652,
             "ipProtocol" : 0,

--- a/tests/pcap/cloudshark-bgp-md5.test
+++ b/tests/pcap/cloudshark-bgp-md5.test
@@ -33,6 +33,7 @@
                "255"
             ],
             "dstTTLCnt" : 2,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1259261324431,
             "initRTT" : 3,
@@ -161,6 +162,7 @@
                1
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1259261324431,
             "ipProtocol" : 6,

--- a/tests/pcap/cloudshark-dtls1.test
+++ b/tests/pcap/cloudshark-dtls1.test
@@ -56,6 +56,7 @@
                52
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1404648102097,
             "ipProtocol" : 17,
@@ -567,6 +568,7 @@
                56
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1404648108283,
             "ipProtocol" : 17,

--- a/tests/pcap/curl-enabled-tls13.test
+++ b/tests/pcap/curl-enabled-tls13.test
@@ -123,6 +123,7 @@
                38
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1565212114674,
             "ipProtocol" : 17,
@@ -211,6 +212,7 @@
                38
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1565212114677,
             "http" : {

--- a/tests/pcap/dns-caa.test
+++ b/tests/pcap/dns-caa.test
@@ -92,6 +92,7 @@
                121
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1710770772045,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-dnskey.test
+++ b/tests/pcap/dns-dnskey.test
@@ -40,6 +40,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1393428477365,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-error.test
+++ b/tests/pcap/dns-error.test
@@ -65,6 +65,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1394587409097,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-flags0000.test
+++ b/tests/pcap/dns-flags0000.test
@@ -50,6 +50,7 @@
                53
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1393422583830,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-flags0110.test
+++ b/tests/pcap/dns-flags0110.test
@@ -100,6 +100,7 @@
                61
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1393428477363,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-https.test
+++ b/tests/pcap/dns-https.test
@@ -65,6 +65,7 @@
                121
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1710773996363,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-mx.test
+++ b/tests/pcap/dns-mx.test
@@ -119,6 +119,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386104996973,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-notify.test
+++ b/tests/pcap/dns-notify.test
@@ -54,6 +54,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1379970300840,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-punycode.test
+++ b/tests/pcap/dns-punycode.test
@@ -195,6 +195,7 @@
                59
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1528986536421,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-tcp.test
+++ b/tests/pcap/dns-tcp.test
@@ -265,6 +265,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385482078892,
             "initRTT" : 0,
@@ -554,6 +555,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385482080084,
             "initRTT" : 0,

--- a/tests/pcap/dns-udp.test
+++ b/tests/pcap/dns-udp.test
@@ -152,6 +152,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385400647217,
             "ipProtocol" : 17,
@@ -361,6 +362,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385400648218,
             "ipProtocol" : 17,
@@ -452,6 +454,7 @@
                "Juniper Networks"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1482767159342,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-update.test
+++ b/tests/pcap/dns-update.test
@@ -51,6 +51,7 @@
                118
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1467464484984,
             "ipProtocol" : 17,

--- a/tests/pcap/dns-wiresharkrepo.test
+++ b/tests/pcap/dns-wiresharkrepo.test
@@ -482,6 +482,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1112172466496,
             "ipProtocol" : 17,
@@ -636,6 +637,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1112172737737,
             "ipProtocol" : 17,
@@ -774,6 +776,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1112172737740,
             "ipProtocol" : 17,
@@ -886,6 +889,7 @@
                58
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1112172737755,
             "ipProtocol" : 17,
@@ -998,6 +1002,7 @@
                58
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1112172737776,
             "ipProtocol" : 17,
@@ -1110,6 +1115,7 @@
                58
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1112172737794,
             "ipProtocol" : 17,
@@ -1222,6 +1228,7 @@
                58
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1112172737915,
             "ipProtocol" : 17,
@@ -1334,6 +1341,7 @@
                58
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1112172745357,
             "ipProtocol" : 17,

--- a/tests/pcap/fbzero-android.test
+++ b/tests/pcap/fbzero-android.test
@@ -36,6 +36,7 @@
                84
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1479719879541,
             "initRTT" : 72,

--- a/tests/pcap/ftp.test
+++ b/tests/pcap/ftp.test
@@ -40,6 +40,7 @@
                50
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1454301530932,
             "initRTT" : 12,

--- a/tests/pcap/gre-erspan-vxlan.test
+++ b/tests/pcap/gre-erspan-vxlan.test
@@ -39,6 +39,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1652950005864,
             "http" : {

--- a/tests/pcap/gre-erspan.test
+++ b/tests/pcap/gre-erspan.test
@@ -56,6 +56,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1402723255667,
             "icmp" : {

--- a/tests/pcap/gre-sample.test
+++ b/tests/pcap/gre-sample.test
@@ -46,6 +46,7 @@
                63
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1055289968793,
             "icmp" : {
@@ -212,6 +213,7 @@
                45
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1055289973849,
             "ipProtocol" : 17,
@@ -347,6 +349,7 @@
                63
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1055289978756,
             "initRTT" : 22,
@@ -557,6 +560,7 @@
                "ARIN"
             ],
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1055289987055,
             "ipProtocol" : 17,
@@ -694,6 +698,7 @@
                63
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1055289992849,
             "ipProtocol" : 17,
@@ -839,6 +844,7 @@
                52
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1055289996849,
             "ipProtocol" : 17,

--- a/tests/pcap/gtp-u.test
+++ b/tests/pcap/gtp-u.test
@@ -42,6 +42,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1260442415441,
             "icmp" : {

--- a/tests/pcap/http-100-continue.test
+++ b/tests/pcap/http-100-continue.test
@@ -25,6 +25,7 @@
                59
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1580405643172,
             "http" : {

--- a/tests/pcap/http-301-get.test
+++ b/tests/pcap/http-301-get.test
@@ -38,6 +38,7 @@
                50
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385394928482,
             "http" : {

--- a/tests/pcap/http-500-head.test
+++ b/tests/pcap/http-500-head.test
@@ -25,6 +25,7 @@
                53
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1361891420707,
             "http" : {

--- a/tests/pcap/http-basicauth.test
+++ b/tests/pcap/http-basicauth.test
@@ -37,6 +37,7 @@
                48
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1414604109610,
             "http" : {

--- a/tests/pcap/http-content-gzip.test
+++ b/tests/pcap/http-content-gzip.test
@@ -38,6 +38,7 @@
                46
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1407242224712,
             "http" : {

--- a/tests/pcap/http-content-zip.test
+++ b/tests/pcap/http-content-zip.test
@@ -36,6 +36,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1388428585136,
             "http" : {

--- a/tests/pcap/http-digestauth.test
+++ b/tests/pcap/http-digestauth.test
@@ -37,6 +37,7 @@
                118
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1414887555048,
             "http" : {

--- a/tests/pcap/http-no-length.test
+++ b/tests/pcap/http-no-length.test
@@ -36,6 +36,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1273479692982,
             "http" : {

--- a/tests/pcap/http-post-upload.test
+++ b/tests/pcap/http-post-upload.test
@@ -28,6 +28,7 @@
                "64"
             ],
             "dstTTLCnt" : 2,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1553758814359,
             "http" : {

--- a/tests/pcap/http-simple-get.test
+++ b/tests/pcap/http-simple-get.test
@@ -28,6 +28,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385391358382,
             "http" : {

--- a/tests/pcap/http-syn-ack.test
+++ b/tests/pcap/http-syn-ack.test
@@ -21,6 +21,7 @@
                228
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1467366160266,
             "http" : {

--- a/tests/pcap/http-tcp-seq-issue.test
+++ b/tests/pcap/http-tcp-seq-issue.test
@@ -30,6 +30,7 @@
                57
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1559004678546,
             "http" : {

--- a/tests/pcap/http-wrapped-header.test
+++ b/tests/pcap/http-wrapped-header.test
@@ -36,6 +36,7 @@
                244
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1404135320459,
             "http" : {

--- a/tests/pcap/http-xff.test
+++ b/tests/pcap/http-xff.test
@@ -38,6 +38,7 @@
                59
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1454513228371,
             "http" : {

--- a/tests/pcap/https-connect.test
+++ b/tests/pcap/https-connect.test
@@ -90,6 +90,7 @@
                57
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1567450613383,
             "http" : {

--- a/tests/pcap/https-generalizedtime.test
+++ b/tests/pcap/https-generalizedtime.test
@@ -111,6 +111,7 @@
                52
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1421771550035,
             "http" : {

--- a/tests/pcap/https2-301-get.test
+++ b/tests/pcap/https2-301-get.test
@@ -101,6 +101,7 @@
                50
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385410273592,
             "initRTT" : 20,

--- a/tests/pcap/https3-301-get.test
+++ b/tests/pcap/https3-301-get.test
@@ -100,6 +100,7 @@
                50
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385396821013,
             "http" : {

--- a/tests/pcap/igmp.test
+++ b/tests/pcap/igmp.test
@@ -19,6 +19,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571745677855,
             "ipProtocol" : 2,

--- a/tests/pcap/imap-tag.test
+++ b/tests/pcap/imap-tag.test
@@ -38,6 +38,7 @@
                56
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387759542002,
             "initRTT" : 72,

--- a/tests/pcap/ip-boundaries.test
+++ b/tests/pcap/ip-boundaries.test
@@ -20,6 +20,7 @@
                "Juniper Networks"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387253713030,
             "ipProtocol" : 17,

--- a/tests/pcap/ipv6-gtp6.test
+++ b/tests/pcap/ipv6-gtp6.test
@@ -244,6 +244,7 @@
             "dstOuterRIR" : [
                ""
             ],
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1513078266494,
             "ipProtocol" : 17,

--- a/tests/pcap/ipv6-in-ipv4.test
+++ b/tests/pcap/ipv6-in-ipv4.test
@@ -37,6 +37,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1214308747487,
             "icmp" : {

--- a/tests/pcap/irc-cap-req.test
+++ b/tests/pcap/irc-cap-req.test
@@ -25,6 +25,7 @@
                44
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483561576585,
             "initRTT" : 58,

--- a/tests/pcap/irc.test
+++ b/tests/pcap/irc.test
@@ -38,6 +38,7 @@
                50
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387554241634,
             "initRTT" : 15,

--- a/tests/pcap/kafka.test
+++ b/tests/pcap/kafka.test
@@ -26,6 +26,7 @@
                51
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483521857249,
             "initRTT" : 70,

--- a/tests/pcap/krb5-tcp.test
+++ b/tests/pcap/krb5-tcp.test
@@ -24,6 +24,7 @@
                124
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1466265698248,
             "initRTT" : 1,

--- a/tests/pcap/krb5-udp.test
+++ b/tests/pcap/krb5-udp.test
@@ -20,6 +20,7 @@
                "ICANN, IANA Department"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1466252055201,
             "ipProtocol" : 17,

--- a/tests/pcap/ldap-and-search.test
+++ b/tests/pcap/ldap-and-search.test
@@ -25,6 +25,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1132019262677,
             "initRTT" : 0,

--- a/tests/pcap/ldap-simpleauth.test
+++ b/tests/pcap/ldap-simpleauth.test
@@ -37,6 +37,7 @@
                124
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1463256456040,
             "initRTT" : 1,

--- a/tests/pcap/ldap-ssl.test
+++ b/tests/pcap/ldap-ssl.test
@@ -45,6 +45,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1422673532664,
             "initRTT" : 0,

--- a/tests/pcap/long-session.test
+++ b/tests/pcap/long-session.test
@@ -36,6 +36,7 @@
                247
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1401385380102,
             "initRTT" : 0,
@@ -187,6 +188,7 @@
                247
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1401385380102,
             "ipProtocol" : 6,

--- a/tests/pcap/modbus.test
+++ b/tests/pcap/modbus.test
@@ -31,6 +31,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1093521678945,
             "ipProtocol" : 6,
@@ -131,6 +132,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1093521681696,
             "initRTT" : 0,
@@ -303,6 +305,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1093521953490,
             "initRTT" : 0,
@@ -436,6 +439,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1093522326102,
             "initRTT" : 0,
@@ -592,6 +596,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1093522946554,
             "initRTT" : 0,
@@ -712,6 +717,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1093523065562,
             "initRTT" : 0,
@@ -892,6 +898,7 @@
                43
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1153491879610,
             "initRTT" : 6288,
@@ -1830,6 +1837,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1342774499588,
             "initRTT" : 0,

--- a/tests/pcap/mongo.test
+++ b/tests/pcap/mongo.test
@@ -25,6 +25,7 @@
                53
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483459978959,
             "initRTT" : 171,
@@ -141,6 +142,7 @@
                52
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483558834969,
             "initRTT" : 81,
@@ -254,6 +256,7 @@
                56
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483726705497,
             "initRTT" : 3,
@@ -359,6 +362,7 @@
                50
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483737232974,
             "initRTT" : 2,
@@ -466,6 +470,7 @@
                "61"
             ],
             "dstTTLCnt" : 2,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483814916005,
             "initRTT" : 51,

--- a/tests/pcap/mpls-basic.test
+++ b/tests/pcap/mpls-basic.test
@@ -16,6 +16,7 @@
                "packets" : 0,
                "port" : 711
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 952109329022,
             "ipProtocol" : 17,
@@ -98,6 +99,7 @@
                "packets" : 0,
                "port" : 711
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 952109332196,
             "ipProtocol" : 17,
@@ -188,6 +190,7 @@
                253
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34887,
             "fileId" : [],
             "firstPacket" : 952109337199,
             "icmp" : {
@@ -296,6 +299,7 @@
                253
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34887,
             "fileId" : [],
             "firstPacket" : 952109346874,
             "initRTT" : 0,

--- a/tests/pcap/mysql-allow.test
+++ b/tests/pcap/mysql-allow.test
@@ -31,6 +31,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1398217358961,
             "initRTT" : 0,

--- a/tests/pcap/mysql-deny.test
+++ b/tests/pcap/mysql-deny.test
@@ -30,6 +30,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1398195861493,
             "initRTT" : 0,

--- a/tests/pcap/mysql-tls.test
+++ b/tests/pcap/mysql-tls.test
@@ -46,6 +46,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1482552218498,
             "initRTT" : 0,

--- a/tests/pcap/no-syn-ack.test
+++ b/tests/pcap/no-syn-ack.test
@@ -29,6 +29,7 @@
                61
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1482381409512,
             "initRTT" : 0,
@@ -144,6 +145,7 @@
                58
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483544164032,
             "http" : {

--- a/tests/pcap/openssl-ssl3.test
+++ b/tests/pcap/openssl-ssl3.test
@@ -161,6 +161,7 @@
                53
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1413337769995,
             "initRTT" : 1,

--- a/tests/pcap/openssl-tls1-tls1_2.test
+++ b/tests/pcap/openssl-tls1-tls1_2.test
@@ -162,6 +162,7 @@
                53
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1413338207695,
             "initRTT" : 1,

--- a/tests/pcap/openssl-tls1.test
+++ b/tests/pcap/openssl-tls1.test
@@ -161,6 +161,7 @@
                51
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1413337821624,
             "initRTT" : 1,

--- a/tests/pcap/openssl-tls1_1.test
+++ b/tests/pcap/openssl-tls1_1.test
@@ -162,6 +162,7 @@
                53
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1413337837095,
             "initRTT" : 1,

--- a/tests/pcap/openssl-tls1_2-tls1.test
+++ b/tests/pcap/openssl-tls1_2-tls1.test
@@ -159,6 +159,7 @@
                247
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1413338074954,
             "initRTT" : 0,

--- a/tests/pcap/openssl-tls1_2.test
+++ b/tests/pcap/openssl-tls1_2.test
@@ -162,6 +162,7 @@
                53
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1413337896106,
             "initRTT" : 1,

--- a/tests/pcap/oracle.test
+++ b/tests/pcap/oracle.test
@@ -26,6 +26,7 @@
                54
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476102172344,
             "initRTT" : 85,

--- a/tests/pcap/ospf.test
+++ b/tests/pcap/ospf.test
@@ -31,6 +31,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571662508236,
             "ipProtocol" : 17,
@@ -134,6 +135,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571662508569,
             "ipProtocol" : 103,
@@ -624,6 +626,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571662508795,
             "ipProtocol" : 89,
@@ -814,6 +817,7 @@
                "mac-cnt" : 1,
                "packets" : 0
             },
+            "ethertype" : 1500,
             "fileId" : [],
             "firstPacket" : 1571662509461,
             "ipProtocol" : 0,
@@ -1012,6 +1016,7 @@
                "mac-cnt" : 1,
                "packets" : 0
             },
+            "ethertype" : 35020,
             "fileId" : [],
             "firstPacket" : 1571662511903,
             "ipProtocol" : 0,
@@ -1099,6 +1104,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662515683,
             "ipProtocol" : 6,
@@ -1190,6 +1196,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662515687,
             "icmp" : {
@@ -1309,6 +1316,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571662521545,
             "ipProtocol" : 6,
@@ -1401,6 +1409,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571662538526,
             "ipProtocol" : 6,
@@ -1501,6 +1510,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571662548073,
             "ipProtocol" : 6,
@@ -1609,6 +1619,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567185,
             "ipProtocol" : 6,
@@ -1704,6 +1715,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567189,
             "ipProtocol" : 6,
@@ -1799,6 +1811,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567192,
             "ipProtocol" : 6,
@@ -1894,6 +1907,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567195,
             "ipProtocol" : 6,
@@ -1992,6 +2006,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567263,
             "ipProtocol" : 6,
@@ -2090,6 +2105,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567268,
             "ipProtocol" : 6,
@@ -2188,6 +2204,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567273,
             "ipProtocol" : 6,
@@ -2286,6 +2303,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567276,
             "ipProtocol" : 6,
@@ -2384,6 +2402,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567279,
             "ipProtocol" : 6,
@@ -2482,6 +2501,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662567282,
             "ipProtocol" : 6,
@@ -2574,6 +2594,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662572190,
             "icmp" : {
@@ -2666,6 +2687,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662572491,
             "ipProtocol" : 17,
@@ -2756,6 +2778,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662572665,
             "ipProtocol" : 6,
@@ -2854,6 +2877,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662574339,
             "ipProtocol" : 17,
@@ -2944,6 +2968,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662575795,
             "ipProtocol" : 6,
@@ -3039,6 +3064,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662576891,
             "ipProtocol" : 6,
@@ -3134,6 +3160,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662576896,
             "ipProtocol" : 6,
@@ -3229,6 +3256,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662576898,
             "ipProtocol" : 6,
@@ -3324,6 +3352,7 @@
                "PCS Computer Systems GmbH"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662576901,
             "ipProtocol" : 6,
@@ -3423,6 +3452,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571662578777,
             "ipProtocol" : 17,
@@ -3532,6 +3562,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1571662591197,
             "icmp" : {
@@ -3608,6 +3639,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571662595101,
             "ipProtocol" : 2,

--- a/tests/pcap/packetlife-ISIS_level2_adjacency.test
+++ b/tests/pcap/packetlife-ISIS_level2_adjacency.test
@@ -14,6 +14,7 @@
                "mac-cnt" : 1,
                "packets" : 0
             },
+            "ethertype" : 1500,
             "fileId" : [],
             "firstPacket" : 1213758559132,
             "ipProtocol" : 0,

--- a/tests/pcap/padded-udp.test
+++ b/tests/pcap/padded-udp.test
@@ -20,6 +20,7 @@
                "port" : 12345
             },
             "dstRIR" : "APNIC",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1715858838018,
             "ipProtocol" : 17,

--- a/tests/pcap/pim.test
+++ b/tests/pcap/pim.test
@@ -16,6 +16,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1571744396019,
             "ipProtocol" : 103,

--- a/tests/pcap/pop3-tag.test
+++ b/tests/pcap/pop3-tag.test
@@ -38,6 +38,7 @@
                56
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387659689446,
             "initRTT" : 443,

--- a/tests/pcap/postgres-badpass.test
+++ b/tests/pcap/postgres-badpass.test
@@ -36,6 +36,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1399312748531,
             "initRTT" : 2,

--- a/tests/pcap/postgres-good.test
+++ b/tests/pcap/postgres-good.test
@@ -25,6 +25,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1399300685023,
             "initRTT" : 0,

--- a/tests/pcap/postgres-no-sslrequest.test
+++ b/tests/pcap/postgres-no-sslrequest.test
@@ -25,6 +25,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1103485433560,
             "initRTT" : 0,

--- a/tests/pcap/pppoe.test
+++ b/tests/pcap/pppoe.test
@@ -104,6 +104,7 @@
                109
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34916,
             "fileId" : [],
             "firstPacket" : 1193676055856,
             "initRTT" : 47,

--- a/tests/pcap/quic24-wireshark.test
+++ b/tests/pcap/quic24-wireshark.test
@@ -36,6 +36,7 @@
                53
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1429686316293,
             "ipProtocol" : 17,

--- a/tests/pcap/quic33-wireshark.test
+++ b/tests/pcap/quic33-wireshark.test
@@ -36,6 +36,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1462966377795,
             "ipProtocol" : 17,

--- a/tests/pcap/quic34.test
+++ b/tests/pcap/quic34.test
@@ -31,6 +31,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1467241187446,
             "ipProtocol" : 17,

--- a/tests/pcap/quic43.test
+++ b/tests/pcap/quic43.test
@@ -30,6 +30,7 @@
                "Juniper Networks"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1550968206562,
             "ipProtocol" : 17,

--- a/tests/pcap/quicietf.test
+++ b/tests/pcap/quicietf.test
@@ -30,6 +30,7 @@
                "Juniper Networks"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1631043254696,
             "http" : {

--- a/tests/pcap/quicietfooo.test
+++ b/tests/pcap/quicietfooo.test
@@ -30,6 +30,7 @@
                "Juniper Networks"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1645739312034,
             "http" : {

--- a/tests/pcap/radius.test
+++ b/tests/pcap/radius.test
@@ -36,6 +36,7 @@
                56
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1463339353458,
             "ipProtocol" : 17,

--- a/tests/pcap/sctp-www.test
+++ b/tests/pcap/sctp-www.test
@@ -35,6 +35,7 @@
                59
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1137034844756,
             "ipProtocol" : 132,
@@ -216,6 +217,7 @@
                59
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1137034844891,
             "ipProtocol" : 132,
@@ -383,6 +385,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "APNIC",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1137034844900,
             "ipProtocol" : 132,

--- a/tests/pcap/single-packets.test
+++ b/tests/pcap/single-packets.test
@@ -31,6 +31,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525510773,
             "http" : {
@@ -191,6 +192,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "APNIC",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525512112,
             "http" : {
@@ -388,6 +390,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525512547,
             "http" : {
@@ -547,6 +550,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525514170,
             "http" : {
@@ -729,6 +733,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "RIPE",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525525879,
             "http" : {
@@ -916,6 +921,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525528386,
             "http" : {
@@ -1112,6 +1118,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525533174,
             "http" : {
@@ -1274,6 +1281,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525534767,
             "http" : {
@@ -1460,6 +1468,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1532525539024,
             "http" : {

--- a/tests/pcap/smb-port80.test
+++ b/tests/pcap/smb-port80.test
@@ -35,6 +35,7 @@
                126
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1379519109833,
             "initRTT" : 163,

--- a/tests/pcap/smb-smb1-ascii.test
+++ b/tests/pcap/smb-smb1-ascii.test
@@ -25,6 +25,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1429783872765,
             "initRTT" : 0,

--- a/tests/pcap/smb-smbclient.test
+++ b/tests/pcap/smb-smbclient.test
@@ -25,6 +25,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387494788141,
             "initRTT" : 0,

--- a/tests/pcap/smbtorture-ntlmssp-moloch-crash.test
+++ b/tests/pcap/smbtorture-ntlmssp-moloch-crash.test
@@ -26,6 +26,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1132371118535,
             "initRTT" : 0,

--- a/tests/pcap/smbtorture-ntlmssp.test
+++ b/tests/pcap/smbtorture-ntlmssp.test
@@ -26,6 +26,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1132371118535,
             "initRTT" : 0,

--- a/tests/pcap/smtp-data-250.test
+++ b/tests/pcap/smtp-data-250.test
@@ -81,6 +81,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386338020379,
             "initRTT" : 36,

--- a/tests/pcap/smtp-data-521.test
+++ b/tests/pcap/smtp-data-521.test
@@ -76,6 +76,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386251815266,
             "initRTT" : 209,

--- a/tests/pcap/smtp-decrypted.test
+++ b/tests/pcap/smtp-decrypted.test
@@ -121,6 +121,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1733385184602,
             "initRTT" : 2,
@@ -392,6 +393,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1733486380138,
             "initRTT" : 3,
@@ -646,6 +648,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1733486381079,
             "initRTT" : 0,
@@ -873,6 +876,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1733486838269,
             "initRTT" : 2,

--- a/tests/pcap/smtp-moloch-bof.test
+++ b/tests/pcap/smtp-moloch-bof.test
@@ -64,6 +64,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1446834929262,
             "initRTT" : 0,

--- a/tests/pcap/smtp-nospaces.test
+++ b/tests/pcap/smtp-nospaces.test
@@ -35,6 +35,7 @@
                ],
                "srcCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1453298297881,
             "initRTT" : 0,

--- a/tests/pcap/smtp-originating.test
+++ b/tests/pcap/smtp-originating.test
@@ -114,6 +114,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1389625273848,
             "initRTT" : 27,

--- a/tests/pcap/smtp-rcpt-553.test
+++ b/tests/pcap/smtp-rcpt-553.test
@@ -45,6 +45,7 @@
                ],
                "srcCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386252622425,
             "initRTT" : 37,

--- a/tests/pcap/smtp-starttls.test
+++ b/tests/pcap/smtp-starttls.test
@@ -139,6 +139,7 @@
                ],
                "smtpHelloCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1388017124762,
             "initRTT" : 5,

--- a/tests/pcap/smtp-subject-8859-b.test
+++ b/tests/pcap/smtp-subject-8859-b.test
@@ -127,6 +127,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386358271061,
             "initRTT" : 0,

--- a/tests/pcap/smtp-subject-8859-multi.test
+++ b/tests/pcap/smtp-subject-8859-multi.test
@@ -104,6 +104,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386877497906,
             "initRTT" : 0,

--- a/tests/pcap/smtp-subject-8859-q.test
+++ b/tests/pcap/smtp-subject-8859-q.test
@@ -104,6 +104,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386817725755,
             "initRTT" : 1,

--- a/tests/pcap/smtp-subject-encoded-empty.test
+++ b/tests/pcap/smtp-subject-encoded-empty.test
@@ -62,6 +62,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1398431422481,
             "initRTT" : 1,

--- a/tests/pcap/smtp-subject-gb2312-b.test
+++ b/tests/pcap/smtp-subject-gb2312-b.test
@@ -135,6 +135,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386358422209,
             "initRTT" : 0,

--- a/tests/pcap/smtp-subject-multi-nospace.test
+++ b/tests/pcap/smtp-subject-multi-nospace.test
@@ -61,6 +61,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1394730057309,
             "initRTT" : 1,

--- a/tests/pcap/smtp-subject-utf8-mixed.test
+++ b/tests/pcap/smtp-subject-utf8-mixed.test
@@ -104,6 +104,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386817958900,
             "initRTT" : 1,

--- a/tests/pcap/smtp-subject-utf8-q.test
+++ b/tests/pcap/smtp-subject-utf8-q.test
@@ -95,6 +95,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1384762012670,
             "initRTT" : 39,

--- a/tests/pcap/smtp-subject-windows.test
+++ b/tests/pcap/smtp-subject-windows.test
@@ -62,6 +62,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1394118475009,
             "initRTT" : 1,

--- a/tests/pcap/smtp-zip.test
+++ b/tests/pcap/smtp-zip.test
@@ -120,6 +120,7 @@
                ],
                "useragentCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387291817187,
             "initRTT" : 0,

--- a/tests/pcap/socks-http-example.test
+++ b/tests/pcap/socks-http-example.test
@@ -28,6 +28,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386004309468,
             "http" : {
@@ -263,6 +264,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386004312331,
             "http" : {
@@ -497,6 +499,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386004317979,
             "http" : {

--- a/tests/pcap/socks-http-pass.test
+++ b/tests/pcap/socks-http-pass.test
@@ -28,6 +28,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386090517357,
             "initRTT" : 0,
@@ -147,6 +148,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386090528538,
             "initRTT" : 0,
@@ -280,6 +282,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386090534425,
             "http" : {

--- a/tests/pcap/socks-https-example.test
+++ b/tests/pcap/socks-https-example.test
@@ -238,6 +238,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386004472572,
             "http" : {
@@ -662,6 +663,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386004475691,
             "http" : {
@@ -1083,6 +1085,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386004480852,
             "http" : {

--- a/tests/pcap/socks4-https.test
+++ b/tests/pcap/socks4-https.test
@@ -142,6 +142,7 @@
                52
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1415053640836,
             "initRTT" : 160,

--- a/tests/pcap/socks5-http-302-frag.test
+++ b/tests/pcap/socks5-http-302-frag.test
@@ -38,6 +38,7 @@
                103
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385474294492,
             "http" : {

--- a/tests/pcap/socks5-http-302.test
+++ b/tests/pcap/socks5-http-302.test
@@ -38,6 +38,7 @@
                103
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385474294492,
             "http" : {

--- a/tests/pcap/socks5-rdp.test
+++ b/tests/pcap/socks5-rdp.test
@@ -36,6 +36,7 @@
                126
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386644255859,
             "initRTT" : 123,

--- a/tests/pcap/socks5-reverse.test
+++ b/tests/pcap/socks5-reverse.test
@@ -38,6 +38,7 @@
                56
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1386790367120,
             "http" : {

--- a/tests/pcap/socks5-smtp-503.test
+++ b/tests/pcap/socks5-smtp-503.test
@@ -43,6 +43,7 @@
                ],
                "smtpHelloCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1385474626674,
             "initRTT" : 1730,

--- a/tests/pcap/ssh2-moloch-crash.test
+++ b/tests/pcap/ssh2-moloch-crash.test
@@ -37,6 +37,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387565111946,
             "initRTT" : 0,

--- a/tests/pcap/ssh2.test
+++ b/tests/pcap/ssh2.test
@@ -37,6 +37,7 @@
                60
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1387565111946,
             "initRTT" : 0,

--- a/tests/pcap/stun.test
+++ b/tests/pcap/stun.test
@@ -31,6 +31,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "TEST",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483104480102,
             "ipProtocol" : 17,
@@ -145,6 +146,7 @@
                "Juniper Networks"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483109179834,
             "ipProtocol" : 17,
@@ -241,6 +243,7 @@
                55
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483325250913,
             "ipProtocol" : 6,
@@ -342,6 +345,7 @@
                "Juniper Networks"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483326849006,
             "ipProtocol" : 17,
@@ -415,6 +419,7 @@
                "ICANN, IANA Department"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483331734283,
             "ipProtocol" : 17,
@@ -488,6 +493,7 @@
                "ICANN, IANA Department"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483331743573,
             "ipProtocol" : 17,

--- a/tests/pcap/tcpdump-geneve.test
+++ b/tests/pcap/tcpdump-geneve.test
@@ -50,6 +50,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1422828273817,
             "icmp" : {
@@ -198,6 +199,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1422828273999,
             "initRTT" : 0,

--- a/tests/pcap/tds5.test
+++ b/tests/pcap/tds5.test
@@ -37,6 +37,7 @@
                61
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1465335293231,
             "initRTT" : 0,

--- a/tests/pcap/thrift.test
+++ b/tests/pcap/thrift.test
@@ -36,6 +36,7 @@
                61
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1463682642097,
             "initRTT" : 1,
@@ -180,6 +181,7 @@
                51
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1483833315772,
             "initRTT" : 2,

--- a/tests/pcap/tls-client-sessionid.test
+++ b/tests/pcap/tls-client-sessionid.test
@@ -36,6 +36,7 @@
                54
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1420490708340,
             "http" : {

--- a/tests/pcap/tls13.test
+++ b/tests/pcap/tls13.test
@@ -35,6 +35,7 @@
                58
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1483560476240,
             "http" : {

--- a/tests/pcap/twovlan.test
+++ b/tests/pcap/twovlan.test
@@ -36,6 +36,7 @@
                54
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1456042921641,
             "http" : {

--- a/tests/pcap/v6-http.test
+++ b/tests/pcap/v6-http.test
@@ -16,6 +16,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1186341079159,
             "icmp" : {
@@ -155,6 +156,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1186341098054,
             "icmp" : {
@@ -232,6 +234,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1186341098474,
             "icmp" : {
@@ -307,6 +310,7 @@
                "packets" : 0,
                "port" : 5353
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1186341099605,
             "ipProtocol" : 17,
@@ -405,6 +409,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1186341269082,
             "icmp" : {
@@ -499,6 +504,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1186341404189,
             "http" : {

--- a/tests/pcap/v6.test
+++ b/tests/pcap/v6.test
@@ -204,6 +204,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159902141,
             "ipProtocol" : 17,
@@ -283,6 +284,7 @@
                255
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159907494,
             "icmp" : {
@@ -386,6 +388,7 @@
                "64"
             ],
             "dstTTLCnt" : 2,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159907620,
             "icmp" : {
@@ -654,6 +657,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159908759,
             "ipProtocol" : 17,
@@ -725,6 +729,7 @@
                "packets" : 0,
                "port" : 521
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159914439,
             "ipProtocol" : 17,
@@ -906,6 +911,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159918251,
             "ipProtocol" : 17,
@@ -986,6 +992,7 @@
                61
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159918266,
             "initRTT" : 28,
@@ -1310,6 +1317,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929568,
             "ipProtocol" : 17,
@@ -1385,6 +1393,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929585,
             "ipProtocol" : 17,
@@ -1520,6 +1529,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929588,
             "ipProtocol" : 17,
@@ -1595,6 +1605,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929601,
             "ipProtocol" : 17,
@@ -1667,6 +1678,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929603,
             "ipProtocol" : 17,
@@ -1739,6 +1751,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929604,
             "ipProtocol" : 17,
@@ -1811,6 +1824,7 @@
                "Megahertz Corporation"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929611,
             "icmp" : {
@@ -1987,6 +2001,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929612,
             "ipProtocol" : 17,
@@ -2062,6 +2077,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929627,
             "ipProtocol" : 17,
@@ -2138,6 +2154,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929635,
             "ipProtocol" : 17,
@@ -2210,6 +2227,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929679,
             "ipProtocol" : 17,
@@ -2282,6 +2300,7 @@
                "Megahertz Corporation"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929691,
             "icmp" : {
@@ -2458,6 +2477,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929692,
             "ipProtocol" : 17,
@@ -2533,6 +2553,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929708,
             "ipProtocol" : 17,
@@ -2605,6 +2626,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929718,
             "ipProtocol" : 17,
@@ -2677,6 +2699,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929730,
             "ipProtocol" : 17,
@@ -2749,6 +2772,7 @@
                "Megahertz Corporation"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929788,
             "icmp" : {
@@ -2895,6 +2919,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929789,
             "ipProtocol" : 17,
@@ -2970,6 +2995,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929805,
             "ipProtocol" : 17,
@@ -3042,6 +3068,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159929873,
             "ipProtocol" : 17,
@@ -3238,6 +3265,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159936681,
             "ipProtocol" : 17,
@@ -3317,6 +3345,7 @@
                59
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159937408,
             "icmp" : {
@@ -3501,6 +3530,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159937432,
             "ipProtocol" : 17,
@@ -3669,6 +3699,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159938429,
             "ipProtocol" : 17,
@@ -3837,6 +3868,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159939424,
             "ipProtocol" : 17,
@@ -3908,6 +3940,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159951927,
             "icmp" : {
@@ -3983,6 +4016,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159952222,
             "icmp" : {
@@ -4174,6 +4208,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159956705,
             "ipProtocol" : 17,
@@ -4249,6 +4284,7 @@
                "3Com"
             ],
             "dstOuiCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159961962,
             "icmp" : {
@@ -4324,6 +4360,7 @@
                "packets" : 0,
                "port" : 0
             },
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159962650,
             "icmp" : {
@@ -4477,6 +4514,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159962652,
             "ipProtocol" : 17,
@@ -4626,6 +4664,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159962782,
             "ipProtocol" : 17,
@@ -4775,6 +4814,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159963775,
             "ipProtocol" : 17,
@@ -4924,6 +4964,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159964777,
             "ipProtocol" : 17,
@@ -5073,6 +5114,7 @@
                230
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 921159965780,
             "ipProtocol" : 17,

--- a/tests/pcap/vxlan.test
+++ b/tests/pcap/vxlan.test
@@ -27,6 +27,7 @@
             ],
             "dstOuterOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1467818432675,
             "ipProtocol" : 17,
@@ -148,6 +149,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1467818432676,
             "icmp" : {

--- a/tests/pcap/wireshark-bdat.test
+++ b/tests/pcap/wireshark-bdat.test
@@ -68,6 +68,7 @@
                ],
                "subjectCnt" : 1
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476878885946,
             "initRTT" : 0,

--- a/tests/pcap/wireshark-dhcp.test
+++ b/tests/pcap/wireshark-dhcp.test
@@ -36,6 +36,7 @@
                ],
                "typeCnt" : 2
             },
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1102274184317,
             "ipProtocol" : 17,
@@ -132,6 +133,7 @@
             ],
             "dstOuiCnt" : 1,
             "dstRIR" : "ARIN",
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1102274184317,
             "ipProtocol" : 17,

--- a/tests/pcap/wireshark-dtls0.test
+++ b/tests/pcap/wireshark-dtls0.test
@@ -57,6 +57,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1150121069248,
             "ipProtocol" : 17,

--- a/tests/pcap/wireshark-dtls12.test
+++ b/tests/pcap/wireshark-dtls12.test
@@ -35,6 +35,7 @@
                63
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1527230471076,
             "ipProtocol" : 17,

--- a/tests/pcap/wireshark-esp.test
+++ b/tests/pcap/wireshark-esp.test
@@ -35,6 +35,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435037629,
             "ipProtocol" : 50,
@@ -132,6 +133,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435056630,
             "ipProtocol" : 50,
@@ -229,6 +231,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435075674,
             "ipProtocol" : 50,
@@ -326,6 +329,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435094676,
             "ipProtocol" : 50,
@@ -423,6 +427,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435199683,
             "ipProtocol" : 50,
@@ -520,6 +525,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435218685,
             "ipProtocol" : 50,
@@ -617,6 +623,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435237736,
             "ipProtocol" : 50,
@@ -714,6 +721,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435256758,
             "ipProtocol" : 50,
@@ -811,6 +819,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435361771,
             "ipProtocol" : 50,
@@ -908,6 +917,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435380893,
             "ipProtocol" : 50,
@@ -1005,6 +1015,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435399895,
             "ipProtocol" : 50,
@@ -1102,6 +1113,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1140435418897,
             "ipProtocol" : 50,
@@ -1188,6 +1200,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140435683595,
             "ipProtocol" : 50,
@@ -1263,6 +1276,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140435702637,
             "ipProtocol" : 50,
@@ -1338,6 +1352,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140435721711,
             "ipProtocol" : 50,
@@ -1413,6 +1428,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140435740713,
             "ipProtocol" : 50,
@@ -1488,6 +1504,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140435845816,
             "ipProtocol" : 50,
@@ -1563,6 +1580,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140435864818,
             "ipProtocol" : 50,
@@ -1638,6 +1656,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140435883839,
             "ipProtocol" : 50,
@@ -1713,6 +1732,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140435902840,
             "ipProtocol" : 50,
@@ -1788,6 +1808,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140436007955,
             "ipProtocol" : 50,
@@ -1863,6 +1884,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140436026969,
             "ipProtocol" : 50,
@@ -1938,6 +1960,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140436045975,
             "ipProtocol" : 50,
@@ -2013,6 +2036,7 @@
                64
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 34525,
             "fileId" : [],
             "firstPacket" : 1140436064977,
             "ipProtocol" : 50,

--- a/tests/pcap/wireshark-lldp.test
+++ b/tests/pcap/wireshark-lldp.test
@@ -14,6 +14,7 @@
                "mac-cnt" : 1,
                "packets" : 0
             },
+            "ethertype" : 35020,
             "fileId" : [],
             "firstPacket" : 1121119005000,
             "ipProtocol" : 0,

--- a/tests/pcap/wireshark-retrans.test
+++ b/tests/pcap/wireshark-retrans.test
@@ -26,6 +26,7 @@
                62
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1259023909119,
             "http" : {

--- a/tests/pcap/wireshark-smb-on-windows10.test
+++ b/tests/pcap/wireshark-smb-on-windows10.test
@@ -26,6 +26,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476605363990,
             "initRTT" : 6,
@@ -141,6 +142,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476605364031,
             "initRTT" : 32,
@@ -282,6 +284,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476605590407,
             "initRTT" : 0,
@@ -403,6 +406,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476605590466,
             "initRTT" : 0,
@@ -520,6 +524,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476605590477,
             "initRTT" : 0,
@@ -637,6 +642,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476605590489,
             "initRTT" : 0,
@@ -754,6 +760,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476605609916,
             "initRTT" : 0,
@@ -875,6 +882,7 @@
                128
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1476605761415,
             "initRTT" : 0,

--- a/tests/pcap/y2038-bgp.test
+++ b/tests/pcap/y2038-bgp.test
@@ -32,6 +32,7 @@
                "255"
             ],
             "dstTTLCnt" : 2,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1259261324435,
             "ipProtocol" : 6,
@@ -132,6 +133,7 @@
                1
             ],
             "dstTTLCnt" : 1,
+            "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1259261324435,
             "ipProtocol" : 6,

--- a/viewer/views/mixins.pug
+++ b/viewer/views/mixins.pug
@@ -1,5 +1,8 @@
 //- Display a clickable value
 mixin clickableValue(expr, value, parse, session)
+  if (Array.isArray(value) && value.length > 0)
+    - value=value[0]
+
   if (value !== undefined)
     arkime-session-field.detail-field(expr=expr, value=value, parse=parse, :field=`getField('${expr}')`, session=session, pull-left=true)
   else

--- a/viewer/views/sessionDetail.pug
+++ b/viewer/views/sessionDetail.pug
@@ -25,6 +25,11 @@ dl
   +arrayList(session, "protocol", "Protocols", "protocols")
 
   dt
+    +clickableLabel('ethertype', 'Ethertype')
+  dd
+    +clickableValue('ethertype', session.ethertype)
+
+  dt
     +clickableLabel('ip.protocol', 'IP Protocol')
   dd
     +clickableValue('ip.protocol', session.ipProtocol)


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
