### PR TITLE
Add FTP parser and fix 220- multi-line banner classification

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3972 Improved STUN/TURN parser: extract XOR-PEER-ADDRESS, more methods, and stun.attributes field
   - #3973 Improved OSPF parser: per-(src,dst) sessions and ospf.msgType/routerId/areaId fields, tag weak auth
   - #3977 Improved RADIUS parser: extract radius.msgType, radius.nasIp, and radius.nasPort
+  - #3978 New FTP parser: detect multi-line 220- banners and add ftp.banner, ftp.command,
+          ftp.filename, ftp.responseCode fields; tag ftp:password when PASS is seen
 ## WISE
   - #3968 Improve JSON Array Parsing: shortcut paths now expand arrays at any
           intermediate position, not just the final value

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1605,6 +1605,7 @@ int  arkime_field_count(int pos, ArkimeSession_t *session);
 void arkime_field_certsinfo_update_extra (void *cert, char *key, char *value);
 GPtrArray *arkime_field_certsinfo_get_extra(const ArkimeSession_t *session, const char *key);
 void arkime_field_free(ArkimeSession_t *session);
+void arkime_field_free_one(ArkimeSession_t *session, int pos);
 void arkime_field_exit();
 
 int arkime_field_by_exp_add_internal(const char *exp, ArkimeFieldType type, ArkimeFieldGetFunc getCb, ArkimeFieldSetFunc setCb);

--- a/capture/field.c
+++ b/capture/field.c
@@ -1367,6 +1367,77 @@ void arkime_field_free(ArkimeSession_t *session)
     session->fields = 0;
 }
 /******************************************************************************/
