### PR TITLE
Fix CSV injection and stored XSS in viewer exports and session detail

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4004 Fix Ubuntu 26.04 builds having the incorrect dependencies
 ## All
   - #4030 Fix hidePcap/hideFiles/hideStats/disablePcapDownload failing open for users with the permission inherited from multiple roles
+  - #4031 Fix CSV formula injection in session, connection, and user CSV exports by neutralizing cells starting with = + - @
 ## Capture
   - #3996 Added mssing ntlm.detail.jade for NTLM session detail rendering
   - #3996 Added opcua parser (OPC UA Binary) with opcua.endpointUrl, opcua.securityPolicyUri and SenderCertificate parsing
@@ -89,6 +90,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4018 Added support for preauth and postauth endpoint registration to plugins
   - #4027 Fix viewer crash when /api/sessions/csv with ids fails to build the query
   - #4027 Fix malformed TOTP codes causing a request error instead of being treated as invalid
+  - #4031 Fix potential stored XSS in session detail
+  - #4031 Fix possible stored XSS in hunt search string
 ## Wise
   - #3999 Mark phpipam appCode/password and fieldactions/valueactions url fields as secret so they are redacted in /config/get
   - #3999 Add /api/user endpoint and hide save/import/create-source UI controls from non-wiseAdmin users

--- a/capture/parsers/smb.c
+++ b/capture/parsers/smb.c
@@ -455,7 +455,7 @@ LOCAL int smb1_parse(ArkimeSession_t *session, SMBInfo_t *smb, BSB *bsb, char *s
     return 0;
 }
 /******************************************************************************/
