### PR TITLE
Security hardening across contrib, release, tests and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
         if: ${{ matrix.viewertest == 'normal' }}
         run: |
           export PATH=/opt/arkime/bin:$PATH
-          (chown -R opensearch /opensearch-2.7.0; cd /opensearch-2.7.0 ; su opensearch -c "ES_JAVA_OPTS='-Xms1000m -Xmx1000m' bin/opensearch" > /tmp/os &)
+          (chown -R opensearch /opensearch-2.7.0; cd /opensearch-2.7.0 ; su opensearch -c "OPENSEARCH_JAVA_OPTS='-Xms1000m -Xmx1000m' bin/opensearch" > /tmp/os &)
           sleep 30
           cat /tmp/os
           (cd tests ; G_SLICE=always-malloc ./tests.pl --viewer)
@@ -400,9 +400,8 @@ jobs:
           usesh: true
           prepare: |
             pkg update -f
-            pkg install -y bash git curl perl5 openssl jq yq sudo gmake autoconf automake m4 libtool autoconf-archive gtar p5-LWP-Protocol-https p5-JSON p5-Test-Differences p5-Socket6
+            pkg install -y bash git curl perl5 openssl jq yq sudo gmake autoconf automake m4 libtool autoconf-archive gtar pcre2 python3 p5-LWP-Protocol-https p5-JSON p5-Test-Differences p5-Socket6
           run: |
-            pkg install -y git pcre2
             git config --global --add safe.directory `pwd`
             git config --global --add safe.directory /home/runner/work/arkime/arkime
             ./easybutton-build.sh --dir /usr/local/share/arkime ${{ matrix.buildopt }} --rminstall --nothirdparty

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,9 +236,9 @@ jobs:
           arch: ${{ contains(matrix.version, 'aarch64') && 'aarch64' || 'x86_64' }}
           usesh: true
           prepare: |
-            pkg install -y bash git curl perl5 openssl jq yq sudo gmake autoconf automake m4 libtool autoconf-archive gtar p5-LWP-Protocol-https p5-JSON p5-Test-Differences p5-Socket6
+            pkg update -f
+            pkg install -y bash git curl perl5 openssl jq yq sudo gmake autoconf automake m4 libtool autoconf-archive gtar pcre2 python3 p5-LWP-Protocol-https p5-JSON p5-Test-Differences p5-Socket6
           run: |
-            pkg install -y git pcre2
             git config --global --add safe.directory `pwd`
             git config --global --add safe.directory /home/runner/work/arkime/arkime
             ./easybutton-build.sh --dir /usr/local/share/arkime ${{ matrix.buildopt }} --rminstall --nothirdparty

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,11 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 6.3.2 2026/05/xx
+## Breaking
+  - #3982 docker.sh: TLS verification is now enforced by default for Elasticsearch/OpenSearch
+          connections. Pass `--insecure` to skip verification (e.g. self-signed certs).
+          The `ARKIME__insecure` environment variable is no longer supported and the
+          container will exit if it is set.
 ## Release
   - #3941 Move to using curl instead of wget everywhere and now depend on package
   - #3975 Node 22.22.3

--- a/contrib/decodeDrops.c
+++ b/contrib/decodeDrops.c
@@ -20,11 +20,21 @@ int main(int argc, char *argv[])
     int ver, cnt, i;
     char isIp4;
 
