### PR TITLE
Sctp 1

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -509,7 +509,7 @@ typedef struct {
 #define ARKIME_WHICH_IS_CLIENT(_w) ((_w & 1) == 0)
 #define ARKIME_WHICH_IS_SERVER(_w) ((_w & 1) == 1)
 #define ARKIME_WHICH_GET_ID(_w) ((_w >> 8) & 0xffff)
-#define ARKIME_WHICH_SET_ID(_w, _id) ((_w & 0xffff00) | (_id << 8))
+#define ARKIME_WHICH_SET_ID(_w, _id) ((_w & 0x1) | (_id << 8))
 
 #define ARKIME_PARSER_UNREGISTER -1
 typedef int  (* ArkimeParserFunc) (struct arkime_session *session, void *uw, const uint8_t *data, int remaining, int which);
@@ -650,19 +650,16 @@ typedef struct arkime_sctp_data {
     uint32_t                 len;
     int                      which;
     uint32_t                 tsn;
+    uint16_t                 protoId;
+    uint8_t                  flags;
 } ArkimeSctpData_t;
-/******************************************************************************/
-typedef struct {
-    uint16_t                ssn[2];
-    uint16_t                id;
-} ArkimeSCTPStream_t;
 /******************************************************************************/
 typedef struct arkime_sctp {
     struct arkime_sctp_data *sd_next, *sd_prev;
     int                      sd_count;
     GPtrArray               *streams;
     uint32_t                 tsn[2];
-    uint32_t                 initTag;
+    uint32_t                 initTag[2];
 } ArkimeSCTP_t;
 /******************************************************************************/
 /*
@@ -1077,8 +1074,8 @@ void  arkime_parsers_classifier_register_tcp_internal(const char *name, void *uw
 void  arkime_parsers_classifier_register_udp_internal(const char *name, void *uw, int offset, const uint8_t *match, int matchlen, ArkimeClassifyFunc func, size_t sessionsize, int apiversion);
 #define arkime_parsers_classifier_register_udp(name, uw, offset, match, matchlen, func) arkime_parsers_classifier_register_udp_internal(name, uw, offset, match, matchlen, func, sizeof(ArkimeSession_t), ARKIME_API_VERSION)
 
-void  arkime_parsers_classifier_register_sctp_protocol_internal(const char *name, uint32_t protocol, int matchlen, ArkimeClassifyFunc func, size_t sessionsize, int apiversion);
-#define arkime_parsers_classifier_register_sctp_protocol(name, protocol, func) arkime_parsers_classifier_register_sctp_protocol_internal(name, protocol, func, sizeof(ArkimeSession_t), ARKIME_API_VERSION)
+void  arkime_parsers_classifier_register_sctp_protocol_internal(const char *name, void *uw, uint32_t protocol, ArkimeClassifyFunc func, size_t sessionsize, int apiversion);
+#define arkime_parsers_classifier_register_sctp_protocol(name, uw, protocol, func) arkime_parsers_classifier_register_sctp_protocol_internal(name, uw, protocol, func, sizeof(ArkimeSession_t), ARKIME_API_VERSION)
 
 void  arkime_parsers_classifier_register_sctp_internal(const char *name, void *uw, int offset, const uint8_t *match, int matchlen, ArkimeClassifyFunc func, size_t sessionsize, int apiversion);
 #define arkime_parsers_classifier_register_sctp(name, uw, offset, match, matchlen, func) arkime_parsers_classifier_register_sctp_internal(name, uw, offset, match, matchlen, func, sizeof(ArkimeSession_t), ARKIME_API_VERSION)

--- a/capture/db.c
+++ b/capture/db.c
@@ -834,28 +834,28 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
                            "\"srcZero\":%d,"
                            "\"dstZero\":%d"
                            "},",
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_SYN],
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK],
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_ACK],
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_PSH],
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_FIN],
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_RST],
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_URG],
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_SRC_ZERO],
-                           session->tcpFlagCnt[ARKIME_TCPFLAG_DST_ZERO]
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN],
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK],
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_ACK],
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_PSH],
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_FIN],
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_RST],
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_URG],
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SRC_ZERO],
+                           session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_DST_ZERO]
                           );
 
-        if (session->synTime && session->ackTime) {
-            BSB_EXPORT_sprintf(jbsb, "\"initRTT\":%u,", ((session->ackTime - session->synTime) / 2));
+        if (session->tcpData.synTime && session->tcpData.ackTime) {
+            BSB_EXPORT_sprintf(jbsb, "\"initRTT\":%u,", ((session->tcpData.ackTime - session->tcpData.synTime) / 2));
         }
 
-        if (session->synTime || session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]) {
+        if (session->tcpData.synTime || session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]) {
             BSB_EXPORT_cstr(jbsb, "\"tcpseq\":{");
-            if (session->synTime) {
-                BSB_EXPORT_sprintf(jbsb, "\"src\":%u,", session->synSeq[0]);
+            if (session->tcpData.synTime) {
+                BSB_EXPORT_sprintf(jbsb, "\"src\":%u,", session->tcpData.synSeq[0]);
             }
-            if (session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]) {
-                BSB_EXPORT_sprintf(jbsb, "\"dst\":%u", session->synSeq[1]);
+            if (session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]) {
+                BSB_EXPORT_sprintf(jbsb, "\"dst\":%u", session->tcpData.synSeq[1]);
             } else {
                 BSB_EXPORT_rewind(jbsb, 1); // Remove src comma
             }

--- a/capture/dll.h
+++ b/capture/dll.h
@@ -101,8 +101,13 @@
            (element) != (void *)(head); \
            (element)=(element)->name##next)
 
-#define DLL_FOREACH_REMOVABLE(name,head,element, temp) \
+#define DLL_FOREACH_REMOVABLE(name,head,element,temp) \
       for ((element) = (head)->name##next, (temp) = (element)->name##next; \
+           (element) != (void *)(head); \
+           (element) = (temp), (temp) = (temp)->name##next)
+
+#define DLL_FOREACH_REMOVABLE_START(name,head,element,temp) \
+      for ((temp) = (element)->name##next; \
            (element) != (void *)(head); \
            (element) = (temp), (temp) = (temp)->name##next)
 

--- a/capture/field.c
+++ b/capture/field.c
@@ -1830,37 +1830,37 @@ LOCAL void *arkime_field_getcb_dst_port(const ArkimeSession_t *session, int UNUS
 /******************************************************************************/
 LOCAL void *arkime_field_getcb_tcpflags_syn(const ArkimeSession_t *session, int UNUSED(pos))
 {
-    return (void *)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_SYN];
+    return (void *)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN];
 }
 /******************************************************************************/
 LOCAL void *arkime_field_getcb_tcpflags_syn_ack(const ArkimeSession_t *session, int UNUSED(pos))
 {
-    return (void *)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK];
+    return (void *)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK];
 }
 /******************************************************************************/
 LOCAL void *arkime_field_getcb_tcpflags_ack(const ArkimeSession_t *session, int UNUSED(pos))
 {
-    return (void *)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_ACK];
+    return (void *)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_ACK];
 }
 /******************************************************************************/
 LOCAL void *arkime_field_getcb_tcpflags_psh(const ArkimeSession_t *session, int UNUSED(pos))
 {
-    return (void *)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_PSH];
+    return (void *)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_PSH];
 }
 /******************************************************************************/
 LOCAL void *arkime_field_getcb_tcpflags_rst(const ArkimeSession_t *session, int UNUSED(pos))
 {
-    return (void *)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_RST];
+    return (void *)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_RST];
 }
 /******************************************************************************/
 LOCAL void *arkime_field_getcb_tcpflags_fin(const ArkimeSession_t *session, int UNUSED(pos))
 {
-    return (void *)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_FIN];
+    return (void *)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_FIN];
 }
 /******************************************************************************/
 LOCAL void *arkime_field_getcb_tcpflags_urg(const ArkimeSession_t *session, int UNUSED(pos))
 {
-    return (void *)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_URG];
+    return (void *)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_URG];
 }
 /******************************************************************************/
 LOCAL void *arkime_field_getcb_tcp_synSet(const ArkimeSession_t *session, int UNUSED(pos))

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -64,19 +64,18 @@ LOCAL patricia_tree_t       *newipTree6 = 0;
 extern ArkimeFieldOps_t      readerFieldOps[256];
 extern ArkimeSchemeAction_t *schemeActions[256];
 
