### PR TITLE
Fix viewer crash on Session Detail for no-PCAP sessions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -76,6 +76,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           and shortcut ($) autocomplete in search expression
   - #3928 Cap /api/sessions/summary length parameter at 1000
   - #3931 Remove last manualQuery option which wasn't implemented
+  - #3934 Fix not handling sessions correctly with no PCAP
 
 6.2.0 2026/04/20
 ## BREAKING

--- a/tests/api-sessionDetail.t
+++ b/tests/api-sessionDetail.t
@@ -1,4 +1,4 @@
-use Test::More tests => 34;
+use Test::More tests => 39;
 
 use Cwd;
 use URI::Escape;
@@ -153,3 +153,41 @@ ok($sd =~ m{NETWORK PROGRAM 1.0}s);
 
 unlink "../assets/scheme1.pcap";
 esPost("/tests_files/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "term": { "name": "http://localhost:8123/assets/scheme1.pcap" } } }');
+
+# Session with no packetPos / no fileId (e.g. session forwarded from a metadata-only
+# source). /detail must tell the client to hidepackets, and /packets must not crash
+# the viewer with TypeError: Cannot set properties of undefined (setting 'id').
+my $noPcapTag = "no-pcap-detail-regression-tag";
+my $noPcapDocId = "abcdef0123456789nopcap00";
+my $noPcapIndex = "tests_sessions3-26m04";
+my $noPcapDoc = '{
+  "@timestamp": 1745000000000,
+  "firstPacket": 1745000000000,
+  "lastPacket": 1745000001000,
+  "node": "test",
+  "ipProtocol": 17,
+  "source": {"ip": "10.99.99.10", "port": 1000, "bytes": 100, "packets": 1},
+  "destination": {"ip": "10.99.99.20", "port": 53, "bytes": 100, "packets": 1},
+  "network": {"packets": 2, "bytes": 200},
+  "totDataBytes": 100,
+  "length": 1,
+  "protocol": ["udp"],
+  "protocolCnt": 1,
+  "tags": ["' . $noPcapTag . '"],
+  "tagsCnt": 1
+}';
+esPost("/$noPcapIndex/_doc/$noPcapDocId?refresh=wait_for", $noPcapDoc);
+
+my $noPcapList = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("tags=$noPcapTag"));
+is (scalar @{$noPcapList->{data}}, 1, "no-pcap session indexed");
+my $noPcapId = $noPcapList->{data}->[0]->{id};
+
+$sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$noPcapId/detail")->content;
+ok($sd =~ m{sessionid="\Q$noPcapId\E"}s, "no-pcap /detail rendered");
+ok($sd =~ m{hidepackets="true"}, "no-pcap /detail sets hidepackets=\"true\"");
+
+my $noPcapPackets = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$noPcapId/packets?line=false&ts=false&base=ascii");
+is ($noPcapPackets->code, 200, "no-pcap /packets returns 200 (no crash)");
+ok($noPcapPackets->content !~ m{Cannot set properties of undefined}, "no-pcap /packets does not throw TypeError");
+
+esPost("/$noPcapIndex/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "term": { "tags": "' . $noPcapTag . '" } } }');

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -1250,7 +1250,7 @@ class SessionAPIs {
       const fields = session.fields;
 
       if (!fields.packetPos) {
-        return endCb(null);
+        return endCb(null, fields);
       }
 
       if (maxPackets && fields.packetPos.length > maxPackets) {
@@ -2589,7 +2589,7 @@ class SessionAPIs {
           },
           allowedAttributes: {
             img: ['src'],
-            '*': [':download', 'download', '#button-content', 'class', 'value', 'sessionid', 'hidePackets', 'v-if', 'target', 'href', ':href', '@click', 'v-has-permission', 'text', ':text', ':sessions', '@done', ':cluster', ':single', ':message', ':type', ':done', 'expr', ':expr', ':separator', ':field', 'pull-left', 'size', 'variant', 'columns', 'style', 'suffix', 'target', 'v-for', 'key', ':key', ':add', 'title']
+            '*': [':download', 'download', '#button-content', 'class', 'value', 'sessionid', 'hidepackets', 'v-if', 'target', 'href', ':href', '@click', 'v-has-permission', 'text', ':text', ':sessions', '@done', ':cluster', ':single', ':message', ':type', ':done', 'expr', ':expr', ':separator', ':field', 'pull-left', 'size', 'variant', 'columns', 'style', 'suffix', 'target', 'v-for', 'key', ':key', ':add', 'title']
           }
         });
         res.send(html);

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -423,7 +423,7 @@ function createSessionDetail () {
     });
   }, function () {
     internals.sessionDetailNew = 'include views/mixins.pug\n' +
-                                 'div.session-detail(sessionid=session.id,hidePackets=hidePackets)\n' +
+                                 'div.session-detail(sessionid=session.id,hidepackets=hidePackets)\n' +
                                  '  include views/sessionOptions\n' +
                                  '  b-card-group(columns)\n' +
                                  '    b-card\n' +

--- a/viewer/vueapp/src/components/sessions/SessionDetail.vue
+++ b/viewer/vueapp/src/components/sessions/SessionDetail.vue
@@ -195,6 +195,7 @@ const createDetailDataComponent = () => {
   return defineAsyncComponent(async () => {
     try {
       const response = await SessionsService.getDetail(props.session.id, props.session.node, props.session.cluster);
+      hidePackets.value = /hidepackets="true"/i.test(response);
       return sessionDetailData.getVueInstance(response, props.session); // render the session detail data
     } catch (err) {
       console.log('Error loading session detail data', err);


### PR DESCRIPTION
- Server: processSessionId now passes fields back via endCb when there are no packetPos, so /packets callers don't dereference undefined
- Server: pug template emits lowercase hidepackets attribute (sanitize-html lowercases attribute names) and sanitizer allow list updated
- Client: SessionDetail.vue parses hidepackets from rendered detail HTML and sets the ref so getPackets early-returns
- Test: add regression test in api-sessionDetail.t (tag no-pcap-detail-regression-tag) covering /detail and /packets for a session with no fileId/packetPos

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
