### PR TITLE
Harden Parliament against malicious cluster responses and crafted API input

### DIFF
--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1936,6 +1936,10 @@ app.put('/parliament/api/ignoreIssues', [isUser, checkCookieToken], (req, res, n
   }
 
   const ms = req.body.ms ?? 3600000; // Default to 1 hour
+  if (typeof ms !== 'number' || !Number.isFinite(ms)) {
+    return res.serverError(422, 'ms must be a finite number.');
+  }
+
   let ignoreUntil = Date.now() + ms;
   if (ms === -1) { ignoreUntil = -1; } // -1 means ignore it forever
 

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -267,6 +267,15 @@ class Parliament {
     }
   };
 
+  // allowlist of general settings that can be set via apiUpdateSettings, so
+  // clients can't write arbitrary keys into settings.general (mass assignment)
+  static generalSettingKeys = new Set([
+    'noPackets', 'noPacketsLength', 'outOfDate', 'esQueryTimeout',
+    'removeIssuesAfter', 'removeAcknowledgedAfter', 'lowDiskSpace',
+    'lowDiskSpaceType', 'lowDiskSpaceES', 'lowDiskSpaceESType',
+    'hostname', 'wiseUrl', 'cont3xtUrl', 'includeUrl'
+  ]);
+
   static async initialize (options) {
     Parliament.name = options.name;
 
@@ -406,6 +415,9 @@ class Parliament {
 
       // save general settings
       for (const s in req.body.settings.general) {
+        // ignore any keys that aren't known general settings
+        if (!Parliament.generalSettingKeys.has(s)) { continue; }
+
         let setting = req.body.settings.general[s];
 
         if (s === 'hostname') { // hostname must be a string

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -670,8 +670,8 @@ class Parliament {
       return res.serverError(422, 'A cluster must have a title.');
     }
 
-    if (!ArkimeUtil.isString(req.body.url) || !(req.body.url.startsWith('http') || req.body.url.startsWith('/'))) {
-      return res.serverError(422, 'A cluster must have a url that starts with http or /.');
+    if (!ArkimeUtil.isString(req.body.url) || !(req.body.url.startsWith('http') || req.body.url.startsWith('/')) || req.body.url.startsWith('//')) {
+      return res.serverError(422, 'A cluster must have a url that starts with http or / (and not //).');
     }
 
     if (req.body.description && !ArkimeUtil.isString(req.body.description)) {
@@ -682,8 +682,8 @@ class Parliament {
       return res.serverError(422, 'A cluster must have a string localUrl.');
     }
 
-    if (req.body.localUrl && !(req.body.localUrl.startsWith('http') || req.body.localUrl.startsWith('/'))) {
-      return res.serverError(422, 'A cluster localUrl must start with http or /.');
+    if (req.body.localUrl && (!(req.body.localUrl.startsWith('http') || req.body.localUrl.startsWith('/')) || req.body.localUrl.startsWith('//'))) {
+      return res.serverError(422, 'A cluster localUrl must start with http or / (and not //).');
     }
 
     if (req.body.type && !ArkimeUtil.isString(req.body.type)) {
@@ -790,8 +790,8 @@ class Parliament {
       return res.serverError(422, 'A cluster must have a title.');
     }
 
-    if (!ArkimeUtil.isString(req.body.url) || !(req.body.url.startsWith('http') || req.body.url.startsWith('/'))) {
-      return res.serverError(422, 'A cluster must have a url that starts with http or /.');
+    if (!ArkimeUtil.isString(req.body.url) || !(req.body.url.startsWith('http') || req.body.url.startsWith('/')) || req.body.url.startsWith('//')) {
+      return res.serverError(422, 'A cluster must have a url that starts with http or / (and not //).');
     }
 
     if (req.body.description && !ArkimeUtil.isString(req.body.description)) {
@@ -802,8 +802,8 @@ class Parliament {
       return res.serverError(422, 'A cluster must have a string localUrl.');
     }
 
-    if (req.body.localUrl && !(req.body.localUrl.startsWith('http') || req.body.localUrl.startsWith('/'))) {
-      return res.serverError(422, 'A cluster localUrl must start with http or /.');
+    if (req.body.localUrl && (!(req.body.localUrl.startsWith('http') || req.body.localUrl.startsWith('/')) || req.body.localUrl.startsWith('//'))) {
+      return res.serverError(422, 'A cluster localUrl must start with http or / (and not //).');
     }
 
     if (req.body.type && !ArkimeUtil.isString(req.body.type)) {

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1831,7 +1831,7 @@ app.get('/parliament/api/issues', (req, res, next) => {
     }
 
     // filter by search term
-    if (req.query.filter) {
+    if (typeof req.query.filter === 'string') {
       const searchTerm = req.query.filter.toLowerCase();
       return issue.severity.toLowerCase().includes(searchTerm) ||
           (issue.node && issue.node.toLowerCase().includes(searchTerm)) ||
@@ -1847,7 +1847,7 @@ app.get('/parliament/api/issues', (req, res, next) => {
 
   let type = 'string';
   const allowedSortFields = { ignoreUntil: 1, firstNoticed: 1, lastNoticed: 1, acknowledged: 1, title: 1, text: 1, node: 1, cluster: 1, message: 1, severity: 1, type: 1, value: 1 };
-  const sortBy = allowedSortFields[req.query.sort] ? req.query.sort : undefined;
+  const sortBy = (typeof req.query.sort === 'string' && Object.hasOwn(allowedSortFields, req.query.sort)) ? req.query.sort : undefined;
   if (sortBy === 'ignoreUntil' ||
     sortBy === 'firstNoticed' ||
     sortBy === 'lastNoticed' ||

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -11,6 +11,11 @@
 const MIN_PARLIAMENT_VERSION = 7;
 const MIN_DB_VERSION = 79;
 
+// Cap the size of responses we accept from monitored clusters so a malicious
+// or misbehaving viewer/ES node can't exhaust Parliament's memory. Even very
+// large deployments produce health/stats payloads well under this.
+const MAX_CLUSTER_RESPONSE_SIZE = 10 * 1024 * 1024; // 10MB
+
 // ----------------------------------------------------------------------------
 // DEPENDENCIES
 // ----------------------------------------------------------------------------
@@ -1083,7 +1088,10 @@ async function buildAlert (cluster, issue) {
 
   issue.alerted = Date.now();
 
-  const message = `${ArkimeUtil.safeStr(cluster.title)} - ${issue.message}`;
+  // escape the whole composed message: the cluster title, the remote node
+  // name, and any error values come from monitored clusters and must not be
+  // able to inject markup into notifier channels (email, etc.)
+  const message = ArkimeUtil.safeStr(`${cluster.title} - ${issue.message}`);
 
   for (const setNotifier of notifiers) {
 
@@ -1334,6 +1342,8 @@ function getHealth (cluster) {
       url: `${cluster.localUrl ?? cluster.url}/eshealth.json`,
       method: 'GET',
       httpsAgent: internals.httpsAgent,
+      maxContentLength: MAX_CLUSTER_RESPONSE_SIZE,
+      maxBodyLength: MAX_CLUSTER_RESPONSE_SIZE,
       timeout
     };
 
@@ -1383,6 +1393,8 @@ async function getStats (cluster) {
       url: `${cluster.localUrl ?? cluster.url}/api/parliament`,
       method: 'GET',
       httpsAgent: internals.httpsAgent,
+      maxContentLength: MAX_CLUSTER_RESPONSE_SIZE,
+      maxBodyLength: MAX_CLUSTER_RESPONSE_SIZE,
       timeout: Parliament.getGeneralSetting('esQueryTimeout') * 1000
     };
 
@@ -1416,16 +1428,16 @@ async function getStats (cluster) {
       for (const stat of stats.data) {
         // sum delta bytes per second
         if (stat.deltaBytesPerSec) {
-          cluster.deltaBPS += stat.deltaBytesPerSec;
+          cluster.deltaBPS += Number(stat.deltaBytesPerSec) || 0;
         }
 
         // sum delta total dropped per second
         if (stat.deltaTotalDroppedPerSec) {
-          cluster.deltaTDPS += stat.deltaTotalDroppedPerSec;
+          cluster.deltaTDPS += Number(stat.deltaTotalDroppedPerSec) || 0;
         }
 
         if (stat.monitoring) {
-          cluster.monitoring += stat.monitoring;
+          cluster.monitoring += Number(stat.monitoring) || 0;
         }
 
         if ((now - stat.currentTime) <= Parliament.getGeneralSetting('outOfDate') && stat.deltaPacketsPerSec > 0) {

--- a/tests/parliament.t
+++ b/tests/parliament.t
@@ -1,4 +1,4 @@
-use Test::More tests => 101;
+use Test::More tests => 114;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -157,6 +157,10 @@ eq_or_diff($result, from_json('{"text": "There are no acknowledged issues to rem
 $result = parliamentPutToken("/parliament/api/removeSelectedAcknowledgedIssues?arkimeRegressionUser=parliamentAdminP", '{}', $parliamentAdminToken);
 eq_or_diff($result, from_json('{"text": "Must specify the acknowledged issue(s) to remove.", "success": false}'));
 
+# ignoreIssues requires a finite numeric ms (rejects non-numeric ms before it corrupts ignoreUntil)
+$result = parliamentPutToken("/parliament/api/ignoreIssues?arkimeRegressionUser=parliamentAdminP", '{"issues": [{"clusterId": "abc", "type": "esRed"}], "ms": "not-a-number"}', $parliamentAdminToken);
+eq_or_diff($result, from_json('{"text": "ms must be a finite number.", "success": false}'));
+
 # parliament admin can access/update settings/parliament
 $result = parliamentGetToken("/parliament/api/parliament?arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
 ok(exists $result->{settings}->{general});
@@ -183,6 +187,13 @@ $result = parliamentPutToken("/parliament/api/settings?arkimeRegressionUser=parl
 ok($result->{success});
 $result = parliamentGetToken("/parliament/api/parliament?arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
 eq_or_diff($result->{settings}->{general}->{noPacketsLength}, 100);
+
+# unknown settings keys are ignored, not written into settings.general (mass-assignment guard)
+$result = parliamentPutToken("/parliament/api/settings?arkimeRegressionUser=parliamentAdminP", '{"settings": { "general": { "noPacketsLength": 100, "evilKey": 99 } } }', $parliamentAdminToken);
+ok($result->{success});
+$result = parliamentGetToken("/parliament/api/parliament?arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
+eq_or_diff($result->{settings}->{general}->{noPacketsLength}, 100);
+ok(!exists $result->{settings}->{general}->{evilKey});
 
 # notifier types have been initiated
 $result = parliamentGetToken("/parliament/api/notifierTypes?arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
@@ -269,15 +280,19 @@ eq_or_diff($result, from_json('{"groups": [{"clusters": [], "id": "' . $firstGro
 
 # Add cluster requires url
 $result = parliamentPostToken("/parliament/api/groups/$firstGroupId/clusters?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1"}', $parliamentAdminToken);
-eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or /."}'));
+eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or / (and not //)."}'));
 
 # Add cluster url must start with http or /
 $result = parliamentPostToken("/parliament/api/groups/$firstGroupId/clusters?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1", "url": "super/fancy/url"}', $parliamentAdminToken);
-eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or /."}'));
+eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or / (and not //)."}'));
 
 # Add cluster url must start with http or / - ftp
 $result = parliamentPostToken("/parliament/api/groups/$firstGroupId/clusters?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1", "url": "ftp://example.com"}', $parliamentAdminToken);
-eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or /."}'));
+eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or / (and not //)."}'));
+
+# Add cluster url must not be protocol-relative (// would render as an off-site link)
+$result = parliamentPostToken("/parliament/api/groups/$firstGroupId/clusters?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1", "url": "//evil.com"}', $parliamentAdminToken);
+eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or / (and not //)."}'));
 
 # Add cluster with valid http url
 $result = parliamentPostToken("/parliament/api/groups/$firstGroupId/clusters?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1", "url": "http://super/fancy/url"}', $parliamentAdminToken);
@@ -286,11 +301,15 @@ ok ($result->{success});
 
 # Update cluster url must start with http or /
 $result = parliamentPutToken("/parliament/api/groups/$firstGroupId/clusters/$firstClusterId?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1a", "url": "gopher://evil"}', $parliamentAdminToken);
-eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or /."}'));
+eq_or_diff($result, from_json('{"success":false,"text":"A cluster must have a url that starts with http or / (and not //)."}'));
 
 # Update cluster localUrl must start with http or /
 $result = parliamentPutToken("/parliament/api/groups/$firstGroupId/clusters/$firstClusterId?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1a", "url": "http://localhost:8123", "localUrl": "file:///etc/passwd"}', $parliamentAdminToken);
-eq_or_diff($result, from_json('{"success":false,"text":"A cluster localUrl must start with http or /."}'));
+eq_or_diff($result, from_json('{"success":false,"text":"A cluster localUrl must start with http or / (and not //)."}'));
+
+# Update cluster localUrl must not be protocol-relative
+$result = parliamentPutToken("/parliament/api/groups/$firstGroupId/clusters/$firstClusterId?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1a", "url": "http://localhost:8123", "localUrl": "//evil.com"}', $parliamentAdminToken);
+eq_or_diff($result, from_json('{"success":false,"text":"A cluster localUrl must start with http or / (and not //)."}'));
 
 # Update cluster with valid url
 $result = parliamentPutToken("/parliament/api/groups/$firstGroupId/clusters/$firstClusterId?arkimeRegressionUser=parliamentAdminP", '{"title": "cluster 1a", "url": "http://localhost:8123"}', $parliamentAdminToken);
@@ -314,6 +333,38 @@ ok ($result->{success});
 # Delete first group
 $result = parliamentDeleteToken("/parliament/api/groups/$firstGroupId?arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
 eq_or_diff($result, from_json('{"text": "Successfully removed group.", "success": true}'));
+
+# ---- /api/issues query param type confusion guards ----
+# seed persistent issues with two unreachable clusters so the filter/sort
+# code paths actually run over real issues
+$result = parliamentPostToken("/parliament/api/groups?arkimeRegressionUser=parliamentAdminP", '{"title": "issuetest"}', $parliamentAdminToken);
+my $issueGroupId = $result->{group}->{id};
+ok($result->{success});
+
+$result = parliamentPostToken("/parliament/api/groups/$issueGroupId/clusters?arkimeRegressionUser=parliamentAdminP", '{"title": "down1", "url": "http://127.0.0.1:1"}', $parliamentAdminToken);
+ok($result->{success});
+$result = parliamentPostToken("/parliament/api/groups/$issueGroupId/clusters?arkimeRegressionUser=parliamentAdminP", '{"title": "down2", "url": "http://127.0.0.1:1"}', $parliamentAdminToken);
+ok($result->{success});
+
+# two update cycles so the issues are no longer provisional and show up in /api/issues
+parliamentGet("/regressionTests/updateParliament");
+parliamentGet("/regressionTests/updateParliament");
+
+# sanity: there are issues to filter/sort over
+$result = parliamentGetToken("/parliament/api/issues?arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
+ok(scalar @{$result->{issues}} >= 2);
+
+# filter passed as an array is ignored instead of throwing (500) on .toLowerCase()
+$result = parliamentGetToken("/parliament/api/issues?filter=a&filter=b&arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
+ok(exists $result->{issues});
+
+# sort with an inherited prototype key (constructor) is ignored instead of throwing (500) in the comparator
+$result = parliamentGetToken("/parliament/api/issues?sort=constructor&order=asc&arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
+ok(exists $result->{issues});
+
+# clean up the issue test group
+$result = parliamentDeleteToken("/parliament/api/groups/$issueGroupId?arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
+ok($result->{success});
 
 # delete the added users
 viewerGet("/regressionTests/deleteAllUsers");

--- a/tests/parliament.t
+++ b/tests/parliament.t
@@ -358,8 +358,9 @@ ok(scalar @{$result->{issues}} >= 2);
 $result = parliamentGetToken("/parliament/api/issues?filter=a&filter=b&arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
 ok(exists $result->{issues});
 
-# sort with an inherited prototype key (constructor) is ignored instead of throwing (500) in the comparator
-$result = parliamentGetToken("/parliament/api/issues?sort=constructor&order=asc&arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
+# sort with an inherited prototype key is ignored instead of throwing (500) in the comparator
+# (toString instead of constructor, which auth's ppChecker middleware already rejects with a 403)
+$result = parliamentGetToken("/parliament/api/issues?sort=toString&order=asc&arkimeRegressionUser=parliamentAdminP", $parliamentAdminToken);
 ok(exists $result->{issues});
 
 # clean up the issue test group


### PR DESCRIPTION
Security review fixes for Parliament:

- **Cluster polling:** cap responses at 10MB (was unlimited), coerce summed stats with Number(), and escape alert messages so remote clusters can't exhaust memory, corrupt totals, or inject into notifiers.
- **/api/ignoreIssues:** reject non-numeric `ms` (was producing a garbage `ignoreUntil`).
- **/api/issues:** guard `filter`/`sort` params so array/prototype keys can't 500.
- **/api/settings:** allowlist general-settings keys (mass-assignment).
- **Cluster create/update:** reject protocol-relative `//` urls.

Adds parliament.t coverage for the four input-validation fixes.