-LOCAL struct {
+typedef struct {
     union {
         ArkimePacketEnqueue_cb  cb;
         ArkimePacketEnqueue_cb2 cb2;
     };
     void *cbuw;
     int   isCb2;
-} arkimePacketEnqueueCbs[0x100];
-LOCAL int arkimePacketEnqueueCbsCnt = 0;
+} ArkimePacketEnqueue_t;
 
-LOCAL uint8_t udpPortCbs[0x10000];
-LOCAL uint8_t ethernetCbs[0x10000];
-LOCAL uint8_t ipCbs[ARKIME_IPPROTO_MAX];
+LOCAL ArkimePacketEnqueue_t *udpPortCbs[0x10000];
+LOCAL ArkimePacketEnqueue_t *ethernetCbs[0x10000];
+LOCAL ArkimePacketEnqueue_t *ipCbs[ARKIME_IPPROTO_MAX];
 
 int                          tcpMProtocol;
 int                          udpMProtocol;
@@ -874,12 +873,12 @@ LOCAL void arkime_packet_cmd_stats(int UNUSED(argc), char **UNUSED(argv), gpoint
     arkime_command_respond(cc, output, BSB_LENGTH(bsb));
 }
 /******************************************************************************/
-LOCAL ArkimePacketRC arkime_packet_call_enqueue(const int pos, ArkimePacketBatch_t *batch, ArkimePacket_t *const packet, const uint8_t *data, int len)
+LOCAL ArkimePacketRC arkime_packet_call_enqueue(const ArkimePacketEnqueue_t *cb, ArkimePacketBatch_t *batch, ArkimePacket_t *const packet, const uint8_t *data, int len)
 {
-    if (arkimePacketEnqueueCbs[pos].isCb2)
-        return arkimePacketEnqueueCbs[pos].cb2(batch, packet, data, len, arkimePacketEnqueueCbs[pos].cbuw);
+    if (cb->isCb2)
+        return cb->cb2(batch, packet, data, len, cb->cbuw);
     else
-        return arkimePacketEnqueueCbs[pos].cb(batch, packet, data, len);
+        return cb->cb(batch, packet, data, len);
 }
 /******************************************************************************/
 SUPPRESS_ALIGNMENT
