### PR TITLE
capture/erspan: port full ERSPAN Type II/III metadata parsing + correct VLAN parsing

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -611,6 +611,16 @@ typedef struct arkimepacket_t {
     uint32_t       ipOffset: 11;        // offset to ip header from start
     uint32_t       outerIpOffset: 11;   // offset to outer ip header from start
     uint32_t       vni: 24;             // vxlan id
+    uint16_t       erspan_id;           // ERSPAN Span ID
+    uint16_t       erspan_sgt;          // SGT (Security Group Tag)
+    uint32_t       erspan_port;         // Port_ID/Index (platform specific, if present)
+    uint8_t        erspan_type;         // ERSPAN version/type (2/3), non-zero means erspan was parsed
+    uint8_t        erspan_cos;          // ERSPAN COS marking
+    uint8_t        erspan_ver;          // ERSPAN encapsulation version (from header)
+    uint8_t        erspan_truncated;    // T (truncated) flag (0/1)
+    uint8_t        erspan_dir;          // ERSPAN direction bit
+    uint8_t        erspan_bso;          // BSO (Bad/Short/Oversized) 2-bit value
+    uint8_t        erspan_hw;           // Hardware ID
 } ArkimePacket_t;
 
 typedef struct {

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -38,6 +38,15 @@ int                          vlanField;
 LOCAL int                    dot1qField;
 LOCAL int                    dot1adField;
 int                          vniField;
+LOCAL int                    erspanIdField;
+LOCAL int                    erspanDirField;
+LOCAL int                    erspanCosField;
+LOCAL int                    erspanVerField;
+LOCAL int                    erspanBsoStrField;
+LOCAL int                    erspanTruncatedField;
+LOCAL int                    erspanSgtField;
+LOCAL int                    erspanHwField;
+LOCAL int                    erspanPortField;
 LOCAL int                    oui1Field;
 LOCAL int                    oui2Field;
 LOCAL int                    outermac1Field;
@@ -423,6 +432,35 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
 
         if (packet->vni)
             arkime_field_int_add(vniField, session, packet->vni);
+
+        if (packet->erspan_type) {
+            if (packet->erspan_ver)
+                arkime_field_int_add(erspanVerField, session, packet->erspan_ver);
+            if (packet->erspan_id)
+                arkime_field_int_add(erspanIdField, session, packet->erspan_id);
+            arkime_field_int_add(erspanCosField, session, packet->erspan_cos);
+            if (packet->erspan_truncated)
+                arkime_field_string_add_lower(erspanTruncatedField, session, "true", 4);
+            if (packet->erspan_port)
+                arkime_field_int_add(erspanPortField, session, packet->erspan_port);
+            if (packet->erspan_type == 3) {
+                const char *dir_str = packet->erspan_dir ? "egress" : "ingress";
+                arkime_field_string_add_lower(erspanDirField, session, dir_str, strlen(dir_str));
+                if ((packet->erspan_bso & 0x3) != 0x0) {
+                    const char *bso_str = "unknown";
+                    switch (packet->erspan_bso & 0x3) {
+                    case 0x3: bso_str = "bad"; break;
+                    case 0x1: bso_str = "short"; break;
+                    case 0x2: bso_str = "oversized"; break;
+                    }
+                    arkime_field_string_add_lower(erspanBsoStrField, session, bso_str, strlen(bso_str));
+                }
+                if (packet->erspan_sgt)
+                    arkime_field_int_add(erspanSgtField, session, packet->erspan_sgt);
+                if (packet->erspan_hw)
+                    arkime_field_int_add(erspanHwField, session, packet->erspan_hw);
+            }
+        }
 
         if (packet->etherOffset != 0 && packet->outerEtherOffset != packet->etherOffset) {
             arkime_field_macoui_add(session, outermac1Field, outeroui1Field, packet->pkt + packet->outerEtherOffset);
@@ -1931,6 +1969,60 @@ void arkime_packet_init()
                                    ARKIME_FIELD_TYPE_INT_GHASH,  ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
                                    (char *)NULL);
 
+
+    erspanIdField = arkime_field_define("erspan", "integer",
+                                        "erspan.id", "ERSPAN Span ID", "erspan.spanId",
+                                        "ERSPAN span ID",
+                                        ARKIME_FIELD_TYPE_INT_GHASH, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                        (char *)NULL);
+
+    erspanDirField = arkime_field_define("erspan", "termfield",
+                                         "erspan.direction", "ERSPAN Direction", "erspan.direction",
+                                         "ERSPAN direction (ingress/egress)",
+                                         ARKIME_FIELD_TYPE_STR_HASH, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                         (char *)NULL);
+
+    erspanCosField = arkime_field_define("erspan", "integer",
+                                         "erspan.cos", "ERSPAN COS", "erspan.cos",
+                                         "ERSPAN Class of Service/DSCP",
+                                         ARKIME_FIELD_TYPE_INT_GHASH, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                         (char *)NULL);
+
+    erspanVerField = arkime_field_define("erspan", "integer",
+                                         "erspan.ver", "ERSPAN Version", "erspan.version",
+                                         "ERSPAN encapsulation version",
+                                         ARKIME_FIELD_TYPE_INT_GHASH, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                         (char *)NULL);
+
+    erspanBsoStrField = arkime_field_define("erspan", "termfield",
+                                            "erspan.bso.str", "ERSPAN BSO String", "erspan.bso_str",
+                                            "ERSPAN BSO as text (not set/bad/short/oversized)",
+                                            ARKIME_FIELD_TYPE_STR_HASH, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                            (char *)NULL);
+
+    erspanTruncatedField = arkime_field_define("erspan", "termfield",
+                                               "erspan.truncated", "ERSPAN Truncated", "erspan.truncated",
+                                               "ERSPAN truncated flag (true when packet was truncated)",
+                                               ARKIME_FIELD_TYPE_STR_HASH, ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                               (char *)NULL);
+
+    erspanSgtField = arkime_field_define("erspan", "integer",
+                                         "erspan.sgt", "ERSPAN SGT", "erspan.sgt",
+                                         "ERSPAN Security Group Tag",
+                                         ARKIME_FIELD_TYPE_INT_GHASH, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                         (char *)NULL);
+
+    erspanHwField = arkime_field_define("erspan", "integer",
+                                        "erspan.hw", "ERSPAN Hw ID", "erspan.hw",
+                                        "ERSPAN Hardware ID",
+                                        ARKIME_FIELD_TYPE_INT_GHASH, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                        (char *)NULL);
+
+    erspanPortField = arkime_field_define("erspan", "integer",
+                                          "erspan.port", "ERSPAN Port Index", "erspan.port",
+                                          "ERSPAN platform Port_ID/Index",
+                                          ARKIME_FIELD_TYPE_INT_GHASH, ARKIME_FIELD_FLAG_CNT | ARKIME_FIELD_FLAG_LINKED_SESSIONS,
+                                          (char *)NULL);
 
     outerip1Field = arkime_field_define("general", "ip",
                                         "outerip.src", "Src Outer IP", "srcOuterIp",

--- a/capture/parsers/erspan.c
+++ b/capture/parsers/erspan.c
@@ -18,13 +18,28 @@ LOCAL ArkimePacketRC erspan_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), A
         return ARKIME_PACKET_UNKNOWN_ETHER;
     }
 
