### PR TITLE
skip garland timestamp header

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 5.7.2 2025/08/xx
 ## Release
   - #3287 Node 20.19.4
+## Capture/Viewer
+  - #3307 Added garland timestamp plugin
 ## Capture
   - #3294 Improved dhcpv6 parser and ja4d display
   - #3297 Fix lua memory leaks

--- a/capture/plugins/garland.c
+++ b/capture/plugins/garland.c
@@ -1,0 +1,25 @@
+/* garland.c
+ *
+ * Copyright 2025 Arkime. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "arkime.h"
+extern ArkimeConfig_t        config;
+
+/******************************************************************************/
+SUPPRESS_ALIGNMENT
+LOCAL ArkimePacketRC arkime_packet_garland(ArkimePacketBatch_t *batch, ArkimePacket_t *const packet, const uint8_t *data, int len)
+{
+    if (len < 20)
+        return ARKIME_PACKET_CORRUPT;
+
+    return arkime_packet_run_ethernet_cb(batch, packet, data + 18, len - 18, ARKIME_ETHERTYPE_ETHER, "garland");
+}
+/******************************************************************************/
+void arkime_plugin_init()
+{
+    uint32_t ethertype = arkime_config_int(NULL, "garlandEthertype", 0xff12, 0, 0xffff);
+    arkime_packet_set_ethernet_cb(ethertype, arkime_packet_garland);
+}

--- a/capture/plugins/garland.js
+++ b/capture/plugins/garland.js
@@ -1,0 +1,30 @@
+/******************************************************************************/
+/* garland.js
+ *
+ * Copyright 2025 Arkime. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+'use strict';
+
+let Pcap;
+
+function garland (pcap, buffer, obj, pos) {
+  return pcap.ethertyperun(0, buffer.slice(18), obj, pos + 18);
+}
+
+/// ///////////////////////////////////////////////////////////////////////////////
+exports.init = function (config, emitter, api) {
+  const Config = config;
+  Pcap = api.getPcap();
+
+  if (Pcap.setEtherCB === undefined) {
+    console.error('ERROR - Garland plugin requires newer version of Arkime');
+    return;
+  }
+  console.log('Garland plugin initialized');
+
+  const ethertype = parseInt(Config.get('garlandEthertype', 0xff12));
+
+  Pcap.setEtherCB(ethertype, garland);
+};

--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -35,6 +35,7 @@ const internals = {
 class Pcap {
   #count = 0;
   #closing = false;
+  static #etherCBs = {};
 
   constructor (key) {
     this.key = key;
@@ -806,7 +807,15 @@ class Pcap {
     }
   };
 
+  static setEtherCB (type, cb) {
+    Pcap.#etherCBs[type] = cb;
+  };
+
   ethertyperun (type, buffer, obj, pos) {
+    if (Pcap.#etherCBs[type]) {
+      return Pcap.#etherCBs[type](this, buffer, obj, pos);
+    }
+
     switch (type) {
     case 0x88be: // ERSPAN I && II
       this.erspan(buffer, obj, pos);


### PR DESCRIPTION
Add capture/viewer plugins to skip garland headers. fixes #3303 
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
