### PR TITLE
enforce hidePcap/disablePcapDownload on body and bodyhash endpoints

### DIFF
--- a/tests/api-sessions.t
+++ b/tests/api-sessions.t
@@ -1,4 +1,4 @@
-use Test::More tests => 159;
+use Test::More tests => 167;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -384,3 +384,27 @@ tcp,1386004309468,1386004309478,10.180.156.185,53533,US,10.180.156.249,1080,US,2
     # Port 40007: Multiple partial retransmits
     $response = getBinary("/test/raw/" . $portToId{40007} . "?type=dst");
     is (unpack("H*", $response->content), $expectedHex, "tcp-reassembly multi-partial (40007)");
+
+# hidePcap / disablePcapDownload authorization on body & bodyhash endpoints
+    my $bSdId = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("file=$pwd/smtp-zip.pcap"));
+    my $bId = $bSdId->{data}->[0]->{id};
+
+    addUser("-n testuser hpBodyUser hpBodyUser hpBodyUser --hidePcap --roles arkimeUser");
+    addUser("-n testuser dpdBodyUser dpdBodyUser dpdBodyUser --disablePcapDownload --roles arkimeUser");
+
+    my @bodyEndpoints = (
+        "/api/session/test/$bId/body/file/1/x.pellet",
+        "/api/session/test/$bId/bodypng/file/1/x",
+        "/api/sessions/bodyhash/abc123",
+        "/api/session/test/$bId/bodyhash/abc123",
+    );
+
+    for my $url (@bodyEndpoints) {
+        my $sep = ($url =~ /\?/) ? '&' : '?';
+        my $hpResp = $ArkimeTest::userAgent->get(
+            "http://$ArkimeTest::host:8123$url${sep}arkimeRegressionUser=hpBodyUser");
+        is ($hpResp->code, 403, "hidePcap user blocked from $url");
+        my $dpdResp = $ArkimeTest::userAgent->get(
+            "http://$ArkimeTest::host:8123$url${sep}arkimeRegressionUser=dpdBodyUser");
+        is ($dpdResp->code, 403, "disablePcapDownload user blocked from $url");
+    }

--- a/tests/api-sessions.t
+++ b/tests/api-sessions.t
@@ -386,25 +386,23 @@ tcp,1386004309468,1386004309478,10.180.156.185,53533,US,10.180.156.249,1080,US,2
     is (unpack("H*", $response->content), $expectedHex, "tcp-reassembly multi-partial (40007)");
 
 # hidePcap / disablePcapDownload authorization on body & bodyhash endpoints
-    my $bSdId = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("file=$pwd/smtp-zip.pcap"));
-    my $bId = $bSdId->{data}->[0]->{id};
+    my $bId = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("file=$pwd/smtp-zip.pcap"))->{data}->[0]->{id};
 
     addUser("-n testuser hpBodyUser hpBodyUser hpBodyUser --hidePcap --roles arkimeUser");
     addUser("-n testuser dpdBodyUser dpdBodyUser dpdBodyUser --disablePcapDownload --roles arkimeUser");
 
-    my @bodyEndpoints = (
-        "/api/session/test/$bId/body/file/1/x.pellet",
-        "/api/session/test/$bId/bodypng/file/1/x",
-        "/api/sessions/bodyhash/abc123",
-        "/api/session/test/$bId/bodyhash/abc123",
-    );
+    my $base = "http://$ArkimeTest::host:8123";
 
