### PR TITLE
Default userAuthIps to localhost for all header* auth modes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3941 Move to using curl instead of wget everywhere and now depend on package
 ## All
   - #3951 Fix UTF-8 mojibake in user names auto-created via header auth (e.g. behind Caddy/oauth2-proxy)
+  - #3967 All header* auth modes (header, header-jwt, headerOnly, header+digest, header+basic) now
+          default userAuthIps to localhost-only when not explicitly configured
 ## Capture
   - #3954 Add trimEthernetPadding option to strip Ethernet padding/FCS so saved pcap and byte counts match the on-wire IP length
   - #3957 Even when not writing packets still save new sessions midway

--- a/capture/config.c
+++ b/capture/config.c
@@ -1058,6 +1058,7 @@ LOCAL void arkime_config_load()
     if (!status || error) {
         if (config.noConfigOption) {
             LOG("Couldn't load config file (%s) %s", config.configFile, (error ? error->message : ""));
+            g_clear_error(&error);
             g_key_file_load_from_data(keyfile, (gchar *)"[default]\n", (gsize) -1, G_KEY_FILE_NONE, &error);
         } else
             CONFIGEXIT("Couldn't load config file (%s) %s", config.configFile, (error ? error->message : ""));

--- a/capture/parsers/snmp.c
+++ b/capture/parsers/snmp.c
@@ -122,12 +122,12 @@ LOCAL int snmp_parser(ArkimeSession_t *session, void *UNUSED(uw), const uint8_t 
         if (!value)
             return 0;
         if (atag == 4 && alen > 0) {
-            char hex[256];
-            uint32_t hbytes = (alen < (int)(sizeof(hex) / 2)) ? alen : (int)(sizeof(hex) / 2);
-            for (uint32_t i = 0; i < hbytes; i++) {
-                memcpy(hex + i * 2, arkime_char_to_hexstr[value[i]], 2);
+            char hex[257];
+            uint32_t hbytes = (alen < (int)((sizeof(hex) - 1) / 2)) ? alen : (int)((sizeof(hex) - 1) / 2);
+            if (hbytes > 0) {
+                arkime_sprint_hex_string(hex, value, hbytes);
+                arkime_field_string_add(engineIdField, session, hex, hbytes * 2, TRUE);
             }
-            arkime_field_string_add(engineIdField, session, hex, hbytes * 2, TRUE);
         }
 
         // msgAuthoritativeEngineBoots (INTEGER)

--- a/capture/parsers/websocket.c
+++ b/capture/parsers/websocket.c
@@ -57,7 +57,7 @@ typedef struct {
 /******************************************************************************/
 LOCAL void websocket_save(ArkimeSession_t *session, void *uw, int UNUSED(final))
 {
-    WebSocketInfo_t *ws = uw;
+    const WebSocketInfo_t *ws = uw;
     if (!ws)
         return;
     if (ws->frameCnt) {
@@ -221,11 +221,12 @@ LOCAL int websocket_tcp_parser(ArkimeSession_t *session, void *uw, const uint8_t
                         }
                         // RFC 6455 §5.5.1 requires close reason text to be UTF-8.
                         const gchar *utf8End = NULL;
-                        if (g_utf8_validate(reason, rlen, &utf8End)) {
-                            if (rlen > 0)
+                        if (rlen > 0) {
+                            if (g_utf8_validate(reason, rlen, &utf8End)) {
                                 arkime_field_string_add(closeReasonField, session, reason, rlen, TRUE);
-                        } else if (utf8End && utf8End > reason) {
-                            arkime_field_string_add(closeReasonField, session, reason, (int)(utf8End - reason), TRUE);
+                            } else if (utf8End && utf8End > reason) {
+                                arkime_field_string_add(closeReasonField, session, reason, (int)(utf8End - reason), TRUE);
+                            }
                         }
                     }
                 }

--- a/common/auth.js
+++ b/common/auth.js
@@ -200,7 +200,7 @@ class Auth {
           process.exit(1);
         }
       }
-    } else if (Auth.mode === 'header' || Auth.mode === 'header-jwt') {
+    } else if (Auth.mode.startsWith('header')) {
       Auth.#userAuthIps.add('::ffff:127.0.0.0', 96 + 8, 1);
       Auth.#userAuthIps.add('::1', 128, 1);
     } else {


### PR DESCRIPTION
Previously only 'header' and 'header-jwt' inherited the localhost-only default for userAuthIps. Modes 'headerOnly', 'header+digest', and 'header+basic' fell through to ::/0, allowing any reachable client to impersonate header-auth users by sending the configured user header.

Use Auth.mode.startsWith('header') so all header-based modes share the safe default.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
