### PR TITLE
Wise: redact more secret fields, add /api/user, hide admin UI from non-admins

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -47,6 +47,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3999 Add DCERPC labels (even, mapi, iwbemlevel1login, msrp, dnsserver) and fix IRemUnknown/IRemUnknown2/ISystemActivator/ioxidresolver mislabels
 ## Cont3xt
   - #3999 Fix logoutUrl when logoutUrlMethod=GET
+## Wise
+  - #3999 Mark phpipam appCode/password and fieldactions/valueactions url fields as secret so they are redacted in /config/get
+  - #3999 Add /api/user endpoint and hide save/import/create-source UI controls from non-wiseAdmin users
 ## Viewer
   - #3994 Fix SPIView all not allowed error message
 

--- a/tests/wise.t
+++ b/tests/wise.t
@@ -1,5 +1,5 @@
 # WISE tests
-use Test::More tests => 153;
+use Test::More tests => 160;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
@@ -388,6 +388,11 @@ $wise = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8081/source/file:i
 is ($wise->code, 401);
 is ($wise->content, 'Unauthorized');
 
+# /api/user requires auth
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/api/user");
+is ($wise->code, 401, "/api/user unauthenticated returns 401");
+is ($wise->content, 'Unauthorized');
+
 ##### wiseUser
 $ArkimeTest::userAgent->credentials( "$ArkimeTest::host:8081", 'Moloch', 'wiseUser', 'wiseUser' );
 
