### PR TITLE
fix: correct typo in help documentation for search term grouping example

### DIFF
--- a/viewer/vueapp/src/components/help/Help.vue
+++ b/viewer/vueapp/src/components/help/Help.vue
@@ -212,7 +212,7 @@ SPDX-License-Identifier: Apache-2.0
               class="no-decoration">table below</a> for list of all fields and operators supported.
           </dd>
           <dt>Grouping</dt>
-          <dd>You can use parentheses to group search terms (e.g. <code>field1=value1 &amp;&amp; (field2==value2 || field3==value3)</code>).</dd>
+          <dd>You can use parentheses to group search terms (e.g. <code>field1==value1 &amp;&amp; (field2==value2 || field3==value3)</code>).</dd>
           <dt>Logical Operators</dt>
           <dd>Combine search terms using AND (&amp;&amp;) and OR (||).</dd>
           <dt>OR List Queries</dt>


### PR DESCRIPTION
**Title:** docs: fix missing equals sign typo in search grouping help text

**Clearly describe the problem and solution**
**Problem:** In the Help page under the "Grouping" section, the example query uses a single equals sign (`field1=value1`). While functionally acceptable in some contexts, it is inconsistent with the standard `==` equality operator used throughout the rest of the Arkime documentation and could cause confusion for newer users.
**Solution:** Updated the grouping example in `viewer/vueapp/src/components/help/Help.vue` to use `field1==value1` for clarity and consistency.

**Relevant issue number(s) if applicable**
N/A

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
N/A - I am not set up to run the test suite locally, but this PR only adds a single missing equals sign to a text paragraph in the Help.vue file.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**
N/A - I am not set up to run the test suite locally, but this PR only adds a single missing equals sign to a text paragraph in the Help.vue file.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.