### PR TITLE
Skip byte-based UDP classifiers on UDP/53 to avoid DNS false-matches

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3923 UDP packets enforce length correctly
   - #3924, #3930 Remove trailing slash from wiseURL
   - #3927 Cap IMAP/SMTP/HTTP Header buffer lengths
+  - #3932 Skip byte-based UDP classifiers on UDP/53 to avoid DNS false-matches
 ## Cont3xt
   - #3928 Threatstream: ignore per-user host override unless user/key also per-user
   - #3928 csvjson: add 60s timeout and 1GB content/body limits on remote feed loads

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -536,6 +536,7 @@ typedef struct {
 #define ARKIME_WHICH_SET_ID(_w, _id) ((_w & 0x1) | (_id << 8))
 
 #define ARKIME_PARSER_UNREGISTER -1
+// Deprecated: byte-based UDP classifiers are automatically skipped on UDP/53 in arkime_parsers_classify_udp.
 #define ARKIME_RETURN_IF_DNS_PORT if (session->port1 == 53 || session->port2 == 53) return
 typedef int  (* ArkimeParserFunc) (struct arkime_session *session, void *uw, const uint8_t *data, int remaining, int which);
 typedef void (* ArkimeParserFreeFunc) (struct arkime_session *session, void *uw);

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -1254,6 +1254,10 @@ void arkime_parsers_classify_udp(ArkimeSession_t *session, const uint8_t *data, 
         classifersUdpPortDst[session->port2].arr[i]->func(session, data, remaining, which, classifersUdpPortDst[session->port2].arr[i]->uw);
     }
 
+    // Skip byte-based UDP classifiers on the DNS port
+    if (session->port1 == 53 || session->port2 == 53)
+        goto after_byte_classifiers;
+
     for (int i = 0; i < classifersUdp0.cnt; i++) {
         ArkimeClassify_t *c = classifersUdp0.arr[i];
         if (remaining >= c->minlen && memcmp(data + c->offset, c->match, c->matchlen) == 0) {
@@ -1271,6 +1275,7 @@ void arkime_parsers_classify_udp(ArkimeSession_t *session, const uint8_t *data, 
         }
     }
 
+after_byte_classifiers:
     arkime_rules_run_after_classify(session);
     if (config.yara && !config.yaraEveryPacket && !session->stopYara)
         arkime_yara_execute(session, data, remaining, 0);

--- a/capture/parsers/bacnet.c
+++ b/capture/parsers/bacnet.c
@@ -368,8 +368,6 @@ LOCAL int bacnet_udp_parser(ArkimeSession_t *session, void *UNUSED(uw), const ui
 /******************************************************************************/
 LOCAL void bacnet_udp_classify(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which), void *UNUSED(uw))
 {
-    ARKIME_RETURN_IF_DNS_PORT;
-
     if (arkime_session_has_protocol(session, "bacnet"))
         return;
 

--- a/capture/parsers/dnp3.c
+++ b/capture/parsers/dnp3.c
@@ -166,8 +166,6 @@ LOCAL void dnp3_tcp_classify(ArkimeSession_t *session, const uint8_t *data, int 
 /******************************************************************************/
 LOCAL void dnp3_udp_classify(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which), void UNUSED(*uw))
 {
-    ARKIME_RETURN_IF_DNS_PORT;
-
     if (len < DNP3_MIN_LEN) {
         return;
     }

--- a/capture/parsers/gtp.c
+++ b/capture/parsers/gtp.c
@@ -59,7 +59,6 @@ LOCAL ArkimePacketRC gtp_packet_enqueue(ArkimePacketBatch_t *batch, ArkimePacket
 /******************************************************************************/
 LOCAL void gtp_control_udp_classify(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which), void *UNUSED(uw))
 {
-    ARKIME_RETURN_IF_DNS_PORT;
     if (len < 8)
         return;
 

--- a/capture/parsers/misc.c
+++ b/capture/parsers/misc.c
@@ -64,8 +64,6 @@ LOCAL void user_classify(ArkimeSession_t *session, const uint8_t *data, int len,
 /******************************************************************************/
 LOCAL void misc_add_protocol_classify(ArkimeSession_t *session, const uint8_t *UNUSED(data), int UNUSED(len), int UNUSED(which), void *uw)
 {
-    ARKIME_RETURN_IF_DNS_PORT;
-
     arkime_session_add_protocol(session, uw);
 }
 /******************************************************************************/
@@ -239,7 +237,6 @@ LOCAL void omron_fins_tcp_classify(ArkimeSession_t *session, const uint8_t *data
 /******************************************************************************/
 LOCAL void netflow_classify(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which), void *UNUSED(uw))
 {
-    ARKIME_RETURN_IF_DNS_PORT;
     if (len < 24)
         return;
 

--- a/capture/parsers/pana.c
+++ b/capture/parsers/pana.c
@@ -148,7 +148,6 @@ LOCAL void pana_udp_classify(ArkimeSession_t *session, const uint8_t *data, int 
         return;
 
     // Exclude DNS ports
-    ARKIME_RETURN_IF_DNS_PORT;
 
     // PANA header: 2 bytes reserved (0x0000), 2 bytes length, must match packet length
     if (len < 16)

--- a/capture/parsers/rdp.c
+++ b/capture/parsers/rdp.c
@@ -359,8 +359,6 @@ LOCAL int rdp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, in
 /******************************************************************************/
 LOCAL void rdp_udp_classify(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which), void *UNUSED(uw))
 {
-    ARKIME_RETURN_IF_DNS_PORT;
-
     // MS-RDPEUDP SYN: snSourceAck(4) == 0xffffffff
     if (len >= 8 && memcmp(data, "\xff\xff\xff\xff", 4) == 0) {
         arkime_session_add_protocol(session, "rdpudp");

--- a/capture/parsers/synchrophasor.c
+++ b/capture/parsers/synchrophasor.c
@@ -269,8 +269,6 @@ LOCAL void synchrophasor_tcp_classify(ArkimeSession_t *session, const uint8_t *d
 /******************************************************************************/
 LOCAL void synchrophasor_udp_classify(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which), void UNUSED(*uw))
 {
-    ARKIME_RETURN_IF_DNS_PORT;
-
     if (len < SYNCHROPHASOR_MIN_LEN)
         return;
 


### PR DESCRIPTION
- parsers.c: in arkime_parsers_classify_udp, skip the byte-based classifier dispatch (Udp0/Udp1/Udp2) when either side of the session is on UDP/53.  Port-based classifiers still run, so dns.c is unaffected.  Parsers that legitimately need to run on UDP/53 should register a port-based classifier.
- arkime.h: mark ARKIME_RETURN_IF_DNS_PORT as deprecated; keep the macro for out-of-tree parser compatibility.
- Remove now-redundant ARKIME_RETURN_IF_DNS_PORT calls from in-tree parsers (bacnet, dnp3, gtp, misc, pana, rdp, synchrophasor).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
