### PR TITLE
fix another lua mem leak (fixes #3297)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,7 +41,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3307 Added garland timestamp plugin
 ## Capture
   - #3294 Improved dhcpv6 parser and ja4d display
-  - #3297 Fix lua memory leaks
+  - #3297, #3321 Fix lua memory leaks
   - #3298 Fix dns encoding issues with answers
   - #3299 Handle more than 255 ciphers with ja4
   - #3305 added basic ip AH protocol support

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -1031,7 +1031,7 @@ void arkime_parsers_classifier_register_tcp_internal(const char *name, void *uw,
     if (config.debug > 1) {
         char hex[1000];
         arkime_sprint_hex_string(hex, match, matchlen);
-        LOG("adding %s matchlen:%d offset:%d match %s (0x%s)", name, matchlen, offset, match, hex);
+        LOG("adding %s matchlen:%d offset:%d match %.*s (0x%s)", name, matchlen, offset, matchlen, match, hex);
     }
     if (matchlen == 0 || offset != 0) {
         arkime_parsers_classifier_add(&classifersTcp0, c);

--- a/capture/plugins/lua/session.c
+++ b/capture/plugins/lua/session.c
@@ -399,6 +399,8 @@ LOCAL void molua_save(ArkimeSession_t *session, int final)
         }
     }
 
+    mp = session->pluginData[molua_pluginIndex];
+
     if (final && mp) {
         if (mp->table) {
             luaL_unref(Ls[session->thread], LUA_REGISTRYINDEX, mp->table);


### PR DESCRIPTION
Session table wasn't being freed if first used during saved calllback itself

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
