### PR TITLE
Fix UTF-8 mojibake in header-auth auto-created user names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,8 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 6.3.2 2026/05/xx
+## All
+  - #3951 Fix UTF-8 mojibake in user names auto-created via header auth (e.g. behind Caddy/oauth2-proxy)
 
 6.3.1 2026/05/04
 ## Capture

--- a/common/auth.js
+++ b/common/auth.js
@@ -556,7 +556,7 @@ class Auth {
       }
 
       let userId;
-      let vals = req.headers;
+      let vals;
 
       if (Auth.mode === 'header-jwt') {
         // No signature verification — the upstream proxy (ALB, Cloudflare Access, etc.)
@@ -575,7 +575,14 @@ class Auth {
           return done('Failed to decode JWT');
         }
       } else {
-        userId = req.headers[Auth.#userNameHeader].trim();
+        // Node decodes HTTP header values as ISO-8859-1 (RFC 7230). Reverse proxies
+        // (Caddy, nginx, oauth2-proxy, ALB OIDC, etc.) typically write UTF-8 bytes
+        // directly into headers, so non-ASCII characters arrive as mojibake. Re-decode
+        // each string header from latin-1 bytes back to UTF-8 so auto-create
+        // expressions, dynamic roles, and downstream consumers see the original UTF-8
+        // string. Pure-ASCII values are unchanged.
+        vals = Auth.#utf8Headers(req.headers);
+        userId = vals[Auth.#userNameHeader].trim();
       }
 
       if (!userId || userId === '') {
@@ -822,6 +829,18 @@ class Auth {
     }
 
     return 0;
+  }
+
+  // ----------------------------------------------------------------------------
+  // Re-decode header values from latin-1 (Node's default) back to UTF-8.
+  // Pure-ASCII values are unchanged; UTF-8 bytes that Node mis-decoded as latin-1
+  // (e.g. "AndrÃ©" -> "André") are restored to the original UTF-8 string.
+  static #utf8Headers (headers) {
+    const out = {};
+    for (const [k, v] of Object.entries(headers)) {
+      out[k] = typeof v === 'string' ? Buffer.from(v, 'latin1').toString('utf8') : v;
+    }
+    return out;
   }
 
   // ----------------------------------------------------------------------------

--- a/tests/addUser.t
+++ b/tests/addUser.t
@@ -79,7 +79,7 @@ $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8126/", ':arki
 is ($response->code, 403);
 is ($response->content, '{"success":false,"text":"User name header is empty"}');
 
-$response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8126/", ':arkime_user' => 'authtest1');
+$response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8126/", ':arkime_user' => 'authtest1', ':arkime_user_name' => "Andr\xc3\xa9");
 is ($response->code, 200);
 
 $response = viewerGet("/regressionTests/getUser/authtest1");
@@ -89,7 +89,7 @@ delete $mresponse->{lastUsed};
 eq_or_diff($response, $mresponse);
 
 delete $response->{passStore};
-eq_or_diff($response, from_json('{"headerAuthEnabled":true,"enabled":true,"userId":"authtest1","webEnabled":true,"removeEnabled":false,"userName":"authtest1","packetSearch":true,"emailSearch":true,"expression":"","settings":{},"roles":["arkimeUser","cont3xtUser","parliamentUser","wiseUser"]}'));
+eq_or_diff($response, from_json('{"headerAuthEnabled":true,"enabled":true,"userId":"authtest1","webEnabled":true,"removeEnabled":false,"userName":"' . "Andr\xc3\xa9" . '","packetSearch":true,"emailSearch":true,"expression":"","settings":{},"roles":["arkimeUser","cont3xtUser","parliamentUser","wiseUser"]}'));
 
 addUser("-n test3 authtest2 authtest2 authtest2");
 $response = viewerGet("/regressionTests/getUser/authtest2");


### PR DESCRIPTION
Node decodes HTTP header values as ISO-8859-1 (RFC 7230), but reverse proxies (Caddy, nginx, oauth2-proxy, ALB OIDC, etc.) typically write UTF-8 bytes directly into headers. That made non-ASCII user names like "André" arrive as the mojibake "André" and get stored that way.

Re-decode header values from latin-1 back to UTF-8 in the non-JWT header auth path so auto-create expressions, dynamic roles, and downstream consumers see the original UTF-8 string. Pure-ASCII values are bit-identical, and the header-jwt branch is unaffected.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