-    for my $url (@bodyEndpoints) {
-        my $sep = ($url =~ /\?/) ? '&' : '?';
-        my $hpResp = $ArkimeTest::userAgent->get(
-            "http://$ArkimeTest::host:8123$url${sep}arkimeRegressionUser=hpBodyUser");
-        is ($hpResp->code, 403, "hidePcap user blocked from $url");
-        my $dpdResp = $ArkimeTest::userAgent->get(
-            "http://$ArkimeTest::host:8123$url${sep}arkimeRegressionUser=dpdBodyUser");
-        is ($dpdResp->code, 403, "disablePcapDownload user blocked from $url");
+    # body & bodypng: only hidePcap blocks; disablePcapDownload users may still view
+    for my $url ("/api/session/test/$bId/body/file/1/x.pellet",
+                 "/api/session/test/$bId/bodypng/file/1/x") {
+        is   ($ArkimeTest::userAgent->get("$base$url?arkimeRegressionUser=hpBodyUser")->code,  403, "hidePcap blocks $url");
+        isnt ($ArkimeTest::userAgent->get("$base$url?arkimeRegressionUser=dpdBodyUser")->code, 403, "disablePcapDownload allowed on $url");
+    }
+
+    # bodyhash: both hidePcap and disablePcapDownload block
+    for my $url ("/api/sessions/bodyhash/abc123",
+                 "/api/session/test/$bId/bodyhash/abc123") {
+        is ($ArkimeTest::userAgent->get("$base$url?arkimeRegressionUser=hpBodyUser")->code,  403, "hidePcap blocks $url");
+        is ($ArkimeTest::userAgent->get("$base$url?arkimeRegressionUser=dpdBodyUser")->code, 403, "disablePcapDownload blocks $url");
     }

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1802,13 +1802,13 @@ app.getpost(
 
 app.get( // session body file endpoint
   ['/api/session/:nodeName/:id/body/:bodyType/:bodyNum/:bodyName', '/:nodeName/:id/body/:bodyType/:bodyNum/:bodyName'],
-  [checkProxyRequest],
+  [checkProxyRequest, User.checkPermissions(['hidePcap', 'disablePcapDownload'])],
   SessionAPIs.getRawBody
 );
 
 app.get( // session body file image endpoint
   ['/api/session/:nodeName/:id/bodypng/:bodyType/:bodyNum/:bodyName', '/:nodeName/:id/bodypng/:bodyType/:bodyNum/:bodyName'],
-  [checkProxyRequest],
+  [checkProxyRequest, User.checkPermissions(['hidePcap', 'disablePcapDownload'])],
   SessionAPIs.getFilePNG
 );
 
@@ -1862,13 +1862,13 @@ app.get( // session raw packets endpoint
 
 app.get( // session file bodyhash endpoint
   ['/api/sessions/bodyhash/:hash', '/bodyHash/:hash'],
-  [logAction('bodyhash')],
+  [logAction('bodyhash'), User.checkPermissions(['hidePcap', 'disablePcapDownload'])],
   SessionAPIs.getBodyHash
 );
 
 app.get( // session file bodyhash endpoint
   ['/api/session/:nodeName/:id/bodyhash/:hash'],
-  [checkProxyRequest],
+  [checkProxyRequest, User.checkPermissions(['hidePcap', 'disablePcapDownload'])],
   SessionAPIs.getBodyHashFromNode
 );
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1802,13 +1802,13 @@ app.getpost(
 
 app.get( // session body file endpoint
   ['/api/session/:nodeName/:id/body/:bodyType/:bodyNum/:bodyName', '/:nodeName/:id/body/:bodyType/:bodyNum/:bodyName'],
-  [checkProxyRequest, User.checkPermissions(['hidePcap', 'disablePcapDownload'])],
+  [checkProxyRequest, User.checkPermissions(['hidePcap'])],
   SessionAPIs.getRawBody
 );
 
 app.get( // session body file image endpoint
   ['/api/session/:nodeName/:id/bodypng/:bodyType/:bodyNum/:bodyName', '/:nodeName/:id/bodypng/:bodyType/:bodyNum/:bodyName'],
-  [checkProxyRequest, User.checkPermissions(['hidePcap', 'disablePcapDownload'])],
+  [checkProxyRequest, User.checkPermissions(['hidePcap'])],
   SessionAPIs.getFilePNG
 );
 


### PR DESCRIPTION

- Add User.checkPermissions(['hidePcap', 'disablePcapDownload']) middleware to /api/session/:nodeName/:id/body, /bodypng, /bodyhash, and /api/sessions/bodyhash/:hash, matching the existing /packets and /pcap* authorization model.
- Add api-sessions.t regression coverage: restricted users now receive 403 from all four body/bodyhash routes.


## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