@@ -1006,9 +1005,8 @@ LOCAL ArkimePacketRC arkime_packet_ip4(ArkimePacketBatch_t *batch, ArkimePacket_
 
         udphdr = (struct udphdr *)((char *)ip4 + ip_hdr_len);
 
-        int pos;
-        if (len > ip_hdr_len + (int)sizeof(struct udphdr) + 8 && (pos = udpPortCbs[udphdr->uh_dport])) {
-            int rc = arkime_packet_call_enqueue(pos, batch, packet, (uint8_t *)ip4 + ip_hdr_len + sizeof(struct udphdr *), len - ip_hdr_len - sizeof(struct udphdr *));
+        if (len > ip_hdr_len + (int)sizeof(struct udphdr) + 8 && udpPortCbs[udphdr->uh_dport]) {
+            int rc = arkime_packet_call_enqueue(udpPortCbs[udphdr->uh_dport], batch, packet, (uint8_t *)ip4 + ip_hdr_len + sizeof(struct udphdr *), len - ip_hdr_len - sizeof(struct udphdr *));
             if (rc != ARKIME_PACKET_UNKNOWN)
                 return rc;
 
@@ -1187,9 +1185,8 @@ LOCAL ArkimePacketRC arkime_packet_ip6(ArkimePacketBatch_t *batch, ArkimePacket_
             arkime_session_id6(sessionId, ip6->ip6_src.s6_addr, udphdr->uh_sport,
                                ip6->ip6_dst.s6_addr, udphdr->uh_dport, packet->vlan, packet->vni);
 
-            int pos;
-            if (len > ip_hdr_len + (int)sizeof(struct udphdr) + 8 && (pos = udpPortCbs[udphdr->uh_dport])) {
-                int rc = arkime_packet_call_enqueue(pos, batch, packet, (uint8_t *)udphdr + sizeof(struct udphdr *), len - ip_hdr_len - sizeof(struct udphdr *));
+            if (len > ip_hdr_len + (int)sizeof(struct udphdr) + 8 && udpPortCbs[udphdr->uh_dport]) {
+                int rc = arkime_packet_call_enqueue(udpPortCbs[udphdr->uh_dport], batch, packet, (uint8_t *)udphdr + sizeof(struct udphdr *), len - ip_hdr_len - sizeof(struct udphdr *));
                 if (rc != ARKIME_PACKET_UNKNOWN)
                     return rc;
 
@@ -1667,13 +1664,12 @@ ArkimePacketRC arkime_packet_run_ethernet_cb(ArkimePacketBatch_t *batch, ArkimeP
         len -= 2;
     }
 
-    int pos;
-    if ((pos = ethernetCbs[type])) {
-        return arkime_packet_call_enqueue(pos, batch, packet, data, len);
+    if ( ethernetCbs[type]) {
+        return arkime_packet_call_enqueue(ethernetCbs[type], batch, packet, data, len);
     }
 
-    if ((pos = ethernetCbs[ARKIME_ETHERTYPE_UNKNOWN])) {
-        return arkime_packet_call_enqueue(pos, batch, packet, data, len);
+    if (ethernetCbs[ARKIME_ETHERTYPE_UNKNOWN]) {
+        return arkime_packet_call_enqueue(ethernetCbs[ARKIME_ETHERTYPE_UNKNOWN], batch, packet, data, len);
     }
 
     if (config.logUnknownProtocols)
@@ -1682,26 +1678,20 @@ ArkimePacketRC arkime_packet_run_ethernet_cb(ArkimePacketBatch_t *batch, ArkimeP
     return ARKIME_PACKET_UNKNOWN;
 }
 /******************************************************************************/
-LOCAL int arkime_packet_set_enqueue_cb(ArkimePacketEnqueue_cb enqueueCb)
+LOCAL ArkimePacketEnqueue_t *arkime_packet_set_enqueue_cb(ArkimePacketEnqueue_cb enqueueCb)
 {
-    if (arkimePacketEnqueueCbsCnt >= 0xff)
-        LOGEXIT ("ERROR - Too many enqueue callbacks defined");
-    // Don't use 0
-    arkimePacketEnqueueCbsCnt++;
-    arkimePacketEnqueueCbs[arkimePacketEnqueueCbsCnt].cb = enqueueCb;
-    return arkimePacketEnqueueCbsCnt;
+    ArkimePacketEnqueue_t *cb = ARKIME_TYPE_ALLOC0(ArkimePacketEnqueue_t);
+    cb->cb = enqueueCb;
+    return cb;
 }
 /******************************************************************************/
-LOCAL int arkime_packet_set_enqueue_cb2(ArkimePacketEnqueue_cb2 enqueueCb, void *cbuw)
+LOCAL ArkimePacketEnqueue_t *arkime_packet_set_enqueue_cb2(ArkimePacketEnqueue_cb2 enqueueCb, void *cbuw)
 {
-    if (arkimePacketEnqueueCbsCnt >= 0xff)
-        LOGEXIT ("ERROR - Too many enqueue callbacks defined");
-    // Don't use 0
-    arkimePacketEnqueueCbsCnt++;
-    arkimePacketEnqueueCbs[arkimePacketEnqueueCbsCnt].cb2 = enqueueCb;
-    arkimePacketEnqueueCbs[arkimePacketEnqueueCbsCnt].cbuw = cbuw;
-    arkimePacketEnqueueCbs[arkimePacketEnqueueCbsCnt].isCb2 = 1;
-    return arkimePacketEnqueueCbsCnt;
+    ArkimePacketEnqueue_t *cb = ARKIME_TYPE_ALLOC0(ArkimePacketEnqueue_t);
+    cb->cb2 = enqueueCb;
+    cb->cbuw = cbuw;
+    cb->isCb2 = 1;
+    return cb;
 }
 /******************************************************************************/
 void arkime_packet_set_ethernet_cb2(uint16_t type, ArkimePacketEnqueue_cb2 enqueueCb, void *cbuw)
@@ -1730,13 +1720,12 @@ ArkimePacketRC arkime_packet_run_ip_cb(ArkimePacketBatch_t *batch, ArkimePacket_
         return ARKIME_PACKET_CORRUPT;
     }
 
-    int pos;
-    if ((pos = ipCbs[type])) {
-        return arkimePacketEnqueueCbs[pos].cb(batch, packet, data, len);
+    if (ipCbs[type]) {
+        return arkime_packet_call_enqueue(ipCbs[type], batch, packet, data, len);
     }
 
-    if ((pos = ipCbs[ARKIME_IPPROTO_UNKNOWN])) {
-        return arkimePacketEnqueueCbs[pos].cb(batch, packet, data, len);
+    if (ipCbs[ARKIME_IPPROTO_UNKNOWN]) {
+        return arkime_packet_call_enqueue(ipCbs[ARKIME_IPPROTO_UNKNOWN], batch, packet, data, len);
     }
 
     if (config.logUnknownProtocols)
@@ -2311,4 +2300,9 @@ int arkime_mprotocol_register_internal(const char                      *name,
     mProtocols[num].process = process;
     mProtocols[num].sFree = sFree;
     return num;
+}
+/******************************************************************************/
+void arkime_mprotocol_set_mid_save(int mprotocol, ArkimeProtocolSessionMidSave_cb midSave)
+{
+    mProtocols[mprotocol].midSave = midSave;
 }

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -1163,6 +1163,32 @@ void arkime_parsers_classifier_register_sctp_internal(const char *name, void *uw
     }
 }
 /******************************************************************************/
+void arkime_parsers_classifier_register_sctp_protocol_internal(const char *name, void *uw, uint32_t protocol, ArkimeClassifyFunc func, size_t sessionsize, int apiversion)
+{
+    if (sizeof(ArkimeSession_t) != sessionsize) {
+        CONFIGEXIT("Parser '%s' built with different version of arkime.h\n %u != %u", name, (unsigned int)sizeof(ArkimeSession_t),  (unsigned int)sessionsize);
+    }
+
+    if (ARKIME_API_VERSION != apiversion) {
+        CONFIGEXIT("Parser '%s' built with different version of arkime.h\n %d %d", name, ARKIME_API_VERSION, apiversion);
+    }
+
+    if (protocol > 255) {
+        CONFIGEXIT("Parser '%s' protocol must be 0-255", name);
+    }
+
+    ArkimeClassify_t *c = ARKIME_TYPE_ALLOC0(ArkimeClassify_t);
+    c->name     = name;
+    c->uw       = uw;
+    c->func     = func;
+
+    if (config.debug > 1) {
+        LOG("adding %s protocol:%d", name, protocol);
+    }
+
+    arkime_parsers_classifier_add(&classifersSctpProtocol[protocol], c);
+}
+/******************************************************************************/
 void arkime_parsers_classify_udp(ArkimeSession_t *session, const uint8_t *data, int remaining, int which)
 {
     int i;

--- a/capture/parsers/sctp.c
+++ b/capture/parsers/sctp.c
@@ -11,30 +11,42 @@
 #include <arpa/inet.h>
 #include <errno.h>
 
+#define SCTP_DATA_FLAG_E 0x01  /* End bit */
+#define SCTP_DATA_FLAG_B 0x02  /* Beginning bit */
+#define SCTP_DATA_FLAG_U 0x04  /* Unordered bit */
+#define SCTP_DATA_FLAG_I 0x08  /* Immediate SACK bit */
+
+struct sctphdr {
+    uint16_t sctp_sport;
+    uint16_t sctp_dport;
+    uint32_t sctp_verification_tag;
+    uint32_t sctp_checksum;
+} __attribute__((__packed__));
 
 /******************************************************************************/
 extern ArkimeConfig_t        config;
 
 LOCAL  int                   sctpMProtocol;
+LOCAL int                    sctp_raw_packet_func;
 /******************************************************************************/
 SUPPRESS_ALIGNMENT
 LOCAL ArkimePacketRC sctp_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), ArkimePacket_t *const packet, const uint8_t *UNUSED(data), int UNUSED(len))
 {
-    uint8_t              sessionId[ARKIME_SESSIONID_LEN];
-    const struct udphdr *udphdr = (struct udphdr *)(packet->pkt + packet->payloadOffset); /* Not really udp, but port in same location */
+    uint8_t               sessionId[ARKIME_SESSIONID_LEN];
+    const struct sctphdr *sctphdr = (struct sctphdr *)(packet->pkt + packet->payloadOffset);
 
-    if (packet->payloadLen < (int)sizeof(struct udphdr))
+    if (packet->payloadLen < (int)sizeof(struct sctphdr))
         return ARKIME_PACKET_CORRUPT;
 
     if (packet->v6) {
         const struct ip6_hdr *ip6 = (struct ip6_hdr *)(packet->pkt + packet->ipOffset);
-        arkime_session_id6(sessionId, ip6->ip6_src.s6_addr, udphdr->uh_sport,
-                           ip6->ip6_dst.s6_addr, udphdr->uh_dport,
+        arkime_session_id6(sessionId, ip6->ip6_src.s6_addr, sctphdr->sctp_sport,
+                           ip6->ip6_dst.s6_addr, sctphdr->sctp_dport,
                            packet->vlan, packet->vni);
     } else {
         const struct ip *ip4 = (struct ip *)(packet->pkt + packet->ipOffset);
-        arkime_session_id(sessionId, ip4->ip_src.s_addr, udphdr->uh_sport,
-                          ip4->ip_dst.s_addr, udphdr->uh_dport, packet->vlan, packet->vni);
+        arkime_session_id(sessionId, ip4->ip_src.s_addr, sctphdr->sctp_sport,
+                          ip4->ip_dst.s_addr, sctphdr->sctp_dport, packet->vlan, packet->vni);
     }
     packet->mProtocol = sctpMProtocol;
     packet->hash = arkime_session_hash(sessionId);
@@ -44,17 +56,17 @@ LOCAL ArkimePacketRC sctp_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), Ark
 SUPPRESS_ALIGNMENT
 LOCAL void sctp_create_sessionid(uint8_t *sessionId, ArkimePacket_t *packet)
 {
-    const struct udphdr    *udphdr = (struct udphdr *)(packet->pkt + packet->payloadOffset); /* Not really udp, but port in same location */
+    const struct sctphdr    *sctphdr = (struct sctphdr *)(packet->pkt + packet->payloadOffset);
 
     if (packet->v6) {
         const struct ip6_hdr *ip6 = (struct ip6_hdr *)(packet->pkt + packet->ipOffset);
-        arkime_session_id6(sessionId, ip6->ip6_src.s6_addr, udphdr->uh_sport,
-                           ip6->ip6_dst.s6_addr, udphdr->uh_dport,
+        arkime_session_id6(sessionId, ip6->ip6_src.s6_addr, sctphdr->sctp_sport,
+                           ip6->ip6_dst.s6_addr, sctphdr->sctp_dport,
                            packet->vlan, packet->vni);
     } else {
         const struct ip *ip4 = (struct ip *)(packet->pkt + packet->ipOffset);
-        arkime_session_id(sessionId, ip4->ip_src.s_addr, udphdr->uh_sport,
-                          ip4->ip_dst.s_addr, udphdr->uh_dport, packet->vlan, packet->vni);
+        arkime_session_id(sessionId, ip4->ip_src.s_addr, sctphdr->sctp_sport,
+                          ip4->ip_dst.s_addr, sctphdr->sctp_dport, packet->vlan, packet->vni);
     }
 }
 /******************************************************************************/
@@ -63,10 +75,10 @@ LOCAL int sctp_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packe
 {
     const struct ip        *ip4 = (struct ip *)(packet->pkt + packet->ipOffset);
     const struct ip6_hdr   *ip6 = (struct ip6_hdr *)(packet->pkt + packet->ipOffset);
-    const struct udphdr    *udphdr = (struct udphdr *)(packet->pkt + packet->payloadOffset);
+    const struct sctphdr    *sctphdr = (struct sctphdr *)(packet->pkt + packet->payloadOffset);
     if (isNewSession) {
-        session->port1 = ntohs(udphdr->uh_sport);
-        session->port2 = ntohs(udphdr->uh_dport);
+        session->port1 = ntohs(sctphdr->sctp_sport);
+        session->port2 = ntohs(sctphdr->sctp_dport);
         arkime_session_add_protocol(session, "sctp");
     }
 
@@ -80,20 +92,174 @@ LOCAL int sctp_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packe
     }
 
     packet->direction = (dir &&
-                         session->port1 == ntohs(udphdr->uh_sport) &&
-                         session->port2 == ntohs(udphdr->uh_dport)) ? 0 : 1;
+                         session->port1 == ntohs(sctphdr->sctp_sport) &&
+                         session->port2 == ntohs(sctphdr->sctp_dport)) ? 0 : 1;
     session->databytes[packet->direction] += (packet->pktlen - 8);
 
     return 0;
 }
 /******************************************************************************/
+SUPPRESS_ALIGNMENT
+LOCAL int sctp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *const packet)
+{
+    const struct sctphdr    *sctphdr = (struct sctphdr *)(packet->pkt + packet->payloadOffset);
+
+    BSB bsb;
+    BSB_INIT(bsb, packet->pkt + packet->payloadOffset + sizeof(struct sctphdr), packet->payloadLen - sizeof(struct sctphdr));
+
+    while (BSB_REMAINING(bsb) >= 4) {
+        int chunkType = 0, chunkFlags = 0, chunkLen = 0;
+        BSB_IMPORT_u08(bsb, chunkType);
+        BSB_IMPORT_u08(bsb, chunkFlags);
+        BSB_IMPORT_u16(bsb, chunkLen);
+
+        BSB cbsb;
+        BSB_IMPORT_bsb(bsb, cbsb, chunkLen - 4);
+
+        switch (chunkType) {
+        case 0: { // DATA 
+            // DATA chunk
+            uint32_t tsn = 0;
+            uint16_t streamId = 0, streamSeq = 0;
+            uint32_t payloadProtoId = 0;
+
+            BSB_IMPORT_u32(cbsb, tsn);
+            BSB_IMPORT_u16(cbsb, streamId);
+            BSB_IMPORT_u16(cbsb, streamSeq);
+            BSB_IMPORT_u32(cbsb, payloadProtoId);
+
+            LOG("ALW   DATA: tsn: %u (%u) streamId: %u streamSeq: %u payloadProtoId: %u", tsn, session->sctpData.tsn[packet->direction], streamId, streamSeq, payloadProtoId);
+
+            // Only reset the initial TSN if we haven't set it before in each direction
+            if ((session->synSet & (1 << packet->direction)) == 0) {
+                session->sctpData.tsn[packet->direction] = tsn;
+                session->synSet |= (1 << packet->direction);
+            }
+
+            if (tsn == session->sctpData.tsn[packet->direction]) {
+                LOG("ALW     In order packet");
+                session->sctpData.tsn[packet->direction]++;
+
+                if (session->firstBytesLen[packet->direction] == 0) {
+                    session->firstBytesLen[packet->direction] = MIN(8, BSB_REMAINING(cbsb));
+                    memcpy(session->firstBytes[packet->direction], BSB_WORK_PTR(cbsb), session->firstBytesLen[packet->direction]);
+                    arkime_parsers_classify_sctp(session, BSB_WORK_PTR(cbsb), BSB_REMAINING(cbsb), ARKIME_WHICH_SET_ID(packet->direction, streamId));
+                }
+
+                arkime_packet_process_data(session, BSB_WORK_PTR(cbsb), BSB_REMAINING(cbsb), ARKIME_WHICH_SET_ID(packet->direction, streamId));
+            } else if (tsn < session->sctpData.tsn[packet->direction]) {
+                LOG("ALW     Duplicate packet");
+            } else {
+                // Out of order or duplicate packet
+                LOG("ALW     Out of order or duplicate packet, expected %u got %u", session->sctpData.tsn[packet->direction], tsn);
+            }
+            break;
+
+        }
+        case 1: { // INIT
+            uint32_t initTag = 0;
+            uint32_t a_rwnd = 0;
+            uint16_t numOutStreams = 0, numInStreams = 0;
+            uint32_t tsn = 0;
+            arkime_print_hex_string(BSB_WORK_PTR(cbsb), 4);
+            BSB_IMPORT_u32(cbsb, initTag);
+            BSB_IMPORT_u32(cbsb, a_rwnd);
+            BSB_IMPORT_u16(cbsb, numOutStreams);
+            BSB_IMPORT_u16(cbsb, numInStreams);
+            BSB_IMPORT_u32(cbsb, tsn);
+
+            LOG("ALW   INIT: initTag: %x a_rwnd: %u numOutStreams: %u numInStreams: %u tsn: %u",
+                initTag, a_rwnd, numOutStreams, numInStreams, tsn);
+
+            session->sctpData.tsn[packet->direction] = tsn;
+            session->synSet |= (1 << packet->direction);
+            break;
+        }
+        case 2: { // INIT ACK
+            uint32_t initTag = 0;
+            uint32_t a_rwnd = 0;
+            uint16_t numOutStreams = 0, numInStreams = 0;
+            uint32_t tsn = 0;
+            BSB_IMPORT_u32(cbsb, initTag);
+            BSB_IMPORT_u32(cbsb, a_rwnd);
+            BSB_IMPORT_u16(cbsb, numOutStreams);
+            BSB_IMPORT_u16(cbsb, numInStreams);
+            BSB_IMPORT_u32(cbsb, tsn);
+
+            LOG("ALW   INIT ACK: initTag: %u a_rwnd: %u numOutStreams: %u numInStreams: %u tsn: %u",
+                initTag, a_rwnd, numOutStreams, numInStreams, tsn);
+
+            session->sctpData.tsn[packet->direction] = tsn;
+            session->synSet |= (1 << packet->direction);
+            break;
+        }
+        case 3: { // SACK
+            uint32_t cumTSNAck = 0;
+            uint32_t a_rwnd = 0;
+            uint16_t numGapBlocks = 0, numDupTSNs = 0;
+            BSB_IMPORT_u32(cbsb, cumTSNAck);
+            BSB_IMPORT_u32(cbsb, a_rwnd);
+            BSB_IMPORT_u16(cbsb, numGapBlocks);
+            BSB_IMPORT_u16(cbsb, numDupTSNs);
+
+            LOG("ALW   SACK: cumTSNAck: %u a_rwnd: %u numGapBlocks: %u numDupTSNs: %u",
+                cumTSNAck, a_rwnd, numGapBlocks, numDupTSNs);
+            break;
+        }
+        case 7: { // SHUTDOWN
+            uint32_t cumTSNAck = 0;
+            BSB_IMPORT_u32(cbsb, cumTSNAck);
+            LOG("ALW   SHUTDOWN: cumTSNAck: %u", cumTSNAck);
+            break;
+        }
+        case 8: { // SHUTDOWN ACK
+            uint32_t cumTSNAck = 0;
+            BSB_IMPORT_u32(cbsb, cumTSNAck);
+            LOG("ALW   SHUTDOWN ACK: cumTSNAck: %u", cumTSNAck);
+            break;
+        }
+        case 9: { // SHUTDOWN COMPLETE
+            LOG("ALW   SHUTDOWN COMPLETE");
+            break;
+        }
+        case 10: { // COOKIE ECHO
+            uint32_t cookieLen = 0;
+            uint8_t *cookie = NULL;
+            BSB_IMPORT_u32(cbsb, cookieLen);
+            BSB_IMPORT_ptr(cbsb, cookie, cookieLen);
+            LOG("ALW   COOKIE ECHO: cookieLen: %u", cookieLen);
+            break;
+        }
+        case 11: { // COOKIE ACK
+            uint32_t reserved = 0;
+            BSB_IMPORT_u32(cbsb, reserved);
+            LOG("ALW   COOKIE ACK: reserved: %u", reserved);
+            break;
+        }
+        } /* switch */
+    }
+
+    return 0;
+}
+/******************************************************************************/
+LOCAL int sctp_process(ArkimeSession_t *session, ArkimePacket_t *const packet)
+{
+    int freePacket = sctp_packet_process(session, packet);
+    if (ARKIME_PARSERS_HAS_NAMED_FUNC(sctp_raw_packet_func)) {
+        arkime_parsers_call_named_func(sctp_raw_packet_func, session, NULL, 0, packet);
+    }
+    return freePacket;
+}
+/******************************************************************************/
 void arkime_parser_init()
 {
+    sctp_raw_packet_func = arkime_parsers_get_named_func("sctp_raw_packet");
+
     arkime_packet_set_ip_cb(IPPROTO_SCTP, sctp_packet_enqueue);
     sctpMProtocol = arkime_mprotocol_register("sctp",
                                               SESSION_SCTP,
                                               sctp_create_sessionid,
                                               sctp_pre_process,
-                                              NULL,
+                                              sctp_process,
                                               NULL);
 }

--- a/capture/parsers/tcp.c
+++ b/capture/parsers/tcp.c
@@ -188,7 +188,7 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
             if (session->tcpData.synTime == 0) {
                 session->tcpData.synSeq[0] = seq;
                 session->tcpData.synTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000 +
-                                   (packet->ts.tv_usec - session->firstPacket.tv_usec) / 1000 + 1;
+                                           (packet->ts.tv_usec - session->firstPacket.tv_usec) / 1000 + 1;
                 session->tcpData.ackTime = 0;
             }
         }
@@ -231,7 +231,7 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
         ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsAckField, (gpointer)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_ACK]);
         if (session->tcpData.ackTime == 0) {
             session->tcpData.ackTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000 +
-                               (packet->ts.tv_usec - session->firstPacket.tv_usec) / 1000 + 1;
+                                       (packet->ts.tv_usec - session->firstPacket.tv_usec) / 1000 + 1;
         }
     }
 

--- a/capture/parsers/tcp.c
+++ b/capture/parsers/tcp.c
@@ -35,9 +35,16 @@ LOCAL int tcpflagsFinField;
 LOCAL int tcpflagsUrgField;
 
 /******************************************************************************/
+LOCAL void tcp_mid_save(ArkimeSession_t *session)
+{
+    session->tcpData.ackTime = 0;
+    session->tcpData.synTime = 0;
+    memset(session->tcpData.tcpFlagCnt, 0, sizeof(session->tcpData.tcpFlagCnt));
+}
+/******************************************************************************/
 LOCAL void tcp_session_free(ArkimeSession_t *session)
 {
-    if (session->tcpData.td_count == 1 && session->tcpFlagCnt[ARKIME_TCPFLAG_PSH] == 1) {
+    if (session->tcpData.td_count == 1 && session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_PSH] == 1) {
         ArkimeTcpData_t *ftd = DLL_PEEK_HEAD(td_, &session->tcpData);
         const int which = ftd->packet->direction;
         const uint8_t *data = ftd->packet->pkt + ftd->dataOffset;
@@ -83,7 +90,7 @@ LOCAL void tcp_packet_finish(ArkimeSession_t *session)
 
     DLL_FOREACH_REMOVABLE(td_, tcpData, ftd, next) {
         const int which = ftd->packet->direction;
-        const uint32_t tcpSeq = session->tcpSeq[which];
+        const uint32_t tcpSeq = session->tcpData.tcpSeq[which];
 
         /* The sequence number we are looking for is past the start of the packet */
         if (tcpSeq >= ftd->seq) {
@@ -112,7 +119,7 @@ LOCAL void tcp_packet_finish(ArkimeSession_t *session)
             }
 
             arkime_packet_process_data(session, data, len, which);
-            session->tcpSeq[which] += len;
+            session->tcpData.tcpSeq[which] += len;
             session->databytes[which] += len;
             session->totalDatabytes[which] += len;
 
@@ -147,15 +154,15 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
 #endif
 
     if (tcphdr->th_win == 0 && (tcphdr->th_flags & TH_RST) == 0) {
-        session->tcpFlagCnt[ARKIME_TCPFLAG_SRC_ZERO + packet->direction]++;
+        session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SRC_ZERO + packet->direction]++;
     }
 
     if (len < 0)
         return 1;
 
     if (tcphdr->th_flags & TH_URG) {
-        session->tcpFlagCnt[ARKIME_TCPFLAG_URG]++;
-        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsUrgField, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_URG]);
+        session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_URG]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsUrgField, (gpointer)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_URG]);
     }
 
     // add to the long open
