### PR TITLE
Fix capture parser audit findings #85-98

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3913 Fix WISE plugin skipping fields after array-typed fields
   - #3913 Fix S3 listing deadlock when bucket/prefix is empty
   - #3914 Fix ASN.1 OID decoding of first arc per X.690
+  - #3916 Improved NTP and IS-IS parsing
 ## Viewer
   - #3898 show error msg in spiview when All selected but not allowed
   - #3906 add copy button to History Elasticsearch Query section

--- a/capture/parsers/arp.c
+++ b/capture/parsers/arp.c
@@ -44,7 +44,11 @@ LOCAL ArkimePacketRC arp_packet_enqueue(ArkimePacketBatch_t *UNUSED(batch), Arki
     if (len < 28)
         return ARKIME_PACKET_CORRUPT;
 
-    if (data[7] > 2)
+    // Validate Ethernet/IPv4 ARP: htype=1, ptype=0x0800, hlen=6, plen=4, opcode 1 or 2
+    if (data[0] != 0x00 || data[1] != 0x01 ||
+        data[2] != 0x08 || data[3] != 0x00 ||
+        data[4] != 6 || data[5] != 4 ||
+        data[6] != 0 || data[7] < 1 || data[7] > 2)
         return ARKIME_PACKET_CORRUPT;
 
     packet->payloadOffset = data - packet->pkt;

--- a/capture/parsers/isis.c
+++ b/capture/parsers/isis.c
@@ -28,13 +28,17 @@ LOCAL int isis_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packe
     if (isNewSession)
         arkime_session_add_protocol(session, "isis");
 
-    if (packet->pktlen < 22) {
-        snprintf(msg, sizeof(msg), "err-len-%d", packet->pktlen);
+    // The 0x83 IRPD byte is consumed by the ethernet dispatch, so payload
+    // starts at the length-indicator byte (offset 1 within the IS-IS PDU).
+    // PDU type is therefore at payloadOffset + 3 (IS-IS PDU offset 4).
+    if (packet->payloadLen < 4) {
+        snprintf(msg, sizeof(msg), "err-len-%d", packet->payloadLen);
         arkime_field_string_add(typeField, session, msg, -1, TRUE);
         return 0;
     }
 
-    switch (packet->pkt[21]) {
+    const uint8_t pduType = packet->pkt[packet->payloadOffset + 3] & 0x1F;
+    switch (pduType) {
     case 15:
         arkime_field_string_add(typeField, session, "lan-l1-hello", -1, TRUE);
         break;
@@ -63,7 +67,7 @@ LOCAL int isis_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packe
         arkime_field_string_add(typeField, session, "l2-psnp", -1, TRUE);
         break;
     default:
-        snprintf(msg, sizeof(msg), "unk-%d", packet->pkt[21]);
+        snprintf(msg, sizeof(msg), "unk-%d", pduType);
         if (config.debug)
             LOG("isis %s\n", msg);
         arkime_field_string_add(typeField, session, msg, -1, TRUE);

--- a/capture/parsers/misc.c
+++ b/capture/parsers/misc.c
@@ -213,6 +213,10 @@ LOCAL void openvpn_tcp_classify(ArkimeSession_t *session, const uint8_t *data, i
     // OpenVPN TCP: 2-byte length prefix, then byte0 = (opcode << 3) | key_id
     if (len < 16)
         return;
+    uint16_t plen = (data[0] << 8) | data[1];
+    // OpenVPN record must contain at least the opcode byte and minimum payload
+    if (plen < 14 || plen > len - 2)
+        return;
     uint8_t opcode = data[2] >> 3;
     if (opcode < 1 || opcode > 10)
         return;

--- a/capture/parsers/nbns.c
+++ b/capture/parsers/nbns.c
@@ -174,7 +174,7 @@ LOCAL void nbns_parser(ArkimeSession_t *session, const uint8_t *data, int len)
         BSB_IMPORT_skip(bsb, 6);  // rclass + ttl
         BSB_IMPORT_u16(bsb, rdlength);
 
-        if (BSB_IS_ERROR(bsb))
+        if (BSB_IS_ERROR(bsb) || rdlength > BSB_REMAINING(bsb))
             return;
 
         if (nameLen > 0) {
@@ -191,10 +191,15 @@ LOCAL void nbns_parser(ArkimeSession_t *session, const uint8_t *data, int len)
                 // Read IP in network byte order
                 uint32_t ipAddr = 0;
                 BSB_IMPORT_byte(bsb, &ipAddr, 4);
+                if (BSB_IS_ERROR(bsb))
+                    break;
                 remaining -= 6;
 
                 arkime_field_ip4_add(ipField, session, ipAddr);
             }
+            // Skip any leftover bytes if rdlength is not a multiple of 6
+            if (remaining > 0)
+                BSB_IMPORT_skip(bsb, remaining);
         } else {
             // Skip rdata for other record types
             BSB_IMPORT_skip(bsb, rdlength);

--- a/capture/parsers/nsh.c
+++ b/capture/parsers/nsh.c
@@ -20,7 +20,7 @@ LOCAL ArkimePacketRC nsh_packet_enqueue(ArkimePacketBatch_t *batch, ArkimePacket
 
     int length = (data[1] & 0x3f) * 4;
 
-    if (length < 4) {
+    if (length < 8) {
 #ifdef DEBUG_PACKET
         LOG("BAD PACKET: Invalid length %d", length);
 #endif

--- a/capture/parsers/ntp.c
+++ b/capture/parsers/ntp.c
@@ -182,18 +182,8 @@ void arkime_parser_init()
                                      ARKIME_FIELD_TYPE_STR_GHASH, ARKIME_FIELD_FLAG_CNT,
                                      (char *)NULL);
 
-    // NTP uses UDP port 123
-    // First byte encodes LI (2 bits), Version (3 bits), Mode (3 bits)
-    // Common patterns: 0x1b (v3 client), 0x23 (v4 client), 0x24 (v4 server), 0xe3 (v4 broadcast)
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\x13", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\x19", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\x1a", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\x1b", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\x1c", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\x21", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\x23", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\x24", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\xd9", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\xdb", 1, ntp_udp_classify);
-    arkime_parsers_classifier_register_udp("ntp", NULL, 0, (const uint8_t *)"\xe3", 1, ntp_udp_classify);
+    // NTP uses UDP port 123. Register by port and let ntp_udp_classify
+    // validate version/mode/stratum so all valid first-byte combinations
+    // are covered (LI 0-3 x VN 1-4 x Mode 1-7).
+    arkime_parsers_classifier_register_port("ntp", NULL, 123, ARKIME_PARSERS_PORT_UDP, ntp_udp_classify);
 }

--- a/capture/parsers/ppp.c
+++ b/capture/parsers/ppp.c
@@ -26,15 +26,17 @@ LOCAL ArkimePacketRC pppoe_packet_enqueue(ArkimePacketBatch_t *batch, ArkimePack
     BSB_IMPORT_u16(bsb, plen);
     BSB_IMPORT_u16(bsb, type);
 
-    if (BSB_IS_ERROR(bsb) || plen != len - 6)
+    if (BSB_IS_ERROR(bsb) || plen < 2 || plen > len - 6)
         return ARKIME_PACKET_CORRUPT;
+
+    int payloadLen = plen - 2; // plen includes the 2-byte protocol type field
 
     packet->tunnel |= ARKIME_PACKET_TUNNEL_PPPOE;
     switch (type) {
     case 0x21:
-        return arkime_packet_run_ethernet_cb(batch, packet, BSB_WORK_PTR(bsb), BSB_REMAINING(bsb), ETHERTYPE_IP, "PPP");
+        return arkime_packet_run_ethernet_cb(batch, packet, BSB_WORK_PTR(bsb), payloadLen, ETHERTYPE_IP, "PPP");
     case 0x57:
-        return arkime_packet_run_ethernet_cb(batch, packet, BSB_WORK_PTR(bsb), BSB_REMAINING(bsb), ETHERTYPE_IPV6, "PPP");
+        return arkime_packet_run_ethernet_cb(batch, packet, BSB_WORK_PTR(bsb), payloadLen, ETHERTYPE_IPV6, "PPP");
     default:
         return ARKIME_PACKET_UNKNOWN_ETHER;
     }

--- a/capture/parsers/tcap.c
+++ b/capture/parsers/tcap.c
@@ -67,12 +67,12 @@ LOCAL int tcap_get_app_context(const uint8_t *data, int len, char *out, int outl
             // The structure is: External(0x28) -> context[0](0xA0) -> AARQ/AARE(0x60/0x61) -> context[1](0xA1) -> OID
             const uint8_t *dlgData = BSB_WORK_PTR(bsb);
             // Scan for OID tags in the dialogue portion
-            for (uint32_t i = 0; i + 8 < elemLen; i++) {
+            for (uint32_t i = 0; i + 2 <= elemLen; i++) {
                 if (dlgData[i] == 0x06) {
                     int oidLen = dlgData[i + 1];
-                    if (oidLen > 0 && oidLen < 20 && i + 2 + oidLen <= elemLen) {
+                    if (oidLen >= 4 && oidLen < 20 && i + 2 + oidLen <= elemLen) {
                         // Check if it looks like CAMEL/MAP/INAP OID (starts with 04 00 00 01)
-                        if (oidLen >= 4 && dlgData[i + 2] == 0x04 && dlgData[i + 3] == 0x00 &&
+                        if (dlgData[i + 2] == 0x04 && dlgData[i + 3] == 0x00 &&
                             dlgData[i + 4] == 0x00 && dlgData[i + 5] == 0x01) {
                             const uint8_t *oid = dlgData + i + 2;
                             if (oidLen * 2 >= outlen)

--- a/contrib/decodeDrops.c
+++ b/contrib/decodeDrops.c
@@ -5,6 +5,11 @@
 
 int main(int argc, char *argv[]) 
 {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <drop-file>\n", argv[0]);
+        exit(1);
+    }
+
     FILE *fp = fopen(argv[1], "r");
 
     if (!fp) {

--- a/contrib/tzsp_forwarder.c
+++ b/contrib/tzsp_forwarder.c
@@ -44,11 +44,16 @@ void packet_handler(u_char *user_data, const struct pcap_pkthdr *pkthdr, const u
     // Add END tag (0x01)
     tzsp_packet[offset++] = 0x01;
 
+    // Defensive bound: even though pcap is opened with SNAP_LEN, never trust caplen
+    unsigned int caplen = pkthdr->caplen;
+    if (caplen > SNAP_LEN)
+        caplen = SNAP_LEN;
+
     // Copy packet data
-    memcpy(tzsp_packet + offset, packet, pkthdr->caplen);
+    memcpy(tzsp_packet + offset, packet, caplen);
 
     // Send TZSP packet
-    sendto(sock_fd, tzsp_packet, pkthdr->caplen + offset, 0,
+    sendto(sock_fd, tzsp_packet, caplen + offset, 0,
            (struct sockaddr *)&dest_addr, sizeof(dest_addr));
 }
 


### PR DESCRIPTION
- isis: validate payloadLen and read PDU type from correct offset
- nsh: require minimum 8 bytes (was 4) for full base header
- ppp: validate PPPoE length field range; pass exact plen
- arp: validate Ethernet/IPv4 ARP htype/ptype/hlen/plen/opcode
- misc: OpenVPN TCP - decode 2-byte length prefix and bounds check
- nbns: bounds check rdlength; check IS_ERROR per IP; skip rdata remainder
- ntp: replace 11 byte-pattern classifiers with port 123 classifier
- tcap: fix OID loop bounds (i+2<=elemLen)
- decodeDrops: argc guard and Usage to stderr
- tzsp_forwarder: cap caplen at SNAP_LEN before memcpy/sendto

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
