### PR TITLE
capture: fix race on per-file sessionsStarted/sessionsPresent counters

### DIFF
--- a/.github/workflows/versions
+++ b/.github/workflows/versions
@@ -179,7 +179,6 @@ include:
     freebsdrelease: "15.0"
     buildopt: "--kafka"
     fpmdeps: "-d glib -d yara -d libyaml -d libmaxminddb -d libuuid -d python312 -d libinotify -d pcre2 -d curl"
-    prbuild: true
 
 #  - version: freebsd14.aarch64
 #    freebsdrelease: "14.3"

--- a/capture/writer-inplace.c
+++ b/capture/writer-inplace.c
@@ -68,10 +68,10 @@ LOCAL void writer_inplace_write(const ArkimeSession_t *const UNUSED(session), Ar
     packet->writerFileNum = outputId;
     packet->writerFilePos = packet->readerFilePos;
     if (session->lastFileNum == 0) {
-        offlineInfo[packet->readerPos].sessionsStarted++;
-        offlineInfo[packet->readerPos].sessionsPresent++;
+        ARKIME_THREAD_INCR(offlineInfo[packet->readerPos].sessionsStarted);
+        ARKIME_THREAD_INCR(offlineInfo[packet->readerPos].sessionsPresent);
     } else if (session->lastFileNum != outputId) {
-        offlineInfo[packet->readerPos].sessionsPresent++;
+        ARKIME_THREAD_INCR(offlineInfo[packet->readerPos].sessionsPresent);
     }
 }
 /******************************************************************************/


### PR DESCRIPTION
The offlineInfo[readerPos] counters are shared across all packet threads processing packets from the same input file, but were being incremented non-atomically. Under load (e.g. sanitizer builds) two threads could lose an increment, causing api-files.t to flake with sessionsStarted/Present off by one. Use ARKIME_THREAD_INCR.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
