### PR TITLE
Improve WISE JSON shortcut parsing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,6 +56,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3965 Add mqtt.connackCode for CONNACK return/reason codes
   - #3965 Add snmp.engineId and snmp.secLevel SNMPv3 fields
   - #3966 Add enip parser
+## WISE
+  - #3968 Improve JSON Array Parsing: shortcut paths now expand arrays at any
+          intermediate position, not just the final value
 
 6.3.1 2026/05/04
 ## Capture

--- a/tests/config.test.json
+++ b/tests/config.test.json
@@ -44,6 +44,14 @@
   "keyPath": "ip",
   "fields": "field:tags;shortcut:tag"
  },
+ "file:ipjsonnested": {
+  "file": "../tests/ip.wise.nested.json",
+  "tags": "ipwisenested",
+  "type": "ip",
+  "format": "json",
+  "keyPath": "ip",
+  "fields": "field:tags;shortcut:info.tag"
+ },
  "file:md5": {
   "file": "../tests/md5.wise",
   "tags": "md5wise",

--- a/tests/ip.wise.nested.json
+++ b/tests/ip.wise.nested.json
@@ -1,0 +1,10 @@
+[
+  {
+    "ip": "10.99.0.1",
+    "info": [ {"tag": "nested-v1"}, {"tag": "nested-v2"} ]
+  },
+  {
+    "ip": "10.99.0.2",
+    "info": { "tag": ["final-v3", "final-v4"] }
+  }
+]

--- a/tests/wise.t
+++ b/tests/wise.t
@@ -1,5 +1,5 @@
 # WISE tests
-use Test::More tests => 151;
+use Test::More tests => 153;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
@@ -83,6 +83,22 @@ eq_or_diff($wise, from_json('[{"field":"tags","len":12,"value":"ipwise-comma"},
 {"field":"tags","len":18,"value":"ipwise-jsonl-comma"},
 {"field":"tags","len":10,"value":"ipwisejson"},
 {"field":"tags","len":11,"value":"ipwisejsonl"}]'));
+
+# Nested-object array shortcut walking: shortcut "info.tag" over
+# { "info": [ {"tag": "nested-v1"}, {"tag": "nested-v2"} ] }
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/ip/10.99.0.1")->content;
+$wise = [sort { $a->{value} cmp $b->{value}} @{from_json($wise)}];
+eq_or_diff($wise, from_json('[{"field":"tags","len":12,"value":"ipwisenested"},
+{"field":"tags","len":9,"value":"nested-v1"},
+{"field":"tags","len":9,"value":"nested-v2"}]'), "ipjsonnested intermediate array of objects");
+
+# Final-value array shortcut walking: shortcut "info.tag" over
+# { "info": { "tag": ["final-v3", "final-v4"] } }
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/ip/10.99.0.2")->content;
+$wise = [sort { $a->{value} cmp $b->{value}} @{from_json($wise)}];
+eq_or_diff($wise, from_json('[{"field":"tags","len":8,"value":"final-v3"},
+{"field":"tags","len":8,"value":"final-v4"},
+{"field":"tags","len":12,"value":"ipwisenested"}]'), "ipjsonnested final value array");
 
 # IP File jsonl Dump
 $wise = "[" . $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/dump/file:ipjsonl")->content . "]";
@@ -255,7 +271,7 @@ eq_or_diff($wise, '[{"field":"tags","len":10,"value":"wisebymac1"},
 
 # Sources
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/sources")->content;
-eq_or_diff($wise, '["fieldactions:test","file:domain","file:email","file:ip","file:ipcsv","file:ipjson","file:ipjsonl","file:ja3","file:mac","file:md5","file:sha256","file:url","reversedns","url:aws-ips","url:gcloud-ips4","url:gcloud-ips6","valueactions:test"]',"/sources");
+eq_or_diff($wise, '["fieldactions:test","file:domain","file:email","file:ip","file:ipcsv","file:ipjson","file:ipjsonl","file:ipjsonnested","file:ja3","file:mac","file:md5","file:sha256","file:url","reversedns","url:aws-ips","url:gcloud-ips4","url:gcloud-ips6","valueactions:test"]',"/sources");
 
 # Types
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/types")->content;

--- a/wiseService/source.databricks.js
+++ b/wiseService/source.databricks.js
@@ -86,17 +86,7 @@ class DatabricksSource extends WISESource {
       const key = item[this.keyPath];
       if (!key) { continue; }
 
-      const args = [];
-      for (const k in this.shortcuts) {
-        if (item[k] !== undefined) {
-          args.push(this.shortcuts[k].pos);
-          if (Array.isArray(item[k])) {
-            args.push(item[k][0]);
-          } else {
-            args.push(item[k]);
-          }
-        }
-      }
+      const args = this.parseJSONElement(item);
 
       const newitem = WISESource.encodeResult.apply(null, args);
 
@@ -168,17 +158,7 @@ class DatabricksSource extends WISESource {
 
     const item = results[0];
 
-    const args = [];
-    for (const k in this.shortcuts) {
-      if (item[k] !== undefined) {
-        args.push(this.shortcuts[k].pos);
-        if (Array.isArray(item[k])) {
-          args.push(item[k][0]);
-        } else {
-          args.push(item[k]);
-        }
-      }
-    }
+    const args = this.parseJSONElement(item);
     const newresult = WISESource.combineResults([WISESource.encodeResult.apply(null, args), this.tagsResult]);
     return cb(null, newresult);
   }

--- a/wiseService/source.elasticsearch.js
+++ b/wiseService/source.elasticsearch.js
@@ -77,14 +77,6 @@ class ElasticsearchSource extends WISESource {
     // TODO: Should be option to do search vs get
     // TODO: Should be an option to add more than most recent
 
-    // Convert shortcuts into array of key path
-    const shortcuts = [];
-    const shortcutsValue = [];
-    for (const k in this.shortcuts) {
-      shortcuts.push(k.split('.'));
-      shortcutsValue.push(this.shortcuts[k]);
-    }
-
     this.client.search({ index: this.esIndex, body: query }, (err, { body: result }) => {
       if (err || result.error || !result.hits || result.hits.hits.length === 0) {
         return cb(null, undefined);
@@ -94,26 +86,7 @@ class ElasticsearchSource extends WISESource {
       if (eskey === undefined) {
         return cb(null, undefined);
       }
-      const args = [];
-
-      for (let k = 0; k < shortcuts.length; k++) {
-        let objs = json;
-        // Walk the shortcut path
-        for (let j = 0; objs && j < shortcuts[k].length; j++) {
-          objs = objs[shortcuts[k][j]];
-        }
-
-        if (!objs) continue;
-
-        args.push(shortcutsValue[k].pos);
-        if (Array.isArray(objs)) {
-          args.push(objs[0]);
-        } else if (typeof objs !== 'string') {
-          args.push(objs.toString());
-        } else {
-          args.push(objs);
-        }
-      }
+      const args = this.parseJSONElement(json);
       const newresult = WISESource.combineResults([WISESource.encodeResult.apply(null, args), this.tagsResult]);
       return cb(null, newresult);
     });

--- a/wiseService/source.splunk.js
+++ b/wiseService/source.splunk.js
@@ -95,17 +95,7 @@ class SplunkSource extends WISESource {
         const key = item[this.keyPath];
         if (!key) { continue; }
 
-        const args = [];
-        for (const k in this.shortcuts) {
-          if (item[k] !== undefined) {
-            args.push(this.shortcuts[k].pos);
-            if (Array.isArray(item[k])) {
-              args.push(item[k][0]);
-            } else {
-              args.push(item[k]);
-            }
-          }
-        }
+        const args = this.parseJSONElement(item);
 
         const newitem = WISESource.encodeResult.apply(null, args);
 
@@ -182,17 +172,7 @@ class SplunkSource extends WISESource {
 
       const item = results.results[0];
 
-      const args = [];
-      for (const k in this.shortcuts) {
-        if (item[k] !== undefined) {
-          args.push(this.shortcuts[k].pos);
-          if (Array.isArray(item[k])) {
-            args.push(item[k][0]);
-          } else {
-            args.push(item[k]);
-          }
-        }
-      }
+      const args = this.parseJSONElement(item);
       const newresult = WISESource.combineResults([WISESource.encodeResult.apply(null, args), this.tagsResult]);
       return cb(null, newresult);
     } catch (err) {

--- a/wiseService/source.urlapi.js
+++ b/wiseService/source.urlapi.js
@@ -53,14 +53,6 @@ class URLApiSource extends WISESource {
 
     url = url.replace(/{value}/g, encodeURIComponent(key));
 
-    // Convert shortcuts into array of key path
-    const shortcuts = [];
-    const shortcutsValue = [];
-    for (const k in this.shortcuts) {
-      shortcuts.push(k.split('.'));
-      shortcutsValue.push(this.shortcuts[k]);
-    }
-
     axios.get(url, { headers: this.headers })
       .then((response) => {
         if (response.status === 404) {
@@ -72,26 +64,7 @@ class URLApiSource extends WISESource {
         if (eskey === undefined) {
           return cb(null, undefined);
         }
-        const args = [];
-
-        for (let k = 0; k < shortcuts.length; k++) {
-          let objs = json;
-          // Walk the shortcut path
-          for (let j = 0; objs && j < shortcuts[k].length; j++) {
-            objs = objs[shortcuts[k][j]];
-          }
-
-          if (!objs) continue;
-
-          args.push(shortcutsValue[k].pos);
-          if (Array.isArray(objs)) {
-            args.push(objs[0]);
-          } else if (typeof objs !== 'string') {
-            args.push(objs.toString());
-          } else {
-            args.push(objs);
-          }
-        }
+        const args = this.parseJSONElement(json);
         const newresult = WISESource.combineResults([WISESource.encodeResult.apply(null, args), this.tagsResult]);
         return cb(null, newresult);
       }).catch((err) => {

--- a/wiseService/wiseSource.js
+++ b/wiseService/wiseSource.js
@@ -262,14 +262,6 @@ class WISESource {
 
       const keyPath = this.keyPath.split('.');
 
-      // Convert shortcuts into array of key path
-      const shortcuts = [];
-      const shortcutsValue = [];
-      for (const k in this.shortcuts) {
-        shortcuts.push(k.split('.'));
-        shortcutsValue.push(this.shortcuts[k]);
-      }
-
       for (let i = 0; i < json.length; i++) {
         // Walk the key path
         let key = json[i];
@@ -281,34 +273,7 @@ class WISESource {
           continue;
         }
 
-        const args = [];
-        // Check each shortcut
-        for (let k = 0; k < shortcuts.length; k++) {
-          let objs = json[i];
-          // Walk the shortcut path
-          for (let j = 0; objs && j < shortcuts[k].length; j++) {
-            objs = objs[shortcuts[k][j]];
-          }
-
-          // Always pretend we have an array
-          if (!Array.isArray(objs)) {
-            objs = [objs];
-          }
-
-          for (let o = 0; o < objs.length; o++) {
-            const obj = objs[o];
-            if (obj !== undefined && obj !== null && obj !== '') {
-              args.push(shortcutsValue[k].pos);
-              if (shortcutsValue[k].mod === 1) {
-                args.push(obj.toLowerCase());
-              } else if (shortcutsValue[k].mod === 2) {
-                args.push(obj.toUpperCase());
-              } else {
-                args.push(obj);
-              }
-            }
-          }
-        }
+        const args = this.parseJSONElement(json[i]);
 
         if (Array.isArray(key)) {
           key.forEach((part) => {
@@ -322,6 +287,73 @@ class WISESource {
     } catch (e) {
       endCb(e);
     }
+  }
+
+  // ----------------------------------------------------------------------------
+  /**
+   * Util function to walk a JSON object using the configured shortcuts and
+   * build an args array suitable for {@link WISESource.encodeResult}.
+   *
+   * Each shortcut path may traverse intermediate arrays as well as a final
+   * array value: e.g. with shortcut `a.b.c`, the input
+   *   `{ a: [ { b: { c: "v1" } }, { b: { c: "v2" } } ] }`
+   * yields both `v1` and `v2`. With shortcut `d.e`, the input
+   *   `{ d: { e: ["v3", "v4"] } }`
+   * yields both `v3` and `v4`.
+   *
+   * @param {object} json - the JSON object (single element) to extract from
+   * @returns {Array} alternating pos/value entries for encodeResult
+   */
+  parseJSONElement (json) {
+    const args = [];
+    for (const k in this.shortcuts) {
+      const path = k.split('.');
+      const sv = this.shortcuts[k];
+      const values = [];
+      WISESource.#collectShortcutValues(json, path, 0, values);
+
+      for (let o = 0; o < values.length; o++) {
+        let val = values[o];
+        if (val === undefined || val === null || val === '') {
+          continue;
+        }
+        if (typeof val !== 'string') {
+          val = val.toString();
+        }
+        if (sv.mod === 1) {
+          val = val.toLowerCase();
+        } else if (sv.mod === 2) {
+          val = val.toUpperCase();
+        }
+        args.push(sv.pos);
+        args.push(val);
+      }
+    }
+    return args;
+  }
+
+  // ----------------------------------------------------------------------------
+  /**
+   * Recursively walk obj following path, expanding any arrays encountered
+   * along the way (including a final array value), and push leaf values
+   * into out.
+   * @private
+   */
+  static #collectShortcutValues (obj, path, idx, out) {
+    if (obj === undefined || obj === null) {
+      return;
+    }
+    if (Array.isArray(obj)) {
+      for (let i = 0; i < obj.length; i++) {
+        WISESource.#collectShortcutValues(obj[i], path, idx, out);
+      }
+      return;
+    }
+    if (idx === path.length) {
+      out.push(obj);
+      return;
+    }
+    WISESource.#collectShortcutValues(obj[path[idx]], path, idx + 1, out);
   }
 
   // ----------------------------------------------------------------------------


### PR DESCRIPTION
Refactor shortcut walking in wiseSource.parseJSONArray, source.elasticsearch, source.urlapi, source.splunk, and source.databricks to share a single helper, parseJSONElement, on WISESource.

The new helper expands arrays found at any intermediate position along a shortcut path (e.g. shortcut 'a.b.c' against {a:[{b:{c:'v1'}},{b:{c:'v2'}}]} now yields both v1 and v2), in addition to the previously-supported final-value array case. Also honors mod (lower/upper-case) consistently and filters undefined/null/empty values.

Adds file:ipjsonnested test source plus wise.t cases covering both intermediate-array and final-value-array expansion.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
