### PR TITLE
Fix NTLM base64 decode crash on short Authorization headers

### DIFF
--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -830,20 +830,19 @@ gboolean arkime_parsers_ntlm_decode_base64(ArkimeSession_t *session,
     if (b64len < 11 || memcmp(b64, "TlRMTVNTUA", 10) != 0)
         return FALSE;
 
-    char *s = g_strndup(b64, b64len);
-    gsize out_len = 0;
-    guchar *decoded = g_base64_decode(s, &out_len);
-    g_free(s);
+    if (b64len > 16384)
+        b64len = 16384;
 
-    gboolean dispatched = FALSE;
-    if (decoded) {
-        if (out_len >= 12) {
-            arkime_parsers_ntlm_decode(session, decoded, out_len);
-            dispatched = TRUE;
-        }
-        g_free(decoded);
-    }
-    return dispatched;
+    guchar decoded[12288];
+    gint state = 0;
+    guint save = 0;
+    gsize out_len = g_base64_decode_step(b64, b64len, decoded, &state, &save);
+
+    if (out_len < 12)
+        return FALSE;
+
+    arkime_parsers_ntlm_decode(session, decoded, out_len);
+    return TRUE;
 }
 /******************************************************************************/
 LOCAL int filewext_cmp(const void *a, const void *b)

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -359,15 +359,8 @@ LOCAL void arkime_http_parse_authorization(ArkimeSession_t *session, char *str)
         const char *scheme_end = space;
         const char *b64 = scheme_end;
         while (*b64 && isspace((unsigned char) * b64)) b64++;
-        if (*b64) {
-            char *dup = g_strdup(b64);
-            gsize dlen;
-            g_base64_decode_inplace(dup, &dlen);
-            if (dlen >= 8 && dlen <= UINT32_MAX && memcmp(dup, "NTLMSSP\0", 8) == 0) {
-                arkime_parsers_ntlm_decode(session, (const uint8_t *)dup, (uint32_t)dlen);
-            }
-            g_free(dup);
-        }
+        if (*b64)
+            arkime_parsers_ntlm_decode_base64(session, b64, strlen(b64));
         return;
     }
 


### PR DESCRIPTION
- http.c: route NTLM/Negotiate Authorization through arkime_parsers_ntlm_decode_base64 instead of g_strdup + g_base64_decode_inplace, avoiding GLib assertion 'input_length > 1' on 1-char base64
- parsers.c: use g_base64_decode_step with a fixed stack buffer (no copy, no VLA, input capped at 16384 bytes)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