@@ -165,24 +172,24 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
 
     if (tcphdr->th_flags & TH_SYN) {
         if (tcphdr->th_flags & TH_ACK) {
-            session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]++;
-            ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsSynAckField, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]);
+            session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]++;
+            ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsSynAckField, (gpointer)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK]);
 
             if (!session->haveTcpSession) {
 #ifdef DEBUG_TCP
                 LOG("syn-ack first");
 #endif
-                session->tcpSeq[(packet->direction + 1) % 2] = ntohl(tcphdr->th_ack);
-                session->synSeq[1] = seq;
+                session->tcpData.tcpSeq[(packet->direction + 1) % 2] = ntohl(tcphdr->th_ack);
+                session->tcpData.synSeq[1] = seq;
             }
         } else {
-            session->tcpFlagCnt[ARKIME_TCPFLAG_SYN]++;
-            ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsSynField, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_SYN]);
-            if (session->synTime == 0) {
-                session->synSeq[0] = seq;
-                session->synTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000 +
+            session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN]++;
+            ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsSynField, (gpointer)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN]);
+            if (session->tcpData.synTime == 0) {
+                session->tcpData.synSeq[0] = seq;
+                session->tcpData.synTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000 +
                                    (packet->ts.tv_usec - session->firstPacket.tv_usec) / 1000 + 1;
-                session->ackTime = 0;
+                session->tcpData.ackTime = 0;
             }
         }
 
