### PR TITLE
capture: improve OSPF parser (#3973)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           other UDP traffic with identical headers is no longer over-deduplicated
   - #3970 Added full OpenVPN classifier/parser
   - #3972 Improved STUN/TURN parser: extract XOR-PEER-ADDRESS, more methods, and stun.attributes field
+  - #3973 Improved OSPF parser: per-(src,dst) sessions and ospf.msgType/routerId/areaId fields, tag weak auth
 ## WISE
   - #3968 Improve JSON Array Parsing: shortcut paths now expand arrays at any
           intermediate position, not just the final value

--- a/capture/parsers/ospf.c
+++ b/capture/parsers/ospf.c
@@ -9,23 +9,84 @@
 extern ArkimeConfig_t        config;
 
 LOCAL int ospfMProtocol;
+LOCAL int msgTypeField;
+LOCAL int routerIdField;
+LOCAL int areaIdField;
 
 /******************************************************************************/
-LOCAL void ospf_create_sessionid(uint8_t *sessionId, ArkimePacket_t *const UNUSED(packet))
+LOCAL void ospf_create_sessionid(uint8_t *sessionId, ArkimePacket_t *const packet)
 {
-    // uint8_t *data = packet->pkt + packet->payloadOffset;
+    const struct ip           *ip4 = (struct ip *)(packet->pkt + packet->ipOffset);
+    const struct ip6_hdr      *ip6 = (struct ip6_hdr *)(packet->pkt + packet->ipOffset);
 
-    sessionId[0] = 4;
-    sessionId[1] = ospfMProtocol;
-    sessionId[2] = sessionId[3] = 0;
-
-    // for now, lump all ospf into the same session
+    if (packet->v6) {
+        arkime_session_id6(sessionId, ip6->ip6_src.s6_addr, 0,
+                           ip6->ip6_dst.s6_addr, 0, packet->vlan, packet->vni);
+    } else {
+        arkime_session_id(sessionId, ip4->ip_src.s_addr, 0,
+                          ip4->ip_dst.s_addr, 0, packet->vlan, packet->vni);
+    }
 }
 /******************************************************************************/
-LOCAL int ospf_pre_process(ArkimeSession_t *session, ArkimePacket_t *const UNUSED(packet), int isNewSession)
+LOCAL int ospf_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packet, int isNewSession)
 {
     if (isNewSession)
         arkime_session_add_protocol(session, "ospf");
+
+    // Only inspect the first few packets per session; OSPF identifiers
+    // stabilize quickly and don't need to be re-parsed on every Hello.
+    if (session->packets[0] + session->packets[1] > 10)
+        return 0;
+
+    if (packet->payloadLen < 12)
+        return 0;
+
+    const uint8_t *data = packet->pkt + packet->payloadOffset;
+    const uint8_t version = data[0];
+    const uint8_t type = data[1];
+
+    if (version != 2 && version != 3)
+        return 0;
+
+    const char *typeName = NULL;
+    char buf[32];
+    switch (type) {
+    case 1:
+        typeName = "Hello";
+        break;
+    case 2:
+        typeName = "DBDesc";
+        break;
+    case 3:
+        typeName = "LSReq";
+        break;
+    case 4:
+        typeName = "LSUpdate";
+        break;
+    case 5:
+        typeName = "LSAck";
+        break;
+    default:
+        snprintf(buf, sizeof(buf), "unk-%d", type);
+        typeName = buf;
+    }
+    arkime_field_string_add(msgTypeField, session, typeName, -1, TRUE);
+
+    char ipbuf[INET_ADDRSTRLEN];
+    snprintf(ipbuf, sizeof(ipbuf), "%u.%u.%u.%u", data[4], data[5], data[6], data[7]);
+    arkime_field_string_add(routerIdField, session, ipbuf, -1, TRUE);
+
+    snprintf(ipbuf, sizeof(ipbuf), "%u.%u.%u.%u", data[8], data[9], data[10], data[11]);
+    arkime_field_string_add(areaIdField, session, ipbuf, -1, TRUE);
+
+    // OSPFv2 AuType at offset 14: tag weak/missing authentication
+    if (version == 2 && packet->payloadLen >= 16) {
+        const uint16_t auType = (data[14] << 8) | data[15];
+        if (auType == 0)
+            arkime_session_add_tag(session, "ospf:auth-null");
+        else if (auType == 1)
+            arkime_session_add_tag(session, "ospf:auth-simple");
+    }
 
     return 0;
 }
@@ -63,4 +124,22 @@ void arkime_parser_init()
                                               NULL,
                                               NULL,
                                               600);
