### PR TITLE
DCERPC label fixes/additions + Cont3xt logoutUrl GET fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3998 Identify AD CS web enrollment over HTTP (ESC8) as protocols adcs-web/adcs-ndes/adcs-cep/adcs-ces based on URL path
   - #3998 Identify RPC-over-HTTP (Outlook Anywhere / RPC Proxy) as protocol rpc-over-http via RPC_IN_DATA/RPC_OUT_DATA verb classifiers
   - #3998 Identify WinRM / WS-Management (PowerShell Remoting, evil-winrm, WEF) as protocol winrm via POST /wsman
+  - #3999 Add DCERPC labels (even, mapi, iwbemlevel1login, msrp, dnsserver) and fix IRemUnknown/IRemUnknown2/ISystemActivator/ioxidresolver mislabels
+## Cont3xt
+  - #3999 Fix logoutUrl when logoutUrlMethod=GET
 ## Viewer
   - #3994 Fix SPIView all not allowed error message
 

--- a/capture/parsers/dcerpc.c
+++ b/capture/parsers/dcerpc.c
@@ -328,18 +328,23 @@ void arkime_parser_init()
     arkime_parsers_register_sub("dcerpc", "3dde7c30-165d-11d1-ab8f-00805f14db40", NULL, "bkrp");         // Backup Key Remote Protocol, DPAPI/Mimikatz
     arkime_parsers_register_sub("dcerpc", "f6beaff7-1e19-4fbb-9f8f-b89e2018337c", NULL, "even6");        // Modern EventLog (MS-EVEN6)
     arkime_parsers_register_sub("dcerpc", "897e2e5f-93f3-4376-9c9c-fd2277495c27", NULL, "frs2");         // DFS Replication (MS-FRS2)
-    arkime_parsers_register_sub("dcerpc", "99fcfec4-5260-101b-bbcb-00aa0021347a", NULL, "iobjectexporter"); // DCOM IObjectExporter / OXID resolver
+    arkime_parsers_register_sub("dcerpc", "99fcfec4-5260-101b-bbcb-00aa0021347a", NULL, "ioxidresolver");  // DCOM IObjectExporter / OXID resolver
     arkime_parsers_register_sub("dcerpc", "12345778-1234-abcd-ef00-0123456789ab", NULL, "lsarpc");       // LSA
     arkime_parsers_register_sub("dcerpc", "6bffd098-a112-3610-9833-46c3f87e345a", NULL, "wkssvc");       // Workstation service
     arkime_parsers_register_sub("dcerpc", "3919286a-b10c-11d0-9ba8-00c04fd92ef5", NULL, "dssetup");      // Domain setup
     arkime_parsers_register_sub("dcerpc", "e1af8308-5d1f-11c9-91a4-08002b14a0fa", NULL, "epmapper");     // Endpoint mapper
     arkime_parsers_register_sub("dcerpc", "86d35949-83c9-4044-b424-db363231fd0c", NULL, "itaskscheduler"); // Task scheduler v2
-    arkime_parsers_register_sub("dcerpc", "00000131-0000-0000-c000-000000000046", NULL, "ioxidresolver"); // DCOM resolver
-    arkime_parsers_register_sub("dcerpc", "00000134-0000-0000-c000-000000000046", NULL, "iremunknown");   // DCOM remote unknown
-    arkime_parsers_register_sub("dcerpc", "000001a0-0000-0000-c000-000000000046", NULL, "iremunknown2");  // DCOM remote unknown v2
+    arkime_parsers_register_sub("dcerpc", "00000131-0000-0000-c000-000000000046", NULL, "iremunknown");     // DCOM IRemUnknown (MS-DCOM)
+    arkime_parsers_register_sub("dcerpc", "00000134-0000-0000-c000-000000000046", NULL, "iremunknown2");    // DCOM IRemUnknown2 (MS-DCOM)
+    arkime_parsers_register_sub("dcerpc", "000001a0-0000-0000-c000-000000000046", NULL, "isystemactivator"); // DCOM ISystemActivator (MS-DCOM), DCOMExec
     arkime_parsers_register_sub("dcerpc", "ccd8c074-d0e5-4a40-92b4-d074faa6ba28", NULL, "witness");       // SMB Witness Service
     arkime_parsers_register_sub("dcerpc", "afa8bd80-7d8a-11c9-bef4-08002b102989", NULL, "mgmt");          // RPC management
     arkime_parsers_register_sub("dcerpc", "f5cc5a18-4264-101a-8c59-08002b2f8426", NULL, "nspi");          // Name Service Provider Interface