@@ -190,16 +197,16 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
 
         // Only reset the initial SYN if we haven't set it before in each direction
         if ((session->synSet & (1 << packet->direction)) == 0) {
-            session->tcpSeq[packet->direction] = seq + 1;
+            session->tcpData.tcpSeq[packet->direction] = seq + 1;
             session->synSet |= (1 << packet->direction);
         }
         return 1;
     }
 
     if (tcphdr->th_flags & TH_RST) {
-        session->tcpFlagCnt[ARKIME_TCPFLAG_RST]++;
-        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsRstField, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_RST]);
-        int64_t diff = tcp_sequence_diff(seq, session->tcpSeq[packet->direction]);
+        session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_RST]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsRstField, (gpointer)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_RST]);
+        int64_t diff = tcp_sequence_diff(seq, session->tcpData.tcpSeq[packet->direction]);
         if (diff  <= 0) {
             if (diff == 0 && !session->closingQ) {
                 arkime_session_mark_for_close(session, SESSION_TCP);
@@ -207,39 +214,39 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
             return 1;
         }
 
-        session->tcpState[packet->direction] = ARKIME_TCP_STATE_FIN_ACK;
+        session->tcpData.tcpState[packet->direction] = ARKIME_TCP_STATE_FIN_ACK;
     }
 
     if (tcphdr->th_flags & TH_FIN) {
-        session->tcpFlagCnt[ARKIME_TCPFLAG_FIN]++;
-        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsFinField, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_FIN]);
-        session->tcpState[packet->direction] = ARKIME_TCP_STATE_FIN;
+        session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_FIN]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsFinField, (gpointer)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_FIN]);
+        session->tcpData.tcpState[packet->direction] = ARKIME_TCP_STATE_FIN;
     }
 
     if ((tcphdr->th_flags & (TH_FIN | TH_RST | TH_PUSH | TH_SYN | TH_ACK)) == TH_ACK) {
-        session->tcpFlagCnt[ARKIME_TCPFLAG_ACK]++;
+        session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_ACK]++;
         if (session->tcpFlagAckCnt[packet->direction] < 0xff) {
             session->tcpFlagAckCnt[packet->direction]++;
         }
