### PR TITLE
Add Shannon entropy capture plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #3999 Add DCERPC labels (even, mapi, iwbemlevel1login, msrp, dnsserver) and fix IRemUnknown/IRemUnknown2/ISystemActivator/ioxidresolver mislabels
   - #4008 Extract arp.ip / arp.mac / arp.oui / arp.opcode from ARP packets
   - #4010 Fix crash on startup when rootPlugins is set
+  - #4013 Add entropy plugin to calculate the Shannon entropy of the TCP/UDP data bytes per direction, with entropyChunkSize and entropyMaxUniqueValues options
 ## Cont3xt
   - #3999 Fix logoutUrl when logoutUrlMethod=GET
 ## Viewer

--- a/capture/plugins/entropy.c
+++ b/capture/plugins/entropy.c
@@ -1,0 +1,104 @@
+/******************************************************************************/
+/* entropy.c  -- Calculate the Shannon entropy of the TCP/UDP data bytes
+ *
+ * The plugin keeps a 256 element histogram (one uint32_t counter per byte
+ * value) of all the TCP and UDP data bytes seen in a session.  When the
+ * session is saved the Shannon entropy is calculated from the histogram and
+ * stored, multiplied by 100, as an integer field.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <math.h>
+#include "arkime.h"
+
+extern ArkimeConfig_t        config;
+
+LOCAL int entropy_plugin_num;
+LOCAL int entropy_field;
+
+typedef struct {
+    uint32_t counts[256];
+    uint32_t total;
+} EntropyData_t;
+
+/******************************************************************************/
+LOCAL EntropyData_t *entropy_get_data(ArkimeSession_t *session)
+{
+    EntropyData_t *ed = session->pluginData[entropy_plugin_num];
+    if (!ed) {
+        ed = ARKIME_TYPE_ALLOC0(EntropyData_t);
+        session->pluginData[entropy_plugin_num] = ed;
+    }
+    return ed;
+}
+/******************************************************************************/
+LOCAL void entropy_add_bytes(ArkimeSession_t *session, const uint8_t *data, int len)
+{
+    if (len <= 0)
+        return;
+
+    EntropyData_t *ed = entropy_get_data(session);
+    for (int i = 0; i < len; i++) {
+        ed->counts[data[i]]++;
+    }
+    ed->total += len;
+}
+/******************************************************************************/
+LOCAL void entropy_tcp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which))
+{
+    entropy_add_bytes(session, data, len);
+}
+/******************************************************************************/
+LOCAL void entropy_udp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which))
+{
+    entropy_add_bytes(session, data, len);
+}
+/******************************************************************************/
+LOCAL void entropy_save(ArkimeSession_t *session, int final)
+{
+    EntropyData_t *ed = session->pluginData[entropy_plugin_num];
+    if (!ed)
+        return;
+
+    if (ed->total > 0) {
+        double entropy = 0.0;
+        for (int i = 0; i < 256; i++) {
+            if (ed->counts[i] == 0)
+                continue;
+            double p = (double)ed->counts[i] / (double)ed->total;
+            entropy -= p * log2(p);
+        }
+        arkime_field_int_add(entropy_field, session, (int)(entropy * 100.0 + 0.5));
+    }
+
+    if (final) {
+        ARKIME_TYPE_FREE(EntropyData_t, ed);
+        session->pluginData[entropy_plugin_num] = 0;
+    } else {
+        // mid save - record the value above and start a fresh histogram
+        memset(ed->counts, 0, sizeof(ed->counts));
+        ed->total = 0;
+    }
+}
+/******************************************************************************/
+void arkime_plugin_init()
+{
+    entropy_plugin_num = arkime_plugins_register("entropy", TRUE);
+
+    entropy_field = arkime_field_define("general", "integer",
+                                        "entropy", "Entropy", "entropy",
+                                        "Shannon entropy of the TCP/UDP data bytes, multiplied by 100",
+                                        ARKIME_FIELD_TYPE_INT, 0,
+                                        (char *)NULL);
+
+    arkime_plugins_set_cb("entropy",
+                          NULL,
+                          entropy_udp_cb,
+                          entropy_tcp_cb,
+                          NULL,
+                          entropy_save,
+                          NULL,
+                          NULL,
+                          NULL);
+}