-LOCAL int smb2_parse(ArkimeSession_t *session, const SMBInfo_t *smb, BSB *bsb, char *state, uint32_t *remlen, int UNUSED(which))
+LOCAL int smb2_parse(ArkimeSession_t *session, const SMBInfo_t *UNUSED(smb), BSB *bsb, char *state, uint32_t *remlen, int UNUSED(which))
 {
     const uint8_t *start = BSB_WORK_PTR(*bsb);
 

--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -41,6 +41,21 @@ class ArkimeUtil {
 
   // ---------------------------------------------------------------------------
   /**
+   * Neutralize CSV/spreadsheet formula injection. A cell that begins with one
+   * of = + - @ TAB CR can execute as a formula when the export is opened in
+   * Excel/Google Sheets. Since values can come from captured traffic or other
+   * untrusted input, prefix risky cells with a single quote.
+   */
+  static csvSafeStr (str) {
+    if (typeof str !== 'string') { str = String(str); }
+    if (str.length > 0 && '=+-@\t\r'.includes(str[0])) {
+      return "'" + str;
+    }
+    return str;
+  }
+
+  // ---------------------------------------------------------------------------
+  /**
    * For both arrays and single values escape entities
    */
   static safeStr (str) {

--- a/common/user.js
+++ b/common/user.js
@@ -655,9 +655,12 @@ class User {
           if (value === undefined) {
             value = '';
           } else if (Array.isArray(value)) {
-            value = '"' + value.join(', ').replace(/"/g, '""') + '"';
-          } else if (typeof (value) === 'string' && (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r'))) {
-            value = '"' + value.replace(/"/g, '""') + '"';
+            value = '"' + value.map(v => ArkimeUtil.csvSafeStr(String(v))).join(', ').replace(/"/g, '""') + '"';
+          } else if (typeof (value) === 'string') {
+            value = ArkimeUtil.csvSafeStr(value);
+            if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+              value = '"' + value.replace(/"/g, '""') + '"';
+            }
           }
           values.push(value);
         }

--- a/common/vueapp/vueFilters.js
+++ b/common/vueapp/vueFilters.js
@@ -4,6 +4,22 @@
 import moment from 'moment-timezone';
 
 /**
+ * Escapes HTML special characters.
+ *
+ * @param {string} str The string to escape
+ * @returns {string}   The HTML-escaped string
+ */
+export const escapeHtml = function (str) {
+  if (str === undefined || str === null) { return str; }
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+
+/**
  * Rounds a number using Math.round
  *
  * @example

--- a/tests/api-sessionDetail.t
+++ b/tests/api-sessionDetail.t
@@ -1,4 +1,4 @@
-use Test::More tests => 39;
+use Test::More tests => 42;
 
 use Cwd;
 use URI::Escape;
@@ -176,7 +176,7 @@ my $noPcapDoc = '{
   "tags": ["' . $noPcapTag . '"],
   "tagsCnt": 1
 }';
-esPost("/$noPcapIndex/_doc/$noPcapDocId?refresh=wait_for", $noPcapDoc);
+esPost("/$noPcapIndex/_doc/$noPcapDocId?refresh=true", $noPcapDoc);
 
 my $noPcapList = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("tags=$noPcapTag"));
 is (scalar @{$noPcapList->{data}}, 1, "no-pcap session indexed");
@@ -191,3 +191,36 @@ is ($noPcapPackets->code, 200, "no-pcap /packets returns 200 (no crash)");
 ok($noPcapPackets->content !~ m{Cannot set properties of undefined}, "no-pcap /packets does not throw TypeError");
 
 esPost("/$noPcapIndex/_delete_by_query?conflicts=proceed&refresh", '{ "query": { "term": { "tags": "' . $noPcapTag . '" } } }');
+
+# Test we escape {
+my $xssTag = "dns-vue-xss-regression-tag";
+my $xssDocId = "abcdef0123456789dnsxss00";
+my $xssDoc = '{
+  "@timestamp": 1745000000000,
+  "firstPacket": 1745000000000,
+  "lastPacket": 1745000001000,
+  "node": "test",
+  "ipProtocol": 17,
+  "source": {"ip": "10.99.99.11", "port": 1001, "bytes": 100, "packets": 1},
+  "destination": {"ip": "10.99.99.21", "port": 53, "bytes": 100, "packets": 1},
+  "network": {"packets": 2, "bytes": 200},
+  "totDataBytes": 100,
+  "length": 1,
+  "protocol": ["dns"],
+  "protocolCnt": 1,
+  "dns": [{"opcode": "QUERY", "qt": "A", "qc": "IN", "queryHost": "{constructor", "hostCnt": 1, "host": ["{constructor"]}],
+  "dnsCnt": 1,
+  "tags": ["' . $xssTag . '"],
+  "tagsCnt": 1
+}';
+esPost("/$noPcapIndex/_doc/$xssDocId?refresh=true", $xssDoc);
+
+my $xssList = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("tags=$xssTag"));
+is (scalar @{$xssList->{data}}, 1, "dns xss session indexed");
+my $xssId = $xssList->{data}->[0]->{id};
+
+$sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$xssId/detail")->content;
+ok($sd =~ m{Query A - &#123;constructor}s, "dns queryHost { escaped to &#123; in /detail");
+ok($sd !~ m{[^"]\{constructor}s, "dns queryHost has no raw { in /detail");
+
+esDelete("/$noPcapIndex/_doc/$xssDocId?refresh=true");

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,7 +1,7 @@
 # Many of these test user/roles start with sac- (skip auto create) because
 # otherwise viewer in regression mode would auto create the user.
 # Some day should remove all autocreate code.
-use Test::More tests => 262;
+use Test::More tests => 266;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -33,6 +33,18 @@ my $json;
     eq_or_diff ($csv, 'userId, userName, enabled, webEnabled, headerAuthEnabled, roles, emailSearch, removeEnabled, packetSearch, hideStats, hideFiles, hidePcap, disablePcapDownload, expression, timeLimit
 anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
 ', "CSV Users");
+
+# csv formula injection - userName/expression starting with a trigger char must be neutralized with a leading '
+    $json = viewerPostToken("/api/user", '{"userId": "sac-csvinj", "userName": "=cmd|calc", "enabled":true, "password":"password", "roles":["arkimeUser"], "expression":"+danger"}', $token);
+    eq_or_diff($json, from_json('{"text": "User created successfully", "success": true}'));
+
+    my $csvinj = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/users.csv", Content => "")->content;
+    $csvinj =~ s/\r//g;
+    like ($csvinj, qr/sac-csvinj,'=cmd\|calc,/, "CSV neutralizes formula in userName");
+    like ($csvinj, qr/,'\+danger,/, "CSV neutralizes formula in expression");
+    unlike ($csvinj, qr/,=cmd/, "CSV has no raw formula userName");
+
+    $json = viewerDeleteToken("/api/user/sac-csvinj", $token);
 
 # Can't create system rule
     $json = viewerPostToken("/api/user", '{"userId": "usersAdmin", "userName": "UserName", "enabled":true, "password":"password"}', $token);

--- a/viewer/apiConnections.js
+++ b/viewer/apiConnections.js
@@ -546,14 +546,14 @@ class ConnectionAPIs {
       res.write('\r\n');
 
       for (let i = 0, ilen = links.length; i < ilen; i++) {
-        res.write('"' + nodes[links[i].source].id.replaceAll('"', '""') + '"' + separator +
-                  '"' + nodes[links[i].target].id.replaceAll('"', '""') + '"' + separator +
+        res.write('"' + ArkimeUtil.csvSafeStr(nodes[links[i].source].id).replaceAll('"', '""') + '"' + separator +
+                  '"' + ArkimeUtil.csvSafeStr(nodes[links[i].target].id).replaceAll('"', '""') + '"' + separator +
                        links[i].value + separator);
         for (let f = 0, flen = fields.length; f < flen; f++) {
           const df = displayFields[fields[f]];
           if (df) {
             const val = links[i][df.dbField];
-            res.write(val !== undefined && val !== null ? val.toString() : '');
+            res.write(val !== undefined && val !== null ? ArkimeUtil.csvSafeStr(val.toString()) : '');
           } else {
             res.write('');
           }

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -31,6 +31,34 @@ const { LRUCache } = require('lru-cache');
 const sanitizeHtml = require('sanitize-html');
 const BuildQuery = require('./buildQuery');
 
+// Replace pug's escape with the same algorithm plus {. Detail HTML must be
+// sanitized with decodeEntities:false so the &#123; survives to the client.
+const pugRuntime = require('pug-runtime');
+const pugMatchHtmlVue = /["&<>{]/;
+pugRuntime.escape = function pugEscapeVue (_html) {
+  const html = '' + _html;
+  const regexResult = pugMatchHtmlVue.exec(html);
+  if (!regexResult) return _html;
+
+  let result = '';
+  let i, lastIndex, esc;
+  for (i = regexResult.index, lastIndex = 0; i < html.length; i++) {
+    switch (html.charCodeAt(i)) {
+    case 34: esc = '&quot;'; break;
+    case 38: esc = '&amp;'; break;
+    case 60: esc = '&lt;'; break;
+    case 62: esc = '&gt;'; break;
+    case 123: esc = '&#123;'; break;
+    default: continue;
+    }
+    if (lastIndex !== i) result += html.substring(lastIndex, i);
+    lastIndex = i + 1;
+    result += esc;
+  }
+  if (lastIndex !== i) return result + html.substring(lastIndex, i);
+  else return result;
+};
+
 const headerlru = new LRUCache({ max: 100 });
 
 const SEGMENTS_REGEX = /^(time|all)$/;
@@ -169,13 +197,16 @@ class SessionAPIs {
           }
 
           if (Array.isArray(value)) {
-            const singleValue = '"' + value.map(v => String(v).replace(/"/g, '""')).join(', ') + '"';
+            const singleValue = '"' + value.map(v => ArkimeUtil.csvSafeStr(String(v)).replace(/"/g, '""')).join(', ') + '"';
             values.push(singleValue);
           } else {
             if (value === undefined) {
               value = '';
-            } else if (typeof (value) === 'string' && (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r'))) {
-              value = '"' + value.replace(/"/g, '""') + '"';
+            } else if (typeof (value) === 'string') {
+              value = ArkimeUtil.csvSafeStr(value);
+              if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+                value = '"' + value.replace(/"/g, '""') + '"';
+              }
             }
             values.push(value);
           }
@@ -2583,6 +2614,7 @@ class SessionAPIs {
           console.log('/api/session/%s/%s/detail rendering', ArkimeUtil.sanitizeStr(req.params.nodeName), ArkimeUtil.sanitizeStr(req.params.id), data.replace(/>/g, '>\n'));
         }
         const html = sanitizeHtml(data, {
+          parser: { decodeEntities: false }, // keep &#123; from pugEscapeVue so it survives to the client
           allowedTags: ['h3', 'h4', 'h5', 'h6', 'a', 'b', 'i', 'strong', 'em', 'div', 'pre', 'span', 'br', 'img', 'ul', 'li', 'b-dropdown', 'b-dropdown-item', 'arkime-toast', 'arkime-session-field', 'arkime-tag-sessions', 'arkime-export-pcap', 'arkime-remove-data', 'arkime-send-sessions', 'b-card-group', 'b-card', 'h4', 'dl', 'dt', 'dd', 'field-actions', 'b-dropdown-divider', 'template'],
           allowedClasses: {
             '*': ['ts-value', 'text-theme-quaternary', 'imagetag', 'file', 'nav-link', 'cursor-pointer', 'nav', 'nav-link', 'nav-pills', 'nav-item', 'mb-3', 'mb-2', 'me-1', 'me-5', 'ms-1', 'row', 'col-md-6', 'offset-md-6', 'sessionsrc', 'sessiondst', 'session-detail-ts', 'alert', 'alert-danger', 'session-detail', 'pull-right', 'small', 'dstcol', 'srccol', 'fa', 'fa-info-circle', 'fa-lg', 'fa-exclamation-triangle', 'sessionln', 'src-col-tip', 'dst-col-tip', 'fa-download', 'fa-arrow-circle-up', 'fa-arrow-circle-down', 'fa-link', 'clickable-label', 'detail-field', 'no-wrap', 'card-title', 'tag-list', 'btn', 'btn-xs', 'btn-theme-secondary', 'fa-plus-circle', 'str', 'bytes']

--- a/viewer/vueapp/src/components/hunt/Hunt.vue
+++ b/viewer/vueapp/src/components/hunt/Hunt.vue
@@ -494,7 +494,7 @@ SPDX-License-Identifier: Apache-2.0
                         <span v-html="$t('hunts.runningJob-headHtml', { matched: commaString(runningJob.matchedSessions) })" />
                         <span
                           v-if="canView"
-                          v-html="$t('hunts.runningJob-canViewHtml', { search: runningJob.search, searchType: runningJob.searchType })" />
+                          v-html="$t('hunts.runningJob-canViewHtml', { search: escapeHtml(runningJob.search), searchType: runningJob.searchType })" />
                         <span
                           v-if="runningJob.failedSessionIds && runningJob.failedSessionIds.length"
                           v-html="$t('hunts.runningJob-outOfHtml', {
@@ -862,7 +862,7 @@ import HuntData from './HuntData.vue';
 import HuntRow from './HuntRow.vue';
 import RoleDropdown from '@common/RoleDropdown.vue';
 import NotifierDropdown from '@common/NotifierDropdown.vue';
-import { commaString, round } from '@common/vueFilters.js';
+import { commaString, round, escapeHtml } from '@common/vueFilters.js';
 import { resolveMessage } from '@common/resolveI18nMessage';
 // import utils
 import Utils from '../utils/utils';
@@ -1003,6 +1003,7 @@ export default {
   methods: {
     round,
     commaString,
+    escapeHtml,
     /**
      * Cancels the pending session query (if it's still pending) and runs a new
      * query if requested

--- a/viewer/vueapp/src/components/hunt/HuntData.vue
+++ b/viewer/vueapp/src/components/hunt/HuntData.vue
@@ -69,7 +69,7 @@ SPDX-License-Identifier: Apache-2.0
       <span
         v-html="$t('hunts.results-searchedHtml', {
           matched: commaString(localJob.matchedSessions),
-          search: localJob.search,
+          search: escapeHtml(localJob.search),
           searchType: localJob.searchType,
           searched: localJob.failedSessionIds && localJob.failedSessionIds.length ? commaString(localJob.searchedSessions - localJob.failedSessionIds.length) : commaString(localJob.searchedSessions),
           total: commaString(localJob.totalSessions)
@@ -285,7 +285,7 @@ import HuntStatus from './HuntStatus.vue';
 import HuntService from './HuntService';
 import Focus from '@common/Focus.vue';
 import RoleDropdown from '@common/RoleDropdown.vue';
-import { commaString, timezoneDateString } from '@common/vueFilters.js';
+import { commaString, timezoneDateString, escapeHtml } from '@common/vueFilters.js';
 
 export default {
   name: 'HuntData',
@@ -336,6 +336,7 @@ export default {
   methods: {
     commaString,
     timezoneDateString,
+    escapeHtml,
     removeJob: function (job, list) {
       this.$emit('removeJob', job, list);
     },


### PR DESCRIPTION
- Neutralize CSV formula injection in session, connection, and user CSV exports
- Escape captured fields in session detail so they aren't interpreted
- Escape hunt search string before vue-i18n interpolation into v-html
- Fix unused parameter warning in smb2_parse

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
