### PR TITLE
exit in python mode faster

### DIFF
--- a/capture/packet.c
+++ b/capture/packet.c
@@ -178,6 +178,19 @@ void arkime_packet_process_data(ArkimeSession_t *session, const uint8_t *data, i
 /******************************************************************************/
 void arkime_packet_thread_wake(int thread)
 {
+    if (thread >= config.packetThreads) {
+        LOGEXIT("ERROR - arkime_packet_thread_wake called with invalid thread %d", thread);
+    }
+
+    if (thread < 0) {
+        for (thread = 0; thread < config.packetThreads; thread++) {
+            ARKIME_LOCK(packetQ[thread].lock);
+            ARKIME_COND_SIGNAL(packetQ[thread].lock);
+            ARKIME_UNLOCK(packetQ[thread].lock);
+        }
+        return;
+    }
+
     ARKIME_LOCK(packetQ[thread].lock);
     ARKIME_COND_SIGNAL(packetQ[thread].lock);
     ARKIME_UNLOCK(packetQ[thread].lock);

--- a/capture/python.c
+++ b/capture/python.c
@@ -1507,6 +1507,10 @@ void arkime_python_exit()
         return;
     }
 
+    if (config.debug)
+        LOG("Exiting Python");
+    arkime_packet_thread_wake(-1);
+
     while (threads > 0) {
         if (config.debug > 1)
             LOG("Waiting for %d Python threads to exit", threads);


### PR DESCRIPTION
When in python mode exiting was taking an extra second because of packet thread cond wait timeout, now python exit tries to wake the threads
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
