### PR TITLE
Capture parser hardening and LDAP/SNMP misclassification fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3917 Improved SMB parsing of share/filename
   - #3917 Improved SNMP GetBulkRequest parsing
   - #3917 Extract VNI from GENEVE tunnels
+  - #3918 scheme http no longer requires a port (defaults to 80/443)
+  - #3918 fix SNMP sessions showing up as LDAP too
 ## Viewer
   - #3898 show error msg in spiview when All selected but not allowed
   - #3906 add copy button to History Elasticsearch Query section

--- a/capture/command.c
+++ b/capture/command.c
@@ -155,6 +155,11 @@ void arkime_command_register(const char *name, ArkimeCommandFunc func, const cha
         commandsArray = g_ptr_array_new();
     }
 
+    if (g_hash_table_contains(commandsHash, name)) {
+        LOG("WARNING - Command '%s' already registered, ignoring duplicate", name);
+        return;
+    }
+
     Command_t *cmd = ARKIME_TYPE_ALLOC0(Command_t);
     cmd->name = g_strdup(name);
     cmd->func = func;
@@ -174,6 +179,11 @@ void arkime_command_register_opts(const char *name, ArkimeCommandFunc func, cons
     if (!commandsHash) {
         commandsHash = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, arkime_command_free);
         commandsArray = g_ptr_array_new();
+    }
+
+    if (g_hash_table_contains(commandsHash, name)) {
+        LOG("WARNING - Command '%s' already registered, ignoring duplicate", name);
+        return;
     }
 
     Command_t *cmd = ARKIME_TYPE_ALLOC0(Command_t);