@@ -396,6 +401,12 @@ $wise = from_json($ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/con
 ok ($wise->{success});
 ok (exists $wise->{config});
 my $config = $wise->{config};
+
+# /api/user as wiseUser - should succeed and not include wiseAdmin role
+$wise = from_json($ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/api/user")->content);
+is ($wise->{userId}, 'wiseUser', "/api/user wiseUser userId");
+ok (grep { $_ eq 'wiseUser' } @{$wise->{roles}}, "/api/user wiseUser has wiseUser role");
+ok (!(grep { $_ eq 'wiseAdmin' } @{$wise->{roles}}), "/api/user wiseUser does not have wiseAdmin role");
 
 # save config - wiseUser
 $wise = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8081/config/save", Content => to_json({configCode => "thecode"}), "Content-Type" => "application/json;charset=UTF-8")->content;
@@ -411,6 +422,11 @@ is($wise->{app}, "wiseService", "wise appversion app field");
 
 ##### wiseAdmin
 $ArkimeTest::userAgent->credentials( "$ArkimeTest::host:8081", 'Moloch', 'wiseAdmin', 'wiseAdmin' );
+
+# /api/user as wiseAdmin - should include wiseAdmin role
+$wise = from_json($ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/api/user")->content);
+is ($wise->{userId}, 'wiseAdmin', "/api/user wiseAdmin userId");
+ok (grep { $_ eq 'wiseAdmin' } @{$wise->{roles}}, "/api/user wiseAdmin has wiseAdmin role");
 
 # save config - wiseAdmin
 $wise = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8081/config/save", Content => to_json({configCode => "thecode"}), "Content-Type" => "application/json;charset=UTF-8")->content;

--- a/wiseService/source.fieldactions.js
+++ b/wiseService/source.fieldactions.js
@@ -250,7 +250,7 @@ exports.initSource = function (api) {
     types: [], // This is a fake source, no types
     format: 'valueactions', // Which vueapp editor to use
     fields: [
-      { name: 'url', required: true, help: 'The file to load, can be a file path, redis url (Format is redis://[:password@]host:port/db-number/key, redis-sentinel://[[sentinelPassword]:[password]@]host[:port]/redis-name/db-number/key, or redis-cluster://[:password@]host:port/db-number/key), or elasticsearch url (elasticsearch://host:9200/INDEX/_doc/DOCNAME)' }
+      { name: 'url', required: true, password: true, help: 'The file to load, can be a file path, redis url (Format is redis://[:password@]host:port/db-number/key, redis-sentinel://[[sentinelPassword]:[password]@]host[:port]/redis-name/db-number/key, or redis-cluster://[:password@]host:port/db-number/key), or elasticsearch url (elasticsearch://host:9200/INDEX/_doc/DOCNAME)' }
     ]
   });
 

--- a/wiseService/source.phpipam.js
+++ b/wiseService/source.phpipam.js
@@ -485,11 +485,11 @@ exports.initSource = function (api) {
     fields: [
       { name: 'url', required: true, help: 'phpIPAM base URL, e.g. https://ipam.example.com' },
       { name: 'appId', required: true, help: 'phpIPAM Application ID' },
-      { name: 'appCode', required: true, help: 'phpIPAM Application Security Code (used as static token for App Code auth)' },
+      { name: 'appCode', required: true, password: true, help: 'phpIPAM Application Security Code (used as static token for App Code auth)' },
       { name: 'verifyTLS', required: false, help: 'Set false to disable TLS certificate verification (for self-signed/internal certs). Default true.' },
       { name: 'useSessionAuth', required: false, help: 'Set true to use user-token auth (POST /user/ to get session token). Default false.' },
       { name: 'username', required: false, help: 'Username for useSessionAuth=true. Defaults to appId.' },
-      { name: 'password', required: false, help: 'Password for useSessionAuth=true. Defaults to appCode.' },
+      { name: 'password', required: false, password: true, help: 'Password for useSessionAuth=true. Defaults to appCode.' },
       { name: 'preloadAddresses', required: false, help: 'Bulk-load all registered addresses per subnet at startup/reload (default true). Set false to do live per-IP lookups instead.' },
       { name: 'addrConcurrency', required: false, help: 'Max parallel subnet address-fetch requests during preload. Default 10.' },
       { name: 'reload', required: false, help: 'Minutes between full cache refresh. Default 60.' },

--- a/wiseService/source.valueactions.js
+++ b/wiseService/source.valueactions.js
@@ -250,7 +250,7 @@ exports.initSource = function (api) {
     types: [], // This is a fake source, no types
     format: 'valueactions',
     fields: [
-      { name: 'url', required: true, help: 'The file to load, can be a file path, redis url (Format is redis://[:password@]host:port/db-number/key, redis-sentinel://[[sentinelPassword]:[password]@]host[:port]/redis-name/db-number/key, or redis-cluster://[:password@]host:port/db-number/key), or elasticsearch url (elasticsearch://host:9200/INDEX/_doc/DOCNAME)' }
+      { name: 'url', required: true, password: true, help: 'The file to load, can be a file path, redis url (Format is redis://[:password@]host:port/db-number/key, redis-sentinel://[[sentinelPassword]:[password]@]host[:port]/redis-name/db-number/key, or redis-cluster://[:password@]host:port/db-number/key), or elasticsearch url (elasticsearch://host:9200/INDEX/_doc/DOCNAME)' }
     ]
   });
 

--- a/wiseService/vueapp/src/components/Config.vue
+++ b/wiseService/vueapp/src/components/Config.vue
@@ -52,7 +52,9 @@ SPDX-License-Identifier: Apache-2.0
           </li>
         </ul>
 
-        <span class="px-1 no-wrap">
+        <span
+          class="px-1 no-wrap"
+          v-if="isWiseAdmin">
           <hr>
           <b-button
             block
@@ -95,6 +97,7 @@ SPDX-License-Identifier: Apache-2.0
               {{ $t('wise.config.resetFile') }}
             </b-button>
             <b-button
+              v-if="isWiseAdmin"
               variant="primary"
               :disabled="fileSaveDisabled"
               @click="saveSourceFile">
@@ -102,7 +105,7 @@ SPDX-License-Identifier: Apache-2.0
             </b-button>
           </form>
           <form
-            v-else-if="configViewSelected === 'config'"
+            v-else-if="configViewSelected === 'config' && isWiseAdmin"
             class="form-inline pull-right ms-5">
             <div class="input-group">
               <input
@@ -391,6 +394,7 @@ SPDX-License-Identifier: Apache-2.0
               {{ $t('wise.config.resetFile') }}
             </b-button>
             <b-button
+              v-if="isWiseAdmin"
               variant="primary"
               :disabled="fileSaveDisabled"
               @click="saveSourceFile">
@@ -620,6 +624,7 @@ export default {
     this.loadConfigDefs();
     this.loadCurrConfig();
     this.loadSourceData();
+    this.loadCurrentUser();
   },
   data: function () {
     return {
@@ -650,6 +655,7 @@ export default {
       displayAdvancedFields: {},
       rawValueActions: false,
       currValueActionsFile: [],
+      isWiseAdmin: false,
       valueActionsFields: [
         { name: 'key', required: true, class: 'col-md-6', help: 'The unique ID of the value action' },
         { name: 'name', required: true, depends: 'key', class: 'col-md-6', help: 'The name of the value action to show the user' },
@@ -742,6 +748,13 @@ export default {
     }
   },
   methods: {
+    loadCurrentUser: function () {
+      WiseService.getCurrentUser().then((user) => {
+        this.isWiseAdmin = user && Array.isArray(user.roles) && user.roles.includes('wiseAdmin');
+      }).catch(() => {
+        this.isWiseAdmin = false;
+      });
+    },
     selectSource: function (sourceKey) {
       this.selectedSourceKey = sourceKey;
       this.$router.push({

--- a/wiseService/vueapp/src/components/wise.service.js
+++ b/wiseService/vueapp/src/components/wise.service.js
@@ -16,6 +16,9 @@ export default {
   getCurrConfig: async function () {
     return await fetchWrapper({ url: 'config/get' });
   },
+  getCurrentUser: async function () {
+    return await fetchWrapper({ url: 'api/user' });
+  },
   getSourceFile: async function (sourceName) {
     return await fetchWrapper({ url: 'source/' + sourceName + '/get' });
   },

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -1461,6 +1461,17 @@ if (internals.webconfig) {
 
   // ----------------------------------------------------------------------------
   /**
+   * GET - /api/user
+   *
+   * Fetches the currently logged in user, so the UI can gate admin-only actions.
+   *       This is an authenticated API and requires wiseService to be started with --webconfig.
+   * @name "/api/user"
+   * @returns {ArkimeUser} The currently logged in user.
+   */
+  app.get('/api/user', [ArkimeUtil.noCacheJson, isWiseUser], User.apiGetUser);
+
+  // ----------------------------------------------------------------------------
+  /**
    * GET - Used by wise UI to retrieve the raw file being used by the section.
    *       This is an authenticated API and requires wiseService to be started with --webconfig.
    *
@@ -1622,7 +1633,7 @@ if (internals.webconfig) {
   app.get('/api/appversion', (req, res) => {
     return res.send({ app: 'wiseService', version: version.version });
   });
-  app.get(['/source/:source/get', '/config/get'], (req, res) => {
+  app.get(['/source/:source/get', '/config/get', '/api/user'], (req, res) => {
     return res.send({ success: false, text: 'Must start wiseService with --webconfig option' });
   });
   app.put(['/source/:source/put', '/config/save'], (req, res) => {


### PR DESCRIPTION
- Mark phpipam appCode/password and fieldactions/valueactions url fields password:true so /config/get redacts them
- Add /api/user endpoint (wiseUser required) so UI can detect role
- Hide save/import/create-source controls in Config.vue from non-wiseAdmin users
- tests/wise.t: cover /api/user for unauth, wiseUser, wiseAdmin

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