--- a/capture/plugins/entropy.c
+++ b/capture/plugins/entropy.c
@@ -1,13 +1,17 @@
 /******************************************************************************/
 /* entropy.c  -- Calculate the Shannon entropy of the TCP/UDP data bytes
  *
- * The plugin keeps a 256 element histogram (one uint32_t counter per byte
- * value) of the TCP and UDP data bytes seen in a session, separately for each
- * direction (src/dst).  Every entropyChunkSize bytes (per direction) the
- * Shannon entropy is calculated, stored (multiplied by 100) as a unique
- * integer in the field, and the histogram reset.  Any remaining bytes are
- * flushed on save.  Up to entropyMaxUniqueValues unique values are recorded
- * per direction.
+ * The plugin keeps a 256 element histogram of the TCP and UDP data bytes seen
+ * in a session, separately for each direction (src/dst).  Every
+ * entropyChunkSize bytes (per direction) the Shannon entropy is calculated,
+ * stored (multiplied by 100) as a unique integer in the field, and the
+ * histogram reset.  Any remaining bytes are flushed on save.  Up to
+ * entropyMaxUniqueValues unique values are recorded per direction.
+ *
+ * When entropyChunkSize fits in a uint16_t a uint16_t histogram is used to
+ * halve the per-session memory, otherwise a uint32_t histogram is used.  The
+ * width is chosen once at startup and the matching set of callbacks is
+ * registered, so the per-byte hot path has no extra branching.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,92 +26,98 @@ LOCAL int      entropy_field[2];
 LOCAL uint32_t entropyChunkSize;
 LOCAL uint32_t entropyMaxUniqueValues;
 
-typedef struct {
-    uint32_t counts[2][256];
-    uint32_t total[2];
-    uint8_t  stop[2];
-} EntropyData_t;
-
-#define ENTROPY_NUM_VALUES(session, which) \
+#define ENTROPY_NUM_VALUES(session, which)                                                             \
     ((session)->fields[entropy_field[which]] ? (session)->fields[entropy_field[which]]->iarray->len : 0)
 
 /******************************************************************************/
