### PR TITLE
Don't split TCP flow when reordered original SYN looks like port reuse

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4008 Extract arp.ip / arp.mac / arp.oui / arp.opcode from ARP packets
   - #4010 Fix crash on startup when rootPlugins is set
   - #4013 Add entropy plugin to calculate the Shannon entropy of the TCP/UDP data bytes per direction, with entropyChunkSize and entropyMaxUniqueValues options
+  - #4019 Fix TCP flow split into two sessions when a reordered original SYN (arriving after FIN/RST, e.g. across multiple capture interfaces/reader threads) was mistaken for a port reuse
 ## Cont3xt
   - #3999 Fix logoutUrl when logoutUrlMethod=GET
 ## Viewer

--- a/capture/parsers/tcp.c
+++ b/capture/parsers/tcp.c
@@ -218,6 +218,10 @@ LOCAL int tcp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *con
 #endif
                 session->tcpData.tcpSeq[(packet->direction + 1) % 2] = ntohl(tcphdr->th_ack);
                 session->tcpData.synSeq[1] = seq;
+                // Record the client's initial seq (ISN) that this syn-ack acknowledges, so a
+                // reordered/retransmitted original client SYN can be recognized as belonging to
+                // this session instead of being mistaken for a port reuse.
+                session->tcpData.synSeq[0] = ntohl(tcphdr->th_ack) - 1;
             }
         } else {
             session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SYN]++;
@@ -420,9 +424,13 @@ LOCAL int tcp_pre_process(ArkimeSession_t *session, ArkimePacket_t *const packet
     const struct ip6_hdr      *ip6 = (struct ip6_hdr *)(packet->pkt + packet->ipOffset);
     const struct tcphdr       *tcphdr = (struct tcphdr *)(packet->pkt + packet->payloadOffset);
 
-    // If this is an old session that hash RSTs and we get a syn, probably a port reuse, close old session
+    // If this is an old session that has RSTs/FINs and we get a syn, probably a port reuse, close old session.
+    // But if the syn's seq matches the original client ISN we already know about, this is just the original
+    // SYN arriving reordered (e.g. spread across capture interfaces/reader threads) or a retransmit - keep it
+    // in the same session instead of splitting one flow into two.
     if (!isNewSession && (tcphdr->th_flags & TH_SYN) && ((tcphdr->th_flags & TH_ACK) == 0) &&
-        (session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_RST] || session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_FIN])) {
+        (session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_RST] || session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_FIN]) &&
+        ntohl(tcphdr->th_seq) != session->tcpData.synSeq[0]) {
         return 1;
     }
 


### PR DESCRIPTION
The port-reuse heuristic closed the session and started a new one on any bare SYN seen after a FIN/RST. With asymmetric capture across multiple interfaces/reader threads, the original client SYN can be processed after the rest of the flow, splitting one flow into two sessions with the same 5-tuple, vlan and communityId.

Record the client ISN inferred from a syn-ack-first session and skip the port-reuse split when the incoming SYN's seq matches it.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
