### PR TITLE
Fix crash on startup when rootPlugins is set (#4009)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3998 Identify WinRM / WS-Management (PowerShell Remoting, evil-winrm, WEF) as protocol winrm via POST /wsman
   - #3999 Add DCERPC labels (even, mapi, iwbemlevel1login, msrp, dnsserver) and fix IRemUnknown/IRemUnknown2/ISystemActivator/ioxidresolver mislabels
   - #4008 Extract arp.ip / arp.mac / arp.oui / arp.opcode from ARP packets
+  - #4010 Fix crash on startup when rootPlugins is set
 ## Cont3xt
   - #3999 Fix logoutUrl when logoutUrlMethod=GET
 ## Viewer

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1506,7 +1506,7 @@ typedef uint32_t (* ArkimePluginOutstandingFunc) ();
 #define ARKIME_PLUGIN_SMTP_OHC     0x00200000
 
 void arkime_plugins_init();
-void arkime_plugins_load(char **plugins);
+void arkime_plugins_load(char **plugins, gboolean loadParsers);
 void arkime_plugins_reload();
 
 int  arkime_plugins_register_internal(const char *name, gboolean storeData, size_t sessionsize, int apiversion);

--- a/capture/main.c
+++ b/capture/main.c
@@ -1154,7 +1154,7 @@ LLVMFuzzerInitialize(int *UNUSED(argc), char ***UNUSED(argv))
     arkime_yara_init();
     arkime_parsers_init();
     arkime_session_init();
-    arkime_plugins_load(config.plugins);
+    arkime_plugins_load(config.plugins, TRUE);
     arkime_config_load_override_ips();
     arkime_rules_init();
     arkime_reader_scheme_register("fuzz", NULL, NULL);
@@ -1213,7 +1213,7 @@ LLVMFuzzerInitialize(int *UNUSED(argc), char ***UNUSED(argv))
     arkime_parsers_init();
     arkime_session_init();
     arkime_dedup_init();
-    arkime_plugins_load(config.plugins);
+    arkime_plugins_load(config.plugins, TRUE);
     arkime_config_load_override_ips();
     arkime_rules_init();
     arkime_packet_batch_init(&batch);
@@ -1297,7 +1297,7 @@ int main(int argc, char **argv)
     arkime_writers_init();
     arkime_readers_init();
     arkime_plugins_init();
-    arkime_plugins_load(config.rootPlugins);
+    arkime_plugins_load(config.rootPlugins, FALSE);
     if (config.pcapReadOffline) {
         if (useScheme ||
             (config.pcapReadFiles && config.pcapReadFiles[0] && strstr(config.pcapReadFiles[0], "://")) ||
@@ -1323,7 +1323,7 @@ int main(int argc, char **argv)
     arkime_parsers_init();
     arkime_session_init();
     arkime_dedup_init();
-    arkime_plugins_load(config.plugins);
+    arkime_plugins_load(config.plugins, TRUE);
     arkime_config_load_override_ips();
     arkime_rules_init();
     g_timeout_add(1, arkime_ready_gfunc, 0);

--- a/capture/plugins.c
+++ b/capture/plugins.c
@@ -75,7 +75,7 @@ LOCAL void arkime_plugins_cmd_list(int UNUSED(argc), char UNUSED( * *argv), gpoi
 }
 
 /******************************************************************************/
-void arkime_plugins_load(char **plugins)
+void arkime_plugins_load(char **plugins, gboolean loadParsers)
 {
 
     if (!config.pluginsDir)
@@ -131,8 +131,12 @@ void arkime_plugins_load(char **plugins)
         g_free (path);
     }
 
-    int arkime_parsers_load();
-    arkime_parsers_load();
+    // A plugin may register a new load extension (e.g. .lua), so reload parsers
+    // to pick those up. Skipped for rootPlugins, which run before parsers init.
+    if (loadParsers) {
+        int arkime_parsers_load();
+        arkime_parsers_load();
+    }
 }
 /******************************************************************************/
 LOCAL int arkime_plugins_load_so(const char *path)


### PR DESCRIPTION
rootPlugins are loaded before arkime_parsers_init(), but arkime_plugins_load() called arkime_parsers_load() which dereferences the not-yet-created extensionsArr. Add a loadParsers flag so the parser reload only runs for plugin loads that happen after parsers are initialized.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
