### PR TITLE
capture: security hardening, bounds checks, and BSB_IMPORT_bsb conversions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,9 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 6.2.1 2026/04/xx
+## Capture
+  - #3910 Corrupt UDP packets could have invalid byte counts
+  - #3910 TCP DNS packets might not be parsed correctly depending on segmentation
 ## Viewer
   - #3898 show error msg in spiview when All selected but not allowed
   - #3906 add copy button to History Elasticsearch Query section

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -303,20 +303,18 @@ typedef struct {
 #define ARKIME_COND_BROADCAST(var)      pthread_cond_broadcast(&var##_cond)
 #define ARKIME_COND_SIGNAL(var)         pthread_cond_signal(&var##_cond)
 
-#define ARKIME_THREAD_INCR(var)          __sync_add_and_fetch(&var, 1);
-#define ARKIME_THREAD_INCRNEW(var)       __sync_add_and_fetch(&var, 1);
-#define ARKIME_THREAD_INCROLD(var)       __sync_fetch_and_add(&var, 1);
-#define ARKIME_THREAD_INCR_NUM(var, num) __sync_add_and_fetch(&var, num);
+#define ARKIME_THREAD_INCR(var)          __sync_add_and_fetch(&var, 1)
+#define ARKIME_THREAD_INCRNEW(var)       __sync_add_and_fetch(&var, 1)
+#define ARKIME_THREAD_INCROLD(var)       __sync_fetch_and_add(&var, 1)
+#define ARKIME_THREAD_INCR_NUM(var, num) __sync_add_and_fetch(&var, num)
 
-#define ARKIME_THREAD_DECR(var)          __sync_sub_and_fetch(&var, 1);
-#define ARKIME_THREAD_DECRNEW(var)       __sync_sub_and_fetch(&var, 1);
-#define ARKIME_THREAD_DECROLD(var)       __sync_fetch_and_sub(&var, 1);
-#define ARKIME_THREAD_DECR_NUM(var, num) __sync_sub_and_fetch(&var, num);
-
-#define ARKIME_THREAD_CAS(ptr, old, new) __sync_bool_compare_and_swap((ptr), (old), (new))
+#define ARKIME_THREAD_DECR(var)          __sync_sub_and_fetch(&var, 1)
+#define ARKIME_THREAD_DECRNEW(var)       __sync_sub_and_fetch(&var, 1)
+#define ARKIME_THREAD_DECROLD(var)       __sync_fetch_and_sub(&var, 1)
+#define ARKIME_THREAD_DECR_NUM(var, num) __sync_sub_and_fetch(&var, num)
 
 /* You are probably looking here because you think 24 is too low, really it isn't.
- * Instead, increase the number of threads used for reading packets.
+ * Instead, use jemalloc and increase the number of threads used for reading packets.
  * https://arkime.com/faq#why-am-i-dropping-packets
  */
 #define ARKIME_MAX_PACKET_THREADS 24

--- a/capture/command.c
+++ b/capture/command.c
@@ -234,7 +234,7 @@ void arkime_command_client_incref(void *vcc)
 void arkime_command_client_decref(void *vcc)
 {
     CommandClient_t *cc = (CommandClient_t *)vcc;
-    int newrefs = ARKIME_THREAD_DECRNEW(cc->refs)
+    int newrefs = ARKIME_THREAD_DECRNEW(cc->refs);
     if (newrefs == 0) {
         g_object_unref(cc->socket);
         ARKIME_TYPE_FREE(CommandClient_t, cc);

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -989,6 +989,9 @@ LOCAL ArkimePacketRC arkime_packet_ip4(ArkimePacketBatch_t *batch, ArkimePacket_
 
         udphdr = (struct udphdr *)((char *)ip4 + ip_hdr_len);
 
+        if (ntohs(udphdr->uh_ulen) < sizeof(struct udphdr))
+            return ARKIME_PACKET_CORRUPT;
+
         if (len > ip_hdr_len + (int)sizeof(struct udphdr) + 8 && udpPortCbs[udphdr->uh_dport]) {
             int rc = arkime_packet_call_enqueue(udpPortCbs[udphdr->uh_dport], batch, packet, (uint8_t *)ip4 + ip_hdr_len + sizeof(struct udphdr), len - ip_hdr_len - sizeof(struct udphdr));
             if (rc != ARKIME_PACKET_UNKNOWN_IP)
@@ -1165,6 +1168,9 @@ LOCAL ArkimePacketRC arkime_packet_ip6(ArkimePacketBatch_t *batch, ArkimePacket_
             }
 
             udphdr = (struct udphdr *)(data + ip_hdr_len);
+
+            if (ntohs(udphdr->uh_ulen) < sizeof(struct udphdr))
+                return ARKIME_PACKET_CORRUPT;
 
             arkime_session_id6(sessionId, ip6->ip6_src.s6_addr, udphdr->uh_sport,
                                ip6->ip6_dst.s6_addr, udphdr->uh_dport, packet->vlan, packet->vni);

--- a/capture/parsers/camel.c
+++ b/capture/parsers/camel.c
@@ -244,7 +244,7 @@ LOCAL int camel_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, 
 
         if (tag == 0x6C) {
             BSB compBsb;
-            BSB_INIT(compBsb, BSB_WORK_PTR(bsb), MIN(elemLen, BSB_REMAINING(bsb)));
+            BSB_IMPORT_bsb(bsb, compBsb, MIN(elemLen, BSB_REMAINING(bsb)));
 
             while (BSB_REMAINING(compBsb) >= 4) {
                 uint8_t compTag = 0;
@@ -266,7 +266,7 @@ LOCAL int camel_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, 
 
                 if (compTag == 0xA1 || compTag == 0xA2) {
                     BSB invBsb;
-                    BSB_INIT(invBsb, BSB_WORK_PTR(compBsb), MIN(compLen, BSB_REMAINING(compBsb)));
+                    BSB_IMPORT_bsb(compBsb, invBsb, MIN(compLen, BSB_REMAINING(compBsb)));
 
                     int currentOpcode = -1;
                     while (BSB_REMAINING(invBsb) >= 3) {
@@ -311,6 +311,7 @@ LOCAL int camel_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, 
                             BSB_IMPORT_skip(invBsb, invLen);
                         }
                     }
+                    continue;
                 }
 
                 BSB_IMPORT_skip(compBsb, compLen);

--- a/capture/parsers/dns.c
+++ b/capture/parsers/dns.c
@@ -251,13 +251,6 @@ typedef struct {
 typedef HASH_VAR(t_, DNSHash_t, DNSHead_t, 1);
 typedef HASH_VAR(t_, DNSHashStd_t, DNSHead_t, 10);
 
-typedef struct {
-    uint8_t            *data[2];
-    uint16_t            size[2];
-    uint16_t            pos[2];
-    uint16_t            len[2];
-} DNSInfo_t;
-
 extern ArkimeConfig_t        config;
 LOCAL  int                   dnsField;
 LOCAL  int                   dnsHostField;
@@ -282,17 +275,6 @@ LOCAL int dns_cmp(const void *keyv, const void *elementv);
 
 LOCAL char                  *root = "<root>";
 
-/******************************************************************************/
-LOCAL void dns_free(ArkimeSession_t *UNUSED(session), void *uw)
-{
-    DNSInfo_t            *info          = uw;
-
-    if (info->data[0])
-        ARKIME_SIZE_FREE("dns data", info->data[0]);
-    if (info->data[1])
-        ARKIME_SIZE_FREE("dns data", info->data[1]);
-    ARKIME_TYPE_FREE(DNSInfo_t, info);
-}
 /******************************************************************************/
 LOCAL int dns_name_element(BSB *nbsb, BSB *bsb)
 {
@@ -1208,53 +1190,29 @@ continueerr:
 /******************************************************************************/
 LOCAL int dns_tcp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, int len, int which)
 {
-    DNSInfo_t *info = uw;
-    while (len >= 2) {
+    ArkimeParserBuf_t *pb = uw;
 
-        // First packet of request
-        if (info->len[which] == 0) {
-            int dnslength = ((data[0] & 0xff) << 8) | (data[1] & 0xff);
+    if (arkime_parser_buf_add(pb, which, data, len) < 0)
+        return ARKIME_PARSER_UNREGISTER;
 
-            if (dnslength < 18) {
-                arkime_parsers_unregister(session, uw);
-                return 0;
-            }
+    while (pb->len[which] >= 2) {
+        int dnslength = ((pb->buf[which][0] & 0xff) << 8) | (pb->buf[which][1] & 0xff);
 
-            // Have all the data in this first packet, just parse it
-            if (dnslength <= len - 2) {
-                dns_parser(session, 0, data + 2, dnslength);
-                data += 2 + dnslength;
-                len -= 2 + dnslength;
-                continue;
-            }
-            // Don't have all the data, will need to save off
+        if (dnslength < 18)
+            return ARKIME_PARSER_UNREGISTER;
 
-            if (info->size[which] == 0) {
-                info->size[which] = MAX(1024, dnslength);
-                info->data[which] = ARKIME_SIZE_ALLOC("dns.data", info->size[which]);
-            } else if (info->size[which] < dnslength) {
-                ARKIME_SIZE_REALLOC("dns data", info->data[which], dnslength);
-                info->size[which] = dnslength;
-            }
-
-            memcpy(info->data[which], data + 2, len - 2);
-            info->len[which] = dnslength;
-            info->pos[which] = len - 2;
-            return 0;
-        } else {
-            int rem = info->len[which] - info->pos[which];
-            if (rem <= len) {
-                memcpy(info->data[which] + info->pos[which], data, rem);
-                len -= rem;
-                data += rem;
-                dns_parser(session, 0, info->data[which], info->len[which]);
-                info->len[which] = 0;
-            } else {
-                memcpy(info->data[which] + info->pos[which], data, len);
-                info->pos[which] += len;
-                return 0;
-            }
+        int frameLen = dnslength + 2;
+        if (frameLen > (int)sizeof(pb->buf[which])) {
+            arkime_session_add_tag(session, "dns:tcp-message-too-long");
+            arkime_parser_buf_skip(pb, which, frameLen);
+            continue;
         }
+
+        if (pb->len[which] < frameLen)
+            return 0;
+
+        dns_parser(session, 0, pb->buf[which] + 2, dnslength);
+        arkime_parser_buf_del(pb, which, frameLen);
     }
     return 0;
 }
@@ -1263,8 +1221,8 @@ LOCAL void dns_tcp_classify(ArkimeSession_t *session, const uint8_t *UNUSED(data
 {
     if (session->port2 == 53 && !arkime_session_has_protocol(session, "dns")) {
         arkime_session_add_protocol(session, "dns");
-        DNSInfo_t  *info = ARKIME_TYPE_ALLOC0(DNSInfo_t);
-        arkime_parsers_register(session, dns_tcp_parser, info, dns_free);
+        ArkimeParserBuf_t *info = arkime_parser_buf_create();
+        arkime_parsers_register(session, dns_tcp_parser, info, arkime_parser_buf_session_free);
     }
 }
 /******************************************************************************/

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -137,7 +137,7 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
         etotlen = MIN(etotlen, BSB_REMAINING(cbsb));
 
         BSB ebsb;
-        BSB_INIT(ebsb, BSB_WORK_PTR(cbsb), etotlen);
+        BSB_IMPORT_bsb(cbsb, ebsb, etotlen);
 
         while (BSB_REMAINING(ebsb) >= 4) {
             uint16_t etype = 0, elen = 0;
@@ -318,6 +318,9 @@ LOCAL int dtls_udp_parser(ArkimeSession_t *session, void *UNUSED(uw), const uint
 {
     BSB bbuf;
 
+    if (len < 13)
+        return 0;
+
     // 22 is handshake
     if (data[0] != 22) {
         arkime_parsers_unregister(session, uw);
@@ -326,7 +329,7 @@ LOCAL int dtls_udp_parser(ArkimeSession_t *session, void *UNUSED(uw), const uint
 
     BSB_INIT(bbuf, data, len);
 
-    while (BSB_NOT_ERROR(bbuf) && BSB_REMAINING(bbuf) > 11) {
+    while (BSB_NOT_ERROR(bbuf) && BSB_REMAINING(bbuf) >= 13) {
         BSB_IMPORT_skip(bbuf, 11);
         uint16_t tlen = 0;
         BSB_IMPORT_u16(bbuf, tlen);
@@ -335,8 +338,7 @@ LOCAL int dtls_udp_parser(ArkimeSession_t *session, void *UNUSED(uw), const uint
             return 0;
 
         BSB msgBuf;
-        BSB_INIT(msgBuf, BSB_WORK_PTR(bbuf), tlen);
-        BSB_IMPORT_skip(bbuf, tlen);
+        BSB_IMPORT_bsb(bbuf, msgBuf, tlen);
 
         while (BSB_NOT_ERROR(bbuf) && BSB_NOT_ERROR(msgBuf) && BSB_REMAINING(msgBuf) > 12) {
             uint8_t handshakeType = 0;

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -139,7 +139,8 @@ void http_common_add_header_value(ArkimeSession_t *session, int pos, const char 
         break;
     case ARKIME_FIELD_TYPE_IP:
     case ARKIME_FIELD_TYPE_IP_GHASH: {
-        gchar **parts = g_strsplit(s, ",", 0);
+        char *ipstr = g_strndup(s, l);
+        gchar **parts = g_strsplit(ipstr, ",", 0);
 
         for (int i = 0; parts[i]; i++) {
             arkime_field_ip_add_str(pos, session, parts[i]);
@@ -155,6 +156,7 @@ void http_common_add_header_value(ArkimeSession_t *session, int pos, const char 
         }
 
         g_strfreev(parts);
+        g_free(ipstr);
         break;
     }
     case ARKIME_FIELD_TYPE_OBJECT:

--- a/capture/parsers/http2.c
+++ b/capture/parsers/http2.c
@@ -341,6 +341,7 @@ LOCAL int http2_parse_frame(ArkimeSession_t *session, HTTP2Info_t *http2, int wh
 
     // type will only be DATA if this is the first part of a data frame, anything else will be shortcutted in http_parse
     if (type == NGHTTP2_DATA) {
+        int dataLen = MIN((int)len, BSB_REMAINING(bsb));
         http2->dataStreamId[which] = streamId;
         if (len > BSB_REMAINING(bsb)) {
             http2->used[which] = 0;
@@ -348,7 +349,7 @@ LOCAL int http2_parse_frame(ArkimeSession_t *session, HTTP2Info_t *http2, int wh
         } else {
             http2->dataNeeded[which] = 0;
         }
-        http2_parse_frame_data(session, http2, which, flags, streamId, BSB_WORK_PTR(bsb), BSB_REMAINING(bsb), TRUE);
+        http2_parse_frame_data(session, http2, which, flags, streamId, BSB_WORK_PTR(bsb), dataLen, TRUE);
 
         // Don't need to memmove below
         if (http2->dataNeeded[which] != 0)

--- a/capture/parsers/mqtt.c
+++ b/capture/parsers/mqtt.c
@@ -316,7 +316,7 @@ LOCAL int mqtt_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
 
         // Parse based on packet type
         BSB packetBsb;
-        BSB_INIT(packetBsb, BSB_WORK_PTR(bsb), remainingLen);
+        BSB_IMPORT_bsb(bsb, packetBsb, remainingLen);
 
         switch (packetType) {
         case 1: // CONNECT
@@ -329,8 +329,6 @@ LOCAL int mqtt_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
             mqtt_parse_subscribe(session, &packetBsb, mqtt->version);
             break;
         }
-
-        BSB_IMPORT_skip(bsb, remainingLen);
 
         if (BSB_IS_ERROR(bsb))
             break;

--- a/capture/parsers/rdp.c
+++ b/capture/parsers/rdp.c
@@ -239,22 +239,25 @@ LOCAL int rdp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, in
             break;  // Wait for more data
         }
 
+        BSB frameBsb;
+        BSB_IMPORT_bsb(bsb, frameBsb, tpktLen - 4);
+
         // X.224 header
         uint8_t x224Code = 0;
-        BSB_IMPORT_skip(bsb, 1);  // x224 length
-        BSB_IMPORT_u08(bsb, x224Code);
+        BSB_IMPORT_skip(frameBsb, 1);  // x224 length
+        BSB_IMPORT_u08(frameBsb, x224Code);
 
         // Connection Request (0xE0)
         if (x224Code == 0xE0) {
-            BSB_IMPORT_skip(bsb, 5);  // dst-ref, src-ref, class
+            BSB_IMPORT_skip(frameBsb, 5);  // dst-ref, src-ref, class
 
             // Look for cookie and RDP negotiation request
-            if (BSB_REMAINING(bsb) >= 17) {
-                const uint8_t *cookiePtr = BSB_WORK_PTR(bsb);
+            if (BSB_REMAINING(frameBsb) >= 17) {
+                const uint8_t *cookiePtr = BSB_WORK_PTR(frameBsb);
                 if (memcmp(cookiePtr, "Cookie: mstshash=", 17) == 0) {
-                    BSB_IMPORT_skip(bsb, 17);
-                    const uint8_t *start = BSB_WORK_PTR(bsb);
-                    int maxLen = BSB_REMAINING(bsb);
+                    BSB_IMPORT_skip(frameBsb, 17);
+                    const uint8_t *start = BSB_WORK_PTR(frameBsb);
+                    int maxLen = BSB_REMAINING(frameBsb);
                     int userLen = 0;
 
                     while (userLen < maxLen && start[userLen] != '\r' && start[userLen] != '\n')
@@ -263,22 +266,22 @@ LOCAL int rdp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, in
                     if (userLen > 0)
                         arkime_field_string_add_lower(userField, session, (char *)start, userLen);
 
-                    BSB_IMPORT_skip(bsb, userLen);
+                    BSB_IMPORT_skip(frameBsb, userLen);
                     // Skip CRLF
-                    if (BSB_REMAINING(bsb) >= 2)
-                        BSB_IMPORT_skip(bsb, 2);
+                    if (BSB_REMAINING(frameBsb) >= 2)
+                        BSB_IMPORT_skip(frameBsb, 2);
                 }
             }
 
             // RDP Negotiation Request at end
-            if (BSB_REMAINING(bsb) >= 8) {
+            if (BSB_REMAINING(frameBsb) >= 8) {
                 uint8_t negType = 0;
-                BSB_IMPORT_u08(bsb, negType);
+                BSB_IMPORT_u08(frameBsb, negType);
 
                 if (negType == TYPE_RDP_NEG_REQ) {
-                    BSB_IMPORT_skip(bsb, 3);  // flags, length
+                    BSB_IMPORT_skip(frameBsb, 3);  // flags, length
                     uint32_t requestedProtocols = 0;
-                    BSB_LIMPORT_u32(bsb, requestedProtocols);
+                    BSB_LIMPORT_u32(frameBsb, requestedProtocols);
                     rdp_add_protocols(session, requestedProtocolsField, requestedProtocols);
                 }
             }
@@ -286,17 +289,17 @@ LOCAL int rdp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, in
         }
         // Connection Confirm (0xD0)
         else if (x224Code == 0xD0) {
-            BSB_IMPORT_skip(bsb, 5);  // dst-ref, src-ref, class
+            BSB_IMPORT_skip(frameBsb, 5);  // dst-ref, src-ref, class
 
             // RDP Negotiation Response at end
-            if (BSB_REMAINING(bsb) >= 8) {
+            if (BSB_REMAINING(frameBsb) >= 8) {
                 uint8_t negType = 0;
-                BSB_IMPORT_u08(bsb, negType);
+                BSB_IMPORT_u08(frameBsb, negType);
 
                 if (negType == TYPE_RDP_NEG_RSP) {
-                    BSB_IMPORT_skip(bsb, 3);  // flags, length
+                    BSB_IMPORT_skip(frameBsb, 3);  // flags, length
                     uint32_t selectedProtocol = 0;
-                    BSB_LIMPORT_u32(bsb, selectedProtocol);
+                    BSB_LIMPORT_u32(frameBsb, selectedProtocol);
                     rdp_add_protocols(session, selectedProtocolField, selectedProtocol);
                 }
             }
@@ -304,23 +307,23 @@ LOCAL int rdp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, in
         }
         // Data (0xF0) - could be MCS Connect Initial
         else if (x224Code == 0xF0) {
-            BSB_IMPORT_skip(bsb, 1);  // EOT
+            BSB_IMPORT_skip(frameBsb, 1);  // EOT
 
             // Check for MCS Connect Initial (BER tag 0x7f65)
-            if (BSB_REMAINING(bsb) >= 2) {
+            if (BSB_REMAINING(frameBsb) >= 2) {
                 uint8_t tag1 = 0, tag2 = 0;
-                BSB_IMPORT_u08(bsb, tag1);
-                BSB_IMPORT_u08(bsb, tag2);
+                BSB_IMPORT_u08(frameBsb, tag1);
+                BSB_IMPORT_u08(frameBsb, tag2);
 
                 if (tag1 == 0x7f && tag2 == 0x65) {
                     // Skip BER length encoding
                     uint8_t lenByte = 0;
-                    BSB_IMPORT_u08(bsb, lenByte);
+                    BSB_IMPORT_u08(frameBsb, lenByte);
                     if (lenByte & 0x80) {
                         int lenBytes = lenByte & 0x7f;
-                        BSB_IMPORT_skip(bsb, lenBytes);
+                        BSB_IMPORT_skip(frameBsb, lenBytes);
                     }
-                    rdp_parse_mcs_connect(session, &bsb);
+                    rdp_parse_mcs_connect(session, &frameBsb);
                     rdp->state[which] = RDP_STATE_GOT_MCS;
                 }
             }

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -8,6 +8,8 @@
 
 //#define EMAILDEBUG
 
+#define SMTP_MAX_LINE_LEN 10000
+
 extern ArkimeConfig_t   config;
 extern char            *arkime_char_to_hex;
 extern uint8_t          arkime_char_to_hexstr[256][3];
@@ -861,6 +863,12 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
             break;
         }
         }
+
+        if (line->len > SMTP_MAX_LINE_LEN) {
+            arkime_session_add_tag(session, "smtp:line-too-long");
+            return ARKIME_PARSER_UNREGISTER;
+        }
+
         data++;
         remaining--;
 

--- a/capture/parsers/stun.c
+++ b/capture/parsers/stun.c
@@ -292,7 +292,12 @@ LOCAL int stun_tcp_parser(ArkimeSession_t *session, void *uw, const uint8_t *dat
     while (pb->len[which] >= 20) {
         uint16_t msgLen = (pb->buf[which][2] << 8) | pb->buf[which][3];
 
-        if (msgLen + 20 > (int)sizeof(pb->buf[0]) || pb->len[which] < msgLen + 20)
+        if (msgLen + 20 > (int)sizeof(pb->buf[0])) {
+            arkime_session_add_tag(session, "stun:message-too-long");
+            return ARKIME_PARSER_UNREGISTER;
+        }
+
+        if (pb->len[which] < msgLen + 20)
             return 0;
 
         stun_parser(session, NULL, pb->buf[which], msgLen + 20, which);

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -175,7 +175,7 @@ LOCAL uint32_t tls_process_server_hello(ArkimeSession_t *session, const uint8_t 
         etotlen = MIN(etotlen, BSB_REMAINING(bsb));
 
         BSB ebsb;
-        BSB_INIT(ebsb, BSB_WORK_PTR(bsb), etotlen);
+        BSB_IMPORT_bsb(bsb, ebsb, etotlen);
 
         while (BSB_REMAINING(ebsb) > 0) {
             int etype = 0, elen = 0;
@@ -384,7 +384,7 @@ LOCAL uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uin
             etotlen = MIN(etotlen, BSB_REMAINING(cbsb));
 
             BSB ebsb;
-            BSB_INIT(ebsb, BSB_WORK_PTR(cbsb), etotlen);
+            BSB_IMPORT_bsb(cbsb, ebsb, etotlen);
 
             while (BSB_REMAINING(ebsb) >= 4) {
                 uint16_t etype = 0, elen = 0;
@@ -797,4 +797,3 @@ void arkime_parser_init()
     tls_process_server_hello_func = arkime_parsers_add_named_func("tls_process_server_hello", tls_process_server_hello);
     tls_process_server_certificate_func = arkime_parsers_get_named_func("tls_process_server_certificate");
 }
-


### PR DESCRIPTION
Security / bounds checks:
- packet: drop packets with UDP uh_ulen < sizeof(udphdr) for IPv4 and IPv6
- dtls: require at least 13 bytes before parsing; tighten record loop guard
- http2: clamp DATA frame length to BSB_REMAINING when parsing
- http: g_strndup header value before splitting (header value is not NUL-terminated)
- smtp: cap line length and unregister with smtp:line-too-long tag
- stun: unregister with stun:message-too-long tag instead of looping
- dns (tcp): switch parser to ArkimeParserBuf_t; cap frames at buffer size and tag dns:tcp-message-too-long, removing custom realloc/copy logic

BSB_IMPORT_bsb conversions (replace BSB_INIT + manual skip):
- camel, dtls, mqtt, tls, rdp

Other:
- arkime.h: remove trailing semicolons from ARKIME_THREAD_INCR/DECR* macros so they can be used as expressions; update MAX_PACKET_THREADS comment
- command: add missing semicolon after ARKIME_THREAD_DECRNEW (uncovered by the macro change above)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