--- a/capture/parsers/ldap.c
+++ b/capture/parsers/ldap.c
@@ -147,6 +147,12 @@ LOCAL void ldap_classify(ArkimeSession_t *session, const uint8_t *data, int len,
         if (!value || apc != 0 || atag != 2)
             return;
 
+        // protocolOp must be APPLICATION class constructed (raw byte 0x60-0x7F).
+        // This rejects SNMPv3 / other ASN.1 sequences whose second child is a
+        // UNIVERSAL SEQUENCE (0x30) that would otherwise pass the apc/atag check.
+        if (BSB_REMAINING(bsb) < 2 || (BSB_WORK_PTR(bsb)[0] & 0xC0) != 0x40)
+            return;
+
         // protocolOp
         value = arkime_parsers_asn_get_tlv(&bsb, &apc, &atag, &alen);
         if (!value || apc != 1 || atag > 25)

--- a/capture/parsers/quic.c
+++ b/capture/parsers/quic.c
@@ -274,6 +274,8 @@ LOCAL int quic_fb_tcp_parser(ArkimeSession_t *session, void *uw, const uint8_t *
         return 0;
 
     int len = (fbzero->buf[0][6] << 8) | fbzero->buf[0][5];
+    if (len + 9 > fbzero->bufMax)
+        return ARKIME_PARSER_UNREGISTER;
     if (fbzero->len[0] < len + 9)
         return 0;
 

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -504,15 +504,18 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                 arkime_session_add_tag(session, "smtp:authplain");
                 if (line->len > 11) {
                     gsize out_len = 0;
-                    gsize zation = 0;
                     if (line->str[11] && line->str[12]) {
                         g_base64_decode_inplace(line->str + 11, &out_len);
                     }
-                    zation = strlen(line->str + 11);
-                    if (zation < out_len) {
-                        gsize cation = strlen(line->str + 11 + zation + 1);
-                        if (cation + zation + 1 < out_len) {
-                            arkime_field_string_add_lower(userField, session, line->str + 11 + zation + 1, cation);
+                    const char *base = line->str + 11;
+                    const char *nul1 = memchr(base, 0, out_len);
+                    if (nul1) {
+                        gsize zation = nul1 - base;
+                        const char *user = base + zation + 1;
+                        gsize remaining = out_len - zation - 1;
+                        const char *nul2 = memchr(user, 0, remaining);
+                        if (nul2) {
+                            arkime_field_string_add_lower(userField, session, (char *)user, nul2 - user);
                         }
                     }
                     *state = EMAIL_CMD;
@@ -550,15 +553,17 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
         }
         case EMAIL_AUTHPLAIN_RETURN: {
             gsize out_len = 0;
-            gsize zation = 0;
             if (line->str[0] && line->str[1]) {
                 g_base64_decode_inplace(line->str, &out_len);
             }
-            zation = strlen(line->str);
-            if (zation < out_len) {
-                gsize cation = strlen(line->str + zation + 1);
-                if (cation + zation + 1 < out_len) {
-                    arkime_field_string_add_lower(userField, session, line->str + zation + 1, cation);
+            const char *nul1 = memchr(line->str, 0, out_len);
+            if (nul1) {
+                gsize zation = nul1 - line->str;
+                const char *user = line->str + zation + 1;
+                gsize remaining = out_len - zation - 1;
+                const char *nul2 = memchr(user, 0, remaining);
+                if (nul2) {
+                    arkime_field_string_add_lower(userField, session, (char *)user, nul2 - user);
                 }
             }
             *state = EMAIL_CMD;

--- a/capture/parsers/socks.c
+++ b/capture/parsers/socks.c
@@ -99,7 +99,7 @@ LOCAL int socks5_parser(ArkimeSession_t *session, void *uw, const uint8_t *data,
         socks->state5[(which + 1) % 2] = SOCKS5_STATE_VER_REPLY;
         break;
     case SOCKS5_STATE_VER_REPLY:
-        if (remaining != 2 || data[0] != 5 || data[1] > 2) {
+        if (remaining < 2 || data[0] != 5 || data[1] > 2) {
             arkime_parsers_unregister(session, uw);
             return 0;
         }
@@ -123,7 +123,7 @@ LOCAL int socks5_parser(ArkimeSession_t *session, void *uw, const uint8_t *data,
 
         return 2;
     case SOCKS5_STATE_USER_REQUEST:
-        if (remaining < 2 || (3 + data[1] > (int)remaining) || (2 + data[1] + 1 + data[data[1] + 2]  > (int)remaining)) {
+        if (remaining < 2 || data[0] != 1 || (3 + data[1] > (int)remaining) || (2 + data[1] + 1 + data[data[1] + 2]  > (int)remaining)) {
             arkime_parsers_unregister(session, uw);
             return 0;
         }
@@ -133,6 +133,15 @@ LOCAL int socks5_parser(ArkimeSession_t *session, void *uw, const uint8_t *data,
         socks->state5[which] = SOCKS5_STATE_CONN_REQUEST;
         return 2 + data[1] + 1 + data[data[1] + 2];
     case SOCKS5_STATE_USER_REPLY:
+        if (remaining < 2 || data[0] != 1) {
+            arkime_parsers_unregister(session, uw);
+            return 0;
+        }
+        if (data[1] != 0) {
+            arkime_session_add_tag(session, "socks:auth-failed");
+            arkime_parsers_unregister(session, uw);
+            return 0;
+        }
         socks->state5[which] = SOCKS5_STATE_CONN_REPLY;
         return 2;
     case SOCKS5_STATE_CONN_REQUEST:
@@ -175,7 +184,12 @@ LOCAL int socks5_parser(ArkimeSession_t *session, void *uw, const uint8_t *data,
         arkime_parsers_classify_tcp(session, data + consumed, remaining - consumed, which);
         return consumed;
     case SOCKS5_STATE_CONN_REPLY: {
-        if (remaining < 6) {
+        if (remaining < 6 || data[0] != 5 || data[2] != 0) {
+            arkime_parsers_unregister(session, uw);
+            return 0;
+        }
+        if (data[1] != 0) {
+            arkime_session_add_tag(session, "socks:connect-failed");
             arkime_parsers_unregister(session, uw);
             return 0;
         }

--- a/capture/plugins.c
+++ b/capture/plugins.c
@@ -148,6 +148,7 @@ LOCAL int arkime_plugins_load_so(const char *path)
 
     if (!g_module_symbol(plugin, "arkime_plugin_init", (gpointer *)(char *)&plugin_init) || plugin_init == NULL) {
         LOG("ERROR - Module %s doesn't have a arkime_plugin_init", path);
+        g_module_close(plugin);
         return 1;
     }
 

--- a/capture/plugins/suricata.c
+++ b/capture/plugins/suricata.c
@@ -292,6 +292,8 @@ LOCAL void suricata_process()
     uint16_t        srcPort = 0;
     uint16_t        dstPort = 0;
     uint16_t        vlan = 0;
+    gboolean        srcIpOk = FALSE;
+    gboolean        dstIpOk = FALSE;
 
     memset(&srcIp, 0, sizeof(srcIp));
     memset(&dstIp, 0, sizeof(dstIp));
@@ -340,13 +342,23 @@ LOCAL void suricata_process()
                 return;
             }
         } else if (MATCH(line, "src_ip")) {
-            suricata_parse_ip(line + out[i + 2], out[i + 3], &srcIp);
+            srcIpOk = suricata_parse_ip(line + out[i + 2], out[i + 3], &srcIp);
         } else if (MATCH(line, "src_port")) {
-            srcPort = atoi(line + out[i + 2]);
+            int p = arkime_atoin(line + out[i + 2], out[i + 3]);
+            if (p < 0 || p > 65535) {
+                suricata_item_free(item);
+                return;
+            }
+            srcPort = (uint16_t)p;
         } else if (MATCH(line, "dest_ip")) {
-            suricata_parse_ip(line + out[i + 2], out[i + 3], &dstIp);
+            dstIpOk = suricata_parse_ip(line + out[i + 2], out[i + 3], &dstIp);
         } else if (MATCH(line, "dest_port")) {
-            dstPort = atoi(line + out[i + 2]);
+            int p = arkime_atoin(line + out[i + 2], out[i + 3]);
+            if (p < 0 || p > 65535) {
+                suricata_item_free(item);
+                return;
+            }
+            dstPort = (uint16_t)p;
         } else if (MATCH(line, "flow_id")) {
             item->flow_id = g_strndup(line + out[i + 2], out[i + 3]);
             item->flow_id_len = out[i + 3];
@@ -367,11 +379,18 @@ LOCAL void suricata_process()
             suricata_process_alert(line + out[i + 2], out[i + 3], item);
         } else if (MATCH(line, "vlan")) {
             if (*(line + out[i + 2]) == '[') {
-                vlan = atoi(line + out[i + 2] + 1);
+                vlan = arkime_atoin(line + out[i + 2] + 1, out[i + 3] - 1);
             } else {
-                vlan = atoi(line + out[i + 2]);
+                vlan = arkime_atoin(line + out[i + 2], out[i + 3]);
             }
         }
+    }
+
+    if (!srcIpOk || !dstIpOk) {
+        if (config.debug)
+            LOG("WARNING - Suricata alert missing/invalid src or dst ip");
+        suricata_item_free(item);
+        return;
     }
 
 #pragma GCC diagnostic push

--- a/capture/reader-scheme-http.c
+++ b/capture/reader-scheme-http.c
@@ -58,7 +58,7 @@ LOCAL int scheme_http_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchem
     rc += curl_url_get(h, CURLUPART_HOST, &host, 0);
 
     char *port = NULL;
-    rc += curl_url_get(h, CURLUPART_PORT, &port, 0);
+    curl_url_get(h, CURLUPART_PORT, &port, 0);
 
     char *path = NULL;
     rc += curl_url_get(h, CURLUPART_PATH, &path, 0);
@@ -73,8 +73,16 @@ LOCAL int scheme_http_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchem
         return 1;
     }
 
+    const char *effPort = port;
+    if (!effPort) {
+        if (scheme && strcasecmp(scheme, "https") == 0)
+            effPort = "443";
+        else
+            effPort = "80";
+    }
+
     char hostport[1000];
-    snprintf(hostport, sizeof(hostport), "%s://%s:%s", scheme, host, port);
+    snprintf(hostport, sizeof(hostport), "%s://%s:%s", scheme, host, effPort);
 
     void *server = g_hash_table_lookup(servers, hostport);
     if (!server) {

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -126,7 +126,7 @@ LOCAL char *scheme_s3_escape(const char *str, int len)
     return out;
 }
 /******************************************************************************/
-LOCAL void scheme_s3_done(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
+LOCAL void scheme_s3_done(int code, uint8_t *data, int data_len, gpointer uw)
 {
     S3Request *req = uw;
     if (!req->isDir) {
@@ -144,6 +144,15 @@ LOCAL void scheme_s3_done(int UNUSED(code), uint8_t *data, int data_len, gpointe
     }
 
     ARKIME_UNLOCK(waitingdir);
+
+    if (code < 200 || code >= 300) {
+        LOG("ERROR - S3 list request failed with HTTP %d for %s", code, req->url);
+        ARKIME_LOCK(s3Items->lock);
+        s3Items->done = 1;
+        ARKIME_COND_BROADCAST(s3Items->lock);
+        ARKIME_UNLOCK(s3Items->lock);
+        return;
+    }
 
     const char *next = arkime_memstr((const char *)data, data_len, "<NextContinuationToken>", 23);
 
@@ -205,7 +214,7 @@ LOCAL int scheme_s3_read(uint8_t *data, int data_len, gpointer uw)
 /******************************************************************************/
 LOCAL void scheme_s3_request(void *server, const ArkimeCredentials_t *creds, const char *path, const char *bucket, S3Request *req, gboolean pathStyle, ArkimeHttpRead_cb cb)
 {
-    char           objectkey[1000];
+    char           objectkey[1600];
 
     if (pathStyle)
         snprintf(objectkey, sizeof(objectkey), "/%s%s", bucket, path);
@@ -382,6 +391,17 @@ LOCAL int scheme_s3_load_full_dir(const char *dir, ArkimeSchemeFlags flags, Arki
     }
 
     char **paths = g_strsplit(path, "/", 3);  // Split into at most 3: empty, bucket, prefix
+
+    if (!paths[0] || !paths[1] || paths[1][0] == 0) {
+        LOG("ERROR - S3 directory URL missing bucket: %s", dir);
+        g_strfreev(paths);
+        curl_free(scheme);
+        curl_free(host);
+        curl_free(port);
+        curl_free(path);
+        curl_url_cleanup(h);
+        return 1;
+    }
 
     char schemehostport[300];
     if (port)
@@ -600,6 +620,17 @@ LOCAL int scheme_s3_load_full(const char *uri, ArkimeSchemeFlags flags, ArkimeSc
     }
 
     char **paths = g_strsplit(path, "/", 0);
+
+    if (!paths[0] || !paths[1] || paths[1][0] == 0) {
+        LOG("ERROR - S3 file URL missing bucket: %s", uri);
+        g_strfreev(paths);
+        curl_free(scheme);
+        curl_free(host);
+        curl_free(port);
+        curl_free(path);
+        curl_url_cleanup(h);
+        return 1;
+    }
 
     char schemehostport[300];
     if (port)

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -129,6 +129,11 @@ LOCAL void sqs_done(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
         uint32_t receiptLen = 0;
         uint8_t *receipt = (uint8_t *)arkime_js0n_get(messages + out[i], out[i + 1], "ReceiptHandle", &receiptLen);
 
+        if (!receipt || receiptLen == 0) {
+            LOG("No ReceiptHandle %.*s", out[i + 1], messages + out[i]);
+            continue;
+        }
+
         uint32_t bodyLen = 0;
         uint8_t *body = (uint8_t *)arkime_js0n_get(messages + out[i], out[i + 1], "Body", &bodyLen);
         if (!body) {
@@ -242,13 +247,13 @@ LOCAL int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags, ArkimeScheme
     }
 
     // Construct the request URL
-    char receiveFullPath[1000];
+    char receiveFullPath[1600];
     snprintf(receiveFullPath, sizeof(receiveFullPath), "/%s/%s?Action=ReceiveMessage&Version=2012-11-05&MaxNumberOfMessages=1&WaitTimeSeconds=10", uris[3], uris[4]);
 
     if (config.debug)
         LOG("receiveFullPath: %s", receiveFullPath);
 
-    char deleteFullPath[1000];
+    char deleteFullPath[1600];
     snprintf(deleteFullPath, sizeof(deleteFullPath), "/%s/%s", uris[3], uris[4]);
 
     char *headers[5] = {"Content-Type: application/x-www-form-urlencoded", "Expect:", "Accept: application/json", NULL, NULL};
@@ -292,7 +297,7 @@ LOCAL int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags, ArkimeScheme
         ARKIME_UNLOCK(req->items->lock);
 
         if (item->bucket && item->key) {
-            char s3url[1000];
+            char s3url[1600];
             if (isaws) {
                 snprintf(s3url, sizeof(s3url), "s3://%s/%s", item->bucket, item->key);
             } else if (s3Host) {

--- a/tests/api-multiunique.t
+++ b/tests/api-multiunique.t
@@ -106,6 +106,7 @@ ipwise, 3
 ipwise2, 3
 ipwisecsv, 4
 smtp:authlogin, 1
+socks:auth-failed, 1
 socks:password, 2
 srcip, 4
 wisebyhost2, 7

--- a/tests/api-unique.t
+++ b/tests/api-unique.t
@@ -110,6 +110,7 @@ ipwise, 3
 ipwise2, 3
 ipwisecsv, 4
 smtp:authlogin, 1
+socks:auth-failed, 1
 socks:password, 2
 srcip, 4
 wisebyhost2, 7

--- a/tests/pcap/snmpv3_synthetic.test
+++ b/tests/pcap/snmpv3_synthetic.test
@@ -34,11 +34,10 @@
      "lte" : 1700000000000
     },
     "protocol" : [
-     "ldap",
      "snmp",
      "udp"
     ],
-    "protocolCnt" : 3,
+    "protocolCnt" : 2,
     "segmentCnt" : 1,
     "server" : {
      "bytes" : 0
@@ -181,11 +180,10 @@
      "lte" : 1700000002000
     },
     "protocol" : [
-     "ldap",
      "snmp",
      "udp"
     ],
-    "protocolCnt" : 3,
+    "protocolCnt" : 2,
     "segmentCnt" : 1,
     "server" : {
      "bytes" : 0
@@ -332,11 +330,10 @@
      "lte" : 1700000004000
     },
     "protocol" : [
-     "ldap",
      "snmp",
      "udp"
     ],
-    "protocolCnt" : 3,
+    "protocolCnt" : 2,
     "segmentCnt" : 1,
     "server" : {
      "bytes" : 0

--- a/tests/pcap/socks-http-pass.test
+++ b/tests/pcap/socks-http-pass.test
@@ -239,9 +239,10 @@
     ],
     "srcTTLCnt" : 1,
     "tags" : [
+     "socks:auth-failed",
      "socks:password"
     ],
-    "tagsCnt" : 1,
+    "tagsCnt" : 2,
     "tcpflags" : {
      "ack" : 6,
      "ae" : 0,


### PR DESCRIPTION
- LDAP classifier now requires APPLICATION class for protocolOp; fixes SNMPv3 (and other ASN.1 sequences) being tagged as ldap
- SOCKS5 parser hardening: validate VER/RSV fields, add socks:auth-failed and socks:connect-failed tags on bad status
- SMTP AUTH PLAIN uses memchr bounded by output length
- QUIC fbzero buffer-overflow guard before wait-loop
- Suricata plugin validates ip/port/vlan and rejects malformed alerts
- scheme http no longer requires explicit port (defaults to 80/443)
- scheme s3 validates bucket, checks HTTP status, larger url buffers
- command registration rejects duplicate names
- plugin loader closes module handle when arkime_plugin_init missing
- regenerate snmpv3_synthetic and socks-http-pass test goldens

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
