### PR TITLE
Log more information on role failures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,6 +56,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3918 scheme http no longer requires a port (defaults to 80/443)
   - #3918 fix SNMP sessions showing up as LDAP too
   - #3919 Remove ftp protocol if we are sure smtp
+## All
+  - #3920 Log more information on role failures
 ## Viewer
   - #3898 show error msg in spiview when All selected but not allowed
   - #3906 add copy button to History Elasticsearch Query section

--- a/common/user.js
+++ b/common/user.js
@@ -1766,6 +1766,21 @@ class User {
       }
     }
   }
+
+  async logRoleFailure (role) {
+    try {
+      const roles = Array.isArray(role) ? role : [role];
+      let urm;
+      if (!User.#dynamicRolesFuncs) {
+        urm = 'not using';
+      } else {
+        urm = '{' + roles.map(r => `${r}: ${User.#dynamicRolesFuncs.has(r) ? 'set' : 'cleared'}`).join(', ') + '}';
+      }
+      console.log('Missing %s role - userId: %s roles: %s expanded roles: %s user-role-mappings: %s', roles.join(','), this.userId, this.roles, await this.getRoles(), urm);
+    } catch (e) {
+      console.log('ERROR - logRoleFailure failed:', e.message);
+    }
+  }
 }
 
 /******************************************************************************/

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -196,6 +196,7 @@ Auth.app(app);
 // check for cont3xtUser
 app.use((req, res, next) => {
   if (!req.user.hasRole('cont3xtUser')) {
+    req.user.logRoleFailure('cont3xtUser');
     return res.send('Need cont3xtUser role assigned');
   }
   next();

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -976,6 +976,7 @@ function isUser (req, res, next) {
     return next();
   }
 
+  req.user.logRoleFailure('parliamentUser');
   res.status(403).json({
     success: false,
     text: 'Permission Denied: Not a Parliament user'
@@ -987,6 +988,7 @@ function isAdmin (req, res, next) {
     return next();
   }
 
+  req.user.logRoleFailure('parliamentAdmin');
   res.status(403).json({
     success: false,
     text: 'Permission Denied: Not a Parliament admin'

--- a/tests/mini-aws.pl
+++ b/tests/mini-aws.pl
@@ -22,6 +22,8 @@
 
 use strict;
 use warnings;
+STDOUT->autoflush(1);
+STDERR->autoflush(1);
 $SIG{INT} = sub { exit 0; };
 use IO::Socket::IP;
 use IO::Select;

--- a/viewer/apiMisc.js
+++ b/viewer/apiMisc.js
@@ -278,6 +278,7 @@ class MiscAPIs {
     }
 
     if (!req.user.hasRole(internals.uploadRoles)) {
+      req.user.logRoleFailure(internals.uploadRoles);
       res.status(403);
       return res.end('Not covered by role');
     }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -311,9 +311,7 @@ app.use(async (req, res, next) => {
   }
 
   if (!req.user.hasRole('arkimeUser')) {
-    if (Config.debug) {
-      console.log('Missing arkimeUser userId: %s roles: %s expanded roles: %s', req.user.userId, req.user.roles, await req.user.getRoles());
-    }
+    req.user.logRoleFailure('arkimeUser');
     return res.status(403).send('Need arkimeUser role assigned');
   }
   next();

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -1429,7 +1429,7 @@ function isWiseAdmin (req, res, next) {
   if (req.user.hasRole('wiseAdmin')) {
     return next();
   } else {
-    console.log(`${req.user.userId} is not wiseAdmin`);
+    req.user.logRoleFailure('wiseAdmin');
     return res.send(JSON.stringify({ success: false, text: 'Not authorized, check log file' }));
   }
 }
@@ -1439,7 +1439,7 @@ function isWiseUser (req, res, next) {
   if (req.user.hasRole('wiseUser')) {
     return next();
   } else {
-    console.log(`${req.user.userId} is not wiseUser`);
+    req.user.logRoleFailure('wiseUser');
     return res.send(JSON.stringify({ success: false, text: 'Not authorized, check log file' }));
   }
 }


### PR DESCRIPTION
Add User.logRoleFailure helper that prints userId, roles, expanded roles, and per-role user-role-mappings status. Use it from cont3xt, parliament, viewer, wise, and apiMisc upload handler.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