+
+    msgTypeField = arkime_field_define("ospf", "lotermfield",
+                                       "ospf.msgType", "OSPF Msg Type", "ospf.msgType",
+                                       "OSPF packet type",
+                                       ARKIME_FIELD_TYPE_STR_GHASH, 0,
+                                       (char *)NULL);
+
+    routerIdField = arkime_field_define("ospf", "termfield",
+                                        "ospf.routerId", "Router ID", "ospf.routerId",
+                                        "OSPF Router ID",
+                                        ARKIME_FIELD_TYPE_STR_GHASH, 0,
+                                        (char *)NULL);
+
+    areaIdField = arkime_field_define("ospf", "termfield",
+                                      "ospf.areaId", "Area ID", "ospf.areaId",
+                                      "OSPF Area ID",
+                                      ARKIME_FIELD_TYPE_STR_GHASH, 0,
+                                      (char *)NULL);
 }

--- a/capture/parsers/ospf.c
+++ b/capture/parsers/ospf.c
@@ -14,6 +14,7 @@ LOCAL int routerIdField;
 LOCAL int areaIdField;
 
 /******************************************************************************/
+SUPPRESS_ALIGNMENT
 LOCAL void ospf_create_sessionid(uint8_t *sessionId, ArkimePacket_t *const packet)
 {
     const struct ip           *ip4 = (struct ip *)(packet->pkt + packet->ipOffset);

--- a/db/db.pl
+++ b/db/db.pl
@@ -5476,6 +5476,19 @@ sub sessions3Update
     "node" : {
       "type" : "keyword"
     },
+    "ospf" : {
+      "properties" : {
+        "msgType" : {
+          "type" : "keyword"
+        },
+        "routerId" : {
+          "type" : "keyword"
+        },
+        "areaId" : {
+          "type" : "keyword"
+        }
+      }
+    },
     "oracle" : {
       "properties" : {
         "host" : {

--- a/tests/pcap/arkime_synthetic.test
+++ b/tests/pcap/arkime_synthetic.test
@@ -2438,6 +2438,17 @@
      "packets" : 1
     },
     "node" : "test",
+    "ospf" : {
+     "areaId" : [
+      "0.0.0.0"
+     ],
+     "msgType" : [
+      "Hello"
+     ],
+     "routerId" : [
+      "10.0.21.100"
+     ]
+    },
     "packetLen" : [
      94
     ],
@@ -2470,6 +2481,10 @@
      1
     ],
     "srcTTLCnt" : 1,
+    "tags" : [
+     "ospf:auth-null"
+    ],
+    "tagsCnt" : 1,
     "totDataBytes" : 0
    },
    "header" : {

--- a/tests/pcap/ospf.test
+++ b/tests/pcap/ospf.test
@@ -638,13 +638,26 @@
     "fileId" : [],
     "firstPacket" : 1571662508795,
     "ipProtocol" : 89,
-    "lastPacket" : 1571662609191,
-    "length" : 100396,
+    "lastPacket" : 1571662608769,
+    "length" : 99974,
     "network" : {
-     "bytes" : 4876,
-     "packets" : 54
+     "bytes" : 2398,
+     "packets" : 27
     },
     "node" : "test",
+    "ospf" : {
+     "areaId" : [
+      "0.0.0.0"
+     ],
+     "msgType" : [
+      "DBDesc",
+      "Hello",
+      "LSReq"
+     ],
+     "routerId" : [
+      "172.16.0.2"
+     ]
+    },
     "packetLen" : [
      98,
      98,
@@ -653,113 +666,59 @@
      98,
      98,
      98,
-     98,
-     98,
-     98,
-     98,
-     98,
-     98,
-     98,
      94,
-     98,
      82,
-     122,
      86,
-     138,
      122,
-     86,
-     82,
      94,
      126,
-     94,
-     150,
      138,
      138,
      94,
-     150,
      94,
-     94,
-     98,
      82,
-     122,
      86,
-     138,
      122,
-     86,
-     82,
      94,
      126,
-     94,
-     150,
      138,
      138,
      94,
-     150,
-     94,
-     98,
-     98,
      98,
      98
     ],
     "packetPos" : [
      374,
-     472,
      10362,
-     10628,
      20313,
-     20495,
      31563,
-     31941,
      41830,
-     41928,
      50554,
-     50652,
      62872,
-     63054,
      75080,
-     75565,
      75663,
-     75745,
      75867,
-     75953,
      76091,
-     76213,
-     76299,
      76381,
      76475,
-     76782,
-     76876,
      77026,
      82788,
-     82926,
-     83020,
      83170,
      87423,
-     87740,
      87838,
-     87920,
      88042,
-     88128,
      88266,
-     88388,
-     88474,
      88556,
      88650,
-     88957,
-     89051,
      89201,
      93373,
-     93511,
-     93605,
      93755,
      98169,
-     98267,
-     110103,
-     110285
+     110103
     ],
     "packetRange" : {
      "gte" : 1571662508795,
-     "lte" : 1571662609191
+     "lte" : 1571662608769
     },
     "protocol" : [
      "ospf"
@@ -777,17 +736,16 @@
        "name" : "Cool Beans!"
       }
      },
-     "bytes" : 4876,
+     "bytes" : 2398,
      "geo" : {
       "country_iso_code" : "CA"
      },
      "ip" : "10.0.0.2",
      "mac" : [
-      "08:00:27:1f:08:22",
       "08:00:27:76:e3:69"
      ],
-     "mac-cnt" : 2,
-     "packets" : 54,
+     "mac-cnt" : 1,
+     "packets" : 27,
      "port" : 0
     },
     "srcDscp" : [
@@ -804,9 +762,186 @@
     ],
     "srcTTLCnt" : 1,
     "tags" : [
-     "dstip"
+     "dstip",
+     "ospf:auth-null"
     ],