-    fread(&ver, 4, 1, fp);
+    if (fread(&ver, 4, 1, fp) != 1) {
+        fprintf(stderr, "Failed to read version\n");
+        exit(1);
+    }
     printf ("Version: %d\n", ver);
     if (ver == 1) {
-        fread(&cnt, 4, 1, fp);
+        if (fread(&cnt, 4, 1, fp) != 1) {
+            fprintf(stderr, "Failed to read count\n");
+            exit(1);
+        }
         printf ("Count: %d\n", cnt);
+        if (cnt < 0 || cnt > 10000000) {
+            fprintf(stderr, "Implausible count %d; aborting\n", cnt);
+            exit(1);
+        }
         
         unsigned short port;
         unsigned char  key[16];
@@ -32,19 +42,29 @@ int main(int argc, char *argv[])
         unsigned short flags;
         
         for (i = 0; i < cnt; i++) {
-            fread(&port, 2, 1, fp);
-            fread(key, 4, 1, fp);
-            fread(&expire, 4, 1, fp);
-            fread(&flags, 2, 1, fp);
+            if (fread(&port, 2, 1, fp) != 1 ||
+                fread(key, 4, 1, fp) != 1 ||
+                fread(&expire, 4, 1, fp) != 1 ||
+                fread(&flags, 2, 1, fp) != 1) {
+                fprintf(stderr, "Truncated record at index %d\n", i);
+                exit(1);
+            }
 
             time_t texpire = expire;
             printf("%24.24s %d.%d.%d.%d:%d\n", ctime(&texpire), key[0], key[1], key[2], key[3], htons(port));
         }
     } else if (ver == 2) {
-        fread(&isIp4, 1, 1, fp);
-        fread(&cnt, 4, 1, fp);
+        if (fread(&isIp4, 1, 1, fp) != 1 ||
+            fread(&cnt, 4, 1, fp) != 1) {
+            fprintf(stderr, "Failed to read header\n");
+            exit(1);
+        }
         printf ("isIp4: %d\n", isIp4);
         printf ("Count: %d\n", cnt);
+        if (cnt < 0 || cnt > 10000000) {
+            fprintf(stderr, "Implausible count %d; aborting\n", cnt);
+            exit(1);
+        }
         
         unsigned short port;
         unsigned char  key[16];
@@ -53,11 +73,14 @@ int main(int argc, char *argv[])
         unsigned short flags;
         
         for (i = 0; i < cnt; i++) {
-            fread(&port, 2, 1, fp);
-            fread(key, (isIp4?4:16), 1, fp);
-            fread(&last, 4, 1, fp);
-            fread(&goodFor, 4, 1, fp);
-            fread(&flags, 2, 1, fp);
+            if (fread(&port, 2, 1, fp) != 1 ||
+                fread(key, (isIp4?4:16), 1, fp) != 1 ||
+                fread(&last, 4, 1, fp) != 1 ||
+                fread(&goodFor, 4, 1, fp) != 1 ||
+                fread(&flags, 2, 1, fp) != 1) {
+                fprintf(stderr, "Truncated record at index %d\n", i);
+                exit(1);
+            }
 
             time_t texpire = last + goodFor;
             printf("%24.24s %d.%d.%d.%d:%d\n", ctime(&texpire), key[0], key[1], key[2], key[3], htons(port));

--- a/contrib/moloch_query
+++ b/contrib/moloch_query
@@ -17,8 +17,10 @@ import binascii
 import concurrent.futures
 from datetime import datetime
 from elasticsearch import Elasticsearch
+import getpass
 import ipaddress
 import json
+import os
 import re
 import requests
 from requests.auth import HTTPDigestAuth
@@ -44,9 +46,15 @@ parser.add_argument("-t", "--timeout", help="Elasticsearch scroll timeout", defa
 parser.add_argument("--esurl", help="Elasticsearch URL (proto://host:port)", required=True)
 parser.add_argument("--molurl", help="Moloch node (proto://host:port)", required=True)
 parser.add_argument("--apiuser", help="Moloch API username", required=True)
-parser.add_argument("--apipass", help="Moloch API password", required=True)
+parser.add_argument("--apipass",
+                    help="Moloch API password. INSECURE: visible via `ps`. "
+                         "Omit to be prompted.",
+                    default=None)
 
 args = parser.parse_args()
+
+if args.apipass is None:
+    args.apipass = getpass.getpass("Moloch API password: ")
 
 sess = requests.Session()  # Http(s) connection to Moloch for finding sessions
 s = None  # Placeholder for worker http(s) sessions

--- a/contrib/netflow2arkime.pl
+++ b/contrib/netflow2arkime.pl
@@ -69,7 +69,10 @@ my $ESUSER = $ENV{ARKIME_default__elasticsearchBasicAuth} || $ENV{ARKIME__elasti
 my $ESAPIKEY = $ENV{ARKIME_default__elasticsearchAPIKey} || $ENV{ARKIME__elasticsearchAPIKey} || "";
 my $INSECURE = 0;        # Disable SSL certificate verification
 
-my %seen_flows;          # For de-duplication
+my %seen_flows;          # For de-duplication; value is insertion epoch
+my $SEEN_FLOWS_TTL = 600;   # Seconds to retain dedup entries
+my $SEEN_FLOWS_MAX = 1_000_000;  # Hard cap to bound memory
+my $seen_flows_last_prune = time();
 my @batch;               # Batch of documents to send
 my $total_flows = 0;
 my $total_sent = 0;
@@ -77,10 +80,15 @@ my $total_skipped = 0;
 
 # For binary NetFlow
 my %templates;           # NetFlow v9/IPFIX templates per exporter
+my %templates_seen;      # stream_id -> last-seen epoch (for pruning)
+my $TEMPLATES_TTL = 3600;   # Drop templates not seen for an hour
+my $TEMPLATES_MAX = 10_000; # Hard cap on number of distinct exporter streams
+my $templates_last_prune = time();
 
 ################################################################################
 # Parse command line options
 ################################################################################
+my @ORIG_ARGV = @ARGV;
 Getopt::Long::Configure("pass_through");
 GetOptions(
     "elasticsearch=s" => \$ELASTICSEARCH,
@@ -114,6 +122,15 @@ if ($ESUSER ne "" && $ESUSER !~ /:/) {
     print STDERR "\n";
     chomp($pass);
     $ESUSER .= ":$pass";
+} elsif ($ESUSER =~ /:/ && grep { /^--?esuser(=|$)/ } @ORIG_ARGV) {
+    warn "WARNING: passing the password via --esuser USER:PASS exposes it through `ps`. " .
+         "Prefer the ARKIME__elasticsearchBasicAuth environment variable, " .
+         "or pass only --esuser USER to be prompted.\n";
+}
+
+if ($ESAPIKEY ne "" && grep { /^--?esapikey(=|$)/ } @ORIG_ARGV) {
+    warn "WARNING: passing --esapikey on the command line exposes it through `ps`. " .
+         "Prefer the ARKIME__elasticsearchAPIKey environment variable.\n";
 }
 
 usage() if $HELP;
@@ -235,6 +252,8 @@ my $ua = LWP::UserAgent->new(timeout => 120);
 
 # Configure SSL options
 if ($INSECURE) {
+    warn "WARNING: --insecure specified; TLS certificate verification is DISABLED. " .
+         "Connections are vulnerable to man-in-the-middle attacks.\n";
     $ua->ssl_opts(
         SSL_verify_mode => 0,
         verify_hostname => 0,
@@ -690,6 +709,51 @@ sub flush_all_pending {
 }
 
 ################################################################################
+# Bounded-cache pruning to prevent unbounded memory growth in long-running mode
+################################################################################
+sub prune_seen_flows {
+    my $now = time();
+    # Time-based prune at most once every 60s
+    if ($now - $seen_flows_last_prune >= 60) {
+        for my $k (keys %seen_flows) {
+            delete $seen_flows{$k} if $now - $seen_flows{$k} > $SEEN_FLOWS_TTL;
+        }
+        $seen_flows_last_prune = $now;
+    }
+    # Hard cap: if still over the limit, drop oldest entries
+    if (scalar(keys %seen_flows) > $SEEN_FLOWS_MAX) {
+        my @oldest = sort { $seen_flows{$a} <=> $seen_flows{$b} } keys %seen_flows;
+        my $drop = scalar(@oldest) - int($SEEN_FLOWS_MAX * 0.9);
+        for (my $i = 0; $i < $drop; $i++) {
+            delete $seen_flows{$oldest[$i]};
+        }
+        warn "seen_flows cache exceeded $SEEN_FLOWS_MAX entries; dropped $drop oldest\n" if $DEBUG;
+    }
+}
+
+sub prune_templates {
+    my $now = time();
+    if ($now - $templates_last_prune >= 60) {
+        for my $k (keys %templates_seen) {
+            if ($now - $templates_seen{$k} > $TEMPLATES_TTL) {
+                delete $templates{$k};
+                delete $templates_seen{$k};
+            }
+        }
+        $templates_last_prune = $now;
+    }
+    if (scalar(keys %templates_seen) > $TEMPLATES_MAX) {
+        my @oldest = sort { $templates_seen{$a} <=> $templates_seen{$b} } keys %templates_seen;
+        my $drop = scalar(@oldest) - int($TEMPLATES_MAX * 0.9);
+        for (my $i = 0; $i < $drop; $i++) {
+            delete $templates{$oldest[$i]};
+            delete $templates_seen{$oldest[$i]};
+        }
+        warn "templates cache exceeded $TEMPLATES_MAX entries; dropped $drop oldest\n" if $DEBUG;
+    }
+}
+
+################################################################################
 # Calculate index name from timestamp
 ################################################################################
 sub get_index_name {
@@ -739,13 +803,14 @@ sub process_flow {
     
     # De-duplication check
     if ($DEDUP) {
+        prune_seen_flows();
         my $dedup_key = flow_key($flow, 1);
         if (exists $seen_flows{$dedup_key}) {
             $total_skipped++;
             print STDERR "Skipping duplicate: $dedup_key\n" if $DEBUG > 1;
             return;
         }
-        $seen_flows{$dedup_key} = 1;
+        $seen_flows{$dedup_key} = time();
     }
     
     # Combine bidirectional flows
@@ -850,6 +915,7 @@ sub process_binary_netflow {
         }
         
         $templates{$stream_id} ||= [];
+        $templates_seen{$stream_id} = time();
         
         # Decode the NetFlow/IPFIX packet
         my ($HeaderHashRef, $TemplateArrayRef, $FlowArrayRef, $ErrorsArrayRef) =
@@ -857,6 +923,7 @@ sub process_binary_netflow {
         
         # Update templates
         $templates{$stream_id} = $TemplateArrayRef;
+        prune_templates();
         
         # Log errors
         if (@$ErrorsArrayRef) {
@@ -1038,8 +1105,13 @@ sub decode_binary_flow {
 sub process_nfdump_files {
     my @files = @_;
     
-    # Check if nfdump is available
-    my $nfdump_version = `$NFDUMP_PATH -V 2>&1`;
+    # Check if nfdump is available (use list-form to avoid shell interpretation of $NFDUMP_PATH)
+    my $nfdump_version = "";
+    if (open(my $vh, '-|', $NFDUMP_PATH, '-V')) {
+        local $/;
+        $nfdump_version = <$vh>;
+        close($vh);
+    }
     if ($? != 0) {
         die "Error: nfdump not found at '$NFDUMP_PATH'.\n" .
             "Install nfdump or specify path with --nfdump /path/to/nfdump\n";

--- a/release/Configure
+++ b/release/Configure
@@ -85,8 +85,12 @@ if [ "$1" == "--cont3xt" ]; then
 
     while [ -z "$ARKIME_PASSWORD" ]; do
         echo -n "Password to encrypt users, keys, etc. Should be the same across tools [must create one] "
-        read -r ARKIME_PASSWORD
+        read -rs ARKIME_PASSWORD
+        echo
     done
+    # Escape characters that are special in sed replacements: \ first, then & and the / delimiter
+    ARKIME_PASSWORD=${ARKIME_PASSWORD//\\/\\\\}
+    ARKIME_PASSWORD=${ARKIME_PASSWORD//&/\\&}
     ARKIME_PASSWORD=${ARKIME_PASSWORD//\//\\/}
 
 
@@ -165,8 +169,12 @@ fi
 
 while [ -z "$ARKIME_PASSWORD" ]; do
     echo -n "Password to encrypt S2S and other things, don't use spaces [must create one] "
-    read -r ARKIME_PASSWORD
+    read -rs ARKIME_PASSWORD
+    echo
 done
+# Escape characters that are special in sed replacements: \ first, then & and the / delimiter
+ARKIME_PASSWORD=${ARKIME_PASSWORD//\\/\\\\}
+ARKIME_PASSWORD=${ARKIME_PASSWORD//&/\\&}
 ARKIME_PASSWORD=${ARKIME_PASSWORD//\//\\/}
 
 ################################################################################

--- a/release/arkime_config_interfaces.sh
+++ b/release/arkime_config_interfaces.sh
@@ -27,42 +27,49 @@ done
 # Extract list of interfaces
 
 nodeVar=$(echo "$node" | sed 's/-/DASH/g; s/:/COLON/g; s/\./DOT/g;' )
+# Defense in depth: ensure nodeVar only contains characters safe for an env var name.
+case "$nodeVar" in
+    *[!A-Za-z0-9_]*|"")
+        echo "Invalid node name: $node" >&2
+        exit 1
+        ;;
+esac
 nodeInterfaceVar="ARKIME_${nodeVar}__interface"
-nodeInterface=$(eval echo \$$nodeInterfaceVar)
+nodeInterface=$(printenv "$nodeInterfaceVar" || true)
 if [ -n "$nodeInterface" ]; then
     interfaces=$(echo "$nodeInterface" | sed 's/;/ /g')
 elif [ -n "$ARKIME__interface" ]; then
     interfaces=$(echo "$ARKIME__interface" | sed 's/;/ /g')
-elif [ ! -f $file ]; then
+elif [ ! -f "$file" ]; then
 # Check the existence of the file
-    echo "File : "$file" seems to be absent/incorrect."
+    echo "File : $file seems to be absent/incorrect."
     exit 1
 else
-    interfaces=$(sed -n "/^\[$node\]\s*$/,/^\[.*\]\s*$/ {p;}" $file | grep "^interface[ =]" | awk -F "=" '{print $2}' | sed 's/;/ /g')
+    interfaces=$(sed -n "/^\[$node\]\s*$/,/^\[.*\]\s*$/ {p;}" "$file" | grep "^interface[ =]" | awk -F "=" '{print $2}' | sed 's/;/ /g')
 
     # Check interfaces, force to default if no interface.
     if [ -z "$interfaces" ]; then
-        interfaces=$(sed -n -e "/^\[default\]\s*$/,/^\[.*\]\s*$/ {p;}" $file | grep "^interface[ =]" | awk -F "=" '{print $2}' | sed 's/;/ /g')
+        interfaces=$(sed -n -e "/^\[default\]\s*$/,/^\[.*\]\s*$/ {p;}" "$file" | grep "^interface[ =]" | awk -F "=" '{print $2}' | sed 's/;/ /g')
     fi
 fi
 
-# Apply settings
+# Apply settings (interfaces is space-separated; intentional word-split)
 for interface in $interfaces ; do
     if [ "$interface" = "dummy" ]; then
         continue
     fi
 
     # Verify NIC existence.
-    checkNic=$(/usr/sbin/ip a | grep $interface)
+    checkNic=$(/usr/sbin/ip a | grep "$interface")
     if [ ! -z "$checkNic" ]; then
-        /usr/sbin/ip link set $interface up || true
-        /usr/sbin/ip link set $interface promisc on || true
-        /sbin/ethtool -G $interface rx 4096 tx 4096 || true
+        /usr/sbin/ip link set "$interface" up || true
+        /usr/sbin/ip link set "$interface" promisc on || true
+        /sbin/ethtool -G "$interface" rx 4096 tx 4096 || true
         for i in rx tx sg tso ufo gso gro lro; do
-            /sbin/ethtool -K $interface $i off || true
+            /sbin/ethtool -K "$interface" "$i" off || true
         done
     else
-        echo "\nATTENTION :\nNIC : "$interface" seems to be absent/incorrect, can not update interface settings."
-        echo "Please check your configuration file : "$file"\n"
+        echo "\nATTENTION :\nNIC : $interface seems to be absent/incorrect, can not update interface settings."
+        echo "Please check your configuration file : $file\n"
     fi
 done

--- a/release/docker.sh
+++ b/release/docker.sh
@@ -96,6 +96,9 @@ show_help() {
     echo "  --basedir <dir>        Use a different base directory for Arkime, default is /opt/arkime"
     echo "  --db <args>            Run db.pl with args, can be specified multiple times"
     echo "  --forever              Run the tools forever, default is just once"
+    echo "  --insecure             Disable TLS certificate verification for ES/OS connections"
+    echo "                         (applies to --wait-for-db, --db, and --add-admin). INSECURE,"
+    echo "                         use only with self-signed certs in trusted networks."
     echo "  --update-geo           Run /opt/arkime/bin/arkime_update_geo.sh"
     echo "  --wait-for-db <dburl>  Wait for Elasticsearch/OpenSearch to be ready before running command"
     echo "  --                     All arguments after this are passed to the command"
@@ -127,16 +130,24 @@ shift
 # Parse options
 DOINIT=0
 DOUPGRADE=0
+INSECURE=0
+ADD_ADMIN=0
 ISM_OPTION=""
 ISM_PARAM=""
 ILM_OPTION=""
 ILM_PARAM=""
 DB_COMMANDS=()
+
+if [ -n "$ARKIME__insecure" ]; then
+    echo "ERROR: ARKIME__insecure environment variable is no longer supported." >&2
+    echo "       Pass --insecure as a CLI option to $0 instead." >&2
+    exit 1
+fi
+
 while [ $# -gt 0 ]; do
     case "$1" in
         --add-admin)
-            echo "Trying to add admin/admin user if missing, please change password ASAP"
-            (cd $BASEDIR/viewer; $BASEDIR/bin/node addUser.js --insecure admin admin admin --admin --createOnly)
+            ADD_ADMIN=1
             shift
             ;;
         --basedir)
@@ -151,6 +162,10 @@ while [ $# -gt 0 ]; do
             ;;
         --forever)
             FOREVER=1
+            shift
+            ;;
+        --insecure)
+            INSECURE=1
             shift
             ;;
         --ilm)
@@ -200,7 +215,7 @@ while [ $# -gt 0 ]; do
             if [ -n "$ARKIME__elasticsearchBasicAuth" ]; then
                 CURL_OPTS="$CURL_OPTS --user $ARKIME__elasticsearchBasicAuth"
             fi
-            if [ -n "$ARKIME__insecure" ]; then
+            if [ $INSECURE -eq 1 ]; then
                 CURL_OPTS="$CURL_OPTS -k"
             fi
             until curl $CURL_OPTS "$WAIT_DB_URL/_cluster/health?wait_for_status=yellow&timeout=30s"; do
@@ -219,6 +234,13 @@ while [ $# -gt 0 ]; do
             ;;
     esac
 done
+
+# Compute the --insecure pass-through for db.pl / addUser.js
+INSECURE_OPT=""
+if [ $INSECURE -eq 1 ]; then
+    echo "WARNING: --insecure specified; TLS certificate verification is DISABLED for ES/OS connections." >&2
+    INSECURE_OPT="--insecure"
+fi
 
 # Handle legacy --init/--upgrade with --ilm/--ism flags
 if [ $DOINIT -eq 1 ]; then
@@ -245,8 +267,14 @@ fi
 
 # Run all db.pl commands
 for db_cmd in "${DB_COMMANDS[@]}"; do
-    $BASEDIR/db/db.pl --insecure $db_cmd || exit 1
+    $BASEDIR/db/db.pl $INSECURE_OPT $db_cmd || exit 1
 done
+
+# Add admin user after DB init/upgrade so the users index exists
+if [ $ADD_ADMIN -eq 1 ]; then
+    echo "Trying to add admin/admin user if missing, please change password ASAP"
+    (cd $BASEDIR/viewer; $BASEDIR/bin/node addUser.js $INSECURE_OPT admin admin admin --admin --createOnly)
+fi
 
 # Figure out what to run
 case "$command" in

--- a/tests/ArkimeTest.pm
+++ b/tests/ArkimeTest.pm
@@ -13,6 +13,7 @@ use URI::Escape;
 use Data::Dumper;
 use IO::Socket::INET;
 use Try::Tiny;
+use Text::ParseWords qw(shellwords);
 
 $ArkimeTest::userAgent = LWP::UserAgent->new(timeout => 120, keep_alive => 10);
 $ArkimeTest::host = "127.0.0.1";
@@ -553,7 +554,21 @@ my ($host, $port, $extraSleep) = @_;
 ################################################################################
 sub addUser {
     #diag ("cd ../viewer ; node addUser.js $ArkimeTest::es -c ../tests/config.test.ini $_[0]\n");
-    return system("cd ../viewer ; node addUser.js $ArkimeTest::es -c ../tests/config.test.ini $_[0]");
+    my @es_args = (
+        '-o', "elasticsearch=$ArkimeTest::elasticsearch",
+        '-o', "usersElasticsearch=$ArkimeTest::usersElasticsearch",
+    );
+    push @es_args, $ENV{INSECURE} if defined $ENV{INSECURE} && $ENV{INSECURE} ne '';
+    my @extras = shellwords($_[0] // '');
+    my $pid = fork();
+    die "fork: $!" if !defined $pid;
+    if ($pid == 0) {
+        chdir('../viewer') or die "chdir ../viewer: $!";
+        exec('node', 'addUser.js', @es_args, '-c', '../tests/config.test.ini', @extras);
+        die "exec: $!";
+    }
+    waitpid($pid, 0);
+    return $?;
 }
 ################################################################################
 sub clearIndex {

--- a/tests/mini-aws.pl
+++ b/tests/mini-aws.pl
@@ -62,25 +62,12 @@ my %conn_buf;    # fileno => raw read buffer
 my %conn_state;  # fileno => { method, uri, query, headers, content_length, body, headers_done }
 
 my $server = IO::Socket::IP->new(
-    LocalHost => '::',
+    LocalHost => '127.0.0.1',
     LocalPort => $port,
     Proto     => 'tcp',
     Listen    => 128,
     ReuseAddr => 1,
-    V6Only    => 0,
-);
-if (!$server) {
-    # Fall back to IPv4-only (e.g. CI runner without IPv6)
-    my $err = $!;
-    $server = IO::Socket::IP->new(
-        LocalHost => '0.0.0.0',
-        LocalPort => $port,
-        Proto     => 'tcp',
-        Listen    => 128,
-        ReuseAddr => 1,
-    ) or die "Cannot start server on port $port: dual-stack=$err v4=$!\n";
-    print "Mini AWS: dual-stack bind failed ($err), using IPv4-only\n";
-}
+) or die "Cannot start server on port $port: $!\n";
 
 my $flags = fcntl($server, F_GETFL, 0);
 fcntl($server, F_SETFL, $flags | O_NONBLOCK);
@@ -325,12 +312,27 @@ sub handle_request {
 
 sub parse_path {
     my ($path) = @_;
+    my ($bucket, $key);
     if ($path =~ m{^/([^/]+)/(.+)$}) {
-        return ($1, $2);
+        ($bucket, $key) = ($1, $2);
     } elsif ($path =~ m{^/([^/]+)/?$}) {
-        return ($1, undef);
+        ($bucket, $key) = ($1, undef);
+    } else {
+        return (undef, undef);
     }
-    return (undef, undef);
+
+    # Reject path-traversal / absolute-path / NUL-byte attempts before any
+    # filesystem use. Bucket must be a single safe segment; key may contain
+    # subdirectories but no '..' components, no leading '/', no NULs.
+    return (undef, undef) if !defined $bucket || $bucket eq '' || $bucket eq '.' || $bucket eq '..';
+    return (undef, undef) if $bucket =~ m{[\\/\0]} || $bucket =~ /\0/;
+    if (defined $key) {
+        return (undef, undef) if $key eq '' || $key =~ /\0/ || $key =~ m{^/};
+        for my $seg (split m{/}, $key) {
+            return (undef, undef) if $seg eq '..';
+        }
+    }
+    return ($bucket, $key);
 }
 
 sub amz_date {

--- a/tests/mini-redis.pl
+++ b/tests/mini-redis.pl
@@ -29,6 +29,7 @@ my %conn_db;   # fileno => db number
 my %conn_buf;  # fileno => read buffer
 
 my $server = IO::Socket::INET->new(
+    LocalAddr => '127.0.0.1',
     LocalPort => $port,
     Proto     => 'tcp',
     Listen    => 128,

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -288,6 +288,11 @@ my ($json) = @_;
 sub doMake {
     foreach my $filename (@ARGV) {
         $filename = substr($filename, 0, -5) if ($filename =~ /\.pcap$/);
+        # Reject filenames with shell metacharacters / NUL since we still need
+        # a shell to set up the pipe + redirection below.
+        if ($filename =~ /[\0\n\r`\$;&|<>(){}*?!"'\\]/) {
+            die "Invalid filename (contains shell metacharacter): $filename\n";
+        }
         if ($main::debug) {
           print("../capture/capture $EXTRA --tests -c config.test.ini -n test -r $filename.pcap 2>&1 1>/dev/null | ./tests.pl --fix > $filename.test\n");
         }
@@ -561,9 +566,11 @@ if ($main::cmd eq "--fix") {
     doReip();
 } elsif ($main::cmd eq "--fuzz") {
     doGeo();
-    my $cmd = "ASAN_OPTIONS=fast_unwind_on_malloc=0 G_SLICE=always-malloc ../capture/fuzzloch-capture -max_len=8196 -timeout=5 @ARGV";
-    print "$cmd\n";
-    system($cmd);
+    local $ENV{ASAN_OPTIONS} = "fast_unwind_on_malloc=0";
+    local $ENV{G_SLICE} = "always-malloc";
+    my @cmd = ("../capture/fuzzloch-capture", "-max_len=8196", "-timeout=5", @ARGV);
+    print join(' ', @cmd), "\n";
+    system(@cmd);
 } elsif ($main::cmd eq "--fuzz2pcap") {
     doFuzz2Pcap();
 } elsif ($main::cmd eq "--fuzz2pcapAll") {


### PR DESCRIPTION
- docker.sh: TLS verification enforced by default; new --insecure CLI flag; ARKIME__insecure env var removed (container exits if set). BREAKING.
- Configure: read passwords without echoing; escape \, &, and / when substituting passwords into config files.
- arkime_config_interfaces.sh: replace eval with printenv and strict node-name validation; quote variables.
- contrib/moloch_query: --apipass optional; prompt via getpass if omitted.
- contrib/netflow2arkime.pl: warn when credentials passed via --esuser/--esapikey; bound flow-dedup and template caches with TTL+LRU; safer nfdump version probe.
- contrib/decodeDrops.c: check every fread return; cap cnt at 10M.
- tests/ArkimeTest.pm addUser: fork+exec list-form using shellwords.
- tests/tests.pl --fuzz: list-form system with env via local %ENV.
- tests/tests.pl doMake: reject filenames containing shell metacharacters.
- tests/mini-aws.pl: bind to 127.0.0.1 only; reject path-traversal in S3 keys.
- tests/mini-redis.pl: bind to 127.0.0.1 only.
- .github/workflows: move all FreeBSD pkg installs into prepare; add python3; rename ES_JAVA_OPTS to OPENSEARCH_JAVA_OPTS.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