+void arkime_field_free_one(ArkimeSession_t *session, int pos)
+{
+    ArkimeString_t             *hstring;
+    ArkimeStringHashStd_t      *shash;
+    ArkimeInt_t                *hint;
+    ArkimeIntHashStd_t         *ihash;
+    ArkimeFieldObject_t        *ho;
+    ArkimeFieldObjectHashStd_t *ohash;
+    ArkimeFieldObjectFreeFunc   freeCB;
+    ArkimeField_t              *field;
+
+    if (pos < 0 || pos >= session->maxFields)
+        return;
+    if (!(field = session->fields[pos]))
+        return;
+
+    switch (config.fields[pos]->type) {
+    case ARKIME_FIELD_TYPE_STR:
+        g_free(field->str);
+        break;
+    case ARKIME_FIELD_TYPE_STR_ARRAY:
+        g_ptr_array_free(field->sarray, TRUE);
+        break;
+    case ARKIME_FIELD_TYPE_STR_HASH:
+        shash = field->shash;
+        HASH_FORALL_POP_HEAD2(s_, *shash, hstring) {
+            g_free(hstring->str);
+            ARKIME_TYPE_FREE(ArkimeString_t, hstring);
+        }
+        ARKIME_TYPE_FREE(ArkimeStringHashStd_t, shash);
+        break;
+    case ARKIME_FIELD_TYPE_INT:
+        break;
+    case ARKIME_FIELD_TYPE_INT_ARRAY_UNIQUE:
+    case ARKIME_FIELD_TYPE_INT_ARRAY:
+        g_array_free(field->iarray, TRUE);
+        break;
+    case ARKIME_FIELD_TYPE_INT_HASH:
+        ihash = field->ihash;
+        HASH_FORALL_POP_HEAD2(i_, *ihash, hint) {
+            ARKIME_TYPE_FREE(ArkimeInt_t, hint);
+        }
+        ARKIME_TYPE_FREE(ArkimeIntHashStd_t, ihash);
+        break;
+    case ARKIME_FIELD_TYPE_FLOAT:
+        break;
+    case ARKIME_FIELD_TYPE_FLOAT_ARRAY:
+        g_array_free(field->farray, TRUE);
+        break;
+    case ARKIME_FIELD_TYPE_IP:
+        g_free(field->ip);
+        break;
+    case ARKIME_FIELD_TYPE_IP_GHASH:
+    case ARKIME_FIELD_TYPE_INT_GHASH:
+    case ARKIME_FIELD_TYPE_STR_GHASH:
+    case ARKIME_FIELD_TYPE_FLOAT_GHASH:
+        g_hash_table_destroy(field->ghash);
+        break;
+    case ARKIME_FIELD_TYPE_OBJECT:
+        freeCB = config.fields[pos]->object_free;
+        ohash = field->ohash;
+        HASH_FORALL_POP_HEAD2(o_, *ohash, ho) {
+            freeCB(ho);
+        }
+        ARKIME_TYPE_FREE(ArkimeFieldObjectHashStd_t, ohash);
+        break;
+    }
+    ARKIME_TYPE_FREE(ArkimeField_t, field);
+    session->fields[pos] = NULL;
+}
+/******************************************************************************/
 int arkime_field_object_register(const char *name, const char *help, ArkimeFieldObjectSaveFunc save, ArkimeFieldObjectFreeFunc free, ArkimeFieldObjectHashFunc hash, ArkimeFieldObjectCmpFunc cmp)
 {
     int object_pos;

--- a/capture/parsers/ftp.c
+++ b/capture/parsers/ftp.c
@@ -1,0 +1,223 @@
+/* Copyright 2012-2017 AOL Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Basic FTP parser - extracts user, password, commands, filenames, response codes, banner
+ */
+#include "arkime.h"
+#include <ctype.h>
+
+extern ArkimeConfig_t   config;
+
+LOCAL  int userField;
+LOCAL  int commandField;
+LOCAL  int filenameField;
+LOCAL  int responseCodeField;
+LOCAL  int bannerField;
+
+#define FTP_LINE_MAX 8192
+
+typedef struct {
+    GString  *line[2];
+    uint8_t   serverWhich;
+    uint8_t   sawBanner;
+} FTPInfo_t;
+
+/******************************************************************************/
+LOCAL int ftp_process_client_line(ArkimeSession_t *session, const char *line, int len)
+{
+    while (len > 0 && (*line == ' ' || *line == '\t')) {
+        line++;
+        len--;
+    }
+    if (len < 3)
+        return 0;
+
+    const char *space = memchr(line, ' ', len);
+    int cmdLen = space ? (int)(space - line) : len;
+    if (cmdLen < 3 || cmdLen > 8)
+        return 0;
+
+    char cmd[16];
+    int i;
+    for (i = 0; i < cmdLen; i++) {
+        if (!isalpha((uint8_t)line[i]))
+            return 0;
+        cmd[i] = toupper((uint8_t)line[i]);
+    }
+    cmd[cmdLen] = 0;
+
+    if (strcmp(cmd, "HELO") == 0 || strcmp(cmd, "EHLO") == 0 || strcmp(cmd, "LHLO") == 0)
+        return 1;
+
+    const char *arg = space ? space + 1 : NULL;
+    int argLen = space ? (len - cmdLen - 1) : 0;
+    while (argLen > 0 && (*arg == ' ' || *arg == '\t')) {
+        arg++;
+        argLen--;
+    }
+    while (argLen > 0 && (arg[argLen - 1] == '\r' || arg[argLen - 1] == ' ' || arg[argLen - 1] == '\t')) {
+        argLen--;
+    }
+
+    arkime_field_string_add(commandField, session, cmd, cmdLen, TRUE);
+
+    if (argLen <= 0)
+        return 0;
+
+    if (strcmp(cmd, "USER") == 0) {
+        arkime_field_string_add_lower(userField, session, arg, argLen);
+    } else if (strcmp(cmd, "PASS") == 0) {
+        arkime_session_add_tag(session, "ftp:password");
+    } else if (strcmp(cmd, "RETR") == 0 || strcmp(cmd, "STOR") == 0 ||
+               strcmp(cmd, "STOU") == 0 || strcmp(cmd, "APPE") == 0 ||
+               strcmp(cmd, "DELE") == 0 || strcmp(cmd, "RNFR") == 0 ||
+               strcmp(cmd, "RNTO") == 0 || strcmp(cmd, "MKD")  == 0 ||
+               strcmp(cmd, "RMD")  == 0 || strcmp(cmd, "SIZE") == 0 ||
+               strcmp(cmd, "MDTM") == 0) {
+        arkime_field_string_add(filenameField, session, arg, argLen, TRUE);
+    }
+    return 0;
+}
+/******************************************************************************/
+LOCAL void ftp_process_server_line(FTPInfo_t *ftp, ArkimeSession_t *session, const char *line, int len)
+{
+    if (len < 4)
+        return;
+    if (!isdigit((uint8_t)line[0]) || !isdigit((uint8_t)line[1]) || !isdigit((uint8_t)line[2]))
+        return;
+
+    int code = (line[0] - '0') * 100 + (line[1] - '0') * 10 + (line[2] - '0');
+    arkime_field_int_add(responseCodeField, session, code);
+
+    if (!ftp->sawBanner && code == 220) {
+        const char *msg = line + 4;
+        int msgLen = len - 4;
+        while (msgLen > 0 && (*msg == '-' || *msg == ' ' || *msg == '\t')) {
+            msg++;
+            msgLen--;
+        }
+        while (msgLen > 0 && (msg[msgLen - 1] == '\r' || msg[msgLen - 1] == ' ' || msg[msgLen - 1] == '\t' || msg[msgLen - 1] == '-')) {
+            msgLen--;
+        }
+        if (msgLen > 0) {
+            arkime_field_string_add(bannerField, session, msg, msgLen, TRUE);
+            ftp->sawBanner = 1;
+        }
+    }
+}
+/******************************************************************************/
+LOCAL int ftp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, int remaining, int which)
+{
+    FTPInfo_t *ftp = uw;
+    GString *buf = ftp->line[which];
+    int isServer = (which == ftp->serverWhich);
+
+    while (remaining > 0) {
+        const uint8_t *lineEnd = memchr(data, '\n', remaining);
+        int chunkLen;
+
+        if (!lineEnd) {
+            if (buf->len + remaining > FTP_LINE_MAX) {
+                g_string_truncate(buf, 0);
+                return ARKIME_PARSER_UNREGISTER;
+            }
+            g_string_append_len(buf, (const char *)data, remaining);
+            return 0;
+        }
+
+        chunkLen = lineEnd - data;
+        if (buf->len + chunkLen > FTP_LINE_MAX) {
+            g_string_truncate(buf, 0);
+            return ARKIME_PARSER_UNREGISTER;
+        }
+        g_string_append_len(buf, (const char *)data, chunkLen);
+
+        int lineLen = buf->len;
+        if (lineLen > 0 && buf->str[lineLen - 1] == '\r')
+            lineLen--;
+
+        if (lineLen > 0) {
+            if (isServer) {
+                ftp_process_server_line(ftp, session, buf->str, lineLen);
+            } else if (ftp_process_client_line(session, buf->str, lineLen)) {
+                arkime_field_free_one(session, bannerField);
+                arkime_field_free_one(session, commandField);
+                arkime_field_free_one(session, filenameField);
+                arkime_field_free_one(session, responseCodeField);
+                arkime_session_rm_protocol(session, "ftp");
+                g_string_truncate(buf, 0);
+                return ARKIME_PARSER_UNREGISTER;
+            }
+        }
+
+        g_string_truncate(buf, 0);
+
+        remaining -= chunkLen + 1;
+        data = lineEnd + 1;
+    }
+
+    return 0;
+}
+/******************************************************************************/
+LOCAL void ftp_free(ArkimeSession_t UNUSED(*session), void *uw)
+{
+    FTPInfo_t *ftp = uw;
+    g_string_free(ftp->line[0], TRUE);
+    g_string_free(ftp->line[1], TRUE);
+    ARKIME_TYPE_FREE(FTPInfo_t, ftp);
+}
+/******************************************************************************/
+LOCAL void ftp_classify(ArkimeSession_t *session, const uint8_t *data, int len, int which, void *UNUSED(uw))
+{
+    if (arkime_session_has_protocol(session, "ftp"))
+        return;
+
+    if (g_strstr_len((const char *)data, len, "LMTP") != NULL)
+        return;
+    if (g_strstr_len((const char *)data, len, "SMTP") != NULL)
+        return;
+    if (g_strstr_len((const char *)data, len, " TLS") != NULL)
+        return;
+
+    arkime_session_add_protocol(session, "ftp");
+
+    FTPInfo_t *ftp = ARKIME_TYPE_ALLOC0(FTPInfo_t);
+    ftp->line[0] = g_string_sized_new(128);
+    ftp->line[1] = g_string_sized_new(128);
+    ftp->serverWhich = which;
+
+    arkime_parsers_register(session, ftp_parser, ftp, ftp_free);
+}
+/******************************************************************************/
+void arkime_parser_init()
+{
+    userField = arkime_field_by_db("user");
+
+    commandField = arkime_field_define("ftp", "uptermfield",
+                                       "ftp.command", "Command", "ftp.command",
+                                       "FTP command",
+                                       ARKIME_FIELD_TYPE_STR_HASH, ARKIME_FIELD_FLAG_CNT,
+                                       (char *)NULL);
+
+    filenameField = arkime_field_define("ftp", "termfield",
+                                        "ftp.filename", "Filename", "ftp.filename",
+                                        "FTP filename argument (RETR/STOR/DELE/RNFR/RNTO/MKD/RMD/SIZE/MDTM)",
+                                        ARKIME_FIELD_TYPE_STR_HASH, ARKIME_FIELD_FLAG_CNT,
+                                        (char *)NULL);
+
+    responseCodeField = arkime_field_define("ftp", "integer",
+                                            "ftp.responseCode", "Response Code", "ftp.responseCode",
+                                            "FTP response code",
+                                            ARKIME_FIELD_TYPE_INT_GHASH, ARKIME_FIELD_FLAG_CNT,
+                                            (char *)NULL);
+
+    bannerField = arkime_field_define("ftp", "termfield",
+                                      "ftp.banner", "Banner", "ftp.banner",
+                                      "FTP server welcome banner",
+                                      ARKIME_FIELD_TYPE_STR_HASH, ARKIME_FIELD_FLAG_CNT,
+                                      (char *)NULL);
+
+    arkime_parsers_classifier_register_tcp("ftp", NULL, 0, (const uint8_t *)"220 ", 4, ftp_classify);
+    arkime_parsers_classifier_register_tcp("ftp", NULL, 0, (const uint8_t *)"220-", 4, ftp_classify);
+}