-    "tagsCnt" : 1,
+    "tagsCnt" : 2,
+    "totDataBytes" : 0
+   },
+   "header" : {
+    "index" : {
+     "_index" : "tests_sessions3-19m10"
+    }
+   }
+  },
+  {
+   "body" : {
+    "@timestamp" : "SET",
+    "client" : {
+     "bytes" : 0
+    },
+    "destination" : {
+     "bytes" : 0,
+     "ip" : "224.0.0.5",
+     "mac" : [
+      "01:00:5e:00:00:05"
+     ],
+     "mac-cnt" : 1,
+     "packets" : 0,
+     "port" : 0
+    },
+    "ethertype" : 2048,
+    "fileId" : [],
+    "firstPacket" : 1571662509191,
+    "ipProtocol" : 89,
+    "lastPacket" : 1571662609191,
+    "length" : 100000,
+    "network" : {
+     "bytes" : 2478,
+     "packets" : 27
+    },
+    "node" : "test",
+    "ospf" : {
+     "areaId" : [
+      "0.0.0.0"
+     ],
+     "msgType" : [
+      "DBDesc",
+      "Hello",
+      "LSReq",
+      "LSUpdate"
+     ],
+     "routerId" : [
+      "172.16.0.1"
+     ]
+    },
+    "packetLen" : [
+     98,
+     98,
+     98,
+     98,
+     98,
+     98,
+     98,
+     98,
+     122,
+     138,
+     86,
+     82,
+     94,
+     150,
+     94,
+     150,
+     98,
+     122,
+     138,
+     86,
+     82,
+     94,
+     150,
+     94,
+     150,
+     98,
+     98
+    ],
+    "packetPos" : [
+     472,
+     10628,
+     20495,
+     31941,
+     41928,
+     50652,
+     63054,
+     75565,
+     75745,
+     75953,
+     76213,
+     76299,
+     76782,
+     76876,
+     82926,
+     83020,
+     87740,
+     87920,
+     88128,
+     88388,
+     88474,
+     88957,
+     89051,
+     93511,
+     93605,
+     98267,
+     110285
+    ],
+    "packetRange" : {
+     "gte" : 1571662509191,
+     "lte" : 1571662609191
+    },
+    "protocol" : [
+     "ospf"
+    ],
+    "protocolCnt" : 1,
+    "segmentCnt" : 1,
+    "server" : {
+     "bytes" : 0
+    },
+    "source" : {
+     "as" : {
+      "full" : "AS0 This is neat",
+      "number" : 0,
+      "organization" : {
+       "name" : "This is neat"
+      }
+     },
+     "bytes" : 2478,
+     "geo" : {
+      "country_iso_code" : "RU"
+     },
+     "ip" : "10.0.0.1",
+     "mac" : [
+      "08:00:27:1f:08:22"
+     ],
+     "mac-cnt" : 1,
+     "packets" : 27,
+     "port" : 0
+    },
+    "srcDscp" : [
+     48
+    ],
+    "srcDscpCnt" : 1,
+    "srcOui" : [
+     "PCS Computer Systems GmbH"
+    ],
+    "srcOuiCnt" : 1,
+    "srcTTL" : [
+     1
+    ],
+    "srcTTLCnt" : 1,
+    "tags" : [
+     "ospf:auth-null",
+     "srcip"
+    ],
+    "tagsCnt" : 2,
+    "test" : {
+     "ASN" : [
+      "AS0 This is neat"
+     ],
+     "GEO" : [
+      "RU"
+     ],
+     "RIR" : [
+      ""
+     ],
+     "ip" : [
+      "10.0.0.1"
+     ],
+     "number" : [
+      83886304
+     ],
+     "string.snow" : [
+      "16777226:0,83886304:0"
+     ]
+    },
     "totDataBytes" : 0
    },
    "header" : {


### PR DESCRIPTION
- Session ID now keyed by (src,dst) IP instead of one lumped session
- Extract ospf.msgType (Hello/DBDesc/LSReq/LSUpdate/LSAck)
- Extract ospf.routerId and ospf.areaId (32-bit IDs in dotted form)
- Tag weak OSPFv2 authentication (ospf:auth-null, ospf:auth-simple)
- Only inspect the first ~10 packets per session

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
