### PR TITLE
Security hardening: cap parser buffers and validate S2S auth shapes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3919 Remove ftp protocol if we are sure smtp
   - #3923 Packets with more than 8 VLANs marked as corrupt
   - #3923 UDP packets enforce length correctly
+  - #3924 Remove trailing slash from wiseURL
+  - #3927 Cap IMAP/SMTP/HTTP Header buffer lengths
 ## Viewer
   - #3898 show error msg in spiview when All selected but not allowed
   - #3906 add copy button to History Elasticsearch Query section
@@ -67,8 +69,6 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3921 Fix Cap Restart graph markers, Session Detail labels slider
           width, Field Actions dropdown, Stats Shrink Index,
           and shortcut ($) autocomplete in search expression
-## WISE
-  - #3924 Remove trailing slash from wiseURL
 
 6.2.0 2026/04/20
 ## BREAKING

--- a/capture/dedup.c
+++ b/capture/dedup.c
@@ -75,6 +75,11 @@ LOCAL DedupSeconds_t *seconds;
 /******************************************************************************/
 int arkime_dedup_should_drop (const ArkimePacket_t *packet, int headerLen)
 {
+    // Cap headerLen to prevent large stack VLA on attacker-controlled IPv6 ext headers
+    if (headerLen <= 0 || headerLen > 256) {
+        return 0;
+    }
+
     struct timespec currentTime;
     clock_gettime(CLOCK_MONOTONIC_COARSE, &currentTime);
 
@@ -134,7 +139,7 @@ int arkime_dedup_should_drop (const ArkimePacket_t *packet, int headerLen)
     }
     MD5_Final(md, &ctx);
 #else
-    uint8_t buf[headerLen + 4];
+    uint8_t buf[260];
     XXH128_hash_t hash;
     if (prefix_len) {
         memcpy(buf, prefix, prefix_len);

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -9,6 +9,14 @@
 //#define HTTPDEBUG 1
 
 #define MAX_URL_LENGTH 4096
+#define HTTP_FIELD_MAX 8192
+#define HTTP_GSTR_APPEND(gs, at, length) do { \
+    if ((gs)->len < HTTP_FIELD_MAX) { \
+        size_t _avail = HTTP_FIELD_MAX - (gs)->len; \
+        size_t _add = (length) < _avail ? (length) : _avail; \
+        g_string_append_len((gs), (at), _add); \
+    } \
+} while (0)
 
 // Only track DELETE, GET, HEAD, POST, PUT, CONNECT, OPTIONS
 #define HTTP_MAX_METHOD 6
@@ -286,7 +294,7 @@ LOCAL int arkime_hp_cb_on_url (http_parser *parser, const char *at, size_t lengt
         http->urlString = g_string_new_len(at, length);
         http->urlWhich = http->which;
     } else
-        g_string_append_len(http->urlString, at, length);
+        HTTP_GSTR_APPEND(http->urlString, at, length);
 
     return 0;
 }
@@ -522,22 +530,22 @@ LOCAL int arkime_hp_cb_on_header_value (http_parser *parser, const char *at, siz
             if (!http->hostString)
                 http->hostString = g_string_new_len(at, length);
             else
-                g_string_append_len(http->hostString, at, length);
+                HTTP_GSTR_APPEND(http->hostString, at, length);
         } else if (strcasecmp("cookie", http->header[http->which]) == 0) {
             if (!http->cookieString)
                 http->cookieString = g_string_new_len(at, length);
             else
-                g_string_append_len(http->cookieString, at, length);
+                HTTP_GSTR_APPEND(http->cookieString, at, length);
         } else if (strcasecmp("authorization", http->header[http->which]) == 0) {
             if (!http->authString)
                 http->authString = g_string_new_len(at, length);
             else
-                g_string_append_len(http->authString, at, length);
+                HTTP_GSTR_APPEND(http->authString, at, length);
         } else if (strcasecmp("proxy-authorization", http->header[http->which]) == 0) {
             if (!http->proxyAuthString)
                 http->proxyAuthString = g_string_new_len(at, length);
             else
-                g_string_append_len(http->proxyAuthString, at, length);
+                HTTP_GSTR_APPEND(http->proxyAuthString, at, length);
         }
     }
 
@@ -545,7 +553,7 @@ LOCAL int arkime_hp_cb_on_header_value (http_parser *parser, const char *at, siz
         if (!http->valueString[http->which])
             http->valueString[http->which] = g_string_new_len(at, length);
         else
-            g_string_append_len(http->valueString[http->which], at, length);
+            HTTP_GSTR_APPEND(http->valueString[http->which], at, length);
     }
 
     return 0;

