### PR TITLE
Fix UAF in command-socket --notify

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -71,7 +71,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           ftp.filename, ftp.responseCode fields; tag ftp:password when PASS is seen
   - #3985 Add shared NTLMSSP decoder with ntlm.* fields, wired into SMB, HTTP, LDAP, DCE-RPC, SMTP, IMAP, POP3, and TDS parsers
   - #3985 Add new POP3 parser that captures USER name and NTLM auth blobs
-  - #3988 Fix UAF in command-socket `--notify`: notify when packets actually drain (FILE_DONE) instead of right after queue, and stop eagerly freeing scheme actions while packets are still in flight
+  - #3988 Fix command-socket `--notify` without `--flush` crashing capture
+  - #3988 Fix crash when using rules with bpfs and different DLTs without using `--flush`
 ## Multies
   - #3983 Support optional HTTP Basic auth via the new `multiESBasicAuth` setting
 ## WISE

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -71,6 +71,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           ftp.filename, ftp.responseCode fields; tag ftp:password when PASS is seen
   - #3985 Add shared NTLMSSP decoder with ntlm.* fields, wired into SMB, HTTP, LDAP, DCE-RPC, SMTP, IMAP, POP3, and TDS parsers
   - #3985 Add new POP3 parser that captures USER name and NTLM auth blobs