-
     BSB bsb;
-
     BSB_INIT(bsb, data, len);
 
-    BSB_IMPORT_u16(bsb, packet->vlan);
-    packet->vlan &= 0xfff; // clear the version bits
+    /* Type II header (8 bytes):
+     * Bytes 0-1: Ver(4) | VLAN(12)
+     * Bytes 2-3: COS(3) | Encap(1) | T(1) | SpanID(10)
+     * Bytes 4-7: Reserved(12) | Index(20)
+     */
+    uint16_t first16 = 0;
+    uint16_t second16 = 0;
+    uint32_t index_word = 0;
+    BSB_IMPORT_u16(bsb, first16);
+    BSB_IMPORT_u16(bsb, second16);
+    BSB_IMPORT_u32(bsb, index_word);
+
+    packet->erspan_ver       = (first16 >> 12) & 0x0f;
+    packet->vlan             = first16 & 0x0fff;
+    packet->erspan_cos       = (second16 >> 13) & 0x07;
+    packet->erspan_truncated = (second16 >> 10) & 0x01;
+    packet->erspan_id        = second16 & 0x03ff;
+    packet->erspan_port      = index_word & 0x000fffff;
+    packet->erspan_type      = 2;
 
     return arkime_packet_run_ethernet_cb(batch, packet, data + 8, len - 8, ARKIME_ETHERTYPE_ETHER, "ERSpan");
 }
@@ -40,24 +55,52 @@ LOCAL ArkimePacketRC erspan_packet_enqueue3(ArkimePacketBatch_t *UNUSED(batch), 
         return ARKIME_PACKET_UNKNOWN_ETHER;
     }
 
-
     BSB bsb;
-
     BSB_INIT(bsb, data, len);
 
-    BSB_IMPORT_u16(bsb, packet->vlan);
-    BSB_IMPORT_skip(bsb, 8);
+    /* Type III header (12 bytes):
+     * Bytes 0-3:  Ver(4) | VLAN(12) | COS(3) | BSO(2) | T(1) | SessionID(10)
+     * Bytes 4-7:  Timestamp(32)
+     * Bytes 8-9:  SGT(16)
+     * Bytes 10-11: P(1) | FT(5) | Hw(6) | D(1) | Gra(2) | O(1)
+     */
+    uint32_t word0 = 0;
+    uint32_t timestamp32 = 0;
+    uint16_t sgt16 = 0;
+    uint16_t flags16 = 0;
+    BSB_IMPORT_u32(bsb, word0);
+    BSB_IMPORT_u32(bsb, timestamp32);
+    BSB_IMPORT_u16(bsb, sgt16);
+    BSB_IMPORT_u16(bsb, flags16);
 