-LOCAL void entropy_flush(ArkimeSession_t *session, EntropyData_t *ed, int which)
-{
-    if (ed->total[which] == 0)
-        return;
-
-    double entropy = 0.0;
-    for (int i = 0; i < 256; i++) {
-        if (ed->counts[which][i] == 0)
-            continue;
-        double p = (double)ed->counts[which][i] / (double)ed->total[which];
-        entropy -= p * log2(p);
-    }
-
-    if (arkime_field_int_add(entropy_field[which], session, (int)(entropy * 100.0 + 0.5))) {
-        if (ENTROPY_NUM_VALUES(session, which) >= entropyMaxUniqueValues)
-            ed->stop[which] = 1;
-    }
-
-    memset(ed->counts[which], 0, sizeof(ed->counts[which]));
-    ed->total[which] = 0;
+/* Generate a complete set of routines for a given count storage width.       */
+#define ENTROPY_DEFINE(BITS, CTYPE)                                                                    \
+typedef struct {                                                                                       \
+    CTYPE    counts[2][256];                                                                           \
+    uint32_t total[2];                                                                                 \
+    uint8_t  stop[2];                                                                                  \
+} EntropyData##BITS##_t;                                                                               \
+                                                                                                       \
+LOCAL void entropy_flush_##BITS(ArkimeSession_t *session, EntropyData##BITS##_t *ed, int which)        \
+{                                                                                                      \
+    if (ed->total[which] == 0)                                                                         \
+        return;                                                                                        \
+                                                                                                       \
+    double entropy = 0.0;                                                                              \
+    for (int i = 0; i < 256; i++) {                                                                    \
+        if (ed->counts[which][i] == 0)                                                                 \
+            continue;                                                                                  \
+        double p = (double)ed->counts[which][i] / (double)ed->total[which];                            \
+        entropy -= p * log2(p);                                                                        \
+    }                                                                                                  \
+                                                                                                       \
+    if (arkime_field_int_add(entropy_field[which], session, (int)(entropy * 100.0 + 0.5))) {           \
+        if (ENTROPY_NUM_VALUES(session, which) >= entropyMaxUniqueValues)                              \
+            ed->stop[which] = 1;                                                                       \
+    }                                                                                                  \
+                                                                                                       \
+    memset(ed->counts[which], 0, sizeof(ed->counts[which]));                                           \
+    ed->total[which] = 0;                                                                              \
+}                                                                                                      \
+                                                                                                       \
+LOCAL void entropy_add_bytes_##BITS(ArkimeSession_t *session, const uint8_t *data, int len, int which) \
+{                                                                                                      \
+    if (len <= 0)                                                                                      \
+        return;                                                                                        \
+                                                                                                       \
+    EntropyData##BITS##_t *ed = session->pluginData[entropy_plugin_num];                               \
+    if (!ed) {                                                                                         \
+        ed = ARKIME_TYPE_ALLOC0(EntropyData##BITS##_t);                                                \
+        session->pluginData[entropy_plugin_num] = ed;                                                  \
+    }                                                                                                  \
+                                                                                                       \
+    if (ed->stop[which])                                                                               \
+        return;                                                                                        \
+                                                                                                       \
+    for (int i = 0; i < len; i++) {                                                                    \
+        ed->counts[which][data[i]]++;                                                                  \
+        ed->total[which]++;                                                                            \
+        if (ed->total[which] >= entropyChunkSize) {                                                    \
+            entropy_flush_##BITS(session, ed, which);                                                  \
+            if (ed->stop[which])                                                                       \
+                return;                                                                                \
+        }                                                                                              \
+    }                                                                                                  \
+}                                                                                                      \
+                                                                                                       \
+LOCAL void entropy_tcp_cb_##BITS(ArkimeSession_t *session, const uint8_t *data, int len, int which)    \
+{                                                                                                      \
+    entropy_add_bytes_##BITS(session, data, len, which);                                               \
+}                                                                                                      \
+                                                                                                       \
+LOCAL void entropy_udp_cb_##BITS(ArkimeSession_t *session, const uint8_t *data, int len, int which)    \
+{                                                                                                      \
+    entropy_add_bytes_##BITS(session, data, len, which);                                               \
+}                                                                                                      \
+                                                                                                       \
+LOCAL void entropy_save_##BITS(ArkimeSession_t *session, int final)                                    \
+{                                                                                                      \
+    EntropyData##BITS##_t *ed = session->pluginData[entropy_plugin_num];                               \
+    if (!ed)                                                                                           \
+        return;                                                                                        \
+                                                                                                       \
+    for (int which = 0; which < 2; which++) {                                                          \
+        if (!ed->stop[which])                                                                          \
+            entropy_flush_##BITS(session, ed, which);                                                  \
+    }                                                                                                  \
+                                                                                                       \
+    if (final) {                                                                                       \
+        ARKIME_TYPE_FREE(EntropyData##BITS##_t, ed);                                                   \
+        session->pluginData[entropy_plugin_num] = 0;                                                   \
+    } else {                                                                                           \
+        /* mid save - record the values above and start fresh */                                       \
+        memset(ed, 0, sizeof(*ed));                                                                    \
+    }                                                                                                  \
 }
-/******************************************************************************/
-LOCAL void entropy_add_bytes(ArkimeSession_t *session, const uint8_t *data, int len, int which)
-{
-    if (len <= 0)
-        return;
 
-    EntropyData_t *ed = session->pluginData[entropy_plugin_num];
-    if (!ed) {
-        ed = ARKIME_TYPE_ALLOC0(EntropyData_t);
-        session->pluginData[entropy_plugin_num] = ed;
-    }
+ENTROPY_DEFINE(32, uint32_t)
+ENTROPY_DEFINE(16, uint16_t)
 
-    if (ed->stop[which])
-        return;
-
-    for (int i = 0; i < len; i++) {
-        ed->counts[which][data[i]]++;
-        ed->total[which]++;
-        if (ed->total[which] >= entropyChunkSize) {
-            entropy_flush(session, ed, which);
-            if (ed->stop[which])
-                return;
-        }
-    }
-}
-/******************************************************************************/
-LOCAL void entropy_tcp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int which)
-{
-    entropy_add_bytes(session, data, len, which);
-}
-/******************************************************************************/
-LOCAL void entropy_udp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int which)
-{
-    entropy_add_bytes(session, data, len, which);
-}
-/******************************************************************************/
-LOCAL void entropy_save(ArkimeSession_t *session, int final)
-{
-    EntropyData_t *ed = session->pluginData[entropy_plugin_num];
-    if (!ed)
-        return;
-
-    for (int which = 0; which < 2; which++) {
-        if (!ed->stop[which])
-            entropy_flush(session, ed, which);
-    }
-
-    if (final) {
-        ARKIME_TYPE_FREE(EntropyData_t, ed);
-        session->pluginData[entropy_plugin_num] = 0;
-    } else {
-        // mid save - record the values above and start fresh
-        memset(ed, 0, sizeof(*ed));
-    }
-}
 /******************************************************************************/
 void arkime_plugin_init()
 {
@@ -128,13 +138,27 @@ void arkime_plugin_init()
                                            ARKIME_FIELD_TYPE_INT_ARRAY_UNIQUE, 0,
                                            (char *)NULL);
 
-    arkime_plugins_set_cb("entropy",
-                          NULL,
-                          entropy_udp_cb,
-                          entropy_tcp_cb,
-                          NULL,
-                          entropy_save,
-                          NULL,
-                          NULL,
-                          NULL);
+    // A uint16_t histogram is enough when no single count (bounded by the
+    // chunk size) can exceed 0xffff, which halves the per-session memory.
+    if (entropyChunkSize <= 0xffff) {
+        arkime_plugins_set_cb("entropy",
+                              NULL,
+                              entropy_udp_cb_16,
+                              entropy_tcp_cb_16,
+                              NULL,
+                              entropy_save_16,
+                              NULL,
+                              NULL,
+                              NULL);
+    } else {
+        arkime_plugins_set_cb("entropy",
+                              NULL,
+                              entropy_udp_cb_32,
+                              entropy_tcp_cb_32,
+                              NULL,
+                              entropy_save_32,
+                              NULL,
+                              NULL,
+                              NULL);
+    }
 }

