### PR TITLE
Security hardening across viewer, capture, db.pl

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,22 +37,21 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 
 6.3.2 2026/05/xx
 ## Breaking
+  - #3967 All header* auth modes (header, header-jwt, headerOnly, header+digest, header+basic) now
+          default userAuthIps to localhost-only when not explicitly configured
   - #3982 docker.sh: TLS verification is now enforced by default for Elasticsearch/OpenSearch
-          connections. Pass `--insecure` to skip verification (e.g. self-signed certs).
-          The `ARKIME__insecure` environment variable is no longer supported and the
-          container will exit if it is set.
+          connections, use `--insecure` to skip verification
+  - #3983 multies now defaults `multiESHost` to `127.0.0.1` instead of binding to all interfaces.
 ## Release
-  - #3941 Move to using curl instead of wget everywhere and now depend on package
+  - #3941 Move to using curl instead of wget everywhere and now depend on curl package
   - #3975 Node 22.22.3
 ## All
   - #3951 Fix UTF-8 mojibake in user names auto-created via header auth (e.g. behind Caddy/oauth2-proxy)
-  - #3967 All header* auth modes (header, header-jwt, headerOnly, header+digest, header+basic) now
-          default userAuthIps to localhost-only when not explicitly configured
 ## Capture
   - #3954 Add trimEthernetPadding option to strip Ethernet padding/FCS so saved pcap and byte counts match the on-wire IP length
   - #3957 Even when not writing packets still save new sessions midway
-  - #3958 Add stateDir config option (default /tmp) for capture state files (drophash, stoppedsessions); 
-          files now opened with O_NOFOLLOW to prevent symlink attacks
+  - #3958 Add stateDir config option (default /tmp) for capture state files (drophash, stoppedsessions)
+  - #3958 State files now opened with O_NOFOLLOW to prevent symlink attacks
   - #3958 PCAP files now opened with O_NOFOLLOW to prevent symlink attacks
   - #3962 Improved websocket parser; adds websocket.* fields and websocketTextSampleCnt config option
   - #3963 Improved mDNS parsing: handle aggregated queries, unsolicited responses, and flags
@@ -70,6 +69,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3977 Improved RADIUS parser: extract radius.msgType, radius.nasIp, and radius.nasPort
   - #3978 New FTP parser: detect multi-line 220- banners and add ftp.banner, ftp.command,
           ftp.filename, ftp.responseCode fields; tag ftp:password when PASS is seen
+## Multies
+  - #3983 Support optional HTTP Basic auth via the new `multiESBasicAuth` setting
 ## WISE
   - #3968 Improve JSON Array Parsing: shortcut paths now expand arrays at any
           intermediate position, not just the final value

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -1069,6 +1069,7 @@ void writer_simple_init(const char *name)
         simpleDEKMode = ARKIME_DEK_AES256GCM;
     } else if (strcmp(dekMode, "aes-192-cbc") == 0) {
         simpleDEKMode = ARKIME_DEK_AES192CBC;
+        LOG("WARNING - simpleDEKEncoding aes-192-cbc is INSECURE, set simpleDEKEncoding=aes-256-gcm once all instances are upgraded to Arkime 6.2.0 or later");
     } else {
         CONFIGEXIT("Unknown simpleDEKEncoding '%s', must be 'aes-256-gcm' or 'aes-192-cbc'", dekMode);
     }

