### PR TITLE
Remove unimplemented 'Last Used' manualQuery option (#3931)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -73,6 +73,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           width, Field Actions dropdown, Stats Shrink Index,
           and shortcut ($) autocomplete in search expression
   - #3928 Cap /api/sessions/summary length parameter at 1000
+  - #3931 Remove last manualQuery option which wasn't implemented
 
 6.2.0 2026/04/20
 ## BREAKING

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -1729,7 +1729,10 @@ export default {
       });
     },
     shouldIssueQuery: function () {
-      const manualQuery = this.user.settings.manualQuery && JSON.parse(this.user.settings.manualQuery);
+      let manualQuery = this.user.settings.manualQuery;
+      if (typeof manualQuery === 'string') {
+        manualQuery = manualQuery === 'true';
+      }
       const hasExpression = this.query.expression && this.query.expression.length;
       return searchIssued || !manualQuery || (manualQuery && hasExpression);
     },

--- a/viewer/vueapp/src/components/settings/Settings.vue
+++ b/viewer/vueapp/src/components/settings/Settings.vue
@@ -269,7 +269,6 @@ SPDX-License-Identifier: Apache-2.0
                 :model-value="settings.manualQuery"
                 @update:model-value="updateQueryOnPageLoad"
                 :options="[
-                  { text: $t('settings.general.lastUsed'), value: 'last' },
                   { text: $t('settings.general.query-false'), value: 'false' },
                   { text: $t('settings.general.query-true'), value: 'true' }
                 ]" />
@@ -2182,7 +2181,7 @@ export default {
         if (!response.showTimestamps) {
           this.settings.showTimestamps = 'last';
         }
-        if (!response.manualQuery) {
+        if (!response.manualQuery || response.manualQuery === 'last') {
           this.settings.manualQuery = false;
         }
 


### PR DESCRIPTION
- Settings.vue: drop the 'last' radio option for queryOnLoad; it was added during the Vue3 settings refactor but never wired up
- Settings.vue: migrate existing users with manualQuery='last' to false
- Sessions.vue: stop using JSON.parse on manualQuery so unexpected values no longer throw SyntaxError

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