--- a/capture/parsers/ftp.c
+++ b/capture/parsers/ftp.c
@@ -1,4 +1,4 @@
-/* Copyright 2012-2017 AOL Inc. All rights reserved.
+/* Copyright 2026 Andy Wick. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -15,7 +15,7 @@ LOCAL  int filenameField;
 LOCAL  int responseCodeField;
 LOCAL  int bannerField;
 
-#define FTP_LINE_MAX 8192
+#define FTP_LINE_MAX 4096
 
 typedef struct {
     GString  *line[2];

--- a/capture/parsers/ftp.detail.jade
+++ b/capture/parsers/ftp.detail.jade
@@ -1,0 +1,7 @@
+if (session.ftp)
+  div.sessionDetailMeta.bold FTP
+  dl.sessionDetailMeta
+    +arrayList(session.ftp, "banner", "Banner", "ftp.banner")
+    +arrayList(session.ftp, "command", "Commands", "ftp.command")
+    +arrayList(session.ftp, "filename", "Filenames", "ftp.filename")
+    +arrayList(session.ftp, "responseCode", "Response Codes", "ftp.responseCode")

--- a/capture/parsers/misc.c
+++ b/capture/parsers/misc.c
@@ -30,8 +30,6 @@ LOCAL void other220_classify(ArkimeSession_t *session, const uint8_t *data, int 
 {
     if (g_strstr_len((char *)data, len, "LMTP") != NULL) {
         arkime_session_add_protocol(session, "lmtp");
-    } else if (g_strstr_len((char *)data, len, "SMTP") == NULL && g_strstr_len((char *)data, len, " TLS") == NULL) {
-        arkime_session_add_protocol(session, "ftp");
     }
 }
 /******************************************************************************/