-    uint16_t subheader = 0;
-    BSB_IMPORT_u16(bsb, subheader);
+    (void)timestamp32; // not stored; reserved for future use
 
-    if (subheader & 0x0001) {
+    packet->erspan_ver       = (word0 >> 28) & 0x0f;
+    packet->vlan             = (word0 >> 16) & 0x0fff;
+    packet->erspan_cos       = (word0 >> 13) & 0x07;
+    packet->erspan_bso       = (word0 >> 11) & 0x03;
+    packet->erspan_truncated = (word0 >> 10) & 0x01;
+    packet->erspan_id        = word0 & 0x03ff;
+    packet->erspan_sgt       = sgt16;
+    packet->erspan_hw        = (flags16 >> 4) & 0x3f;
+    packet->erspan_dir       = (flags16 >> 3) & 0x01;
+    packet->erspan_type      = 3;
+
+    /* Optional platform subheader (O bit = bit 0 of flags16) */
+    if ((flags16 & 0x0001) && BSB_REMAINING(bsb) >= 8) {
+        const uint8_t *subhdr = BSB_WORK_PTR(bsb);
+        uint8_t platf_id = (subhdr[0] >> 2) & 0x3f;
+        if (platf_id == 0x1) {
+            packet->erspan_port = (subhdr[4] << 24) | (subhdr[5] << 16) |
+                                  (subhdr[6] << 8)  |  subhdr[7];
+        } else if (platf_id == 0x3) {
+            packet->erspan_port = (subhdr[2] << 8) | subhdr[3];
+        }
         BSB_IMPORT_skip(bsb, 8);
     }
 
-    if (BSB_IS_ERROR(bsb)) {
+    if (BSB_IS_ERROR(bsb))
         return ARKIME_PACKET_CORRUPT;
-    }
 
     return arkime_packet_run_ethernet_cb(batch, packet, BSB_WORK_PTR(bsb), BSB_REMAINING(bsb), ARKIME_ETHERTYPE_ETHER, "ERSpan");
 }