--- a/capture/plugins/entropy.c
+++ b/capture/plugins/entropy.c
@@ -23,22 +23,17 @@ typedef struct {
 } EntropyData_t;
 
 /******************************************************************************/
-LOCAL EntropyData_t *entropy_get_data(ArkimeSession_t *session)
-{
-    EntropyData_t *ed = session->pluginData[entropy_plugin_num];
-    if (!ed) {
-        ed = ARKIME_TYPE_ALLOC0(EntropyData_t);
-        session->pluginData[entropy_plugin_num] = ed;
-    }
-    return ed;
-}
-/******************************************************************************/
 LOCAL void entropy_add_bytes(ArkimeSession_t *session, const uint8_t *data, int len)
 {
     if (len <= 0)
         return;
 
-    EntropyData_t *ed = entropy_get_data(session);
+    EntropyData_t *ed = session->pluginData[entropy_plugin_num];
+    if (!ed) {
+        ed = ARKIME_TYPE_ALLOC0(EntropyData_t);
+        session->pluginData[entropy_plugin_num] = ed;
+    }
+
     for (int i = 0; i < len; i++) {
         ed->counts[data[i]]++;
     }

--- a/capture/plugins/entropy.c
+++ b/capture/plugins/entropy.c
@@ -3,9 +3,11 @@
  *
  * The plugin keeps a 256 element histogram (one uint32_t counter per byte
  * value) of the TCP and UDP data bytes seen in a session, separately for each
- * direction (src/dst).  When the session is saved the Shannon entropy is
- * calculated from each histogram and stored, multiplied by 100, as integer
- * fields.
+ * direction (src/dst).  Every entropyChunkSize bytes (per direction) the
+ * Shannon entropy is calculated, stored (multiplied by 100) as a unique
+ * integer in the field, and the histogram reset.  Any remaining bytes are
+ * flushed on save.  Up to entropyMaxUniqueValues unique values are recorded
+ * per direction.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,14 +17,42 @@
 
 extern ArkimeConfig_t        config;
 
-LOCAL int entropy_plugin_num;
-LOCAL int entropy_field[2];
+LOCAL int      entropy_plugin_num;
+LOCAL int      entropy_field[2];
+LOCAL uint32_t entropyChunkSize;
+LOCAL uint32_t entropyMaxUniqueValues;
 
 typedef struct {
     uint32_t counts[2][256];
     uint32_t total[2];
+    uint8_t  stop[2];
 } EntropyData_t;
 
+#define ENTROPY_NUM_VALUES(session, which) \
+    ((session)->fields[entropy_field[which]] ? (session)->fields[entropy_field[which]]->iarray->len : 0)
+
+/******************************************************************************/
+LOCAL void entropy_flush(ArkimeSession_t *session, EntropyData_t *ed, int which)
+{
+    if (ed->total[which] == 0)
+        return;
+
+    double entropy = 0.0;
+    for (int i = 0; i < 256; i++) {
+        if (ed->counts[which][i] == 0)
+            continue;
+        double p = (double)ed->counts[which][i] / (double)ed->total[which];
+        entropy -= p * log2(p);
+    }
+
+    if (arkime_field_int_add(entropy_field[which], session, (int)(entropy * 100.0 + 0.5))) {
+        if (ENTROPY_NUM_VALUES(session, which) >= entropyMaxUniqueValues)
+            ed->stop[which] = 1;
+    }
+
+    memset(ed->counts[which], 0, sizeof(ed->counts[which]));
+    ed->total[which] = 0;
+}
 /******************************************************************************/
 LOCAL void entropy_add_bytes(ArkimeSession_t *session, const uint8_t *data, int len, int which)
 {
@@ -35,10 +65,18 @@ LOCAL void entropy_add_bytes(ArkimeSession_t *session, const uint8_t *data, int 
         session->pluginData[entropy_plugin_num] = ed;
     }
 
+    if (ed->stop[which])
+        return;
+
     for (int i = 0; i < len; i++) {
         ed->counts[which][data[i]]++;
+        ed->total[which]++;
+        if (ed->total[which] >= entropyChunkSize) {
+            entropy_flush(session, ed, which);
+            if (ed->stop[which])
+                return;
+        }
     }
-    ed->total[which] += len;
 }
 /******************************************************************************/
 LOCAL void entropy_tcp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int which)
