### PR TITLE
capture: include UDP payload bytes in dedup hash to fix RTP over-drop

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,6 +56,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3965 Add mqtt.connackCode for CONNACK return/reason codes
   - #3965 Add snmp.engineId and snmp.secLevel SNMPv3 fields
   - #3966 Add enip parser
+  - #3969 Include up to 12 bytes of UDP payload in the packet dedup hash so RTP and
+          other UDP traffic with identical headers is no longer over-deduplicated
 ## WISE
   - #3968 Improve JSON Array Parsing: shortcut paths now expand arrays at any
           intermediate position, not just the final value

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1039,8 +1039,12 @@ LOCAL ArkimePacketRC arkime_packet_ip4(ArkimePacketBatch_t *batch, ArkimePacket_
             packet->payloadLen = ip_len - ip_hdr_len;
         }
 
-        if (config.enablePacketDedup && arkime_dedup_should_drop(packet, ip_hdr_len + sizeof(struct udphdr)))
-            return ARKIME_PACKET_DUPLICATE_DROPPED;
+        if (config.enablePacketDedup) {
+            // Include up to 12 bytes of UDP payload in the dedup hash.
+            const int extra = MIN(12, MIN(udpUlen, len - ip_hdr_len) - (int)sizeof(struct udphdr));
+            if (arkime_dedup_should_drop(packet, ip_hdr_len + sizeof(struct udphdr) + extra))
+                return ARKIME_PACKET_DUPLICATE_DROPPED;
+        }
 
         arkime_session_id(sessionId, ip4->ip_src.s_addr, udphdr->uh_sport,
                           ip4->ip_dst.s_addr, udphdr->uh_dport, packet->vlan, packet->vni);
@@ -1265,8 +1269,12 @@ LOCAL ArkimePacketRC arkime_packet_ip6(ArkimePacketBatch_t *batch, ArkimePacket_
                 packet->payloadLen = ip_len + sizeof(struct ip6_hdr) - ip_hdr_len;
             }
 
-            if (config.enablePacketDedup && arkime_dedup_should_drop(packet, ip_hdr_len + sizeof(struct udphdr)))
-                return ARKIME_PACKET_DUPLICATE_DROPPED;
+            if (config.enablePacketDedup) {
+                // Include up to 12 bytes of UDP payload in the dedup hash.
+                const int extra = MIN(12, MIN(udpUlen, len - ip_hdr_len) - (int)sizeof(struct udphdr));
+                if (arkime_dedup_should_drop(packet, ip_hdr_len + sizeof(struct udphdr) + extra))
+                    return ARKIME_PACKET_DUPLICATE_DROPPED;
+            }
 
             packet->mProtocol = udpMProtocol;
             done = 1;


### PR DESCRIPTION
Dedup previously hashed only the IP + UDP headers. UDP has no sequence number, so legitimate same-flow packets with identical headers (e.g. RTP, DNS retries, heartbeats) hashed identically and were falsely treated as duplicates. TCP was unaffected because seq/ack numbers are already inside the hashed range.

Include up to 12 bytes of UDP payload (clamped to what is available) in the dedup hash on both the IPv4 and IPv6 UDP paths. For RTP this covers the sequence number, timestamp, and SSRC, so every distinct RTP packet hashes uniquely while true on-wire duplicates are still caught.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
