### PR TITLE
Add arkime_session_rm_protocol; drop ftp on confirmed SMTP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3917 Extract VNI from GENEVE tunnels
   - #3918 scheme http no longer requires a port (defaults to 80/443)
   - #3918 fix SNMP sessions showing up as LDAP too
+  - #3919 Remove ftp protocol if we are sure smtp
 ## Viewer
   - #3898 show error msg in spiview when All selected but not allowed
   - #3906 add copy button to History Elasticsearch Query section

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1323,6 +1323,7 @@ void     arkime_session_init();
 void     arkime_session_exit();
 void     arkime_session_add_protocol(ArkimeSession_t *session, const char *protocol);
 gboolean arkime_session_has_protocol(ArkimeSession_t *session, const char *protocol);
+gboolean arkime_session_rm_protocol(ArkimeSession_t *session, const char *protocol);
 void     arkime_session_add_tag(ArkimeSession_t *session, const char *tag);
 
 #define  arkime_session_incr_outstanding(session) (session)->outstandingQueries++

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -530,6 +530,7 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
             } else if (strncasecmp(line->str, "HELO ", 5) == 0 ||
                        strncasecmp(line->str, "EHLO ", 5) == 0) {
                 arkime_field_string_add_lower(helloField, session, line->str + 5, -1);
+                arkime_session_rm_protocol(session, "ftp");
                 *state = EMAIL_CMD;
             } else {
                 *state = EMAIL_CMD;

--- a/capture/session.c
+++ b/capture/session.c
@@ -378,6 +378,23 @@ gboolean arkime_session_has_protocol(ArkimeSession_t *session, const char *proto
     return hstring != 0;
 }
 /******************************************************************************/
+gboolean arkime_session_rm_protocol(ArkimeSession_t *session, const char *protocol)
+{
+    if (!session->fields[protocolField])
+        return FALSE;
+
+    ArkimeStringHashStd_t   *shash = session->fields[protocolField]->shash;
+    ArkimeString_t          *hstring;
+    HASH_FIND(s_, *shash, protocol, hstring);
+    if (!hstring)
+        return FALSE;
+
+    HASH_REMOVE(s_, *shash, hstring);
+    g_free(hstring->str);
+    ARKIME_TYPE_FREE(ArkimeString_t, hstring);
+    return TRUE;
+}
+/******************************************************************************/
 void arkime_session_add_tag(ArkimeSession_t *session, const char *tag)
 {
     arkime_field_string_add(config.tagsStringField, session, tag, -1, TRUE);

--- a/tests/pcap/wireshark-bdat.test
+++ b/tests/pcap/wireshark-bdat.test
@@ -130,11 +130,10 @@
      "lte" : 1476878885949
     },
     "protocol" : [
-     "ftp",
      "smtp",
      "tcp"
     ],
-    "protocolCnt" : 3,
+    "protocolCnt" : 2,
     "segmentCnt" : 1,
     "server" : {
      "bytes" : 130


### PR DESCRIPTION
The 220 banner is shared by FTP and SMTP, so misc.c's other220 classifier may tag a session as ftp before SMTP commands are seen. Once the smtp parser observes a HELO/EHLO command we know for sure the session is SMTP and the ftp tag is spurious.

- Add arkime_session_rm_protocol() helper for removing a protocol from a session's STR_HASH protocol field
- smtp parser removes the ftp protocol tag when it sees HELO/EHLO
- Regenerate wireshark-bdat golden which had spurious ftp tag

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