@@ -58,26 +96,16 @@ LOCAL void entropy_save(ArkimeSession_t *session, int final)
         return;
 
     for (int which = 0; which < 2; which++) {
-        if (ed->total[which] == 0)
-            continue;
-
-        double entropy = 0.0;
-        for (int i = 0; i < 256; i++) {
-            if (ed->counts[which][i] == 0)
-                continue;
-            double p = (double)ed->counts[which][i] / (double)ed->total[which];
-            entropy -= p * log2(p);
-        }
-        arkime_field_int_add(entropy_field[which], session, (int)(entropy * 100.0 + 0.5));
+        if (!ed->stop[which])
+            entropy_flush(session, ed, which);
     }
 
     if (final) {
         ARKIME_TYPE_FREE(EntropyData_t, ed);
         session->pluginData[entropy_plugin_num] = 0;
     } else {
-        // mid save - record the values above and start fresh histograms
-        memset(ed->counts, 0, sizeof(ed->counts));
-        memset(ed->total, 0, sizeof(ed->total));
+        // mid save - record the values above and start fresh
+        memset(ed, 0, sizeof(*ed));
     }
 }
 /******************************************************************************/
@@ -85,16 +113,19 @@ void arkime_plugin_init()
 {
     entropy_plugin_num = arkime_plugins_register("entropy", TRUE);
 
+    entropyChunkSize = arkime_config_int(NULL, "entropyChunkSize", 0xffffffff, 1, 0xffffffff);
+    entropyMaxUniqueValues = arkime_config_int(NULL, "entropyMaxUniqueValues", 10, 1, 0xffffffff);
+
     entropy_field[0] = arkime_field_define("general", "integer",
                                            "entropy.src", "Entropy Src", "entropy.src",
                                            "Shannon entropy of the source TCP/UDP data bytes, multiplied by 100",
-                                           ARKIME_FIELD_TYPE_INT, 0,
+                                           ARKIME_FIELD_TYPE_INT_ARRAY_UNIQUE, 0,
                                            (char *)NULL);
 
     entropy_field[1] = arkime_field_define("general", "integer",
                                            "entropy.dst", "Entropy Dst", "entropy.dst",
                                            "Shannon entropy of the destination TCP/UDP data bytes, multiplied by 100",
-                                           ARKIME_FIELD_TYPE_INT, 0,
+                                           ARKIME_FIELD_TYPE_INT_ARRAY_UNIQUE, 0,
                                            (char *)NULL);
 
     arkime_plugins_set_cb("entropy",

--- a/capture/plugins/entropy.c
+++ b/capture/plugins/entropy.c
@@ -2,9 +2,10 @@
 /* entropy.c  -- Calculate the Shannon entropy of the TCP/UDP data bytes
  *
  * The plugin keeps a 256 element histogram (one uint32_t counter per byte
- * value) of all the TCP and UDP data bytes seen in a session.  When the
- * session is saved the Shannon entropy is calculated from the histogram and
- * stored, multiplied by 100, as an integer field.
+ * value) of the TCP and UDP data bytes seen in a session, separately for each
+ * direction (src/dst).  When the session is saved the Shannon entropy is
+ * calculated from each histogram and stored, multiplied by 100, as integer
+ * fields.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -15,15 +16,15 @@
 extern ArkimeConfig_t        config;
 
 LOCAL int entropy_plugin_num;
-LOCAL int entropy_field;
+LOCAL int entropy_field[2];
 
 typedef struct {
-    uint32_t counts[256];
-    uint32_t total;
+    uint32_t counts[2][256];
+    uint32_t total[2];
 } EntropyData_t;
 
 /******************************************************************************/
-LOCAL void entropy_add_bytes(ArkimeSession_t *session, const uint8_t *data, int len)
+LOCAL void entropy_add_bytes(ArkimeSession_t *session, const uint8_t *data, int len, int which)
 {
     if (len <= 0)
         return;
@@ -35,19 +36,19 @@ LOCAL void entropy_add_bytes(ArkimeSession_t *session, const uint8_t *data, int 
     }
 
     for (int i = 0; i < len; i++) {
-        ed->counts[data[i]]++;
+        ed->counts[which][data[i]]++;
     }
-    ed->total += len;
+    ed->total[which] += len;
 }
 /******************************************************************************/
-LOCAL void entropy_tcp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which))
+LOCAL void entropy_tcp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int which)
 {
-    entropy_add_bytes(session, data, len);
+    entropy_add_bytes(session, data, len, which);
 }
 /******************************************************************************/