-        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsAckField, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_ACK]);
-        if (session->ackTime == 0) {
-            session->ackTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000 +
+        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsAckField, (gpointer)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_ACK]);
+        if (session->tcpData.ackTime == 0) {
+            session->tcpData.ackTime = (packet->ts.tv_sec - session->firstPacket.tv_sec) * 1000 +
                                (packet->ts.tv_usec - session->firstPacket.tv_usec) / 1000 + 1;
         }
     }
 
     if (tcphdr->th_flags & TH_PUSH) {
-        session->tcpFlagCnt[ARKIME_TCPFLAG_PSH]++;
-        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsPshField, (gpointer)(long)session->tcpFlagCnt[ARKIME_TCPFLAG_PSH]);
+        session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_PSH]++;
+        ARKIME_RULES_RUN_FIELD_SET(session, tcpflagsPshField, (gpointer)(long)session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_PSH]);
     }
 
     if (session->stopTCP)
         return 1;
 
     // If we've seen SYN but no SYN_ACK and no tcpSeq set, then just assume we've missed the syn-ack
-    if (session->haveTcpSession && session->tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK] == 0 && session->tcpSeq[packet->direction] == 0) {
+    if (session->haveTcpSession && session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN_ACK] == 0 && session->tcpData.tcpSeq[packet->direction] == 0) {
         arkime_session_add_tag(session, "no-syn-ack");
-        session->tcpSeq[packet->direction] = seq;
+        session->tcpData.tcpSeq[packet->direction] = seq;
     }
 
     ArkimeTcpDataHead_t *const tcpData = &session->tcpData;