+  - #3988 Fix UAF in command-socket `--notify`: notify when packets actually drain (FILE_DONE) instead of right after queue, and stop eagerly freeing scheme actions while packets are still in flight
 ## Multies
   - #3983 Support optional HTTP Basic auth via the new `multiESBasicAuth` setting
 ## WISE

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -313,6 +313,9 @@ typedef struct {
 #define ARKIME_THREAD_DECROLD(var)       __sync_fetch_and_sub(&var, 1)
 #define ARKIME_THREAD_DECR_NUM(var, num) __sync_sub_and_fetch(&var, num)
 
+#define ARKIME_THREAD_ATOMIC_STORE(var, val) __atomic_store_n(&(var), (val), __ATOMIC_RELEASE)
+#define ARKIME_THREAD_ATOMIC_LOAD(var)       __atomic_load_n(&(var), __ATOMIC_ACQUIRE)
+
 /* You are probably looking here because you think 24 is too low, really it isn't.
  * Instead, use jemalloc and increase the number of threads used for reading packets.
  * https://arkime.com/faq#why-am-i-dropping-packets

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -662,6 +662,8 @@ typedef struct {
     uint32_t        sessionsPresent;
     uint8_t         didBatch;
     uint8_t         finishWaiting;
+    void           *notifyClientRef; // command-socket --notify: client to receive file-done
+    char           *notifyFilename;  // filename to report in the notification
 } ArkimeOfflineInfo_t;
 /******************************************************************************/
 typedef enum {

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -549,6 +549,13 @@ LOCAL void *arkime_packet_thread(void *threadp)
             ARKIME_THREAD_DECR(oi->finishWaiting);
             if (oi->finishWaiting == 0) {
                 arkime_db_update_file(oi->outputId, oi->lastBytes, oi->lastBytes, oi->lastPackets, &oi->lastPacketTime, oi->sessionsStarted, oi->sessionsPresent);
+                if (oi->notifyClientRef) {
+                    arkime_command_notify_file_done(oi->notifyClientRef, oi->notifyFilename, oi->lastBytes, oi->lastPackets);
+                    arkime_command_client_decref(oi->notifyClientRef);
+                    g_free(oi->notifyFilename);
+                    oi->notifyClientRef = NULL;
+                    oi->notifyFilename = NULL;
+                }
             }
             ARKIME_UNLOCK(offlineInfoLock);
             arkime_packet_free(packet);

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -822,7 +822,10 @@ gboolean arkime_parsers_ntlm_decode_base64(ArkimeSession_t *session,
     if (!b64 || b64len < 11)
         return FALSE;
 
-    while (b64len > 0 && (*b64 == ' ' || *b64 == '\t')) { b64++; b64len--; }
+    while (b64len > 0 && (*b64 == ' ' || *b64 == '\t')) {
+        b64++;
+        b64len--;
+    }
     while (b64len > 0 && (b64[b64len - 1] == ' ' || b64[b64len - 1] == '\t' ||
                           b64[b64len - 1] == '\r' || b64[b64len - 1] == '\n'))
         b64len--;

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -725,8 +725,8 @@ LOCAL gboolean arkime_ntlm_secbuf(const uint8_t *msg, uint32_t msglen,
 /******************************************************************************/
 LOCAL void arkime_ntlm_add_version(ArkimeSession_t *session, BSB *vb)
 {
-    uint8_t  major, minor;
-    uint16_t build;
+    uint8_t  major = 0, minor = 0;
+    uint16_t build = 0;
     BSB_LIMPORT_u08(*vb, major);
     BSB_LIMPORT_u08(*vb, minor);
     BSB_LIMPORT_u16(*vb, build);

--- a/capture/parsers/imap.c
+++ b/capture/parsers/imap.c
@@ -104,7 +104,8 @@ LOCAL void imap_process_line(IMAPInfo_t *imap, ArkimeSession_t *session, const c
         int blen = len;
         /* Server continuation: "+ TlRMTVN..." */
         if (which == imap->serverWhich && blen > 2 && b[0] == '+' && b[1] == ' ') {
-            b += 2; blen -= 2;
+            b += 2;
+            blen -= 2;
         }
         if (arkime_parsers_ntlm_decode_base64(session, b, blen))
             return;

--- a/capture/parsers/pop3.c
+++ b/capture/parsers/pop3.c
@@ -37,7 +37,8 @@ LOCAL void pop3_process_line(POP3Info_t *pop3, ArkimeSession_t *session, const c
         int blen = len;
         /* Server continuation: "+ TlRMTVN..." */
         if (which == pop3->serverWhich && blen > 2 && b[0] == '+' && b[1] == ' ') {
-            b += 2; blen -= 2;
+            b += 2;
+            blen -= 2;
         }
         if (arkime_parsers_ntlm_decode_base64(session, b, blen)) {
             pop3->ntlmCount++;
@@ -53,7 +54,10 @@ LOCAL void pop3_process_line(POP3Info_t *pop3, ArkimeSession_t *session, const c
         strncasecmp(line, "USER ", 5) == 0) {
         const char *u = line + 5;
         int ulen = len - 5;
-        while (ulen > 0 && isspace((unsigned char)*u)) { u++; ulen--; }
+        while (ulen > 0 && isspace((unsigned char) * u)) {
+            u++;
+            ulen--;
+        }
         while (ulen > 0 && isspace((unsigned char)u[ulen - 1])) ulen--;
         if (ulen > 0)
             arkime_field_string_add_lower(userField, session, u, ulen);

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -467,7 +467,8 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                 const char *b = line->str;
                 int blen = line->len;
                 if (blen > 4 && b[0] == '3' && b[1] == '3' && b[2] == '4' && b[3] == ' ') {
-                    b += 4; blen -= 4;
+                    b += 4;
+                    blen -= 4;
                 }
                 if (arkime_parsers_ntlm_decode_base64(session, b, blen)) {
                     *state = EMAIL_CMD;

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -136,9 +136,16 @@ LOCAL ArkimeScheme_t *uri2scheme(const char *uri)
     return str ? str->uw : NULL;
 }
 /******************************************************************************/
+/******************************************************************************/
+/* Tracks recursion depth of load_thread on the scheme thread. depth==1 means
+ * the outermost call (i.e. add-file/add-dir top level). Nested calls happen
+ * when reading a directory: outer load_thread(DIRHINT) -> readerScheme->load
+ * -> arkime_reader_scheme_load(file) -> inner load_thread(no DIRHINT). */
+LOCAL int loadThreadDepth;
 /* Actually call the scheme load function. This is guaranteed to be on the scheme thread */
 LOCAL void arkime_reader_scheme_load_thread(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions)
 {
+    loadThreadDepth++;
     reader_scheme_pause();
 
     LOG("Processing %s", uri);
@@ -147,7 +154,7 @@ LOCAL void arkime_reader_scheme_load_thread(const char *uri, ArkimeSchemeFlags f
         LOG("ERROR - Unknown scheme for %s", uri);
         if (actions && actions->notifyClientRef)
             arkime_command_notify_file_error(actions->notifyClientRef, uri);
-        return;
+        goto cleanup;
     }
 
     readerState.startPos = 0;
@@ -163,7 +170,17 @@ LOCAL void arkime_reader_scheme_load_thread(const char *uri, ArkimeSchemeFlags f
 
     int rcl = readerScheme->load(uri, flags, actions);
 
-    if (rcl == 0 && !config.dryRun && !config.copyPcap && offlineInfo[readerState.readerPos].didBatch) {
+    gboolean notifyHandedOff = FALSE;
+    if (rcl == 0 && offlineInfo[readerState.readerPos].didBatch) {
+        // Stash an async file-done notification on the offlineInfo slot. The
+        // packet thread will fire file-done + decref when the last packet of
+        // this file has been processed.
+        if (!(flags & ARKIME_SCHEME_FLAG_DIRHINT) && actions && actions->notifyClientRef) {
+            arkime_command_client_incref(actions->notifyClientRef);
+            offlineInfo[readerState.readerPos].notifyClientRef = actions->notifyClientRef;
+            offlineInfo[readerState.readerPos].notifyFilename = g_strdup(uri);
+            notifyHandedOff = TRUE;
+        }
         arkime_packet_batch_end_of_file(readerState.readerPos);
     }
 
@@ -180,25 +197,30 @@ LOCAL void arkime_reader_scheme_load_thread(const char *uri, ArkimeSchemeFlags f
         }
     }
 
-    // Send async completion notification if requested via command socket.
-    // Skip for directory entries (DIRHINT) — only individual files get notifications.
-    if (!(flags & ARKIME_SCHEME_FLAG_DIRHINT) && actions && actions->notifyClientRef) {
+    // Synchronous notification path: load failed or no packets batched. The
+    // packet thread won't fire FILE_DONE so we notify inline. We don't touch
+    // actions->notifyClientRef — for add-dir it's shared across files.
+    if (!(flags & ARKIME_SCHEME_FLAG_DIRHINT) && actions && actions->notifyClientRef && !notifyHandedOff) {
         if (rcl != 0) {
             arkime_command_notify_file_error(actions->notifyClientRef, uri);
         } else {
-            arkime_command_notify_file_done(
-                actions->notifyClientRef, uri,
-                offlineInfo[readerState.readerPos].lastBytes,
-                offlineInfo[readerState.readerPos].lastPackets);
-        }
-        // Release the schemeActions slot — the idle callback holds its own client ref.
-        // Without this, schemeActions keeps actions alive (holding a client ref) until
-        // this slot wraps around, preventing the socket from closing.
-        if (schemeActions[readerState.readerPos]) {
-            reader_scheme_actions_deref(schemeActions[readerState.readerPos]);
-            schemeActions[readerState.readerPos] = NULL;
+            arkime_command_notify_file_done(actions->notifyClientRef, uri,
+                                            offlineInfo[readerState.readerPos].lastBytes,
+                                            offlineInfo[readerState.readerPos].lastPackets);
         }
     }
+
+cleanup:
+    // Outermost load_thread call (depth==1 going to 0): release the client ref
+    // that was attached to actions when --notify was specified. Per-file
+    // notifications already incref'd their own copy onto offlineInfo, so it's
+    // safe to drop the actions-held ref here. Done at outermost depth so that
+    // recursive directory iteration can continue using actions->notifyClientRef.
+    if (loadThreadDepth == 1 && actions && actions->notifyClientRef) {
+        arkime_command_client_decref(actions->notifyClientRef);
+        actions->notifyClientRef = NULL;
+    }
+    loadThreadDepth--;
 }
 /******************************************************************************/
 void arkime_reader_scheme_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions)

--- a/capture/rules.c
+++ b/capture/rules.c
@@ -49,7 +49,7 @@ typedef struct {
     char                *filename;
     char                *name;
     char                *bpf;                        // String version of bpf
-    struct bpf_program   bpfp;
+    struct bpf_program  *bpfp;                       // Atomic pointer; rebuilt on recompile, old defer-freed
     GHashTable          *hash[ARKIME_FIELDS_MAX];    // For each non ip field in rule
     GHashTable          *hashNOT[ARKIME_FIELDS_MAX]; // For each non ip field in rule
     GPtrArray           *match[ARKIME_FIELDS_MAX];   // For any string fields with , modifier or int fields range
@@ -823,6 +823,14 @@ LOCAL void arkime_rules_load_complete()
     memset(&loading, 0, sizeof(loading));
 }
 /******************************************************************************/
+LOCAL void arkime_rules_bpfp_free(gpointer data)
+{
+    struct bpf_program *bpfp = data;
+    if (bpfp->bf_len)
+        pcap_freecode(bpfp);
+    g_free(bpfp);
+}
+/******************************************************************************/
 LOCAL void arkime_rules_free(ArkimeRulesInfo_t *freeing)
 {
     for (int i = 0; i < ARKIME_FIELDS_MAX; i++) {
@@ -849,6 +857,8 @@ LOCAL void arkime_rules_free(ArkimeRulesInfo_t *freeing)
             g_free(rule->name);
             if (rule->bpf)
                 g_free(rule->bpf);
+            if (rule->bpfp)
+                arkime_rules_bpfp_free(rule->bpfp);
 
             free(rule->fields);
             free(rule->fieldsNOT);
@@ -922,7 +932,11 @@ LOCAL void arkime_rules_load(char **names)
     arkime_free_later(freeing, (GDestroyNotify) arkime_rules_free);
 }
 /******************************************************************************/
-/* Called at the start on main thread or each time a new file is open on single thread */
+/* Called on main thread at startup, and on the scheme thread each time a new
+ * offline file is opened. Packet threads may concurrently read rule->bpfp via
+ * arkime_rules_run_session_setup, so we never mutate a live program in place.
+ * Build a fresh struct bpf_program, atomically swap the pointer, and let
+ * arkime_free_later release the old one after readers have quiesced. */
 void arkime_rules_recompile()
 {
     if (deadPcap)
@@ -937,14 +951,17 @@ void arkime_rules_recompile()
             if (!rule->bpf)
                 continue;
 
-            pcap_freecode(&rule->bpfp);
+            struct bpf_program *newbpfp = g_new0(struct bpf_program, 1);
             if (pcapFileHeader.dlt != DLT_NFLOG) {
-                if (pcap_compile(deadPcap, &rule->bpfp, rule->bpf, 1, PCAP_NETMASK_UNKNOWN) == -1 && !config.ignoreErrors) {
+                if (pcap_compile(deadPcap, newbpfp, rule->bpf, 1, PCAP_NETMASK_UNKNOWN) == -1 && !config.ignoreErrors) {
                     CONFIGEXIT("Couldn't compile bpf filter %s: '%s' with %s", rule->filename, rule->bpf, pcap_geterr(deadPcap));
                 }
-            } else {
-                rule->bpfp.bf_len = 0;
             }
+
+            struct bpf_program *oldbpfp = rule->bpfp;
+            ARKIME_THREAD_ATOMIC_STORE(rule->bpfp, newbpfp);
+            if (oldbpfp)
+                arkime_free_later(oldbpfp, arkime_rules_bpfp_free);
         }
     }
 }
@@ -1623,8 +1640,11 @@ void arkime_rules_run_session_setup(ArkimeSession_t *session, ArkimePacket_t *pa
         ArkimeRule_t *rule = g_ptr_array_index(current.rules[ARKIME_RULE_TYPE_SESSION_SETUP], r);
         if (rule->fieldsLen + rule->fieldsNOTLen) {
             arkime_rules_check_rule_fields(session, rule, -1, NULL);
-        } else if (rule->bpfp.bf_len && bpf_filter(rule->bpfp.bf_insns, packet->pkt, packet->pktlen, packet->pktlen)) {
-            arkime_rules_match(session, rule);
+        } else if (rule->bpfp) {
+            struct bpf_program *bpfp = ARKIME_THREAD_ATOMIC_LOAD(rule->bpfp);
+            if (bpfp && bpfp->bf_len && bpf_filter(bpfp->bf_insns, packet->pkt, packet->pktlen, packet->pktlen)) {
+                arkime_rules_match(session, rule);
+            }
         }
     }
 }

--- a/tests/command-socket.t
+++ b/tests/command-socket.t
@@ -13,7 +13,7 @@
 
 use lib ".";
 use strict;
-use Test::More tests => 20;
+use Test::More tests => 22;
 use IO::Socket::UNIX;
 use IO::Select;
 use POSIX ":sys_wait_h";
@@ -77,6 +77,8 @@ my $pid = fork();
 die "fork failed: $!" unless defined $pid;
 
 if ($pid == 0) {
+    open(STDOUT, '>', "/tmp/capture-test1-$$.log");
+    open(STDERR, '>&', STDOUT);
     exec($capture,
         "-c", $config,
         "-n", "test",
@@ -84,6 +86,7 @@ if ($pid == 0) {
         "--command-wait",
         "--flush",
         "--dryrun",
+        "--debug",
     );
     die "exec failed: $!";
 }
@@ -231,3 +234,133 @@ if (!$exited) {
 }
 
 unlink($sockpath) if (-e $sockpath);
+
+# --- Test 7: --notify + -op race regression (no --flush) ---
+# When capture runs WITHOUT --flush, packet processing for a just-loaded file
+# may still be in flight when reader-scheme.c frees the schemeActions slot in
+# the --notify completion path. Packet threads then run arkime_field_ops_run
+# against freed memory and crash inside arkime_field_string_add.
+#
+# Repro: launch capture WITHOUT --flush, queue add-file --notify -op repeatedly
+# against a multi-packet pcap, then verify the process is still alive.
+my $sockpath2 = "$tmpdir/arkime-test2.sock";
+my $racepcap  = "$cwd/pcap/modbus.pcap";
+
+SKIP: {
+    skip "modbus.pcap missing, skipping race test", 2 unless -f $racepcap;
+
+    # Create many symlinks under unique names so each add-file uses a distinct
+    # URI (forcing fresh readerPos rotation and bypassing page-cache effects).
+    my $racedir = "$tmpdir/racepcaps";
+    mkdir($racedir);
+    my $iterations = 40;
+    for (my $i = 0; $i < $iterations; $i++) {
+        symlink($racepcap, "$racedir/race-$i.pcap");
+    }
+
+    my $logfile = "/tmp/capture-racetest-$$.log";
+    diag("capture stdout/stderr -> $logfile");
+
+    my $pid2 = fork();
+    die "fork failed: $!" unless defined $pid2;
+    if ($pid2 == 0) {
+        # Redirect stdout/stderr to a file so we can inspect last output on crash
+        open(STDOUT, '>', $logfile) or die "open $logfile: $!";
+        open(STDERR, '>&', STDOUT) or die "dup STDERR: $!";
+        # Note: no --flush; this is what exposes the race
+        exec($capture,
+            "-c", $config,
+            "-n", "test",
+            "--command-socket", $sockpath2,
+            "--command-wait",
+            "--dryrun",
+            "--debug",
+        );
+        die "exec failed: $!";
+    }
+
+    my $ready2 = 0;
+    for (my $i = 0; $i < 100; $i++) {
+        if (-S $sockpath2) { $ready2 = 1; last; }
+        select(undef, undef, undef, 0.1);
+    }
+
+    skip "race-test capture did not start", 2 unless $ready2;
+
+    my $rsock = IO::Socket::UNIX->new(Peer => $sockpath2, Type => SOCK_STREAM);
+    skip "could not connect to race-test socket", 2 unless defined $rsock;
+    $rsock->autoflush(1);
+    my $rsel = IO::Select->new($rsock);
+
+    # Queue many distinct add-file --notify -op requests back-to-back to
+    # maximize the chance that packets from file N are still in flight in
+    # packet threads when reader-scheme frees actions[N].
+    for (my $i = 0; $i < $iterations; $i++) {
+        print $rsock "add-file --notify -op tags=racetest:$i $racedir/race-$i.pcap\n";
+    }
+
+    # Drain responses for up to ~60s and count file-done notifications.
+    my $done = 0;
+    my $deadline = time() + 60;
+    my $last_progress = time();
+    my $last_done = 0;
+    while (time() < $deadline && $done < $iterations) {
+        my $line = read_line($rsock, $rsel, $deadline - time());
+        last unless defined $line && length($line);
+        for my $l (split /\n/, $line) {
+            $done++ if ($l =~ /^file-done /);
+        }
+        if ($done > $last_done) {
+            $last_done = $done;
+            $last_progress = time();
+        }
+        # If 8s pass with no new file-done, grab a stack sample for diagnosis.
+        if (time() - $last_progress > 8) {
+            my $sample_file = "/tmp/capture-stall-$pid2.txt";
+            system("sample $pid2 3 -file $sample_file >/dev/null 2>&1 &");
+            diag("Stall detected after $done/$iterations file-done; sampling $pid2 -> $sample_file");
+            last;
+        }
+    }
+
+    # The key assertion: process is still alive (didn't crash from UAF).
+    # Use waitpid+WNOHANG instead of kill(0) — kill(0) returns true for
+    # zombies, so a crashed-but-not-reaped capture would falsely pass.
+    my $reaped = waitpid($pid2, WNOHANG);
+    my $alive  = ($reaped == 0);
+    my $why    = "";
+    if (!$alive) {
+        my $status = $?;
+        my $sig    = $status & 127;
+        my $exit   = $status >> 8;
+        $why = $sig ? " (died with signal $sig)" : " (exited with code $exit)";
+        # Dump last lines of capture log into prove output for diagnosis
+        if (open(my $lh, '<', $logfile)) {
+            my @lines = <$lh>;
+            close $lh;
+            my $tail = scalar(@lines) > 50 ? join('', @lines[-50..-1]) : join('', @lines);
+            diag("--- last 50 lines of $logfile ---\n$tail--- end ---");
+        }
+    }
+    ok($alive, "capture still alive after $iterations concurrent --notify + -op requests$why");
+
+    is($done, $iterations, "received file-done for all $iterations requests");
+
+    # Cleanup
+    if ($alive) {
+        print $rsock "shutdown\n";
+    }
+    $rsock->close();
+
+    my $exited2 = 0;
+    for (my $i = 0; $i < 100; $i++) {
+        my $ret = waitpid($pid2, WNOHANG);
+        if ($ret == $pid2) { $exited2 = 1; last; }
+        select(undef, undef, undef, 0.1);
+    }
+    if (!$exited2) {
+        kill('KILL', $pid2);
+        waitpid($pid2, 0);
+    }
+    unlink($sockpath2) if (-e $sockpath2);
+}

--- a/tests/command-socket.t
+++ b/tests/command-socket.t
@@ -259,7 +259,7 @@ SKIP: {
     }
 
     my $logfile = "/tmp/capture-racetest-$$.log";
-    diag("capture stdout/stderr -> $logfile");
+    # diag("capture stdout/stderr -> $logfile");
 
     my $pid2 = fork();
     die "fork failed: $!" unless defined $pid2;


### PR DESCRIPTION
- Defer file-done notification to packet thread's FILE_DONE sentinel so the notification fires when packets have actually drained, not when the file has just been queued.
- Stop eagerly dereferencing the scheme actions slot while packets (and their sessions referencing actions->ops) are still in flight.
- Track load_thread recursion depth so the actions-held client ref is released exactly once at the outermost call, allowing the command-socket client to close after exit.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