--- a/tests/pcap/gre-erspan-vxlan.test
+++ b/tests/pcap/gre-erspan-vxlan.test
@@ -1,172 +1,190 @@
 {
-   "sessions3" : [
-      {
-         "body" : {
-            "@timestamp" : "SET",
-            "client" : {
-               "bytes" : 30
-            },
-            "destination" : {
-               "bytes" : 489,
-               "ip" : "10.16.27.131",
-               "mac" : [
-                  "aa:bb:cc:dd:cc:c1",
-                  "dd:dd:dd:dd:dd:d1"
-               ],
-               "mac-cnt" : 2,
-               "packets" : 3,
-               "port" : 80
-            },
-            "dstOuterASN" : [
-               "---"
-            ],
-            "dstOuterGEO" : [
-               "---"
-            ],
-            "dstOuterIp" : [
-               "172.16.27.121"
-            ],
-            "dstOuterIpCnt" : 1,
-            "dstOuterMac" : [
-               "ee:ee:ee:ee:ee:e1"
-            ],
-            "dstOuterMac-cnt" : 1,
-            "dstOuterRIR" : [
-               "ARIN"
-            ],
-            "dstPayload8" : "485454502f312e31",
-            "dstTTL" : [
-               64
-            ],
-            "dstTTLCnt" : 1,
-            "ethertype" : 2048,
-            "fileId" : [],
-            "firstPacket" : 1652950005864,
-            "http" : {
-               "md5" : [
-                  "f73d2a4f4331dc56920d51fe6ba8ebc9"
-               ],
-               "md5Cnt" : 1,
-               "serverVersion" : [
-                  "1.1"
-               ],
-               "serverVersionCnt" : 1,
-               "sha256" : [
-                  "37f481d025d06cada595431200f7406b368918401a14fb4d3b4b3777c5ff9a4e"
-               ],
-               "sha256Cnt" : 1,
-               "statuscode" : [
-                  200
-               ],
-               "statuscodeCnt" : 1,
-               "uri" : [
-                  "/Hello"
-               ],
-               "uriCnt" : 1
-            },
-            "initRTT" : 1,
-            "ipProtocol" : 6,
-            "lastPacket" : 1652950005876,
-            "length" : 12,
-            "network" : {
-               "bytes" : 1135,
-               "community_id" : "1:vJGJyvSGPn66/zbr0DiR1fCFooo=",
-               "packets" : 7
-            },
-            "node" : "test",
-            "packetLen" : [
-               170,
-               170,
-               170,
-               200,
-               197,
-               170,
-               170
-            ],
-            "packetPos" : [
-               24,
-               194,
-               364,
-               534,
-               734,
-               931,
-               1101
-            ],
-            "packetRange" : {
-               "gte" : 1652950005864,
-               "lte" : 1652950005876
-            },
-            "protocol" : [
-               "gre",
-               "http",
-               "tcp",
-               "vxlan-gpe"
-            ],
-            "protocolCnt" : 4,
-            "segmentCnt" : 1,
-            "server" : {
-               "bytes" : 27
-            },
-            "source" : {
-               "bytes" : 646,
-               "ip" : "10.16.27.12",
-               "mac" : [
-                  "aa:bb:cc:dd:cc:c1",
-                  "dd:dd:dd:dd:dd:d1"
-               ],
-               "mac-cnt" : 2,
-               "packets" : 4,
-               "port" : 65174
-            },
-            "srcOuterASN" : [
-               "---"
-            ],
-            "srcOuterGEO" : [
-               "---"
-            ],
-            "srcOuterIp" : [
-               "172.16.27.131"
-            ],
-            "srcOuterIpCnt" : 1,
-            "srcOuterMac" : [
-               "ff:dd:ff:ff:ff:f1"
-            ],
-            "srcOuterMac-cnt" : 1,
-            "srcOuterRIR" : [
-               "ARIN"
-            ],
-            "srcPayload8" : "474554202f48656c",
-            "srcTTL" : [
-               64
-            ],
-            "srcTTLCnt" : 1,
-            "tags" : [
-               "gretest-erspan-vxlan"
-            ],
-            "tagsCnt" : 1,
-            "tcpflags" : {
-               "ack" : 2,
-               "dstZero" : 0,
-               "fin" : 2,
-               "psh" : 1,
-               "rst" : 0,
-               "srcZero" : 0,
-               "syn" : 1,
-               "syn-ack" : 1,
-               "urg" : 0
-            },
-            "tcpseq" : {
-               "dst" : 0,
-               "src" : 0
-            },
-            "totDataBytes" : 57
-         },
-         "header" : {
-            "index" : {
-               "_index" : "tests_sessions3-220519"
-            }
-         }
-      }
-   ]
+ "sessions3" : [
+  {
+   "body" : {
+    "@timestamp" : "SET",
+    "client" : {
+     "bytes" : 30
+    },
+    "destination" : {
+     "bytes" : 489,
+     "ip" : "10.16.27.131",
+     "mac" : [
+      "aa:bb:cc:dd:cc:c1",
+      "dd:dd:dd:dd:dd:d1"
+     ],
+     "mac-cnt" : 2,
+     "packets" : 3,
+     "port" : 80
+    },
+    "dstOuterASN" : [
+     "---"
+    ],
+    "dstOuterGEO" : [
+     "---"
+    ],
+    "dstOuterIp" : [
+     "172.16.27.121"
+    ],
+    "dstOuterIpCnt" : 1,
+    "dstOuterMac" : [
+     "ee:ee:ee:ee:ee:e1"
+    ],
+    "dstOuterMac-cnt" : 1,
+    "dstOuterRIR" : [
+     "ARIN"
+    ],
+    "dstPayload8" : "485454502f312e31",
+    "dstTTL" : [
+     64
+    ],
+    "dstTTLCnt" : 1,
+    "erspan" : {
+     "cos" : [
+      0
+     ],
+     "cosCnt" : 1,
+     "port" : [
+      1
+     ],
+     "portCnt" : 1,
+     "spanId" : [
+      20
+     ],
+     "spanIdCnt" : 1,
+     "version" : [
+      1
+     ],
+     "versionCnt" : 1
+    },
+    "ethertype" : 2048,
+    "fileId" : [],
+    "firstPacket" : 1652950005864,
+    "http" : {
+     "md5" : [
+      "f73d2a4f4331dc56920d51fe6ba8ebc9"
+     ],
+     "md5Cnt" : 1,
+     "serverVersion" : [
+      "1.1"
+     ],
+     "serverVersionCnt" : 1,
+     "sha256" : [
+      "37f481d025d06cada595431200f7406b368918401a14fb4d3b4b3777c5ff9a4e"
+     ],
+     "sha256Cnt" : 1,
+     "statuscode" : [
+      200
+     ],
+     "statuscodeCnt" : 1,
+     "uri" : [
+      "/Hello"
+     ],
+     "uriCnt" : 1
+    },
+    "initRTT" : 1,
+    "ipProtocol" : 6,
+    "lastPacket" : 1652950005876,
+    "length" : 12,
+    "network" : {
+     "bytes" : 1135,
+     "community_id" : "1:vJGJyvSGPn66/zbr0DiR1fCFooo=",
+     "packets" : 7
+    },
+    "node" : "test",
+    "packetLen" : [
+     170,
+     170,
+     170,
+     200,
+     197,
+     170,
+     170
+    ],
+    "packetPos" : [
+     24,
+     194,
+     364,
+     534,
+     734,
+     931,
+     1101
+    ],
+    "packetRange" : {
+     "gte" : 1652950005864,
+     "lte" : 1652950005876
+    },
+    "protocol" : [
+     "gre",
+     "http",
+     "tcp",
+     "vxlan-gpe"
+    ],
+    "protocolCnt" : 4,
+    "segmentCnt" : 1,
+    "server" : {
+     "bytes" : 27
+    },
+    "source" : {
+     "bytes" : 646,
+     "ip" : "10.16.27.12",
+     "mac" : [
+      "aa:bb:cc:dd:cc:c1",
+      "dd:dd:dd:dd:dd:d1"
+     ],
+     "mac-cnt" : 2,
+     "packets" : 4,
+     "port" : 65174
+    },
+    "srcOuterASN" : [
+     "---"
+    ],
+    "srcOuterGEO" : [
+     "---"
+    ],
+    "srcOuterIp" : [
+     "172.16.27.131"
+    ],
+    "srcOuterIpCnt" : 1,
+    "srcOuterMac" : [
+     "ff:dd:ff:ff:ff:f1"
+    ],
+    "srcOuterMac-cnt" : 1,
+    "srcOuterRIR" : [
+     "ARIN"
+    ],
+    "srcPayload8" : "474554202f48656c",
+    "srcTTL" : [
+     64
+    ],
+    "srcTTLCnt" : 1,
+    "tags" : [
+     "gretest-erspan-vxlan"
+    ],
+    "tagsCnt" : 1,
+    "tcpflags" : {
+     "ack" : 2,
+     "dstZero" : 0,
+     "fin" : 2,
+     "psh" : 1,
+     "rst" : 0,
+     "srcZero" : 0,
+     "syn" : 1,
+     "syn-ack" : 1,
+     "urg" : 0
+    },
+    "tcpseq" : {
+     "dst" : 0,
+     "src" : 0
+    },
+    "totDataBytes" : 57
+   },
+   "header" : {
+    "index" : {
+     "_index" : "tests_sessions3-220519"
+    }
+   }
+  }
+ ]
 }
 

