### PR TITLE
Capture state file hardening: stateDir + O_NOFOLLOW

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3951 Fix UTF-8 mojibake in user names auto-created via header auth (e.g. behind Caddy/oauth2-proxy)
 ## Capture
   - #3954 Add trimEthernetPadding option to strip Ethernet padding/FCS so saved pcap and byte counts match the on-wire IP length
+  - #3958 Add stateDir config option (default /tmp) for capture state files (drophash, stoppedsessions); 
+          files now opened with O_NOFOLLOW to prevent symlink attacks
+  - #3958 PCAP files now opened with O_NOFOLLOW to prevent symlink attacks
 
 6.3.1 2026/05/04
 ## Capture

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1012,6 +1012,7 @@ void arkime_quit();
 uint32_t arkime_get_next_prime(uint32_t v);
 uint32_t arkime_get_next_powerof2(uint32_t v);
 void arkime_check_file_permissions(const char *filename);
+FILE *arkime_state_file_open(const char *name, const char *mode);
 
 typedef void (*ArkimeCredentialsGet)(const char *service);
 void arkime_credentials_register(const char *name, ArkimeCredentialsGet func);

--- a/capture/drophash.c
+++ b/capture/drophash.c
@@ -203,7 +203,8 @@ void arkime_drophash_init(ArkimeDropHashGroup_t *group, const char *file, int ke
 
     group->file = g_strdup(file);
 
-    if (!g_file_test(file, G_FILE_TEST_EXISTS))
+    FILE *fp = arkime_state_file_open(group->file, "r");
+    if (!fp)
         return;
 
     struct timespec currentTime;
@@ -217,12 +218,6 @@ void arkime_drophash_init(ArkimeDropHashGroup_t *group, const char *file, int ke
     uint32_t goodFor;
     uint16_t flags;
     uint16_t port;
-
-    FILE *fp;
-    if (!(fp = fopen(group->file, "r"))) {
-        LOG("ERROR - Couldn't open `%s` to load drophash", group->file);
-        return;
-    }
 
     if (!fread(&ver, 4, 1, fp)) {
         fclose(fp);
@@ -293,8 +288,7 @@ void arkime_drophash_save(ArkimeDropHashGroup_t *group)
     if (!group->file)
         return;
 
-    if (!(fp = fopen(group->file, "w"))) {
-        LOG("ERROR - Couldn't open `%s` to save drophash", group->file);
+    if (!(fp = arkime_state_file_open(group->file, "w"))) {
         return;
     }
     ARKIME_LOCK(group->lock);

--- a/capture/main.c
+++ b/capture/main.c
@@ -9,6 +9,7 @@
 #include <pwd.h>
 #include <grp.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <sys/resource.h>
 #ifdef _POSIX_MEMLOCK
 #include <sys/mman.h>
@@ -415,6 +416,57 @@ LOCAL void terminate(int UNUSED(sig))
 LOCAL void reload(int UNUSED(sig))
 {
     arkime_plugins_reload();
+}
+/******************************************************************************/
+/* Open a per-node state file under the configured `stateDir` (default "/tmp")
+ * using O_NOFOLLOW so an attacker can't redirect Arkime's writes through a
+ * pre-placed symlink.  `name` is the basename of the file (typically
+ * "<nodeName>.<suffix>"); `mode` must be "r" or "w" (binary modes accepted).
+ *
+ * Read mode returns NULL silently if the file does not yet exist; other
+ * failures are logged.  Write mode creates the file with mode 0600 and
+ * truncates it.
+ */
+FILE *arkime_state_file_open(const char *name, const char *mode)
+{
+    LOCAL const char *stateDir = NULL;
+    if (!stateDir) {
+        stateDir = arkime_config_str(NULL, "stateDir", "/tmp");
+    }
+
+    char path[PATH_MAX];
+    int  plen = snprintf(path, sizeof(path), "%s/%s", stateDir, name);
+    if (plen <= 0 || plen >= (int)sizeof(path)) {
+        LOG("ERROR - state file path too long for `%s/%s`", stateDir, name);
+        return NULL;
+    }
+
+    int flags;
+    if (mode[0] == 'w') {
+        flags = O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW | O_CLOEXEC;
+    } else if (mode[0] == 'r') {
+        flags = O_RDONLY | O_NOFOLLOW | O_CLOEXEC;
+    } else {
+        LOG("ERROR - unsupported mode `%s` for state file `%s`", mode, path);
+        return NULL;
+    }
+
+    int fd = open(path, flags, 0600);
+    if (fd < 0) {
+        if (errno == ENOENT && mode[0] == 'r') {
+            return NULL;
+        }
+        LOG("ERROR - Couldn't open state file `%s` (%s): %s", path, mode, strerror(errno));
+        return NULL;
+    }
+
+    FILE *fp = fdopen(fd, mode);
+    if (!fp) {
+        LOG("ERROR - fdopen failed for state file `%s`: %s", path, strerror(errno));
+        close(fd);
+        return NULL;
+    }
+    return fp;
 }
 /******************************************************************************/
 void arkime_check_file_permissions(const char *filename)

--- a/capture/main.c
+++ b/capture/main.c
@@ -429,7 +429,7 @@ LOCAL void reload(int UNUSED(sig))
  */
 FILE *arkime_state_file_open(const char *name, const char *mode)
 {
-    LOCAL const char *stateDir = NULL;
+    static const char *stateDir = NULL;
     if (!stateDir) {
         stateDir = arkime_config_str(NULL, "stateDir", "/tmp");
     }

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1891,16 +1891,16 @@ void arkime_packet_init()
     arkime_packet_thread_exit_func = arkime_get_named_func("arkime_packet_thread_exit");
 
     char filename[PATH_MAX];
-    snprintf(filename, sizeof(filename), "/tmp/%s.tcp.drops.4", config.nodeName);
+    snprintf(filename, sizeof(filename), "%s.tcp.drops.4", config.nodeName);
     arkime_drophash_init(&packetDrop4, filename, 4);
 
-    snprintf(filename, sizeof(filename), "/tmp/%s.tcp.drops.6", config.nodeName);
+    snprintf(filename, sizeof(filename), "%s.tcp.drops.6", config.nodeName);
     arkime_drophash_init(&packetDrop6, filename, 16);
 
-    snprintf(filename, sizeof(filename), "/tmp/%s.tcp.drops.4S", config.nodeName);
+    snprintf(filename, sizeof(filename), "%s.tcp.drops.4S", config.nodeName);
     arkime_drophash_init(&packetDrop4S, filename, 12);
 
-    snprintf(filename, sizeof(filename), "/tmp/%s.tcp.drops.6S", config.nodeName);
+    snprintf(filename, sizeof(filename), "%s.tcp.drops.6S", config.nodeName);
     arkime_drophash_init(&packetDrop6S, filename, 36);
 
     g_timeout_add_seconds(10, arkime_packet_save_drophash, 0);

--- a/capture/reader-bpf.c
+++ b/capture/reader-bpf.c
@@ -107,10 +107,20 @@ LOCAL void *reader_bpf_thread(gpointer readerv)
         // Process packets in the buffer
         p = reader->buf;
         while (p < reader->buf + bytes) {
+            if (p + sizeof(struct bpf_hdr) > reader->buf + bytes) {
+                LOG("ERROR - Truncated BPF header in buffer, skipping remaining %td bytes", reader->buf + bytes - p);
+                break;
+            }
             bh = (struct bpf_hdr *)p;
 
             caplen = bh->bh_caplen;
             u_char *pkt = p + bh->bh_hdrlen;
+
+            if (unlikely(pkt + caplen > reader->buf + bytes)) {
+                LOG("ERROR - BPF packet extends past buffer (hdrlen: %u caplen: %d remaining: %td), skipping",
+                    bh->bh_hdrlen, caplen, reader->buf + bytes - p);
+                break;
+            }
 
             // Check for truncated packets
             if (unlikely(caplen != (int)bh->bh_datalen) && !config.readTruncatedPackets && !config.ignoreErrors) {

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -230,9 +230,9 @@ LOCAL int scheme_file_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchem
         }
 
 
-        fd = open(filename, O_RDONLY);
+        fd = open(filename, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
         if (fd < 0) {
-            LOG("ERROR - pcap open failed - Couldn't realpath file: '%s' with %s (%d)", filename, strerror(errno), errno);
+            LOG("ERROR - pcap open failed - Couldn't open file: '%s' with %s (%d)", filename, strerror(errno), errno);
             return 1;
         }
 

--- a/capture/session.c
+++ b/capture/session.c
@@ -982,14 +982,9 @@ void arkime_session_set_stop_spi(ArkimeSession_t *session, int value)
 /******************************************************************************/
 LOCAL void arkime_session_load_stopped()
 {
-    if (!g_file_test(stoppedFilename, G_FILE_TEST_EXISTS))
+    FILE *fp = arkime_state_file_open(stoppedFilename, "r");
+    if (!fp)
         return;
-
-    FILE *fp;
-    if (!(fp = fopen(stoppedFilename, "r"))) {
-        LOG("ERROR - Couldn't open `%s` to load stopped sessions", stoppedFilename);
-        return;
-    }
 
     int ver;
     if (!fread(&ver, 4, 1, fp)) {
@@ -1052,9 +1047,8 @@ LOCAL gboolean arkime_session_save_stopped(gpointer UNUSED(user_data))
         }
     }
 
-    FILE *fp;
-    if (!(fp = fopen(stoppedFilename, "w"))) {
-        LOG("ERROR - Couldn't open `%s` to save stopped sessions", stoppedFilename);
+    FILE *fp = arkime_state_file_open(stoppedFilename, "w");
+    if (!fp) {
         return G_SOURCE_CONTINUE;
     }
     uint32_t ver = 1;
@@ -1338,7 +1332,7 @@ void arkime_session_init()
 
     g_timeout_add_seconds(10, arkime_session_save_stopped, 0);
 
-    snprintf(stoppedFilename, sizeof(stoppedFilename), "/tmp/%s.stoppedsessions", config.nodeName);
+    snprintf(stoppedFilename, sizeof(stoppedFilename), "%s.stoppedsessions", config.nodeName);
     arkime_session_load_stopped();
     arkime_session_load_collapse();
 


### PR DESCRIPTION
- Add stateDir config option (default /tmp) for capture state files
- New arkime_state_file_open() helper opens state files with O_NOFOLLOW | O_CLOEXEC (mode 0600 on writes), defeating symlink TOCTOU attacks on drophash and stoppedsessions files
- Refactor drophash, session, and packet code to use the helper and store basenames instead of full /tmp/ paths
- Add O_NOFOLLOW | O_CLOEXEC to reader-scheme-file open() after realpath() to close the realpath->open TOCTOU window; fix misleading 'Couldn't realpath' error message in the open() error path
- Add bounds checks in reader-bpf packet loop to validate BPF header and payload fit within the kernel-returned buffer before use

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