-LOCAL void entropy_udp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int UNUSED(which))
+LOCAL void entropy_udp_cb(ArkimeSession_t *session, const uint8_t *data, int len, int which)
 {
-    entropy_add_bytes(session, data, len);
+    entropy_add_bytes(session, data, len, which);
 }
 /******************************************************************************/
 LOCAL void entropy_save(ArkimeSession_t *session, int final)
@@ -56,24 +57,27 @@ LOCAL void entropy_save(ArkimeSession_t *session, int final)
     if (!ed)
         return;
 
-    if (ed->total > 0) {
+    for (int which = 0; which < 2; which++) {
+        if (ed->total[which] == 0)
+            continue;
+
         double entropy = 0.0;
         for (int i = 0; i < 256; i++) {
-            if (ed->counts[i] == 0)
+            if (ed->counts[which][i] == 0)
                 continue;
-            double p = (double)ed->counts[i] / (double)ed->total;
+            double p = (double)ed->counts[which][i] / (double)ed->total[which];
             entropy -= p * log2(p);
         }
-        arkime_field_int_add(entropy_field, session, (int)(entropy * 100.0 + 0.5));
+        arkime_field_int_add(entropy_field[which], session, (int)(entropy * 100.0 + 0.5));
     }
 
     if (final) {
         ARKIME_TYPE_FREE(EntropyData_t, ed);
         session->pluginData[entropy_plugin_num] = 0;
     } else {
-        // mid save - record the value above and start a fresh histogram
+        // mid save - record the values above and start fresh histograms
         memset(ed->counts, 0, sizeof(ed->counts));
-        ed->total = 0;
+        memset(ed->total, 0, sizeof(ed->total));
     }
 }
 /******************************************************************************/
