### PR TITLE
fix Type confusion through parameter tampering 

### DIFF
--- a/viewer/apiConnections.js
+++ b/viewer/apiConnections.js
@@ -85,6 +85,10 @@ class ConnectionAPIs {
         (resultId > 1)) {
       doBaseline = true;
       let baselineDateTmpStr = req.query.baselineDate;
+      if (typeof baselineDateTmpStr !== 'string') {
+        result.err = 'Bad query.baselineDate';
+        return cb([result]);
+      }
       if (baselineDateTmpStr.endsWith('x')) {
         baselineDateIsMultiplier = true;
         baselineDateTmpStr = baselineDateTmpStr.slice(0, -1);


### PR DESCRIPTION
https://github.com/arkime/arkime/blob/10d1dca3b20ed58a523f2882c3a878e5823847e5/viewer/apiConnections.js#L90-L90

Sanitizing untrusted HTTP request parameters is a common technique for preventing injection attacks such as SQL injection or path traversal. This is sometimes done by checking if the request parameters contain blacklisted substrings. However, sanitizing request parameters assuming they have type `String` and using the builtin string methods such as `String.prototype.indexOf` is susceptible to type confusion attacks. In a type confusion attack, an attacker tampers with an HTTP request parameter such that it has a value of type `Array` instead of the expected type `String`. Furthermore, the content of the array has been crafted to bypass sanitizers by exploiting that some identically named methods of strings and arrays behave differently.


Fix the problem, we need to ensure that `req.query.baselineDate` is a string before calling any string methods such as `.endsWith` or `.slice`. The best way is to add a type check (using `typeof` or a robust utility) before using these methods. If the value is not a string, we should handle it as an error or sanitize it appropriately. The fix should be applied in the block where `baselineDateTmpStr` is set and used (lines 87–91). We should also ensure that the early return on line 80 is triggered if the type is not a string, to prevent further processing of invalid input. This can be done by moving the type check closer to where the value is used, or by adding an explicit check before using string methods.

### References
[Node.js API querystring](https://nodejs.org/api/querystring.html)