--- a/capture/parsers/imap.c
+++ b/capture/parsers/imap.c
@@ -98,13 +98,21 @@ LOCAL int imap_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                 lineLen--;
             }
         } else {
-            /* Incomplete line, buffer it */
+            /* Incomplete line, buffer it (cap to prevent unbounded growth) */
+            if (imap->line->len + remaining > 16384) {
+                arkime_session_add_tag(session, "imap:line-too-long");
+                return ARKIME_PARSER_UNREGISTER;
+            }
             g_string_append_len(imap->line, (const char *)data, remaining);
             return 0;
         }
 
         /* Combine with any buffered data */
         if (imap->line->len > 0) {
+            if (imap->line->len + lineLen > 16384) {
+                arkime_session_add_tag(session, "imap:line-too-long");
+                return ARKIME_PARSER_UNREGISTER;
+            }
             g_string_append_len(imap->line, (const char *)data, lineLen);
 
             /* Process the complete line - same logic as unbuffered */

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -9,6 +9,7 @@
 //#define EMAILDEBUG
 
 #define SMTP_MAX_LINE_LEN 10000
+#define SMTP_MAX_BOUNDARIES 128
 
 extern ArkimeConfig_t   config;
 extern char            *arkime_char_to_hex;
@@ -477,10 +478,13 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
             } else if (strncasecmp(line->str, "BDAT", 4) == 0 &&
                        line->len > 5 &&
                        (line->str[4] == ' ' || line->str[4] == '\t')) {
+                int bdatN = arkime_atoin(line->str + 5, line->len - 5);
+                if (bdatN < 0 || bdatN > (1 << 30)) {
+                    arkime_session_add_tag(session, "smtp:bad-bdat");
+                    return ARKIME_PARSER_UNREGISTER;
+                }
                 email->inBDAT |= (1 << which);
-                email->bdatRemaining[which] = arkime_atoin(line->str + 5, line->len - 5) + 1;
-                if (email->bdatRemaining[which] == 0)
-                    email->bdatRemaining[which] = 1;
+                email->bdatRemaining[which] = (guint)bdatN + 1;
 
                 if (email->seenHeaders & (1 << which))
                     *state = EMAIL_DATA;
@@ -648,7 +652,7 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
 
                     arkime_field_string_add(ctField, session, s, -1, TRUE);
                     char *boundary = (char *)arkime_memcasestr(s, line->len - (s - line->str), "boundary=", 9);
-                    if (boundary) {
+                    if (boundary && DLL_COUNT(s_, &email->boundaries) < SMTP_MAX_BOUNDARIES) {
                         ArkimeString_t *string = ARKIME_TYPE_ALLOC0(ArkimeString_t);
                         string->str = g_strdup(smtp_remove_matching(boundary + 9, '"', '"'));
                         string->len = strlen(string->str);
@@ -845,7 +849,7 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                 const char *s = line->str + 13;
                 while (isspace(*s)) s++;
                 char *boundary = (char *)arkime_memcasestr(s, line->len - (s - line->str), "boundary=", 9);
-                if (boundary) {
+                if (boundary && DLL_COUNT(s_, &email->boundaries) < SMTP_MAX_BOUNDARIES) {
                     ArkimeString_t *string = ARKIME_TYPE_ALLOC0(ArkimeString_t);
                     string->str = g_strdup(smtp_remove_matching(boundary + 9, '"', '"'));
                     string->len = strlen(string->str);

--- a/common/auth.js
+++ b/common/auth.js
@@ -1125,6 +1125,15 @@ class Auth {
     try {
       const { iv, salt, data, tag } = JSON.parse(auth);
 
+      // Validate strict shapes BEFORE expensive PBKDF2 (DoS protection)
+      const isHex = /^[0-9a-fA-F]+$/;
+      if (typeof iv !== 'string' || iv.length !== 24 || !isHex.test(iv) ||
+          typeof salt !== 'string' || salt.length !== 32 || !isHex.test(salt) ||
+          typeof tag !== 'string' || tag.length !== 32 || !isHex.test(tag) ||
+          typeof data !== 'string' || data.length === 0 || data.length > 8192 || !isHex.test(data)) {
+        throw new Error('Malformed auth token');
+      }
+
       let key = Auth.#keyCache.get(`${secret}:${salt}`);
       if (!key) {
         key = crypto.pbkdf2Sync(secret, Buffer.from(salt, 'hex'), 300000, 32, 'sha256');


### PR DESCRIPTION
- IMAP: cap buffered line at 16KB; unregister parser on overflow
- HTTP: cap url/host/cookie/auth/proxyAuth/value GString growth at 8KB
- SMTP: cap MIME boundary list at 128 entries
- dedup: skip dedup when headerLen > 256
- auth: validate iv/salt/tag/data hex shapes before PBKDF2 to prevent unauthenticated CPU DoS

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
