### PR TITLE
cppcheck fixes - standardize on int to pointer

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -74,7 +74,7 @@
 #define ARKIME_IPPROTO_MAX     257
 #define ARKIME_SESSION_v6(s) ((s)->sessionId[0] == ARKIME_SESSIONID6_LEN)
 
-#define ARKIME_VAR_ARG_STR_SKIP (char *)1LL
+#define ARKIME_VAR_ARG_STR_SKIP GINT_TO_POINTER(1)
 #define ARKIME_VAR_ARG_INT_SKIP (char *)0x7fffffffffffffffLL
 
 #define POINTER_TO_FLOAT(p) *(float *)&p

--- a/capture/db.c
+++ b/capture/db.c
@@ -694,9 +694,9 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
     if (config.autoGenerateId == 2 && session->filePosArray->len > 1) {
         id_len = snprintf(id, sizeof(id), "%s-%s-%u-%" PRId64, dbInfo[thread].prefix, config.nodeName, (uint32_t)g_array_index(session->fileNumArray, uint32_t, 0), (int64_t)g_array_index(session->filePosArray, int64_t, 1));
 
-        if (session->rootId == (void * )1L)
+        if (session->rootId == GINT_TO_POINTER(1))
             session->rootId = g_strdup(id);
-    } else if (config.autoGenerateId != 1 || session->rootId == (void *)1L) {
+    } else if (config.autoGenerateId != 1 || session->rootId == GINT_TO_POINTER(1)) {
         id_len = snprintf(id, sizeof(id), "%s-", dbInfo[thread].prefix);
 
         uuid_generate(uuid);
@@ -711,7 +711,7 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
             else if (id[i] == '/') id[i] = '_';
         }
 
-        if (session->rootId == (void * )1L)
+        if (session->rootId == GINT_TO_POINTER(1))
             session->rootId = g_strdup(id);
     }
 
