### PR TITLE
capture: improve mDNS parsing (RFC 6762)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           files now opened with O_NOFOLLOW to prevent symlink attacks
   - #3958 PCAP files now opened with O_NOFOLLOW to prevent symlink attacks
   - #3962 Improved websocket parser; adds websocket.* fields and websocketTextSampleCnt config option
+  - #3963 Improved mDNS parsing: handle aggregated queries, unsolicited responses, and flags
 
 6.3.1 2026/05/04
 ## Capture

--- a/capture/parsers/dns.c
+++ b/capture/parsers/dns.c
@@ -593,7 +593,13 @@ LOCAL void dns_parser(ArkimeSession_t *session, int kind, const uint8_t *data, i
         break;
     }
 
-    if (qd_count != 1) {
+    const int mdns = (kind == 2);
+
+    /* mDNS (RFC 6762 §5.3) allows aggregated queries (qd_count > 1) and
+     * unsolicited responses (qd_count == 0). qd_count > 1: parse the first
+     * question and walk past the rest before answers. qd_count == 0:
+     * synthesize a query keyed on root so answers attach to a session record. */
+    if (qd_count != 1 && !mdns) {
         arkime_session_add_tag(session, "dns:qdcount-not-1");
         return;
     }
@@ -601,35 +607,52 @@ LOCAL void dns_parser(ArkimeSession_t *session, int kind, const uint8_t *data, i
     BSB bsb;
     BSB_INIT(bsb, data + 12, len - 12);
 
-    /* QD Section */
     char namebuf[8001];
     int namelen = sizeof(namebuf);
-    char *name = dns_name(session, data, len, &bsb, namebuf, &namelen);
+    char *name = NULL;
 
-    if (BSB_IS_ERROR(bsb) || !name) {
-        return;
-    }
-
-    if (!namelen) {
+    if (qd_count == 0) {
+        /* mDNS response with no question: synthesize key */
         key.query.hostname = root;
+        key.query.type_id = 0;
+        key.query.class_id = 0;
         namelen = 6;
+        name = root;
     } else {
-        key.query.hostname = g_hostname_to_unicode(name);
-        if (!key.query.hostname) {
-            if (namelen > 4 && arkime_memstr((const char *)name, namelen, "xn--", 4)) {
-                arkime_session_add_tag(session, "bad-punycode");
-            } else {
-                arkime_session_add_tag(session, "bad-hostname");
-            }
+        /* QD Section */
+        name = dns_name(session, data, len, &bsb, namebuf, &namelen);
+
+        if (BSB_IS_ERROR(bsb) || !name) {
             return;
         }
+
+        if (!namelen) {
+            key.query.hostname = root;
+            namelen = 6;
+        } else {
+            key.query.hostname = g_hostname_to_unicode(name);
+            if (!key.query.hostname) {
+                if (namelen > 4 && arkime_memstr((const char *)name, namelen, "xn--", 4)) {
+                    arkime_session_add_tag(session, "bad-punycode");
+                } else {
+                    arkime_session_add_tag(session, "bad-hostname");
+                }
+                return;
+            }
+        }
+
+        key.query.type_id = 0;
+        BSB_IMPORT_u16(bsb, key.query.type_id);
+
+        key.query.class_id = 0;
+        BSB_IMPORT_u16(bsb, key.query.class_id);
+
+        /* mDNS (RFC 6762 §5.4): top bit of qclass is the "unicast-response"
+         * (QU) preference, not part of the class value. */
+        if (mdns) {
+            key.query.class_id &= 0x7FFF;
+        }
     }
-
-    key.query.type_id = 0;
-    BSB_IMPORT_u16(bsb, key.query.type_id);
-
-    key.query.class_id = 0;
-    BSB_IMPORT_u16(bsb, key.query.class_id);
 
     ArkimeFieldObject_t *fobject = NULL;;
     DNS_t *dns = NULL;
@@ -716,6 +739,20 @@ LOCAL void dns_parser(ArkimeSession_t *session, int kind, const uint8_t *data, i
         return;
     }
 
+    /* mDNS aggregated query: advance past the remaining question records
+     * so the answer parsing below starts at the correct offset. */
+    if (mdns && qd_count > 1) {
+        for (int q = 1; BSB_NOT_ERROR(bsb) && q < qd_count; q++) {
+            namelen = sizeof(namebuf);
+            dns_name(session, data, len, &bsb, namebuf, &namelen);
+            if (BSB_IS_ERROR(bsb))
+                return;
+            BSB_IMPORT_skip(bsb, 4); // type + class
+        }
+        if (BSB_IS_ERROR(bsb))
+            return;
+    }
+
     if (!dns->ips) {
         dns->ips = g_hash_table_new_full(arkime_field_ip_hash, arkime_field_ip_equal, g_free, NULL);
     }
@@ -770,6 +807,12 @@ LOCAL void dns_parser(ArkimeSession_t *session, int kind, const uint8_t *data, i
             BSB_IMPORT_u16 (bsb, antype);
             uint16_t anclass = 0;
             BSB_IMPORT_u16 (bsb, anclass);
+
+            /* mDNS (RFC 6762 §10.2): top bit of rrclass is the cache-flush
+             * indicator and must be masked off before comparing. */
+            if (mdns) {
+                anclass &= 0x7FFF;
+            }
             uint32_t anttl = 0;
             BSB_IMPORT_u32 (bsb, anttl);
             uint16_t rdlength = 0;

--- a/capture/parsers/websocket.c
+++ b/capture/parsers/websocket.c
@@ -201,7 +201,10 @@ LOCAL int websocket_tcp_parser(ArkimeSession_t *session, void *uw, const uint8_t
             } else if (opcode == 8) {
                 if (payLen >= 2) {
                     uint8_t b0 = pay[0], b1 = pay[1];
-                    if (masked) { b0 ^= maskKey[0]; b1 ^= maskKey[1]; }
+                    if (masked) {
+                        b0 ^= maskKey[0];
+                        b1 ^= maskKey[1];
+                    }
                     int code = (b0 << 8) | b1;
                     arkime_field_int_add(closeCodeField, session, code);
 

--- a/tests/api-multiunique.t
+++ b/tests/api-multiunique.t
@@ -95,7 +95,6 @@ eq_or_diff($txt,
 byip1, 1
 byip2, 1
 cert:certificate-authority, 3
-dns:qdcount-not-1, 1
 domainwise, 7
 dstip, 4
 hosttaggertest1, 7

--- a/tests/api-unique.t
+++ b/tests/api-unique.t
@@ -99,7 +99,6 @@ eq_or_diff($txt,
 byip1, 1
 byip2, 1
 cert:certificate-authority, 3
-dns:qdcount-not-1, 1
 domainwise, 7
 dstip, 4
 hosttaggertest1, 7

--- a/tests/pcap/v6-http.test
+++ b/tests/pcap/v6-http.test
@@ -322,6 +322,167 @@
      "packets" : 0,
      "port" : 5353
     },
+    "dns" : [
+     {
+      "answers" : [
+       {
+        "class" : "IN",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "HINFO"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:a9d2:1782:1995:b63b",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:2d0:9ff:fee3:e8de",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:1033:c4c:7e57:b19e",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "HINFO"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:a9d2:1782:1995:b63b",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:2d0:9ff:fee3:e8de",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:1033:c4c:7e57:b19e",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "name" : "1.e.6.0.8.9.e.c.7.d.9.3.9.9.9.0.0.0.0.0.d.2.0.1.8.f.6.0.1.0.0.2.ip6.arpa",
+        "ttl" : 120,
+        "type" : "PTR"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:999:39d7:ce98:6e1",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "name" : "1.e.6.0.8.9.e.c.7.d.9.3.9.9.9.0.0.0.0.0.d.2.0.1.8.f.6.0.1.0.0.2.ip6.arpa",
+        "ttl" : 120,
+        "type" : "PTR"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:999:39d7:ce98:6e1",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:a9d2:1782:1995:b63b",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:2d0:9ff:fee3:e8de",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:1033:c4c:7e57:b19e",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "name" : "1.e.6.0.8.9.e.c.7.d.9.3.9.9.9.0.0.0.0.0.d.2.0.1.8.f.6.0.1.0.0.2.ip6.arpa",
+        "ttl" : 120,
+        "type" : "PTR"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:999:39d7:ce98:6e1",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:a9d2:1782:1995:b63b",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:2d0:9ff:fee3:e8de",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       },
+       {
+        "class" : "IN",
+        "ip" : "2001:6f8:102d:0:1033:c4c:7e57:b19e",
+        "name" : "linux.local",
+        "ttl" : 120,
+        "type" : "AAAA"
+       }
+      ],
+      "answersCnt" : 20,
+      "headerFlags" : [
+       "AA"
+      ],
+      "opcode" : "QUERY",
+      "qc" : "(null)",
+      "qt" : "(null)",
+      "queryHost" : "<root>",
+      "status" : "NOERROR"
+     },
+     {
+      "host" : [
+       "1.e.6.0.8.9.e.c.7.d.9.3.9.9.9.0.0.0.0.0.d.2.0.1.8.f.6.0.1.0.0.2.ip6.arpa"
+      ],
+      "hostCnt" : 1,
+      "opcode" : "QUERY",
+      "qc" : "IN",
+      "qt" : "ANY",
+      "queryHost" : "1.e.6.0.8.9.e.c.7.d.9.3.9.9.9.0.0.0.0.0.d.2.0.1.8.f.6.0.1.0.0.2.ip6.arpa"
+     }
+    ],
+    "dnsCnt" : 2,
     "ethertype" : 34525,
     "fileId" : [],
     "firstPacket" : 1186341099605,
@@ -397,10 +558,6 @@
      255
     ],
     "srcTTLCnt" : 1,
-    "tags" : [
-     "dns:qdcount-not-1"
-    ],
-    "tagsCnt" : 1,
     "totDataBytes" : 1286
    },
    "header" : {


### PR DESCRIPTION
- Allow aggregated queries (qd_count > 1): parse first question, walk past the rest before answers
- Allow unsolicited responses (qd_count == 0): synthesize a root-keyed query so answers attach to a session record
- Mask the QU bit on query qclass (RFC 6762 §5.4)
- Mask the cache-flush bit on answer rrclass (RFC 6762 §10.2)

Without these fixes most real mDNS traffic was either dropped or had empty class fields.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
