### PR TITLE
If a s3: capture scheme had a path the pcap wouldn't load in viewer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3323, #3328 New db.pl repair implementation that can fix multiple issues
 ## Viewer
   - #3344 Fix parsing quoted arrays in wildcards
+  - #3358 Fixed files created with s3 capture scheme not showing in viewer
+          if not in top level directory
 ## WISE
   - #3339 Elasticsearch source can have paths value shortcuts
 

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -810,6 +810,7 @@ LOCAL SavepcapS3File_t *writer_s3_create(const ArkimePacket_t *packet)
     char              *packetPosEncoding = ARKIME_VAR_ARG_STR_SKIP;
 
     localtime_r(&packet->ts.tv_sec, &tmp);
+    // s3://region/bucket/nodename/XXXX-YYMMDD-XXXX.pcap(.gz|.zst)
     snprintf(filename, sizeof(filename), "s3://%s/%s/%s/#NUMHEX#-%02d%02d%02d-#NUM#.pcap%s", s3Region, s3Bucket, config.nodeName, tmp.tm_year % 100, tmp.tm_mon + 1, tmp.tm_mday, extension[compressionMode]);
 
     SavepcapS3File_t *s3file = ARKIME_TYPE_ALLOC0(SavepcapS3File_t);

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -94,6 +94,8 @@ async function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
       console.log(`File Info for ${fields.node}-${fields.packetPos[0] * -1}`, info);
     }
 
+    // Don't confuse with the s3 capture scheme which will have info.scheme set to s3
+    // s3://region/bucket/nodename/XXXX-YYMMDD-XXXX.pcap(.gz|.zst)
     const parts = splitRemain(info.name, '/', 4);
     info.compressionBlockSize ??= DEFAULT_COMPRESSED_BLOCK_SIZE;
 

--- a/viewer/schemes.js
+++ b/viewer/schemes.js
@@ -104,7 +104,7 @@ async function getBlockS3 (info, pos) {
   const key = `${info.name}:${blockStart}`;
   let block = blocklru.get(key);
   if (!block) {
-    const parts = splitRemain(info.name, '/', 4);
+    const parts = splitRemain(info.name, '/', 3);
 
     const params = {
       Bucket: parts[2],


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