@@ -253,9 +260,9 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
 
     if (tcphdr->th_flags & (TH_ACK | TH_RST)) {
         int owhich = (packet->direction + 1) & 1;
-        if (session->tcpState[owhich] == ARKIME_TCP_STATE_FIN) {
-            session->tcpState[owhich] = ARKIME_TCP_STATE_FIN_ACK;
-            if (session->tcpState[packet->direction] == ARKIME_TCP_STATE_FIN_ACK) {
+        if (session->tcpData.tcpState[owhich] == ARKIME_TCP_STATE_FIN) {
+            session->tcpData.tcpState[owhich] = ARKIME_TCP_STATE_FIN_ACK;
+            if (session->tcpData.tcpState[packet->direction] == ARKIME_TCP_STATE_FIN_ACK) {
 
                 if (!session->closingQ) {
                     arkime_session_mark_for_close(session, SESSION_TCP);
@@ -268,8 +275,8 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
     if (tcphdr->th_flags & TH_ACK) {
         if (session->haveTcpSession &&  // Seen a SYN
             (session->ackedUnseenSegment & (1 << packet->direction)) == 0 &&  // Haven't already tagged
-            session->tcpSeq[(packet->direction + 1) % 2] != 0 &&                  // The syn-ack isn't what is missing
-            (tcp_sequence_diff(session->tcpSeq[(packet->direction + 1) % 2], ntohl(tcphdr->th_ack)) > 1)) { // more then one byte missing
+            session->tcpData.tcpSeq[(packet->direction + 1) % 2] != 0 &&                  // The syn-ack isn't what is missing
+            (tcp_sequence_diff(session->tcpData.tcpSeq[(packet->direction + 1) % 2], ntohl(tcphdr->th_ack)) > 1)) { // more then one byte missing
 
             static const char *tags[2] = {"acked-unseen-segment-src", "acked-unseen-segment-dst"};
             arkime_session_add_tag(session, tags[packet->direction]);
@@ -282,7 +289,7 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
         return 1;
 
     // This packet is before what we are processing
-    int64_t diff = tcp_sequence_diff(session->tcpSeq[packet->direction], seq + len);
+    int64_t diff = tcp_sequence_diff(session->tcpData.tcpSeq[packet->direction], seq + len);
     if (session->haveTcpSession && diff <= 0)
         return 1;
 
@@ -378,11 +385,13 @@ LOCAL int tcp_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packet
 
     // If this is an old session that hash RSTs and we get a syn, probably a port reuse, close old session
     if (!isNewSession && (tcphdr->th_flags & TH_SYN) && ((tcphdr->th_flags & TH_ACK) == 0) &&
-        (session->tcpFlagCnt[ARKIME_TCPFLAG_RST] || session->tcpFlagCnt[ARKIME_TCPFLAG_FIN])) {
+        (session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_RST] || session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_FIN])) {
         return 1;
     }
 
     if (isNewSession) {
+        DLL_INIT(td_, &session->tcpData);
+
         /* if the syn-ack was captured first then the syn probably got dropped.*/
         if ((tcphdr->th_flags & TH_SYN) && (tcphdr->th_flags & TH_ACK)) {
             struct in6_addr tmp;
@@ -443,6 +452,8 @@ void arkime_parser_init()
                                              tcp_pre_process,
                                              tcp_process,
                                              tcp_session_free);
+
+    arkime_mprotocol_set_mid_save(tcpMProtocol, tcp_mid_save);
 
     tcpflagsSynField = arkime_field_by_exp("tcpflags.syn");
     tcpflagsSynAckField = arkime_field_by_exp("tcpflags.syn-ack");

--- a/capture/parsers/udp.c
+++ b/capture/parsers/udp.c
@@ -87,19 +87,7 @@ LOCAL int udp_process(ArkimeSession_t *session, ArkimePacket_t *const packet)
         }
     }
 
-    int i;
-    for (i = 0; i < session->parserNum; i++) {
-        if (session->parserInfo[i].parserFunc) {
-            int consumed = session->parserInfo[i].parserFunc(session, session->parserInfo[i].uw, data, len, packet->direction);
-            if (consumed == ARKIME_PARSER_UNREGISTER) {
-                if (session->parserInfo[i].parserFreeFunc) {
-                    session->parserInfo[i].parserFreeFunc(session, session->parserInfo[i].uw);
-                }
-                memset(&session->parserInfo[i], 0, sizeof(session->parserInfo[i]));
-                continue;
-            }
-        }
-    }
+    arkime_packet_process_data(session, data, len, packet->direction);
 
     if (pluginsCbs & ARKIME_PLUGIN_UDP)
         arkime_plugins_cb_udp(session, data, len, packet->direction);

--- a/capture/session.c
+++ b/capture/session.c
@@ -577,9 +577,10 @@ void arkime_session_mid_save(ArkimeSession_t *session, uint32_t tv_sec)
     session->packets[0] = 0;
     session->packets[1] = 0;
     session->midSave = 0;
-    session->ackTime = 0;
-    session->synTime = 0;
-    memset(session->tcpFlagCnt, 0, sizeof(session->tcpFlagCnt));
+
+
+    if (mProtocols[session->mProtocol].midSave)
+        mProtocols[session->mProtocol].midSave(session);
 }
 /******************************************************************************/
 gboolean arkime_session_decr_outstanding(ArkimeSession_t *session)
@@ -836,7 +837,6 @@ ArkimeSession_t *arkime_session_find_or_create(int mProtocol, uint32_t hash, uin
     session->fields = ARKIME_SIZE_ALLOC0(fields, sizeof(ArkimeField_t *) * config.maxDbField);
     session->maxFields = config.maxDbField;
     session->thread = thread;
-    DLL_INIT(td_, &session->tcpData);
     if (config.numPlugins > 0)
         session->pluginData = ARKIME_SIZE_ALLOC0(pluginData, sizeof(void *) * config.numPlugins);
 

--- a/tests/pcap/sctp-www.test
+++ b/tests/pcap/sctp-www.test
@@ -30,6 +30,7 @@
                "Extreme Networks, Inc."
             ],
             "dstOuiCnt" : 1,
+            "dstPayload8" : "485454502f312e31",
             "dstRIR" : "APNIC",
             "dstTTL" : [
                59
@@ -38,6 +39,61 @@
             "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1137034844756,
+            "http" : {
+               "clientVersion" : [
+                  "1.1"
+               ],
+               "clientVersionCnt" : 1,
+               "host" : [
+                  "203.255.252.194"
+               ],
+               "hostCnt" : 1,
+               "method" : [
+                  "GET"
+               ],
+               "method-GET" : 1,
+               "methodCnt" : 1,
+               "path" : [
+                  "/"
+               ],
+               "pathCnt" : 1,
+               "requestHeader" : [
+                  "accept",
+                  "accept-charset",
+                  "accept-encoding",
+                  "accept-language",
+                  "connection",
+                  "host",
+                  "keep-alive",
+                  "user-agent"
+               ],
+               "requestHeaderCnt" : 8,
+               "requestHeaderField" : [
+                  "accept",
+                  "accept-charset",
+                  "accept-encoding",
+                  "accept-language",
+                  "connection",
+                  "keep-alive"
+               ],
+               "requestHeaderValue" : [
+                  "300",
+                  "euc-kr,utf-8;q=0.7,*;q=0.7",
+                  "gzip,deflate",
+                  "keep-alive",
+                  "ko,en-us;q=0.7,en;q=0.3",
+                  "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+               ],
+               "requestHeaderValueCnt" : 6,
+               "uri" : [
+                  "203.255.252.194/"
+               ],
+               "uriCnt" : 1,
+               "useragent" : [
+                  "Mozilla/5.0 (X11; U; Linux i686; ko-KR; rv:1.7.12) Gecko/20051007 Debian/1.7.12-1"
+               ],
+               "useragentCnt" : 1
+            },
             "ipProtocol" : 132,
             "lastPacket" : 1137034859213,
             "length" : 14458,
@@ -138,9 +194,10 @@
                48926
             ],
             "protocol" : [
+               "http",
                "sctp"
             ],
-            "protocolCnt" : 1,
+            "protocolCnt" : 2,
             "segmentCnt" : 1,
             "server" : {
                "bytes" : 22296
@@ -169,6 +226,7 @@
                "Edimax Technology Co. Ltd."
             ],
             "srcOuiCnt" : 1,
+            "srcPayload8" : "474554202f204854",
             "srcRIR" : "ARIN",
             "srcTTL" : [
                64
@@ -212,6 +270,7 @@
                "Extreme Networks, Inc."
             ],
             "dstOuiCnt" : 1,
+            "dstPayload8" : "485454502f312e31",
             "dstRIR" : "APNIC",
             "dstTTL" : [
                59
@@ -220,6 +279,66 @@
             "ethertype" : 2048,
             "fileId" : [],
             "firstPacket" : 1137034844891,
+            "http" : {
+               "clientVersion" : [
+                  "1.1"
+               ],
+               "clientVersionCnt" : 1,
+               "host" : [
+                  "203.255.252.194"
+               ],
+               "hostCnt" : 1,
+               "method" : [
+                  "GET"
+               ],
+               "method-GET" : 1,
+               "methodCnt" : 1,
+               "path" : [
+                  "/images/protocols_small.gif"
+               ],
+               "pathCnt" : 1,
+               "request-referer" : [
+                  "http://203.255.252.194/"
+               ],
+               "request-refererCnt" : 1,
+               "requestHeader" : [
+                  "accept",
+                  "accept-charset",
+                  "accept-encoding",
+                  "accept-language",
+                  "connection",
+                  "host",
+                  "keep-alive",
+                  "referer",
+                  "user-agent"
+               ],
+               "requestHeaderCnt" : 9,
+               "requestHeaderField" : [
+                  "accept",
+                  "accept-charset",
+                  "accept-encoding",
+                  "accept-language",
+                  "connection",
+                  "keep-alive"
+               ],
+               "requestHeaderValue" : [
+                  "300",
+                  "euc-kr,utf-8;q=0.7,*;q=0.7",
+                  "gzip,deflate",
+                  "image/png,*/*;q=0.5",
+                  "keep-alive",
+                  "ko,en-us;q=0.7,en;q=0.3"
+               ],
+               "requestHeaderValueCnt" : 6,
+               "uri" : [
+                  "203.255.252.194/images/protocols_small.gif"
+               ],
+               "uriCnt" : 1,
+               "useragent" : [
+                  "Mozilla/5.0 (X11; U; Linux i686; ko-KR; rv:1.7.12) Gecko/20051007 Debian/1.7.12-1"
+               ],
+               "useragentCnt" : 1
+            },
             "ipProtocol" : 132,
             "lastPacket" : 1137034859213,
             "length" : 14322,
@@ -310,9 +429,10 @@
                48784
             ],
             "protocol" : [
+               "http",
                "sctp"
             ],
-            "protocolCnt" : 1,
+            "protocolCnt" : 2,
             "segmentCnt" : 1,
             "server" : {
                "bytes" : 20618
@@ -341,6 +461,7 @@
                "Edimax Technology Co. Ltd."
             ],
             "srcOuiCnt" : 1,
+            "srcPayload8" : "474554202f696d61",
             "srcRIR" : "ARIN",
             "srcTTL" : [
                64

--- a/tests/pcap/sctp-www.test
+++ b/tests/pcap/sctp-www.test
@@ -40,6 +40,11 @@
             "fileId" : [],
             "firstPacket" : 1137034844756,
             "http" : {
+               "bodyMagic" : [
+                  "image/gif",
+                  "text/html"
+               ],
+               "bodyMagicCnt" : 2,
                "clientVersion" : [
                   "1.1"
                ],
@@ -48,15 +53,25 @@
                   "203.255.252.194"
                ],
                "hostCnt" : 1,
+               "md5" : [
+                  "d9aeaef2a3e33b942a39ea143b3b189f",
+                  "f76bc7cf1dd6d93781bff70acafb41e2"
+               ],
+               "md5Cnt" : 2,
                "method" : [
                   "GET"
                ],
-               "method-GET" : 1,
+               "method-GET" : 2,
                "methodCnt" : 1,
                "path" : [
-                  "/"
+                  "/",
+                  "/images/CPL@KOREN_logo_menu.gif"
                ],
-               "pathCnt" : 1,
+               "pathCnt" : 2,
+               "request-referer" : [
+                  "http://203.255.252.194/"
+               ],
+               "request-refererCnt" : 1,
                "requestHeader" : [
                   "accept",
                   "accept-charset",
@@ -65,30 +80,110 @@
                   "connection",
                   "host",
                   "keep-alive",
+                  "referer",
                   "user-agent"
                ],
-               "requestHeaderCnt" : 8,
+               "requestHeaderCnt" : 9,
                "requestHeaderField" : [
                   "accept",
+                  "accept",
+                  "accept-charset",
                   "accept-charset",
                   "accept-encoding",
+                  "accept-encoding",
+                  "accept-language",
                   "accept-language",
                   "connection",
+                  "connection",
+                  "keep-alive",
                   "keep-alive"
                ],
                "requestHeaderValue" : [
                   "300",
+                  "300",
+                  "euc-kr,utf-8;q=0.7,*;q=0.7",
                   "euc-kr,utf-8;q=0.7,*;q=0.7",
                   "gzip,deflate",
+                  "gzip,deflate",
+                  "image/png,*/*;q=0.5",
                   "keep-alive",
+                  "keep-alive",
+                  "ko,en-us;q=0.7,en;q=0.3",
                   "ko,en-us;q=0.7,en;q=0.3",
                   "text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
                ],
-               "requestHeaderValueCnt" : 6,
-               "uri" : [
-                  "203.255.252.194/"
+               "requestHeaderValueCnt" : 12,
+               "responseHeader" : [
+                  "accept-ranges",
+                  "connection",
+                  "content-length",
+                  "content-type",
+                  "date",
+                  "etag",
+                  "keep-alive",
+                  "last-modified",
+                  "server"
                ],
-               "uriCnt" : 1,
+               "responseHeaderCnt" : 9,
+               "responseHeaderField" : [
+                  "accept-ranges",
+                  "accept-ranges",
+                  "connection",
+                  "connection",
+                  "content-length",
+                  "content-length",
+                  "content-type",
+                  "content-type",
+                  "date",
+                  "date",
+                  "etag",
+                  "etag",
+                  "keep-alive",
+                  "keep-alive",
+                  "last-modified",
+                  "last-modified",
+                  "server",
+                  "server"
+               ],
+               "responseHeaderValue" : [
+                  "\"420324-1d3e-f63e5d00\"",
+                  "\"420331-3200-f62f1ac0\"",
+                  "12800",
+                  "7486",
+                  "apache/2.0.54 (unix) dav/2 php/4.4.1",
+                  "apache/2.0.54 (unix) dav/2 php/4.4.1",
+                  "bytes",
+                  "bytes",
+                  "image/gif",
+                  "keep-alive",
+                  "keep-alive",
+                  "text/html",
+                  "thu, 05 jan 2006 02:05:07 gmt",
+                  "thu, 05 jan 2006 02:05:08 gmt",
+                  "thu, 12 jan 2006 02:58:00 gmt",
+                  "thu, 12 jan 2006 02:58:00 gmt",
+                  "timeout=15, max=100",
+                  "timeout=15, max=99"
+               ],
+               "responseHeaderValueCnt" : 18,
+               "serverVersion" : [
+                  "1.1"
+               ],
+               "serverVersionCnt" : 1,
+               "sha256" : [
+                  "bd3b81027a56f15fca1a445f40e94c15bd344c6b7f42f8951a06fa37a5a7d07d",
+                  "c5547e55aa988e6b0321c3fb8454aed751b9e05f4a5c328c6dd2469df43593bc"
+               ],
+               "sha256Cnt" : 2,
+               "statuscode" : [
+                  200
+               ],
+               "statuscodeCnt" : 1,
+               "uri" : [
+                  "203.255.252.194/",
+                  "203.255.252.194/images/CPL@KOREN_logo_menu.gif"
+               ],
+               "uriCnt" : 2,
                "useragent" : [
                   "Mozilla/5.0 (X11; U; Linux i686; ko-KR; rv:1.7.12) Gecko/20051007 Debian/1.7.12-1"
                ],
@@ -280,6 +375,10 @@
             "fileId" : [],
             "firstPacket" : 1137034844891,
             "http" : {
+               "bodyMagic" : [
+                  "image/gif"
+               ],
+               "bodyMagicCnt" : 1,
                "clientVersion" : [
                   "1.1"
                ],
@@ -288,6 +387,10 @@
                   "203.255.252.194"
                ],
                "hostCnt" : 1,
+               "md5" : [
+                  "bdd01b3ee59470d3ed2d8325a63e490a"
+               ],
+               "md5Cnt" : 1,
                "method" : [
                   "GET"
                ],
@@ -330,6 +433,53 @@
                   "ko,en-us;q=0.7,en;q=0.3"
                ],
                "requestHeaderValueCnt" : 6,
+               "responseHeader" : [
+                  "accept-ranges",
+                  "connection",
+                  "content-length",
+                  "content-type",
+                  "date",
+                  "etag",
+                  "keep-alive",
+                  "last-modified",
+                  "server"
+               ],
+               "responseHeaderCnt" : 9,
+               "responseHeaderField" : [
+                  "accept-ranges",
+                  "connection",
+                  "content-length",
+                  "content-type",
+                  "date",
+                  "etag",
+                  "keep-alive",
+                  "last-modified",
+                  "server"
+               ],
+               "responseHeaderValue" : [
+                  "\"42033b-4a7f-f62f1ac0\"",
+                  "19071",
+                  "apache/2.0.54 (unix) dav/2 php/4.4.1",
+                  "bytes",
+                  "image/gif",
+                  "keep-alive",
+                  "thu, 05 jan 2006 02:05:07 gmt",
+                  "thu, 12 jan 2006 02:58:00 gmt",
+                  "timeout=15, max=100"
+               ],
+               "responseHeaderValueCnt" : 9,
+               "serverVersion" : [
+                  "1.1"
+               ],
+               "serverVersionCnt" : 1,
+               "sha256" : [
+                  "4c5a14835012f9be8e2e3184895c01b9bd0690f3953a3406487ef74ff12acf96"
+               ],
+               "sha256Cnt" : 1,
+               "statuscode" : [
+                  200
+               ],
+               "statuscodeCnt" : 1,
                "uri" : [
                   "203.255.252.194/images/protocols_small.gif"
                ],


### PR DESCRIPTION
* first pass at sctp support
* refactor tcp (saves 8 bytes per session and now lets sctp use same space
* new MidSave mprotocol call to clear non fields between linked sessions
* in callbacks 'which' now also can contain the sctp stream id, so need to use new ARKIME_WHICH macros for direction if sctp is supported
* sctp python stuff

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