--- a/tests/pcap/gre-erspan.test
+++ b/tests/pcap/gre-erspan.test
@@ -1,310 +1,328 @@
 {
-   "sessions3" : [
-      {
-         "body" : {
-            "@timestamp" : "SET",
-            "client" : {
-               "bytes" : 0
-            },
-            "destination" : {
-               "as" : {
-                  "full" : "AS13335 Cloudflare, Inc.",
-                  "number" : 13335,
-                  "organization" : {
-                     "name" : "Cloudflare, Inc."
-                  }
-               },
-               "bytes" : 0,
-               "geo" : {
-                  "country_iso_code" : "AU"
-               },
-               "ip" : "1.1.1.1",
-               "mac" : [
-                  "01:00:0c:cc:cc:cc"
-               ],
-               "mac-cnt" : 1,
-               "packets" : 0,
-               "port" : 0
-            },
-            "dot1q" : {
-               "id" : [
-                  23
-               ],
-               "idCnt" : 1
-            },
-            "dstOuterMac" : [
-               "64:00:f1:e2:01:01"
-            ],
-            "dstOuterMac-cnt" : 1,
-            "dstOuterOui" : [
-               "Cisco Systems, Inc"
-            ],
-            "dstOuterOuiCnt" : 1,
-            "dstRIR" : "APNIC",
-            "ethertype" : 2048,
-            "fileId" : [],
-            "firstPacket" : 1402723251625,
-            "ipProtocol" : 47,
-            "lastPacket" : 1402723253149,
-            "length" : 1524,
-            "network" : {
-               "bytes" : 903,
-               "packets" : 2,
-               "vlan" : {
-                  "id" : [
-                     23
-                  ],
-                  "id-cnt" : 1
-               }
-            },
-            "node" : "test",
-            "packetLen" : [
-               460,
-               475
-            ],
-            "packetPos" : [
-               24,
-               484
-            ],
-            "packetRange" : {
-               "gte" : 1402723251625,
-               "lte" : 1402723253149
-            },
-            "protocol" : [
-               "corrupt-ip",
-               "gre"
-            ],
-            "protocolCnt" : 2,
-            "segmentCnt" : 1,
-            "server" : {
-               "bytes" : 0
-            },
-            "source" : {
-               "as" : {
-                  "full" : "AS3215 Orange",
-                  "number" : 3215,
-                  "organization" : {
-                     "name" : "Orange"
-                  }
-               },
-               "bytes" : 903,
-               "geo" : {
-                  "country_iso_code" : "FR"
-               },
-               "ip" : "2.2.2.2",
-               "mac" : [
-                  "64:00:f1:e1:02:02",
-                  "64:00:f1:e1:03:03"
-               ],
-               "mac-cnt" : 2,
-               "packets" : 2,
-               "port" : 0
-            },
-            "srcOui" : [
-               "Cisco Systems, Inc"
-            ],
-            "srcOuiCnt" : 1,
-            "srcOuterMac" : [
-               "64:00:f1:e2:01:12"
-            ],
-            "srcOuterMac-cnt" : 1,
-            "srcOuterOui" : [
-               "Cisco Systems, Inc"
-            ],
-            "srcOuterOuiCnt" : 1,
-            "srcRIR" : "RIPE",
-            "srcTTL" : [
-               254
-            ],
-            "srcTTLCnt" : 1,
-            "tags" : [
-               "gretest-erspan"
-            ],
-            "tagsCnt" : 1,
-            "totDataBytes" : 0
-         },
-         "header" : {
-            "index" : {
-               "_index" : "tests_sessions3-140614"
-            }
-         }
-      },
-      {
-         "body" : {
-            "@timestamp" : "SET",
-            "client" : {
-               "bytes" : 160
-            },
-            "destination" : {
-               "as" : {
-                  "full" : "AS20940 Akamai International B.V.",
-                  "number" : 20940,
-                  "organization" : {
-                     "name" : "Akamai International B.V."
-                  }
-               },
-               "bytes" : 328,
-               "geo" : {
-                  "country_iso_code" : "US"
-               },
-               "ip" : "23.0.0.3",
-               "mac" : [
-                  "64:00:f1:e1:03:03"
-               ],
-               "mac-cnt" : 1,
-               "packets" : 2,
-               "port" : 0
-            },
-            "dot1q" : {
-               "id" : [
-                  23
-               ],
-               "idCnt" : 1
-            },
-            "dstOui" : [
-               "Cisco Systems, Inc"
-            ],
-            "dstOuiCnt" : 1,
-            "dstOuterASN" : [
-               "AS13335 Cloudflare, Inc."
-            ],
-            "dstOuterGEO" : [
-               "AU"
-            ],
-            "dstOuterIp" : [
-               "1.1.1.1"
-            ],
-            "dstOuterIpCnt" : 1,
-            "dstOuterMac" : [
-               "64:00:f1:e2:01:01"
-            ],
-            "dstOuterMac-cnt" : 1,
-            "dstOuterOui" : [
-               "Cisco Systems, Inc"
-            ],
-            "dstOuterOuiCnt" : 1,
-            "dstOuterRIR" : [
-               "APNIC"
-            ],
-            "dstRIR" : "ARIN",
-            "dstTTL" : [
-               255
-            ],
-            "dstTTLCnt" : 1,
-            "ethertype" : 2048,
-            "fileId" : [],
-            "firstPacket" : 1402723255667,
-            "icmp" : {
-               "code" : [
-                  0
-               ],
-               "type" : [
-                  0,
-                  8
-               ]
-            },
-            "ipProtocol" : 1,
-            "lastPacket" : 1402723255669,
-            "length" : 2,
-            "network" : {
-               "bytes" : 656,
-               "community_id" : "1:iF3HTcqmaP2JudVO9Vp3ktkojUY=",
-               "packets" : 4,
-               "vlan" : {
-                  "id" : [
-                     23
-                  ],
-                  "id-cnt" : 1
-               }
-            },
-            "node" : "test",
-            "packetLen" : [
-               180,
-               180,
-               180,
-               180
-            ],
-            "packetPos" : [
-               959,
-               1139,
-               1319,
-               1499
-            ],
-            "packetRange" : {
-               "gte" : 1402723255667,
-               "lte" : 1402723255669
-            },
-            "protocol" : [
-               "gre",
-               "icmp"
-            ],
-            "protocolCnt" : 2,
-            "segmentCnt" : 1,
-            "server" : {
-               "bytes" : 160
-            },
-            "source" : {
-               "as" : {
-                  "full" : "AS20940 Akamai International B.V.",
-                  "number" : 20940,
-                  "organization" : {
-                     "name" : "Akamai International B.V."
-                  }
-               },
-               "bytes" : 328,
-               "geo" : {
-                  "country_iso_code" : "US"
-               },
-               "ip" : "23.0.0.2",
-               "mac" : [
-                  "64:00:f1:e1:02:02"
-               ],
-               "mac-cnt" : 1,
-               "packets" : 2,
-               "port" : 0
-            },
-            "srcOui" : [
-               "Cisco Systems, Inc"
-            ],
-            "srcOuiCnt" : 1,
-            "srcOuterASN" : [
-               "AS3215 Orange"
-            ],
-            "srcOuterGEO" : [
-               "FR"
-            ],
-            "srcOuterIp" : [
-               "2.2.2.2"
-            ],
-            "srcOuterIpCnt" : 1,
-            "srcOuterMac" : [
-               "64:00:f1:e2:01:12"
-            ],
-            "srcOuterMac-cnt" : 1,
-            "srcOuterOui" : [
-               "Cisco Systems, Inc"
-            ],
-            "srcOuterOuiCnt" : 1,
-            "srcOuterRIR" : [
-               "RIPE"
-            ],
-            "srcRIR" : "ARIN",
-            "srcTTL" : [
-               255
-            ],
-            "srcTTLCnt" : 1,
-            "tags" : [
-               "gretest-erspan"
-            ],
-            "tagsCnt" : 1,
-            "totDataBytes" : 320
-         },
-         "header" : {
-            "index" : {
-               "_index" : "tests_sessions3-140614"
-            }
-         }
+ "sessions3" : [
+  {
+   "body" : {
+    "@timestamp" : "SET",
+    "client" : {
+     "bytes" : 0
+    },
+    "destination" : {
+     "as" : {
+      "full" : "AS13335 Cloudflare, Inc.",
+      "number" : 13335,
+      "organization" : {
+       "name" : "Cloudflare, Inc."
       }
-   ]
+     },
+     "bytes" : 0,
+     "ip" : "1.1.1.1",
+     "mac" : [
+      "01:00:0c:cc:cc:cc"
+     ],
+     "mac-cnt" : 1,
+     "packets" : 0,
+     "port" : 0
+    },
+    "dot1q" : {
+     "id" : [
+      23
+     ],
+     "idCnt" : 1
+    },
+    "dstOuterMac" : [
+     "64:00:f1:e2:01:01"
+    ],
+    "dstOuterMac-cnt" : 1,
+    "dstOuterOui" : [
+     "Cisco Systems, Inc"
+    ],
+    "dstOuterOuiCnt" : 1,
+    "dstRIR" : "APNIC",
+    "erspan" : {
+     "cos" : [
+      0
+     ],
+     "cosCnt" : 1,
+     "spanId" : [
+      100
+     ],
+     "spanIdCnt" : 1,
+     "version" : [
+      1
+     ],
+     "versionCnt" : 1
+    },
+    "ethertype" : 2048,
+    "fileId" : [],
+    "firstPacket" : 1402723251625,
+    "ipProtocol" : 47,
+    "lastPacket" : 1402723253149,
+    "length" : 1524,
+    "network" : {
+     "bytes" : 903,
+     "packets" : 2,
+     "vlan" : {
+      "id" : [
+       23
+      ],
+      "id-cnt" : 1
+     }
+    },
+    "node" : "test",
+    "packetLen" : [
+     460,
+     475
+    ],
+    "packetPos" : [
+     24,
+     484
+    ],
+    "packetRange" : {
+     "gte" : 1402723251625,
+     "lte" : 1402723253149
+    },
+    "protocol" : [
+     "corrupt-ip",
+     "gre"
+    ],
+    "protocolCnt" : 2,
+    "segmentCnt" : 1,
+    "server" : {
+     "bytes" : 0
+    },
+    "source" : {
+     "bytes" : 903,
+     "geo" : {
+      "country_iso_code" : "SE"
+     },
+     "ip" : "2.2.2.2",
+     "mac" : [
+      "64:00:f1:e1:02:02",
+      "64:00:f1:e1:03:03"
+     ],
+     "mac-cnt" : 2,
+     "packets" : 2,
+     "port" : 0
+    },
+    "srcOui" : [
+     "Cisco Systems, Inc"
+    ],
+    "srcOuiCnt" : 1,
+    "srcOuterMac" : [
+     "64:00:f1:e2:01:12"
+    ],
+    "srcOuterMac-cnt" : 1,
+    "srcOuterOui" : [
+     "Cisco Systems, Inc"
+    ],
+    "srcOuterOuiCnt" : 1,
+    "srcRIR" : "RIPE",
+    "srcTTL" : [
+     254
+    ],
+    "srcTTLCnt" : 1,
+    "tags" : [
+     "gretest-erspan"
+    ],
+    "tagsCnt" : 1,
+    "totDataBytes" : 0
+   },
+   "header" : {
+    "index" : {
+     "_index" : "tests_sessions3-140614"
+    }
+   }
+  },
+  {
+   "body" : {
+    "@timestamp" : "SET",
+    "client" : {
+     "bytes" : 160
+    },
+    "destination" : {
+     "as" : {
+      "full" : "AS20940 Akamai International B.V.",
+      "number" : 20940,
+      "organization" : {
+       "name" : "Akamai International B.V."
+      }
+     },
+     "bytes" : 328,
+     "geo" : {
+      "country_iso_code" : "US"
+     },
+     "ip" : "23.0.0.3",
+     "mac" : [
+      "64:00:f1:e1:03:03"
+     ],
+     "mac-cnt" : 1,
+     "packets" : 2,
+     "port" : 0
+    },
+    "dot1q" : {
+     "id" : [
+      23
+     ],
+     "idCnt" : 1
+    },
+    "dstOui" : [
+     "Cisco Systems, Inc"
+    ],
+    "dstOuiCnt" : 1,
+    "dstOuterASN" : [
+     "AS13335 Cloudflare, Inc."
+    ],
+    "dstOuterGEO" : [
+     "---"
+    ],
+    "dstOuterIp" : [
+     "1.1.1.1"
+    ],
+    "dstOuterIpCnt" : 1,
+    "dstOuterMac" : [
+     "64:00:f1:e2:01:01"
+    ],
+    "dstOuterMac-cnt" : 1,
+    "dstOuterOui" : [
+     "Cisco Systems, Inc"
+    ],
+    "dstOuterOuiCnt" : 1,
+    "dstOuterRIR" : [
+     "APNIC"
+    ],
+    "dstRIR" : "ARIN",
+    "dstTTL" : [
+     255
+    ],
+    "dstTTLCnt" : 1,
+    "erspan" : {
+     "cos" : [
+      0
+     ],
+     "cosCnt" : 1,
+     "spanId" : [
+      100
+     ],
+     "spanIdCnt" : 1,
+     "version" : [
+      1
+     ],
+     "versionCnt" : 1
+    },
+    "ethertype" : 2048,
+    "fileId" : [],
+    "firstPacket" : 1402723255667,
+    "icmp" : {
+     "code" : [
+      0
+     ],
+     "type" : [
+      0,
+      8
+     ]
+    },
+    "ipProtocol" : 1,
+    "lastPacket" : 1402723255669,
+    "length" : 2,
+    "network" : {
+     "bytes" : 656,
+     "community_id" : "1:iF3HTcqmaP2JudVO9Vp3ktkojUY=",
+     "packets" : 4,
+     "vlan" : {
+      "id" : [
+       23
+      ],
+      "id-cnt" : 1
+     }
+    },
+    "node" : "test",
+    "packetLen" : [
+     180,
+     180,
+     180,
+     180
+    ],
+    "packetPos" : [
+     959,
+     1139,
+     1319,
+     1499
+    ],
+    "packetRange" : {
+     "gte" : 1402723255667,
+     "lte" : 1402723255669
+    },
+    "protocol" : [
+     "gre",
+     "icmp"
+    ],
+    "protocolCnt" : 2,
+    "segmentCnt" : 1,
+    "server" : {
+     "bytes" : 160
+    },
+    "source" : {
+     "as" : {
+      "full" : "AS20940 Akamai International B.V.",
+      "number" : 20940,
+      "organization" : {
+       "name" : "Akamai International B.V."
+      }
+     },
+     "bytes" : 328,
+     "geo" : {
+      "country_iso_code" : "US"
+     },
+     "ip" : "23.0.0.2",
+     "mac" : [
+      "64:00:f1:e1:02:02"
+     ],
+     "mac-cnt" : 1,
+     "packets" : 2,
+     "port" : 0
+    },
+    "srcOui" : [
+     "Cisco Systems, Inc"
+    ],
+    "srcOuiCnt" : 1,
+    "srcOuterASN" : [
+     "---"
+    ],
+    "srcOuterGEO" : [
+     "SE"
+    ],
+    "srcOuterIp" : [
+     "2.2.2.2"
+    ],
+    "srcOuterIpCnt" : 1,
+    "srcOuterMac" : [
+     "64:00:f1:e2:01:12"
+    ],
+    "srcOuterMac-cnt" : 1,
+    "srcOuterOui" : [
+     "Cisco Systems, Inc"
+    ],
+    "srcOuterOuiCnt" : 1,
+    "srcOuterRIR" : [
+     "RIPE"
+    ],
+    "srcRIR" : "ARIN",
+    "srcTTL" : [
+     255
+    ],
+    "srcTTLCnt" : 1,
+    "tags" : [
+     "gretest-erspan"
+    ],
+    "tagsCnt" : 1,
+    "totDataBytes" : 320
+   },
+   "header" : {
+    "index" : {
+     "_index" : "tests_sessions3-140614"
+    }
+   }
+  }
+ ]
 }
 


### PR DESCRIPTION
This PR corrects an issue where the VLAN is not parsed correctly from Cisco devices causing the VLAN to be the incorrect number 

It also adds structured parsing of ERSPAN Type II and Type III headers,
extracting metadata into new ArkimePacket_t fields which are then
written to Elasticsearch sessions via packet.c.

New packet fields (ArkimePacket_t):
  erspan_type, erspan_ver, erspan_id, erspan_cos, erspan_truncated,
  erspan_port, erspan_dir, erspan_bso, erspan_sgt, erspan_hw

New ES session fields (erspan.*):
  erspan.id, erspan.direction, erspan.cos, erspan.ver, erspan.bso.str,
  erspan.truncated, erspan.sgt, erspan.hw, erspan.port

Type II: parses Ver, VLAN, COS, T(truncated), SpanID, Index (->port)
Type III: parses Ver, VLAN, COS, BSO, T, SessionID, SGT, Hw, Dir,
          optional platform subheader (platf_id 0x1 and 0x3) for Port_ID

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
