### PR TITLE
Fix writer-s3 hunt stall when session file is missing

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,6 +55,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4010 Fix crash on startup when rootPlugins is set
   - #4013 Add entropy plugin to calculate the Shannon entropy of the TCP/UDP data bytes per direction, with entropyChunkSize and entropyMaxUniqueValues options
   - #4019 Fix TCP flow split into two sessions when a reordered original SYN (arriving after FIN/RST, e.g. across multiple capture interfaces/reader threads) was mistaken for a port reuse
+  - #4021 Fix hunts and PCAP retrieval stalling with the writer-s3 plugin when a session's file is missing
 ## Cont3xt
   - #3999 Fix logoutUrl when logoutUrlMethod=GET
 ## Viewer

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -142,7 +142,8 @@ async function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
       });
     }
   } catch (error) {
-    return;
+    console.log('WARNING - Only have SPI data, PCAP file no longer available', fields.node, error);
+    return endCb('Only have SPI data, PCAP file no longer available for ' + fields.node + '-' + (fields.packetPos[0] * -1), fields);
   }
 
   function readyToProcess () {

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -218,7 +218,7 @@ ${Config.arkimeWebURL()}hunt
     }
 
     // update the hunt with number of matchedSessions and searchedSessions
-    // and the date of the first packet of the last searched session
+    // and the date of the last packet of the last searched session
     const lastPacketTime = session.lastPacket;
     const now = Math.floor(Date.now() / 1000);
 


### PR DESCRIPTION
Call endCb in the processSessionIdS3 catch block instead of silently returning, so hunts and PCAP retrieval no longer stall when a session's file document is missing (fixes #3614).

Fix incorrect comment in apiHunts.js (last packet, not first packet).

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
