### PR TITLE
Security hardening: viewer summary cap, owner validation, cont3xt fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3923 UDP packets enforce length correctly
   - #3924 Remove trailing slash from wiseURL
   - #3927 Cap IMAP/SMTP/HTTP Header buffer lengths
+## Cont3xt
+  - #3928 Threatstream: ignore per-user host override unless user/key also per-user
+  - #3928 csvjson: add 60s timeout and 1GB content/body limits on remote feed loads
 ## Viewer
   - #3898 show error msg in spiview when All selected but not allowed
   - #3906 add copy button to History Elasticsearch Query section
@@ -69,6 +72,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3921 Fix Cap Restart graph markers, Session Detail labels slider
           width, Field Actions dropdown, Stats Shrink Index,
           and shortcut ($) autocomplete in search expression
+  - #3928 Cap /api/sessions/summary length parameter at 1000
 
 6.2.0 2026/04/20
 ## BREAKING

--- a/common/user.js
+++ b/common/user.js
@@ -1666,6 +1666,14 @@ class User {
       return true;
     }
 
+    // reject non-string / empty creator values; otherwise truthy non-strings
+    // would silently bypass the isString check below and be persisted,
+    // breaking ownership
+    if (!ArkimeUtil.isString(resource[creatorProperty])) {
+      res.serverError(403, 'Permission denied');
+      return false;
+    }
+
     if ( // if the resource has a new creator
       resource[creatorProperty] !== dbResource[creatorProperty] &&
       ArkimeUtil.isString(resource[creatorProperty])) {

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -950,6 +950,18 @@ class Integration {
     return ArkimeConfig.getFull(this.configName ?? this.section ?? this.name, key, d);
   }
 
+  // Returns true if the user has set a per-user override for `key`.
+  // Useful to detect mixing of per-user values with globally configured
+  // credentials (which can leak global credentials to user-chosen hosts).
+  hasUserConfig (user, key) {
+    if (user.cont3xt?.keys && !this.locked) {
+      const keys = user.getCont3xtKeys();
+      const configName = this.configName ?? this.name;
+      if (keys[configName]?.[key]) { return true; }
+    }
+    return false;
+  }
+
   userAgent () {
     return this.getConfig('userAgent', ArkimeConfig.get('userAgent', 'cont3xt'));
   }

--- a/cont3xt/integrations/csvjson/index.js
+++ b/cont3xt/integrations/csvjson/index.js
@@ -312,7 +312,11 @@ class CsvJsonIntegration extends Integration {
 
   // ----------------------------------------------------------------------------
   #loadHttp () {
-    axios.get(this.#url)
+    axios.get(this.#url, {
+      timeout: 60 * 1000,
+      maxContentLength: 1024 * 1024 * 1024,
+      maxBodyLength: 1024 * 1024 * 1024
+    })
       .then((response) => {
         return this.#process(response.data);
       })

--- a/cont3xt/integrations/threatstream/index.js
+++ b/cont3xt/integrations/threatstream/index.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 const ArkimeUtil = require('../../../common/arkimeUtil');
+const ArkimeConfig = require('../../../common/arkimeConfig');
 const Integration = require('../../integration.js');
 const axios = require('axios');
 
@@ -134,17 +135,25 @@ class ThreatstreamIntegration extends Integration {
 
   async fetch (user, query) {
     try {
-      const host = this.getUserConfig(user, 'host', 'api.threatstream.com');
+      const tuser = this.getUserConfig(user, 'user');
+      const tkey = this.getUserConfig(user, 'key');
+      if (!tkey || !tuser) {
+        return undefined;
+      }
+
+      // Only honor a per-user host override when the credentials are also
+      // per-user; otherwise the user could redirect global credentials to
+      // an attacker-chosen host (SSRF + credential disclosure).
+      let host;
+      if (this.hasUserConfig(user, 'user') && this.hasUserConfig(user, 'key')) {
+        host = this.getUserConfig(user, 'host', 'api.threatstream.com');
+      } else {
+        host = ArkimeConfig.getFull(this.configName ?? this.section ?? this.name, 'host', 'api.threatstream.com');
+      }
 
       // https://www.oreilly.com/library/view/regular-expressions-cookbook/9781449327453/ch08s15.html + uppercase
       if (!host.match(/^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,}$/)) {
         console.log(`userId: '${user.userId}' bad threatstream hostname: '%s'`, ArkimeUtil.sanitizeStr(host));
-        return undefined;
-      }
-
-      const tuser = this.getUserConfig(user, 'user');
-      const tkey = this.getUserConfig(user, 'key');
-      if (!tkey || !tuser) {
         return undefined;
       }
       const result = await axios.get(`https://${host}/api/v2/intelligence`, {

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2760,6 +2760,12 @@ class SessionAPIs {
     if (req.query.length) {
       topNum = parseInt(req.query.length);
     }
+    if (!Number.isFinite(topNum) || topNum <= 0) {
+      topNum = 20;
+    }
+    if (topNum > 1000) {
+      topNum = 1000;
+    }
 
     const sortOrder = req.body.order === 'asc' ? 'asc' : 'desc';
 


### PR DESCRIPTION
- viewer/apiSessions.js: cap /api/sessions/summary length param at 1000 and validate it as a positive integer before using as ES terms size.
- common/user.js: in setOwner, reject non-string/empty creator values up front so truthy non-strings can't bypass the isString check and be persisted as the resource owner.
- cont3xt/integration.js: add hasUserConfig() helper to detect when a setting comes from per-user config vs global.
- cont3xt/integrations/threatstream: only honor a per-user host override when the user/key are also per-user, otherwise fall back to the global host. Prevents leaking globally-configured Threatstream API credentials to a user-chosen domain (SSRF + credential disclosure).
- cont3xt/integrations/csvjson: add 60s timeout and 1GB maxContentLength/maxBodyLength on remote feed loads.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