@@ -1832,7 +1832,7 @@ LOCAL gboolean arkime_db_flush_gfunc (gpointer user_data )
     for (thread = 0; thread < config.packetThreads; thread++) {
         ARKIME_LOCK(dbInfo[thread].lock);
         if (dbInfo[thread].json && BSB_LENGTH(dbInfo[thread].bsb) > 0 &&
-            ((currentTime.tv_sec - dbInfo[thread].lastSave) >= config.dbFlushTimeout || user_data == (gpointer)1)) {
+            ((currentTime.tv_sec - dbInfo[thread].lastSave) >= config.dbFlushTimeout || user_data == GINT_TO_POINTER(1))) {
 
             char   *json = dbInfo[thread].json;
             int     len = BSB_LENGTH(dbInfo[thread].bsb);
@@ -1875,7 +1875,7 @@ LOCAL void arkime_db_health_check_cb(int UNUSED(code), uint8_t *data, int data_l
         LOG("WARNING - Couldn't find status in '%.*s'", data_len, data);
     } else if ( esHealthMS > 20000) {
         LOG("WARNING - Elasticsearch health check took more then 20 seconds %" PRIu64 "ms", esHealthMS);
-    } else if ((status[0] == 'y' && uw == (gpointer)1L) || (status[0] == 'r')) {
+    } else if ((status[0] == 'y' && uw == GINT_TO_POINTER(1)) || (status[0] == 'r')) {
         LOG("WARNING - Elasticsearch is %.*s and took %" PRIu64 "ms to query health, this may cause issues.  See FAQ.", status_len, status, esHealthMS);
     }
 }
@@ -2727,7 +2727,7 @@ int arkime_db_can_quit()
         if (dbInfo[thread].json && BSB_LENGTH(dbInfo[thread].bsb) > 0) {
             ARKIME_UNLOCK(dbInfo[thread].lock);
 
-            arkime_db_flush_gfunc((gpointer)1);
+            arkime_db_flush_gfunc(GINT_TO_POINTER(1));
             if (config.debug)
                 LOG ("Can't quit, sJson[%d] %u", thread, (uint32_t)BSB_LENGTH(dbInfo[thread].bsb));
             return 1;
@@ -2816,7 +2816,7 @@ void arkime_db_init()
         esBulkQuery = arkime_config_str(NULL, "esBulkQuery", "/_bulk");
         esBulkQueryLen = strlen(esBulkQuery);
 
-        arkime_db_health_check((gpointer)1L);
+        arkime_db_health_check(GINT_TO_POINTER(1));
     }
     myPid = getpid() & 0xffff;
     gettimeofday(&startTime, NULL);
@@ -2888,7 +2888,7 @@ void arkime_db_exit()
             g_source_remove(fieldBSBTimeout);
 
         if (fieldBSB.buf && BSB_LENGTH(fieldBSB) > 0) {
-            arkime_db_fieldsbsb_timeout((gpointer)1);
+            arkime_db_fieldsbsb_timeout(GINT_TO_POINTER(1));
         }
 
         if (fieldBSB.buf) {
@@ -2900,7 +2900,7 @@ void arkime_db_exit()
             g_source_remove(timers[i]);
         }
 
-        arkime_db_flush_gfunc((gpointer)1);
+        arkime_db_flush_gfunc(GINT_TO_POINTER(1));
         dbExit = 1;
         if (!config.noStats) {
             arkime_db_update_stats(0, 1);

--- a/capture/parsers/dns.c
+++ b/capture/parsers/dns.c
@@ -1581,10 +1581,10 @@ LOCAL void *dns_getcb_host(const ArkimeSession_t *session, int UNUSED(pos))
 
     HASH_FORALL2(o_, *ohash, object) {
         const DNS_t *dns = (DNS_t *)object->object;
-        g_hash_table_insert(hash, dns->query.hostname, (void *)1LL);
+        g_hash_table_insert(hash, dns->query.hostname, GINT_TO_POINTER(1));
         ArkimeString_t *hstring;
         HASH_FORALL2(s_, dns->hosts, hstring) {
-            g_hash_table_insert(hash, hstring->str, (void *)1LL);
+            g_hash_table_insert(hash, hstring->str, GINT_TO_POINTER(1));
         }
     }
 
@@ -1607,7 +1607,7 @@ LOCAL void *dns_getcb_host_mailserver(const ArkimeSession_t *session, int UNUSED
         if (dns->mxHosts) {
             ArkimeString_t *hstring;
             HASH_FORALL2(s_, *(dns->mxHosts), hstring) {
-                g_hash_table_insert(hash, hstring->str, (void *)1LL);
+                g_hash_table_insert(hash, hstring->str, GINT_TO_POINTER(1));
             }
         }
     }
@@ -1631,7 +1631,7 @@ LOCAL void *dns_getcb_host_nameserver(const ArkimeSession_t *session, int UNUSED
         if (dns->nsHosts) {
             ArkimeString_t *hstring;
             HASH_FORALL2(s_, *(dns->nsHosts), hstring) {
-                g_hash_table_insert(hash, hstring->str, (void *)1LL);
+                g_hash_table_insert(hash, hstring->str, GINT_TO_POINTER(1));
             }
         }
     }
@@ -1655,7 +1655,7 @@ LOCAL void *dns_getcb_puny(const ArkimeSession_t *session, int UNUSED(pos))
         if (dns->punyHosts) {
             ArkimeString_t *hstring;
             HASH_FORALL2(s_, *(dns->punyHosts), hstring) {
-                g_hash_table_insert(hash, hstring->str, (void *)1LL);
+                g_hash_table_insert(hash, hstring->str, GINT_TO_POINTER(1));
             }
         }
     }
@@ -1677,7 +1677,7 @@ LOCAL void *dns_getcb_status(const ArkimeSession_t *session, int UNUSED(pos))
     HASH_FORALL2(o_, *ohash, object) {
         const DNS_t *dns = (DNS_t *)object->object;
         if (dns->rcode)
-            g_hash_table_insert(hash, dns->rcode, (void *)1LL);
+            g_hash_table_insert(hash, dns->rcode, GINT_TO_POINTER(1));
     }
 
     arkime_free_later(hash, (GDestroyNotify) g_hash_table_destroy);
@@ -1697,7 +1697,7 @@ LOCAL void *dns_getcb_opcode(const ArkimeSession_t *session, int UNUSED(pos))
     HASH_FORALL2(o_, *ohash, object) {
         const DNS_t *dns = (DNS_t *)object->object;
         if (dns->query.opcode)
-            g_hash_table_insert(hash, dns->query.opcode, (void *)1LL);
+            g_hash_table_insert(hash, dns->query.opcode, GINT_TO_POINTER(1));
     }
 
     arkime_free_later(hash, (GDestroyNotify) g_hash_table_destroy);
@@ -1717,7 +1717,7 @@ LOCAL void *dns_getcb_query_type(const ArkimeSession_t *session, int UNUSED(pos)
     HASH_FORALL2(o_, *ohash, object) {
         const DNS_t *dns = (DNS_t *)object->object;
         if (dns->query.type)
-            g_hash_table_insert(hash, dns->query.type, (void *)1LL);
+            g_hash_table_insert(hash, dns->query.type, GINT_TO_POINTER(1));
     }
 
     arkime_free_later(hash, (GDestroyNotify) g_hash_table_destroy);
@@ -1737,7 +1737,7 @@ LOCAL void *dns_getcb_query_class(const ArkimeSession_t *session, int UNUSED(pos
     HASH_FORALL2(o_, *ohash, object) {
         const DNS_t *dns = (DNS_t *)object->object;
         if (dns->query.class)
-            g_hash_table_insert(hash, dns->query.class, (void *)1LL);
+            g_hash_table_insert(hash, dns->query.class, GINT_TO_POINTER(1));
     }
 
     arkime_free_later(hash, (GDestroyNotify) g_hash_table_destroy);
@@ -1756,7 +1756,7 @@ LOCAL void *dns_getcb_query_host(const ArkimeSession_t *session, int UNUSED(pos)
 
     HASH_FORALL2(o_, *ohash, object) {
         const DNS_t *dns = (DNS_t *)object->object;
-        g_hash_table_insert(hash, dns->query.hostname, (void *)1LL);
+        g_hash_table_insert(hash, dns->query.hostname, GINT_TO_POINTER(1));
     }
 
     arkime_free_later(hash, (GDestroyNotify) g_hash_table_destroy);

--- a/capture/plugins/tagger.c
+++ b/capture/plugins/tagger.c
@@ -716,7 +716,7 @@ void arkime_plugin_init()
     dstIpField         = arkime_field_by_exp("ip.dst");
 
     /* Call right away sync, and schedule every 60 seconds async */
-    tagger_fetch_files((gpointer)1);
+    tagger_fetch_files(GINT_TO_POINTER(1));
     g_timeout_add_seconds(60, tagger_fetch_files, 0);
 
 }

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -507,7 +507,7 @@ LOCAL gboolean reader_libpcapfile_read()
         if (!config.dryRun && !config.copyPcap) {
             // Make sure the output file has been opened otherwise we can't update the entry
             while (lastPacketsBatched > 0 && (offlineInfo[readerPos].outputId == 0 || arkime_http_queue_length_best(esServer) > 0)) {
-                g_main_context_iteration(NULL, TRUE);
+                g_main_context_iteration(NULL, FALSE);
             }
             arkime_db_update_file(offlineInfo[readerPos].outputId, lastBytes, lastBytes, lastPackets, &lastPacketTime);
         }
@@ -533,7 +533,7 @@ LOCAL void reader_libpcapfile_opened()
 
     if (config.flushBetween) {
         arkime_session_flush();
-        g_main_context_iteration(NULL, TRUE);
+        g_main_context_iteration(NULL, FALSE);
         int rc[4];
 
         // Pause until all packets and commands are done
@@ -542,7 +542,7 @@ LOCAL void reader_libpcapfile_opened()
                 LOG("Waiting next file %d %d %d %d", rc[0], rc[1], rc[2], rc[3]);
             }
             usleep(5000);
-            g_main_context_iteration(NULL, TRUE);
+            g_main_context_iteration(NULL, FALSE);
         }
     }
 

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -34,7 +34,7 @@ LOCAL char *yaml_names[] = {
 #endif
 
 
-#define YAML_NODE_SEQUENCE_VALUE (char *)1
+#define YAML_NODE_SEQUENCE_VALUE GINT_TO_POINTER(1)
 typedef struct {
     char      *key;
     char      *value;
@@ -123,7 +123,7 @@ LOCAL void arkime_rules_parser_free_node(YamlNode_t *node)
 {
     if (node->key)
         g_free(node->key);
-    if (node->value > YAML_NODE_SEQUENCE_VALUE)
+    if (node->value != YAML_NODE_SEQUENCE_VALUE)
         g_free(node->value);
     if (node->values)
         g_ptr_array_free(node->values, TRUE);

--- a/capture/session.c
+++ b/capture/session.c
@@ -367,7 +367,7 @@ LOCAL void arkime_session_free (ArkimeSession_t *session)
     }
     g_array_free(session->fileNumArray, TRUE);
 
-    if (session->rootId && session->rootId != (void *)1L)
+    if (session->rootId && session->rootId != GINT_TO_POINTER(1))
         g_free(session->rootId);
 
     if (session->parserInfo) {
@@ -452,7 +452,7 @@ void arkime_session_mid_save(ArkimeSession_t *session, uint32_t tv_sec)
         arkime_plugins_cb_pre_save(session, FALSE);
 
     if (!session->rootId) {
-        session->rootId = (void *)1L;
+        session->rootId = GINT_TO_POINTER(1);
     }
 
     arkime_rules_run_before_save(session, 0);


### PR DESCRIPTION
new version of cppcheck didn't like how we were converting int to pointers

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
