### PR TITLE
common: input validation hardening

### DIFF
--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -178,6 +178,11 @@ class ArkimeConfig {
       if (section === undefined || key === undefined) { continue; }
       key = key.replace(/DASH/g, '-').replace(/COLON/g, ':').replace(/DOT/g, '.').replace(/SLASH/g, '/');
 
+      if (ArkimeUtil.isPP(section) || ArkimeUtil.isPP(key)) {
+        console.log(`WARNING - Ignoring environment variable ${e}: section/key looks like prototype pollution`);
+        continue;
+      }
+
       if (ArkimeConfig.#config[section] === undefined) {
         ArkimeConfig.#config[section] = {};
       }

--- a/common/notifier.snmp.js
+++ b/common/notifier.snmp.js
@@ -112,7 +112,14 @@ exports.sendSnmpAlert = function (config, message, links, cb) {
     }
   }
 
-  const port = parseInt(config.port, 10) || 162;
+  let port = 162;
+  if (config.port !== undefined && config.port !== null && config.port !== '') {
+    port = parseInt(config.port, 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      if (cb) { cb({ errors: { snmp: 'Invalid port (must be 1-65535)' } }); }
+      return;
+    }
+  }
   const trapOid = config.trapOid || DEFAULT_TRAP_OID;
 
   let session;

--- a/common/notifier.syslog.js
+++ b/common/notifier.syslog.js
@@ -87,6 +87,12 @@ exports.sendSyslogAlert = function (config, message, links, cb) {
     return;
   }
 
+  const port = parseInt(config.port, 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    if (cb) { cb({ errors: { syslog: 'Invalid port (must be 1-65535)' } }); }
+    return;
+  }
+
   if (links && links.length) {
     for (const link of links) {
       message += ` ${link.text}: ${link.url}`;

--- a/common/user.js
+++ b/common/user.js
@@ -1009,7 +1009,15 @@ class User {
       user.hidePcap = req.body.hidePcap;
       user.disablePcapDownload = req.body.disablePcapDownload;
 
-      user.timeLimit = req.body.timeLimit ? parseInt(req.body.timeLimit) : undefined;
+      if (req.body.timeLimit !== undefined && req.body.timeLimit !== null && req.body.timeLimit !== '') {
+        const tl = parseInt(req.body.timeLimit, 10);
+        if (!Number.isFinite(tl) || tl < 0) {
+          return res.serverError(422, 'timeLimit must be a non-negative integer');
+        }
+        user.timeLimit = tl;
+      } else {
+        user.timeLimit = undefined;
+      }
       user.roles = req.body.roles;
       user.roleAssigners = req.body.roleAssigners ?? [];
 


### PR DESCRIPTION
- arkimeConfig.js: reject prototype-pollution keys (__proto__, constructor, prototype, eval, Function) when applying env-var config overrides via ArkimeUtil.isPP() guard.
- user.js: validate timeLimit is a non-negative integer; reject invalid input with HTTP 422 instead of writing NaN/garbage.
- notifier.snmp.js, notifier.syslog.js: validate port is an integer in 1-65535 before opening the socket; report a clear error via callback instead of passing NaN/out-of-range to the network layer.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