+    arkime_parsers_register_sub("dcerpc", "82273fdc-e32a-18c3-3f78-827929dc23ea", NULL, "even");          // Legacy EventLog (MS-EVEN)
+    arkime_parsers_register_sub("dcerpc", "a4f1db00-ca47-1067-b31f-00dd010662da", NULL, "mapi");          // Exchange MAPI (MS-OXCRPC)
+    arkime_parsers_register_sub("dcerpc", "f309ad18-d86a-11d0-a075-00c04fb68820", NULL, "iwbemlevel1login"); // WMI auth (MS-WMI)
+    arkime_parsers_register_sub("dcerpc", "5a7b91f8-ff00-11d0-a9b2-00c04fb6e6fc", NULL, "msrp");          // Messenger Service (MS-MSRP), net send
+    arkime_parsers_register_sub("dcerpc", "50abc2a4-574d-40b3-9d66-ee4fd5fba076", NULL, "dnsserver");     // DNS Server management (MS-DNSP)
 
     uuidField = arkime_field_define("dcerpc", "termfield",
                                     "dcerpc.uuid", "UUID", "dcerpc.uuid",

--- a/cont3xt/common/vueapp/Logout.vue
+++ b/cont3xt/common/vueapp/Logout.vue
@@ -37,7 +37,7 @@ export default {
   methods: {
     logout () {
       if (this.$constants.LOGOUT_URL_METHOD === 'GET') {
-        this.$router.push(this.$constants.LOGOUT_URL);
+        window.location = this.$constants.LOGOUT_URL;
       } else {
         fetch(this.$constants.LOGOUT_URL, {
           method: 'POST',

--- a/tests/pcap/dcerpc_synthetic.test
+++ b/tests/pcap/dcerpc_synthetic.test
@@ -1887,7 +1887,7 @@
     },
     "dcerpc" : {
      "interface" : [
-      "ioxidresolver"
+      "iremunknown"
      ],
      "interfaceCnt" : 1,
      "msgType" : [
@@ -1963,7 +1963,7 @@
     },
     "protocol" : [
      "dcerpc",
-     "ioxidresolver",
+     "iremunknown",
      "tcp"
     ],
     "protocolCnt" : 3,
@@ -2021,7 +2021,7 @@
     },
     "dcerpc" : {
      "interface" : [
-      "iremunknown"
+      "iremunknown2"
      ],
      "interfaceCnt" : 1,
      "msgType" : [
@@ -2097,7 +2097,7 @@
     },
     "protocol" : [
      "dcerpc",
-     "iremunknown",
+     "iremunknown2",
      "tcp"
     ],
     "protocolCnt" : 3,
@@ -2155,7 +2155,7 @@
     },
     "dcerpc" : {
      "interface" : [
-      "iremunknown2"
+      "isystemactivator"
      ],
      "interfaceCnt" : 1,
      "msgType" : [
@@ -2231,7 +2231,7 @@
     },
     "protocol" : [
      "dcerpc",
-     "iremunknown2",
+     "isystemactivator",
      "tcp"
     ],
     "protocolCnt" : 3,


### PR DESCRIPTION
- capture/parsers/dcerpc.c: Add even, mapi, iwbemlevel1login, msrp, dnsserver
- capture/parsers/dcerpc.c: Fix DCOM labels — IRemUnknown (00000131), IRemUnknown2 (00000134), ISystemActivator (000001a0); rename IObjectExporter (99fcfec4) to ioxidresolver
- cont3xt/common/vueapp/Logout.vue: Use window.location instead of router.push for GET logoutUrl so OIDC end_session_endpoint is actually hit

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
