### PR TITLE
Fix userAuthIps to check real peer address instead of spoofable req.ip

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,11 +53,11 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3999 Add DCERPC labels (even, mapi, iwbemlevel1login, msrp, dnsserver) and fix IRemUnknown/IRemUnknown2/ISystemActivator/ioxidresolver mislabels
 ## Cont3xt
   - #3999 Fix logoutUrl when logoutUrlMethod=GET
+## Viewer
+  - #3994 Fix SPIView all not allowed error message
 ## Wise
   - #3999 Mark phpipam appCode/password and fieldactions/valueactions url fields as secret so they are redacted in /config/get
   - #3999 Add /api/user endpoint and hide save/import/create-source UI controls from non-wiseAdmin users
-## Viewer
-  - #3994 Fix SPIView all not allowed error message
 
 6.4.0 2026/05/20
 ## Breaking

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,12 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 6.4.1 2026/06/xx
+## Breaking
+  - #4005 userAuthIps is now correctly matched against the real connecting peer address.
+          Deployments behind a proxy must ensure the proxy's own address is
+          covered by userAuthIps when authTrustProxy is used.
+## Release
+  - #4004 Fix Ubuntu 26.04 builds having the incorrect dependencies
 ## Capture
   - #3996 Added mssing ntlm.detail.jade for NTLM session detail rendering
   - #3996 Added opcua parser (OPC UA Binary) with opcua.endpointUrl, opcua.securityPolicyUri and SenderCertificate parsing

--- a/common/auth.js
+++ b/common/auth.js
@@ -813,22 +813,28 @@ class Auth {
 
   // ----------------------------------------------------------------------------
   static #checkIps (req, res) {
-    if (req.ip === undefined) {
+    // userAuthIps restricts which connecting peer (typically the trusted auth
+    // proxy) may send requests. It MUST be checked against the real socket peer
+    // address, not req.ip: when trust proxy is enabled req.ip is derived from the
+    // client-supplied X-Forwarded-For header and is therefore spoofable, which
+    // would let an attacker bypass userAuthIps (e.g. the header-auth loopback default).
+    const ip = req.socket?.remoteAddress;
+    if (ip === undefined) {
       return 0;
     }
 
-    if (req.ip.includes(':')) {
-      if (!Auth.#userAuthIps.find(req.ip)) {
+    if (ip.includes(':')) {
+      if (!Auth.#userAuthIps.find(ip)) {
         res.status(403);
-        res.json({ success: false, text: `Not allowed by ip (${req.ip})` });
-        console.log('Blocked (userAuthIps setting) by ip', req.ip, req.url);
+        res.json({ success: false, text: `Not allowed by ip (${ip})` });
+        console.log('Blocked (userAuthIps setting) by ip', ip, req.url);
         return 1;
       }
     } else {
-      if (!Auth.#userAuthIps.find(`::ffff:${req.ip}`)) {
+      if (!Auth.#userAuthIps.find(`::ffff:${ip}`)) {
         res.status(403);
-        res.json({ success: false, text: `Not allowed by ip (${req.ip})` });
-        console.log('Blocked (userAuthIps setting) by ip', req.ip, req.url);
+        res.json({ success: false, text: `Not allowed by ip (${ip})` });
+        console.log('Blocked (userAuthIps setting) by ip', ip, req.url);
         return 1;
       }
     }


### PR DESCRIPTION
When trust proxy is enabled, req.ip is derived from the client-supplied X-Forwarded-For header, so userAuthIps was checking a spoofable value. This allowed bypassing the restriction (including the header-auth loopback default) via a forged X-Forwarded-For. Match against req.socket.remoteAddress.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