@@ -344,6 +342,7 @@ void arkime_parser_init()
     SIMPLE_CLASSIFY_TCP("pop3", "+OK ");
     CLASSIFY_TCP("gh0st", 13, "\x78", gh0st_classify);
     CLASSIFY_TCP("other220", 0, "220 ", other220_classify);
+    CLASSIFY_TCP("other220", 0, "220-", other220_classify);
     CLASSIFY_TCP("vnc", 0, "RFB 0", vnc_classify);
 
     SIMPLE_CLASSIFY_TCP("redis", "+PONG");

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -930,7 +930,7 @@ LOCAL void smtp_classify(ArkimeSession_t *session, const uint8_t *data, int len,
 
     if (memcmp("HELO ", data, 5) == 0 ||
         memcmp("EHLO ", data, 5) == 0 ||
-        (memcmp("220 ", data, 4) == 0 &&
+        ((memcmp("220 ", data, 4) == 0 || memcmp("220-", data, 4) == 0) &&
          g_strstr_len((char *)data, len, "SMTP") != 0)) {
 
         if (arkime_session_has_protocol(session, "smtp"))
@@ -1111,4 +1111,5 @@ void arkime_parser_init()
     arkime_parsers_classifier_register_tcp("smtp", NULL, 0, (uint8_t *)"HELO", 4, smtp_classify);
     arkime_parsers_classifier_register_tcp("smtp", NULL, 0, (uint8_t *)"EHLO", 4, smtp_classify);
     arkime_parsers_classifier_register_tcp("smtp", NULL, 0, (uint8_t *)"220 ", 4, smtp_classify);
+    arkime_parsers_classifier_register_tcp("smtp", NULL, 0, (uint8_t *)"220-", 4, smtp_classify);
 }

--- a/db/db.pl
+++ b/db/db.pl
@@ -4876,6 +4876,34 @@ sub sessions3Update
     "dstOuterASN" : {
       "type" : "keyword"
     },
+    "ftp" : {
+      "properties" : {
+        "banner" : {
+          "type" : "keyword"
+        },
+        "bannerCnt" : {
+          "type" : "long"
+        },
+        "command" : {
+          "type" : "keyword"
+        },
+        "commandCnt" : {
+          "type" : "long"
+        },
+        "filename" : {
+          "type" : "keyword"
+        },
+        "filenameCnt" : {
+          "type" : "long"
+        },
+        "responseCode" : {
+          "type" : "integer"
+        },
+        "responseCodeCnt" : {
+          "type" : "long"
+        }
+      }
+    },
     "http" : {
       "properties" : {
         "authType" : {

--- a/tests/pcap/arkime_synthetic.test
+++ b/tests/pcap/arkime_synthetic.test
@@ -9571,6 +9571,23 @@
     "ethertype" : 2048,
     "fileId" : [],
     "firstPacket" : 1737752637000,
+    "ftp" : {
+     "banner" : [
+      "Welcome to Example FTP Server"
+     ],
+     "bannerCnt" : 1,
+     "command" : [
+      "PASS",
+      "USER"
+     ],
+     "commandCnt" : 2,
+     "responseCode" : [
+      "220",
+      "230",
+      "331"
+     ],
+     "responseCodeCnt" : 3
+    },
     "initRTT" : 1000,
     "ipProtocol" : 6,
     "lastPacket" : 1737752644000,
@@ -9630,6 +9647,10 @@
      64
     ],
     "srcTTLCnt" : 1,
+    "tags" : [
+     "ftp:password"
+    ],
+    "tagsCnt" : 1,
     "tcpflags" : {
      "ack" : 1,
      "ae" : 0,

--- a/tests/pcap/ftp.test
+++ b/tests/pcap/ftp.test
@@ -45,6 +45,23 @@
     "ethertype" : 2048,
     "fileId" : [],
     "firstPacket" : 1454301530932,
+    "ftp" : {
+     "banner" : [
+      "Welcome to mirrors.rit.edu."
+     ],
+     "bannerCnt" : 1,
+     "command" : [
+      "PASS",
+      "USER"
+     ],
+     "commandCnt" : 2,
+     "responseCode" : [
+      "220",
+      "230",
+      "331"
+     ],
+     "responseCodeCnt" : 3
+    },
     "initRTT" : 12,
     "ipProtocol" : 6,
     "lastPacket" : 1454301531009,
@@ -111,6 +128,10 @@
      63
     ],
     "srcTTLCnt" : 1,
+    "tags" : [
+     "ftp:password"
+    ],
+    "tagsCnt" : 1,
     "tcpflags" : {
      "ack" : 3,
      "ae" : 0,


### PR DESCRIPTION
- New capture/parsers/ftp.c extracts ftp.banner, ftp.command, ftp.filename, and ftp.responseCode fields, plus user via shared user field
- Tag ftp:password when PASS is seen (matches http/socks/mqtt convention of never storing password values)
- Classifiers register for both '220 ' and '220-' to handle multi-line banners (RFC 959). Self-unregisters and frees its fields on HELO/EHLO/LHLO so misclassified SMTP/LMTP sessions don't leak ftp.* fields
- ftp_classify is the sole owner of the ftp protocol assignment; removed duplicate logic from misc.c other220_classify (now only adds lmtp)
- smtp.c also registers '220-' so SMTP servers with multi-line greetings are still classified as smtp
- New arkime_field_free_one(session, pos) helper to clear a single field
- ftp.detail.jade for session detail UI

<!-- Provide a clear and descriptive title -->

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