--- a/common/auth.js
+++ b/common/auth.js
@@ -34,6 +34,7 @@ class Auth {
   static #basePath;
   static #requiredAuthHeader;
   static #requiredAuthHeaderVal;
+  static #requiredAuthHeaderHmacs;
   static #userAutoCreateTmpl;
   static #userAutoCreateFuncs;
   static #userAuthIps;
@@ -144,9 +145,10 @@ class Auth {
     }
     Auth.#requiredAuthHeader = options.requiredAuthHeader;
     Auth.#requiredAuthHeaderVal = options.requiredAuthHeaderVal?.split(',').map(s => s.trim()).filter(s => s !== '');
+    Auth.#requiredAuthHeaderHmacs = Auth.#requiredAuthHeaderVal?.map(v => crypto.createHmac('sha256', 'compare').update(v).digest());
     Auth.#userAutoCreateTmpl = options.userAutoCreateTmpl;
     if (Auth.#userAutoCreateTmpl) {
-      console.log('WARNING - userAutoCreateTmpl is deprecated, use [user-auto-create] section instead');
+      console.log('WARNING - userAutoCreateTmpl is deprecated and INSECURE, use [user-auto-create] section instead. This functionality will be removed in Arkime 7.');
     }
 
     const userAutoCreate = ArkimeConfig.getSection('user-auto-create');
@@ -543,14 +545,17 @@ class Auth {
         return done(null, false);
       }
 
-      if (Auth.#requiredAuthHeader !== undefined && Auth.#requiredAuthHeaderVal !== undefined) {
+      if (Auth.#requiredAuthHeader !== undefined && Auth.#requiredAuthHeaderHmacs !== undefined) {
         const authHeader = req.headers[Auth.#requiredAuthHeader];
         if (authHeader === undefined) {
           return done('Missing authorization header');
         }
-        const authorized = authHeader.split(',').some(headerVal => Auth.#requiredAuthHeaderVal.includes(headerVal.trim()));
+        const authorized = authHeader.split(',').some(headerVal => {
+          const h = crypto.createHmac('sha256', 'compare').update(headerVal.trim()).digest();
+          return Auth.#requiredAuthHeaderHmacs.some(expected => crypto.timingSafeEqual(expected, h));
+        });
         if (!authorized) {
-          console.log(`The required auth header '${Auth.#requiredAuthHeader}' expected '${Auth.#requiredAuthHeaderVal}' and has `, ArkimeUtil.sanitizeStr(authHeader));
+          console.log(`The required auth header '${Auth.#requiredAuthHeader}' did not match an expected value, got `, ArkimeUtil.sanitizeStr(authHeader));
           return done('Bad authorization header');
         }
       }
@@ -1119,22 +1124,7 @@ class Auth {
   // Encrypt an object into an auth string
   // IV.E.H
   static obj2auth (obj, secret) {
-    // HACK: Remove in future, for cookies use Next since local
-    if (obj.pid !== undefined) { return Auth.obj2authNext(obj, secret); }
-
-    if (secret) {
-      secret = crypto.createHash('sha256').update(secret).digest();
-    } else {
-      secret = Auth.#serverSecret256;
-    }
-
-    const iv = crypto.randomBytes(16);
-    const c = crypto.createCipheriv('aes-256-cbc', secret, iv);
-    let e = c.update(JSON.stringify(obj), 'utf8', 'hex');
-    e += c.final('hex');
-    e = iv.toString('hex') + '.' + e;
-    const h = crypto.createHmac('sha256', secret).update(e).digest('hex');
-    return e + '.' + h;
+    return Auth.obj2authNext(obj, secret);
   }
 
   // ----------------------------------------------------------------------------

--- a/db/db.pl
+++ b/db/db.pl
@@ -7758,7 +7758,7 @@ sub verify {
 }
 
 if ($ARGV[0] =~ /^urlinfile:\/\//) {
-    open( my $file, substr($ARGV[0], 12)) or die "Couldn't open file ", substr($ARGV[0], 12);
+    open( my $file, '<', substr($ARGV[0], 12)) or die "Couldn't open file ", substr($ARGV[0], 12);
     $main::elasticsearch = <$file>;
     chomp $main::elasticsearch;
     close ($file);
@@ -8435,7 +8435,7 @@ if ($ARGV[1] =~ /^(users-?import|import)$/) {
         die "Couldn't find '$ARGV[2]' in db\n" if (@{$results->{hits}->{hits}} == 0);
 
         foreach my $hit (@{$results->{hits}->{hits}}) {
-            my $script = '{"script" : "ctx._source.name = \"' . $ARGV[3] . '\"; ctx._source.locked = 1;"}';
+            my $script = to_json({script => {source => 'ctx._source.name = params.n; ctx._source.locked = 1', params => {n => $ARGV[3]}}});
             esPost("/${PREFIX}files/_update/" . $hit->{_id}, $script);
         }
         logmsg "Moved " . scalar (@{$results->{hits}->{hits}}) . " file(s) in database\n";

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -51,6 +51,9 @@ ArkimeConfig.loaded(() => {
     if (sensors[sensor].ip) {
       sensors[sensor].ip = sensors[sensor].ip.split(',');
     }
+    if (sensors[sensor].pass === undefined && !sensors[sensor].ip) {
+      console.log(`WARNING - esproxy-sensors '${sensor}' has neither 'pass' nor 'ip' set; any client that knows the sensor name can authenticate.`);
+    }
   }
   console.log(`PREFIX: ${prefix} OLDPREFIX: ${oldprefix}`);
 

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -18,6 +18,7 @@ const http = require('http');
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
+const cryptoLib = require('crypto');
 const ArkimeUtil = require('../common/arkimeUtil');
 const ArkimeConfig = require('../common/arkimeConfig');
 
@@ -50,6 +51,7 @@ process.on('warning', (w) => {
 const esSSLOptions = { rejectUnauthorized: !ArkimeConfig.insecure };
 let httpAgent;
 let httpsAgent;
+let multiESBasicAuthHmac;
 ArkimeConfig.loaded(() => {
   const esClientKey = Config.get('esClientKey');
   const esClientCert = Config.get('esClientCert');
@@ -65,6 +67,11 @@ ArkimeConfig.loaded(() => {
   }
   httpAgent = new http.Agent({ keepAlive: true, keepAliveMsecs: 5000, maxSockets: 100 });
   httpsAgent = new https.Agent(Object.assign({ keepAlive: true, keepAliveMsecs: 5000, maxSockets: 100 }, esSSLOptions));
+
+  const expected = Config.get('multiESBasicAuth');
+  if (expected) {
+    multiESBasicAuthHmac = cryptoLib.createHmac('sha256', 'compare').update(expected).digest();
+  }
 });
 
 const clients = {};
@@ -116,6 +123,27 @@ app.use(function (req, res, next) {
     res.setTimeout(10 * 60 * 1000); // Increase default from 2 min to 10 min
     return next();
   }
+});
+
+// ============================================================================
+// Optional basic auth: if multiESBasicAuth ("user:password") is set in config,
+// require it on every request. Compared in constant time.
+// ============================================================================
+app.use((req, res, next) => {
+  if (!multiESBasicAuthHmac) { return next(); }
+
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Basic ')) {
+    return res.set('WWW-Authenticate', 'Basic').status(401).send();
+  }
+
+  const supplied = Buffer.from(header.slice(6).trim(), 'base64').toString('utf8');
+  const b = cryptoLib.createHmac('sha256', 'compare').update(supplied).digest();
+  if (!cryptoLib.timingSafeEqual(multiESBasicAuthHmac, b)) {
+    return res.set('WWW-Authenticate', 'Basic').status(401).send();
+  }
+
+  return next();
 });
 
 function node2Url (node) {
@@ -1389,7 +1417,7 @@ async function premain () {
   activeESNodes = nodes.slice();
   console.log(nodes);
 
-  ArkimeUtil.createHttpServer(app, Config.get('multiESHost'), Config.get('multiESPort', 8200));
+  ArkimeUtil.createHttpServer(app, Config.get('multiESHost', '127.0.0.1'), Config.get('multiESPort', 8200));
 }
 
 premain();

--- a/viewer/viewerUtils.js
+++ b/viewer/viewerUtils.js
@@ -20,6 +20,7 @@ const internals = require('./internals');
 class ViewerUtils {
   static #oldDBFields = new Map();
   static #caTrustCerts = new Map();
+  static #hostnameRE = /^(?:[a-zA-Z0-9._-]+|\[[0-9a-fA-F:]+\])$/;
 
   // ----------------------------------------------------------------------------
   static addCaTrust (options, node) {
@@ -267,6 +268,10 @@ class ViewerUtils {
 
     if (Config.debug > 1) {
       console.log(`DEBUG: node:${node} is using ${stat.hostname} from OpenSearch/Elasticsearch stats index`);
+    }
+
+    if (!stat.hostname || !ViewerUtils.#hostnameRE.test(stat.hostname)) {
+      throw new Error(`Invalid hostname for node ${ArkimeUtil.sanitizeStr(node)} from stats index: ${ArkimeUtil.sanitizeStr(stat.hostname)}`);
     }
 
     isHttps = Config.isHTTPS(node);


### PR DESCRIPTION
- multies: default multiESHost to 127.0.0.1 instead of binding to all interfaces
- multies: add optional HTTP Basic auth via multiESBasicAuth, with timing-safe HMAC compare
- common/auth: timing-safe compare for requiredAuthHeader, no longer logs expected value
- common/auth: strengthen digest deprecation warning (insecure, removed in Arkime 7)
- common/auth: simplify obj2auth to always use obj2authNext
- viewer/esProxy: startup warning when sensors lack both pass and ip
- viewer/viewerUtils: validate stat.hostname before building proxy URL
- capture/writer-simple: warn when simpleDEKEncoding=aes-192-cbc, recommend aes-256-gcm
- db/db.pl: use 3-arg open() for urlinfile:// to prevent pipe injection
- db/db.pl: use Painless params in mv command to prevent script injection

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