@@ -81,11 +85,17 @@ void arkime_plugin_init()
 {
     entropy_plugin_num = arkime_plugins_register("entropy", TRUE);
 
-    entropy_field = arkime_field_define("general", "integer",
-                                        "entropy", "Entropy", "entropy",
-                                        "Shannon entropy of the TCP/UDP data bytes, multiplied by 100",
-                                        ARKIME_FIELD_TYPE_INT, 0,
-                                        (char *)NULL);
+    entropy_field[0] = arkime_field_define("general", "integer",
+                                           "entropy.src", "Entropy Src", "entropy.src",
+                                           "Shannon entropy of the source TCP/UDP data bytes, multiplied by 100",
+                                           ARKIME_FIELD_TYPE_INT, 0,
+                                           (char *)NULL);
+
+    entropy_field[1] = arkime_field_define("general", "integer",
+                                           "entropy.dst", "Entropy Dst", "entropy.dst",
+                                           "Shannon entropy of the destination TCP/UDP data bytes, multiplied by 100",
+                                           ARKIME_FIELD_TYPE_INT, 0,
+                                           (char *)NULL);
 
     arkime_plugins_set_cb("entropy",
                           NULL,

--- a/capture/plugins/entropy.detail.jade
+++ b/capture/plugins/entropy.detail.jade
@@ -1,0 +1,4 @@
+if (session.entropy !== undefined)
+  div.sessionDetailMeta.bold Shannon Entropy
+  dl.sessionDetailMeta
+    +arrayList(session, "entropy", "Shannon Entropy (x100)", "entropy")

--- a/capture/plugins/entropy.detail.jade
+++ b/capture/plugins/entropy.detail.jade
@@ -1,4 +1,5 @@
-if (session.entropy !== undefined)
+if (session.entropy)
   div.sessionDetailMeta.bold Shannon Entropy
   dl.sessionDetailMeta
-    +arrayList(session, "entropy", "Shannon Entropy (x100)", "entropy")
+    +arrayList(session.entropy, "src", "Shannon Entropy Src (x100)", "entropy.src")
+    +arrayList(session.entropy, "dst", "Shannon Entropy Dst (x100)", "entropy.dst")


### PR DESCRIPTION
Calculates the Shannon entropy of the TCP/UDP data bytes using a u32 histogram and u32 counters, storing the value (x100) in the entropy field. Add entropy.detail.jade for the session detail display.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
