### PR TITLE
add BIG search expression typeahead

### DIFF
--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2535,7 +2535,12 @@ class SessionAPIs {
    * @returns {string} The list of unique fields (with counts if requested)
    */
   static getUnique (req, res) {
-    ArkimeUtil.noCache(req, res, 'text/plain; charset=utf-8');
+    if (req.query.autocomplete !== undefined) {
+      // we want a json array returned when providing the autocomplete options in the search typeahead
+      ArkimeUtil.noCache(req, res, 'application/json; charset=utf-8');
+    } else {
+      ArkimeUtil.setCache(req, res, 'text/plain; charset=utf-8');
+    }
 
     // req.query.exp -> req.query.field by viewer.js:expToField
 

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2539,7 +2539,7 @@ class SessionAPIs {
       // we want a json array returned when providing the autocomplete options in the search typeahead
       ArkimeUtil.noCache(req, res, 'application/json; charset=utf-8');
     } else {
-      ArkimeUtil.setCache(req, res, 'text/plain; charset=utf-8');
+      ArkimeUtil.noCache(req, res, 'text/plain; charset=utf-8');
     }
 
     // req.query.exp -> req.query.field by viewer.js:expToField

--- a/viewer/vueapp/src/components/search/ExpressionTypeahead.vue
+++ b/viewer/vueapp/src/components/search/ExpressionTypeahead.vue
@@ -54,24 +54,28 @@ SPDX-License-Identifier: Apache-2.0
       />
       <BButton
         type="button"
+        id="bigTypeaheadBtn"
         @click="bigTypeahead = !bigTypeahead"
         class="btn btn-outline-secondary btn-clear-input">
         <span class="fa" :class="bigTypeahead ? 'fa-compress' : 'fa-expand'"></span>
+        <BTooltip target="bigTypeaheadBtn">
+          Open a large text area for your search expression.
+        </BTooltip>
       </BButton>
       <template v-if="expression && expression.length > 200">
-        <a type="button"
+        <BButton type="button"
           id="longExpression"
           href="settings#shortcuts"
           class="btn btn-outline-secondary btn-clear-input">
           <span class="fa fa-question-circle">
           </span>
-          <BTooltip
-            target="longExpression"
-            placement="bottom"
-            boundary="window">
-            This is a pretty long search expression, maybe you want to create a shortcut? Click here to go to the shortcut creation page.
+          <BTooltip target="longExpression">
+            This is a pretty long search expression! Click here to go to create a Shortcut.
+            <hr>
+            OR Click the
+            <span class="fa fa-expand ms-1 me-1" /> to open a large text area for your search expression.
           </BTooltip>
-        </a>
+        </BButton>
       </template>
       <BButton
         id="saveExpression"
@@ -143,8 +147,7 @@ SPDX-License-Identifier: Apache-2.0
         v-caret-pos="caretPos"
         v-focus="focusTextArea"
         @input="debounceExprChange"
-        @keydown.enter.prevent.stop="enterClick"
-        @keydown.esc.tab.enter.down.up.prevent.stop="keyup($event)"
+        @keydown.enter.prevent.stop="closeBigTypeahead(true)"
       />
       <!-- results dropdown -->
       <TypeaheadResults
@@ -161,7 +164,7 @@ SPDX-License-Identifier: Apache-2.0
       <template #footer>
         <div class="d-flex w-100 justify-content-between">
           <div>
-            <BButton variant="secondary" @click="closeBigTypeahead(false)">Cancel</BButton>
+            <BButton variant="secondary" @click="closeBigTypeahead(false)">Close</BButton>
             <BButton variant="warning" class="ms-2" @click="clearBigTypeahead">Clear</BButton>
           </div>
           <BButton variant="theme-tertiary" @click="closeBigTypeahead(true)">Search</BButton>
@@ -273,13 +276,13 @@ export default {
     closeBigTypeahead: function (apply) {
       this.bigTypeahead = false;
       this.focusTextArea = false;
+      // clear results under the small input when modal closes
+      this.results = [];
       if (apply) {
         this.$emit('applyExpression');
       }
     },
     clearBigTypeahead: function () {
-      this.bigTypeahead = false;
-      this.focusTextArea = false;
       this.clear();
     },
     showBigTypeahead: function () {

--- a/viewer/vueapp/src/components/search/TypeaheadResults.vue
+++ b/viewer/vueapp/src/components/search/TypeaheadResults.vue
@@ -1,0 +1,93 @@
+<template>
+  <div
+    id="typeahead-results"
+    class="dropdown-menu"
+    :class="{'big-typeahead-results': bigTypeahead, 'typeahead-results': !bigTypeahead}"
+    v-show="expression && results && results.length">
+    <template v-if="autocompletingField">
+      <template v-for="(value, key) in fieldHistoryResults" :key="key+'history'">
+        <a :id="key+'history'"
+          class="dropdown-item cursor-pointer"
+          :class="{'active':key === activeIdx,'last-history-item':key === fieldHistoryResults.length-1}"
+          @click="addToQuery(value)">
+          <span class="fa fa-history"></span>&nbsp;
+          <strong v-if="value.exp">{{ value.exp }}</strong>
+          <strong v-if="!value.exp">{{ value }}</strong>
+          <span v-if="value.friendlyName">- {{ value.friendlyName }}</span>
+          <span class="fa fa-close pull-right mt-1"
+            :title="`Remove ${value.exp} from your field history`"
+            @click.stop.prevent="removeFromFieldHistory(value)">
+          </span>
+          <BTooltip v-if="value.help"  :target="key+'history'">
+            {{ value.help.substring(0, 100) }}
+            <span v-if="value.help.length > 100">
+              ...
+            </span>
+          </BTooltip>
+        </a>
+      </template>
+    </template>
+    <template v-for="(value, key) in results" :key="value+'item'">
+      <a :id="key+'item'"
+        class="dropdown-item cursor-pointer"
+        :title="value.help"
+        :class="{'active':key+fieldHistoryResults.length === activeIdx}"
+        @click="addToQuery(value)">
+        <strong v-if="value.exp">{{ value.exp }}</strong>
+        <strong v-if="!value.exp">{{ value }}</strong>
+        <span v-if="value.friendlyName">- {{ value.friendlyName }}</span>
+        <BTooltip v-if="value.help" :target="key+'item'">
+          {{ value.help.substring(0, 100) }}
+          <span v-if="value.help.length > 100">
+            ...
+          </span>
+        </BTooltip>
+      </a>
+    </template>
+  </div> <!-- /results dropdown -->
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+
+const props = defineProps({
+  expression: String,
+  results: Array,
+  activeIdx: Number,
+  fieldHistoryResults: Array,
+  autocompletingField: Boolean,
+  addToQuery: Function,
+  removeFromFieldHistory: Function,
+  bigTypeahead: Boolean
+});
+</script>
+
+<style>
+.typeahead-results {
+  top: initial;
+  left: initial;
+  display: block;
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: 500px;
+  margin-left: 35px;
+}
+.big-typeahead-results {
+  top: initial;
+  left: initial;
+  display: block;
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: 500px;
+}
+
+.typeahead-results a.last-history-item {
+  border-bottom: 1px solid var(--color-gray);
+}
+
+@media screen and (max-height: 600px) {
+  .typeahead-results {
+    max-height: 250px;
+  }
+}
+</style>

--- a/viewer/vueapp/src/components/search/TypeaheadResults.vue
+++ b/viewer/vueapp/src/components/search/TypeaheadResults.vue
@@ -48,7 +48,6 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
 
 const props = defineProps({
   expression: String,


### PR DESCRIPTION
fixes #2948
use modal for text area search expression
make typeahead results a reusable component
also fix field values being interpreted as string in typeahead

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
