### PR TITLE
Fix assorted code-review issues across capture, cont3xt, and CI

### DIFF
--- a/.github/workflows/delete-old-snapshots.yml
+++ b/.github/workflows/delete-old-snapshots.yml
@@ -21,12 +21,20 @@ jobs:
       - name: Delete old package versions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          DAYS: ${{ inputs.days }}
         run: |
           #!/bin/bash
-          
-          DRY_RUN=${{ inputs.dry_run }}
-          DAYS=${{ inputs.days }}
-          
+
+          if ! echo "$DAYS" | grep -qE '^[0-9]+$'; then
+            echo "ERROR - invalid days '$DAYS', expected a non-negative integer"
+            exit 1
+          fi
+          if [ "$DRY_RUN" != "true" ] && [ "$DRY_RUN" != "false" ]; then
+            echo "ERROR - invalid dry_run '$DRY_RUN', expected true or false"
+            exit 1
+          fi
+
           page=1
           while true; do
             response=$(gh api \
@@ -42,7 +50,7 @@ jobs:
             jq -c '.[] | select(.metadata.container.tags[] | startswith("snapshot-")) | 
                 {id: .id, tag: .metadata.container.tags[0], created_at: .created_at, 
                  days_old: ((now - (.created_at | fromdateiso8601)) / 86400 | floor)}' | \
-            jq -c "select(.days_old > $DAYS)")
+            jq -c --argjson days "$DAYS" 'select(.days_old > $days)')
 
             if [ -n "$result" ]; then
               echo "$result" | while read -r package; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,25 @@ permissions:
   packages: read
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate inputs
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          ITERATION: ${{ github.event.inputs.iteration }}
+        run: |
+          if ! echo "$RELEASE_TAG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "ERROR - invalid release_tag '$RELEASE_TAG', expected e.g. 1.0.0 or 6.0.0-rc1"
+            exit 1
+          fi
+          if ! echo "$ITERATION" | grep -qE '^[0-9]+$'; then
+            echo "ERROR - invalid iteration '$ITERATION', expected a number"
+            exit 1
+          fi
+
   generate-matrix:
+    needs: validate
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -54,6 +72,8 @@ jobs:
 
     env:
       PYTHON: ${{ matrix.python || 'python' }}
+      RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+      ITERATION: ${{ github.event.inputs.iteration }}
 
     runs-on: ${{ matrix.runson || 'ubuntu-latest' }}
 
@@ -85,15 +105,15 @@ jobs:
         if: ${{ matrix.package == 'arch' }}
         run: |
           gem install --no-document fpm rexml erb
-          export ARKIME_VERSION="${{ github.event.inputs.release_tag }}"
-          /root/.local/share/gem/ruby/3.4.0/bin/fpm -s dir -t pacman -n arkime -x opt/arkime/logs -x opt/arkime/raw -v $ARKIME_VERSION --iteration ${{ github.event.inputs.iteration }} --template-scripts --after-install "release/afterinstall.sh" --url "https://arkime.com" --description "Arkime Full Packet System" ${{ matrix.fpmdeps }} -p arkime-${ARKIME_VERSION}-${{github.event.inputs.iteration}}_${{matrix.version}}.pkg.tar.zst /opt/arkime
+          export ARKIME_VERSION="$RELEASE_TAG"
+          /root/.local/share/gem/ruby/3.4.0/bin/fpm -s dir -t pacman -n arkime -x opt/arkime/logs -x opt/arkime/raw -v $ARKIME_VERSION --iteration "$ITERATION" --template-scripts --after-install "release/afterinstall.sh" --url "https://arkime.com" --description "Arkime Full Packet System" ${{ matrix.fpmdeps }} -p arkime-${ARKIME_VERSION}-${ITERATION}_${{matrix.version}}.pkg.tar.zst /opt/arkime
           ls -l *.zst
 
       - name: package rpm
         if: ${{ matrix.package == 'rpm' }}
         run: |
-          export ARKIME_VERSION="${{ github.event.inputs.release_tag }}"
-          fpm -s dir -t rpm --rpm-digest sha256 -n arkime -x opt/arkime/logs -x opt/arkime/raw -v $ARKIME_VERSION --iteration ${{ github.event.inputs.iteration }} --template-scripts --after-install "release/afterinstall.sh" --url "https://arkime.com" --description "Arkime Full Packet System" ${{ matrix.fpmdeps }} --rpm-rpmbuild-define "_build_id_links none" -p arkime-${ARKIME_VERSION}-${{github.event.inputs.iteration}}.${{matrix.version}}.rpm /opt/arkime
+          export ARKIME_VERSION="$RELEASE_TAG"
+          fpm -s dir -t rpm --rpm-digest sha256 -n arkime -x opt/arkime/logs -x opt/arkime/raw -v $ARKIME_VERSION --iteration "$ITERATION" --template-scripts --after-install "release/afterinstall.sh" --url "https://arkime.com" --description "Arkime Full Packet System" ${{ matrix.fpmdeps }} --rpm-rpmbuild-define "_build_id_links none" -p arkime-${ARKIME_VERSION}-${ITERATION}.${{matrix.version}}.rpm /opt/arkime
           ls -l *.rpm
 
       - name: Arkime ENV Variables
@@ -113,7 +133,7 @@ jobs:
       - name: moloch el package rpm
         if: ${{ matrix.version == 'el8.x86_64' || matrix.version == 'el9.x86_64' }}
         run: |
-          export ARKIME_VERSION="${{ github.event.inputs.release_tag }}"
+          export ARKIME_VERSION="$RELEASE_TAG"
           rm -rf /data/moloch; mkdir -p /data
           mv /opt/arkime /data/moloch
           ./easybutton-build.sh ${{ matrix.buildopt }} --dir /data/moloch
@@ -122,14 +142,14 @@ jobs:
           mv /data/moloch/bin/capture /data/moloch/bin/moloch-capture
           /bin/cp -f common/version.js /data/moloch/common/
 
-          fpm -s dir -t rpm -n moloch -x data/moloch/logs -x data/molcoh/raw -v $ARKIME_VERSION --iteration ${{ github.event.inputs.iteration }} --template-scripts --url "https://arkime.com" --description "Moloch Full Packet System" ${{ matrix.fpmdeps }} --rpm-rpmbuild-define "_build_id_links none" -p moloch-${ARKIME_VERSION}-${{github.event.inputs.iteration}}.${{matrix.version}}.rpm /data/moloch
+          fpm -s dir -t rpm -n moloch -x data/moloch/logs -x data/molcoh/raw -v $ARKIME_VERSION --iteration "$ITERATION" --template-scripts --url "https://arkime.com" --description "Moloch Full Packet System" ${{ matrix.fpmdeps }} --rpm-rpmbuild-define "_build_id_links none" -p moloch-${ARKIME_VERSION}-${ITERATION}.${{matrix.version}}.rpm /data/moloch
           ls -l *.rpm
 
       - name: package deb
         if: ${{ matrix.package == 'deb' }}
         run: |
-          export ARKIME_VERSION="${{ github.event.inputs.release_tag }}"
-          fpm -s dir -t deb -n arkime -x opt/arkime/logs -x opt/arkime/raw -v $ARKIME_VERSION --iteration ${{ github.event.inputs.iteration }} --template-scripts --after-install "release/afterinstall.sh" --url "https://arkime.com" --description "Arkime Full Packet System" ${{ matrix.fpmdeps }} -p arkime_${ARKIME_VERSION}-${{github.event.inputs.iteration}}.${{matrix.version}}.deb /opt/arkime
+          export ARKIME_VERSION="$RELEASE_TAG"
+          fpm -s dir -t deb -n arkime -x opt/arkime/logs -x opt/arkime/raw -v $ARKIME_VERSION --iteration "$ITERATION" --template-scripts --after-install "release/afterinstall.sh" --url "https://arkime.com" --description "Arkime Full Packet System" ${{ matrix.fpmdeps }} -p arkime_${ARKIME_VERSION}-${ITERATION}.${{matrix.version}}.deb /opt/arkime
           ls -l *.deb
 
       - name: notice
@@ -220,6 +240,7 @@ jobs:
 
     env:
       PYTHON: ${{ matrix.python || 'python' }}
+      RELEASE_TAG: ${{ github.event.inputs.release_tag }}
 
     runs-on: ${{ matrix.runson || 'ubuntu-latest' }}
 
@@ -235,6 +256,7 @@ jobs:
           release: ${{ matrix.freebsdrelease }}
           arch: ${{ contains(matrix.version, 'aarch64') && 'aarch64' || 'x86_64' }}
           usesh: true
+          envs: 'RELEASE_TAG'
           prepare: |
             pkg update -f
             pkg install -y bash git curl perl5 openssl jq yq sudo gmake autoconf automake m4 libtool autoconf-archive gtar pcre2 python3 p5-LWP-Protocol-https p5-JSON p5-Test-Differences p5-Socket6
@@ -244,7 +266,7 @@ jobs:
             ./easybutton-build.sh --dir /usr/local/share/arkime ${{ matrix.buildopt }} --rminstall --nothirdparty
             ls -l capture/capture
             INSTALL_BUNDLE=bundle gmake install
-            export ARKIME_VERSION="${{ github.event.inputs.release_tag }}"
+            export ARKIME_VERSION="$RELEASE_TAG"
             arch=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
             ./release/freebsdpkg.sh $ARKIME_VERSION ${{ matrix.version }} ${{ matrix.version }} /usr/local/share/arkime
             # mv arkime_*.pkg arkime-main.${{matrix.version}}.pkg || true
@@ -294,6 +316,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.release_tag }}
     steps:
       - name: Log in to registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -305,29 +329,29 @@ jobs:
       - name: Create and push manifest
         run: |
           package="ghcr.io/${{ github.repository_owner }}/arkime/arkime"
-          export ARKIME_MAJOR_VERSION=`echo ${{github.event.inputs.release_tag}} | cut -c 1-1`
+          export ARKIME_MAJOR_VERSION=`echo "$RELEASE_TAG" | cut -c 1-1`
 
           create_and_push() {
             local tag=$1
             local extra=$2
 
             docker manifest create ${package}:${tag} \
-              ${package}:v${{github.event.inputs.release_tag}}-amd64${extra} \
-              ${package}:v${{github.event.inputs.release_tag}}-arm64${extra}
+              ${package}:v${RELEASE_TAG}-amd64${extra} \
+              ${package}:v${RELEASE_TAG}-arm64${extra}
             docker manifest annotate ${package}:${tag} \
-              ${package}:v${{github.event.inputs.release_tag}}-amd64${extra} --arch amd64
+              ${package}:v${RELEASE_TAG}-amd64${extra} --arch amd64
             docker manifest annotate ${package}:${tag} \
-              ${package}:v${{github.event.inputs.release_tag}}-arm64${extra} --arch arm64
+              ${package}:v${RELEASE_TAG}-arm64${extra} --arch arm64
             docker manifest push ${package}:${tag}
           }
 
           ### Normal ###
-          create_and_push "v${{github.event.inputs.release_tag}}" ""
+          create_and_push "v${RELEASE_TAG}" ""
           create_and_push "v${ARKIME_MAJOR_VERSION}-latest" ""
           create_and_push "latest" ""
 
           ### JA4+ ###
-          create_and_push "v${{github.event.inputs.release_tag}}-ja4" "-ja4"
+          create_and_push "v${RELEASE_TAG}-ja4" "-ja4"
           create_and_push "v${ARKIME_MAJOR_VERSION}-ja4-latest" "-ja4"
           create_and_push "ja4-latest" "-ja4"
 
@@ -340,9 +364,10 @@ jobs:
       - name: send
         env:
           SLACK_URL: ${{ secrets.SLACK_URL }}
+          RELEASE_TAG: ${{ github.event.inputs.release_tag }}
         run: |
           echo "Sending msg"
-          export ARKIME_VERSION="v${{ github.event.inputs.release_tag }}"
+          export ARKIME_VERSION="v$RELEASE_TAG"
           echo ARKIME_VERSION: $ARKIME_VERSION
           BODY="{\"icon_emoji\": \":sushi:\", \"username\": \"GitAction\", \"text\":\"Release $ARKIME_VERSION worked!!!\"}"
           curl -XPOST -H "Content-type: application/json" --data "$BODY" $SLACK_URL

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1521,7 +1521,7 @@ void arkime_plugins_set_cb(const char             *name,
                            ArkimePluginSaveFunc    saveFunc,
                            ArkimePluginNewFunc     newFunc,
                            ArkimePluginExitFunc    exitFunc,
-                           ArkimePluginExitFunc    reloadFunc);
+                           ArkimePluginReloadFunc  reloadFunc);
 
 void arkime_plugins_set_http_cb(const char              *name,
                                 ArkimePluginHttpFunc     on_message_begin,

--- a/capture/parsers/dns.c
+++ b/capture/parsers/dns.c
@@ -1426,14 +1426,21 @@ LOCAL void dns_save(BSB *jbsb, ArkimeFieldObject_t *object, struct arkime_sessio
     BSB_EXPORT_u08(*jbsb, '{');
 
 #ifdef DNSDEBUG
-    LOG("DNSDEBUG: Host: %s, Opcode: %s, QC: %s, QT: %s", dns->query.hostname, dns->query.opcode, dns->query.class, dns->query.type);
+    LOG("DNSDEBUG: Host: %s, Opcode: %s, QC ID: %u, QT ID: %u", dns->query.hostname, dns->query.opcode, dns->query.class_id, dns->query.type_id);
 #endif
 
     BSB_EXPORT_sprintf(*jbsb, "\"opcode\":\"%s\",", dns->query.opcode);
     BSB_EXPORT_sprintf(*jbsb, "\"queryHost\":");
     arkime_db_js0n_str(jbsb, (uint8_t *)dns->query.hostname, TRUE);
-    BSB_EXPORT_sprintf(*jbsb, ",\"qc\":\"%s\",", dns->query.class);
-    BSB_EXPORT_sprintf(*jbsb, "\"qt\":\"%s\",", dns->query.type);
+    BSB_EXPORT_u08(*jbsb, ',');
+    if (dns->query.class)
+        BSB_EXPORT_sprintf(*jbsb, "\"qc\":\"%s\",", dns->query.class);
+    else if (dns->query.class_id) // RFC 3597 style for unknown classes, omit for reserved 0 (synthesized mDNS entries)
+        BSB_EXPORT_sprintf(*jbsb, "\"qc\":\"CLASS%u\",", dns->query.class_id);
+    if (dns->query.type)
+        BSB_EXPORT_sprintf(*jbsb, "\"qt\":\"%s\",", dns->query.type);
+    else if (dns->query.type_id) // RFC 3597 style for unknown types, omit for reserved 0 (synthesized mDNS entries)
+        BSB_EXPORT_sprintf(*jbsb, "\"qt\":\"TYPE%u\",", dns->query.type_id);
 
     if (HASH_COUNT(s_, dns->hosts) > 0) {
         SAVE_STRING_HASH(dns->hosts, "host");

--- a/capture/parsers/imap.c
+++ b/capture/parsers/imap.c
@@ -14,7 +14,7 @@ LOCAL  int subjectField;
 LOCAL  int folderField;
 
 typedef struct {
-    GString  *line;
+    GString  *line[2];
     uint8_t   serverWhich;
     uint8_t   inFetch;
     uint8_t   inHeaders;
@@ -172,24 +172,24 @@ LOCAL int imap_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                 lineLen--;
             }
         } else {
-            /* Incomplete line, buffer it (cap to prevent unbounded growth) */
-            if (imap->line->len + remaining > 16384) {
+            /* Incomplete line, buffer it per-direction (cap to prevent unbounded growth) */
+            if (imap->line[which]->len + remaining > 16384) {
                 arkime_session_add_tag(session, "imap:line-too-long");
                 return ARKIME_PARSER_UNREGISTER;
             }
-            g_string_append_len(imap->line, (const char *)data, remaining);
+            g_string_append_len(imap->line[which], (const char *)data, remaining);
             return 0;
         }
 
-        /* Combine with any buffered data */
-        if (imap->line->len > 0) {
-            if (imap->line->len + lineLen > 16384) {
+        /* Combine with any buffered data for this direction */
+        if (imap->line[which]->len > 0) {
+            if (imap->line[which]->len + lineLen > 16384) {
                 arkime_session_add_tag(session, "imap:line-too-long");
                 return ARKIME_PARSER_UNREGISTER;
             }
-            g_string_append_len(imap->line, (const char *)data, lineLen);
-            imap_process_line(imap, session, imap->line->str, imap->line->len, which);
-            g_string_truncate(imap->line, 0);
+            g_string_append_len(imap->line[which], (const char *)data, lineLen);
+            imap_process_line(imap, session, imap->line[which]->str, imap->line[which]->len, which);
+            g_string_truncate(imap->line[which], 0);
         } else {
             imap_process_line(imap, session, (const char *)data, lineLen, which);
         }
@@ -206,7 +206,8 @@ LOCAL void imap_free(ArkimeSession_t UNUSED(*session), void *uw)
 {
     IMAPInfo_t *imap = uw;
 
-    g_string_free(imap->line, TRUE);
+    g_string_free(imap->line[0], TRUE);
+    g_string_free(imap->line[1], TRUE);
     ARKIME_TYPE_FREE(IMAPInfo_t, imap);
 }
 /******************************************************************************/
@@ -228,7 +229,8 @@ LOCAL void imap_classify(ArkimeSession_t *session, const uint8_t *data, int len,
     arkime_session_add_protocol(session, "imap");
 
     IMAPInfo_t *imap = ARKIME_TYPE_ALLOC0(IMAPInfo_t);
-    imap->line = g_string_sized_new(256);
+    imap->line[0] = g_string_sized_new(256);
+    imap->line[1] = g_string_sized_new(256);
     imap->serverWhich = which;
 
     arkime_parsers_register(session, imap_parser, imap, imap_free);

--- a/capture/parsers/isis.c
+++ b/capture/parsers/isis.c
@@ -114,7 +114,7 @@ void arkime_parser_init()
 
 
     typeField = arkime_field_define("isis", "lotermfield",
-                                    "isis.msgType", "isis.msgType", "isis.msgType",
+                                    "isis.msgType", "Msg Type", "isis.msgType",
                                     "ISIS Msg Type field",
                                     ARKIME_FIELD_TYPE_STR_GHASH, 0,
                                     (char *)NULL);

--- a/capture/python.c
+++ b/capture/python.c
@@ -41,6 +41,21 @@ LOCAL __thread int arkimeReaderThread = -1;
 LOCAL int loadingThread = -1;
 
 /******************************************************************************/
+// Convert an opaque Python integer handle (created with PyLong_FromVoidPtr) back
+// into a C pointer. PyLong_AsVoidPtr returns NULL and sets an exception when the
+// argument isn't a valid integer; without this guard a wrong Python argument
+// would be used as an invalid pointer. Sets a ValueError if the handle is NULL
+// without an exception already set (e.g. a literal 0), then returns NULL so the
+// exception propagates back to Python.
+#define ARKIME_PY_HANDLE(var, type, obj) \
+    type *var = (type *)PyLong_AsVoidPtr(obj); \
+    if (var == NULL) { \
+        if (!PyErr_Occurred()) \
+            PyErr_SetString(PyExc_ValueError, "Invalid Arkime handle"); \
+        return NULL; \
+    }
+
+/******************************************************************************/
 LOCAL void arkime_python_cb_map_free(gpointer data)
 {
     ARKIME_TYPE_FREE(ArkimePyCbMap_t, data);
@@ -604,6 +619,8 @@ LOCAL PyObject *arkime_python_session_register_parser(PyObject UNUSED(*self), Py
         return NULL;
     }
 
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+
     if (!PyCallable_Check(py_callback_obj)) {
         PyErr_SetString(PyExc_TypeError, "Callback must be a callable Python object.");
         return NULL;
@@ -611,7 +628,7 @@ LOCAL PyObject *arkime_python_session_register_parser(PyObject UNUSED(*self), Py
     Py_INCREF(py_callback_obj);
 
     arkime_parsers_register2(
-        (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj), // Convert PyObject* to ArkimeSession_t*
+        session,
         arkime_python_session_parsers_cb,
         py_callback_obj,
         arkime_python_session_parsers_free_cb,
@@ -686,6 +703,8 @@ LOCAL PyObject *arkime_python_session_register_parser_buf(PyObject UNUSED(*self)
         return NULL;
     }
 
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+
     if (!PyCallable_Check(py_callback_obj)) {
         PyErr_SetString(PyExc_TypeError, "Callback must be a callable Python object.");
         return NULL;
@@ -697,7 +716,7 @@ LOCAL PyObject *arkime_python_session_register_parser_buf(PyObject UNUSED(*self)
     info->pb = arkime_parser_buf_create();
 
     arkime_parsers_register2(
-        (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj),
+        session,
         arkime_python_session_parsers_buf_cb,
         info,
         arkime_python_session_parsers_buf_free_cb,
@@ -715,7 +734,7 @@ LOCAL PyObject *arkime_python_parser_buf_del(PyObject UNUSED(*self), PyObject *a
         return NULL;
     }
 
-    ArkimeParserBuf_t *pb = (ArkimeParserBuf_t *)PyLong_AsVoidPtr(py_pb_obj);
+    ARKIME_PY_HANDLE(pb, ArkimeParserBuf_t, py_pb_obj);
     arkime_parser_buf_del(pb, which, len);
 
     Py_RETURN_NONE;
@@ -731,7 +750,7 @@ LOCAL PyObject *arkime_python_parser_buf_skip(PyObject UNUSED(*self), PyObject *
         return NULL;
     }
 
-    ArkimeParserBuf_t *pb = (ArkimeParserBuf_t *)PyLong_AsVoidPtr(py_pb_obj);
+    ARKIME_PY_HANDLE(pb, ArkimeParserBuf_t, py_pb_obj);
     arkime_parser_buf_skip(pb, which, skip);
 
     Py_RETURN_NONE;
@@ -747,10 +766,8 @@ LOCAL PyObject *arkime_python_session_add_tag(PyObject UNUSED(*self), PyObject *
     if (!PyArg_ParseTuple(args, "Os", &py_session_obj, &tag_str)) {
         return NULL;
     }
-    arkime_session_add_tag(
-        (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj), // Convert PyObject* to ArkimeSession_t*
-        tag_str
-    );
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+    arkime_session_add_tag(session, tag_str);
     Py_RETURN_NONE;
 }
 /******************************************************************************/
@@ -762,10 +779,8 @@ LOCAL PyObject *arkime_python_session_add_protocol(PyObject UNUSED(*self), PyObj
     if (!PyArg_ParseTuple(args, "Os", &py_session_obj, &protocol_str)) {
         return NULL;
     }
-    arkime_session_add_protocol(
-        (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj), // Convert PyObject* to ArkimeSession_t*
-        protocol_str
-    );
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+    arkime_session_add_protocol(session, protocol_str);
     Py_RETURN_NONE;
 }
 /******************************************************************************/
@@ -777,7 +792,8 @@ LOCAL PyObject *arkime_python_session_has_protocol(PyObject UNUSED(*self), PyObj
     if (!PyArg_ParseTuple(args, "Os", &py_session_obj, &protocol_str)) {
         return NULL;
     }
-    if (arkime_session_has_protocol((ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj), protocol_str)) {
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+    if (arkime_session_has_protocol(session, protocol_str)) {
         Py_RETURN_TRUE;
     } else {
         Py_RETURN_FALSE;
@@ -810,7 +826,8 @@ LOCAL PyObject *arkime_python_session_add_int(PyObject UNUSED(*self), PyObject *
         return NULL;
     }
 
-    gboolean result = arkime_field_int_add(pos, (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj), value);
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+    gboolean result = arkime_field_int_add(pos, session, value);
 
     if (result) {
         Py_RETURN_TRUE;
@@ -845,7 +862,8 @@ LOCAL PyObject *arkime_python_session_add_string(PyObject UNUSED(*self), PyObjec
         return NULL;
     }
 
-    const char *result = arkime_field_string_add(pos, (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj), value, -1, TRUE);
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+    const char *result = arkime_field_string_add(pos, session, value, -1, TRUE);
 
     if (result) {
         Py_RETURN_TRUE;
@@ -862,7 +880,8 @@ LOCAL PyObject *arkime_python_session_incref(PyObject UNUSED(*self), PyObject *a
         return NULL;
     }
 
-    arkime_session_incr_outstanding((ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj));
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+    arkime_session_incr_outstanding(session);
     Py_RETURN_NONE;
 }
 /******************************************************************************/
@@ -874,7 +893,8 @@ LOCAL PyObject *arkime_python_session_decref(PyObject UNUSED(*self), PyObject *a
         return NULL;
     }
 
-    arkime_session_decr_outstanding((ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj));
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
+    arkime_session_decr_outstanding(session);
     Py_RETURN_NONE;
 }
 /******************************************************************************/
@@ -898,7 +918,7 @@ LOCAL PyObject *arkime_python_session_get(PyObject UNUSED(*self), PyObject *args
         return NULL;
     }
 
-    ArkimeSession_t *session = (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj);
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
 
     int pos;
     if (isdigit(field[0]))
@@ -1114,7 +1134,7 @@ LOCAL PyObject *arkime_python_session_set_attr(PyObject UNUSED(*self), PyObject 
         return NULL;
     }
 
-    ArkimeSession_t *session = (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj);
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
 
     if (!session->pythonAttrs) {
         session->pythonAttrs = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, arkime_python_decref);
@@ -1135,7 +1155,7 @@ LOCAL PyObject *arkime_python_session_get_attr(PyObject UNUSED(*self), PyObject 
         return NULL;
     }
 
-    ArkimeSession_t *session = (ArkimeSession_t *)PyLong_AsVoidPtr(py_session_obj);
+    ARKIME_PY_HANDLE(session, ArkimeSession_t, py_session_obj);
 
     if (!session->pythonAttrs) {
         Py_RETURN_NONE;
@@ -1295,7 +1315,7 @@ LOCAL PyObject *arkime_python_packet_get(PyObject UNUSED(*self), PyObject *args)
         return NULL;
     }
 
-    const ArkimePacket_t *packet = (ArkimePacket_t *)PyLong_AsVoidPtr(py_packet_obj);
+    ARKIME_PY_HANDLE(packet, const ArkimePacket_t, py_packet_obj);
 
     switch (field[0]) {
     case 'c':
@@ -1400,7 +1420,7 @@ LOCAL PyObject *arkime_python_packet_set(PyObject UNUSED(*self), PyObject *args)
         return NULL;
     }
 
-    ArkimePacket_t *packet = (ArkimePacket_t *)PyLong_AsVoidPtr(py_packet_obj);
+    ARKIME_PY_HANDLE(packet, ArkimePacket_t, py_packet_obj);
 
     switch (field[0]) {
     case 'e':
@@ -1576,8 +1596,8 @@ LOCAL PyObject *arkime_python_run_ethernet_cb(PyObject UNUSED(*self), PyObject *
         return NULL;
     }
 
-    ArkimePacketBatch_t *batch = (ArkimePacketBatch_t *)PyLong_AsVoidPtr(py_batch_obj);
-    ArkimePacket_t *packet = (ArkimePacket_t *)PyLong_AsVoidPtr(py_packet_obj);
+    ARKIME_PY_HANDLE(batch, ArkimePacketBatch_t, py_batch_obj);
+    ARKIME_PY_HANDLE(packet, ArkimePacket_t, py_packet_obj);
 
     Py_buffer py_data_buf;
     if (PyObject_GetBuffer(py_packet_memview, &py_data_buf, PyBUF_SIMPLE) == -1) {
@@ -1605,8 +1625,8 @@ LOCAL PyObject *arkime_python_run_ip_cb(PyObject UNUSED(*self), PyObject *args)
         return NULL;
     }
 
-    ArkimePacketBatch_t *batch = (ArkimePacketBatch_t *)PyLong_AsVoidPtr(py_batch_obj);
-    ArkimePacket_t *packet = (ArkimePacket_t *)PyLong_AsVoidPtr(py_packet_obj);
+    ARKIME_PY_HANDLE(batch, ArkimePacketBatch_t, py_batch_obj);
+    ARKIME_PY_HANDLE(packet, ArkimePacket_t, py_packet_obj);
 
     Py_buffer py_data_buf;
     if (PyObject_GetBuffer(py_packet_memview, &py_data_buf, PyBUF_SIMPLE) == -1) {

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -117,7 +117,7 @@ LOCAL void scheme_file_monitor_dir(const char *dirname, ArkimeSchemeFlags flags,
     GDir     *dir = g_dir_open(dirname, 0, &error);
 
     if (error)
-        LOGEXIT("ERROR - Couldn't open pcap directory %s: Receive Error: %s", dirname, error->message);
+        LOGEXIT("ERROR - Couldn't open pcap directory %s: %s", dirname, error->message);
 
     while (1) {
         const gchar *filename = g_dir_read_name(dir);

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -158,7 +158,7 @@ LOCAL void scheme_s3_done(int code, uint8_t *data, int data_len, gpointer uw)
 
     if (next) {
         const char *endNext = arkime_memstr((const char *)data, data_len, "</NextContinuationToken>", 24);
-        if (next < endNext) {
+        if (endNext && next < endNext) {
             next += 23;
             req->continuation = scheme_s3_escape(next, endNext - next);
         }
@@ -449,6 +449,8 @@ LOCAL int scheme_s3_load_full_dir(const char *dir, ArkimeSchemeFlags flags, Arki
         .tryAgain = FALSE,
         .first = TRUE
     };
+
+    s3Items->done = 0;
 
     scheme_s3_request(server, creds, uri + strlen(shpb), paths[1], &req, TRUE, NULL);
 

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -42,6 +42,11 @@ LOCAL  int                   simpleGzipLevel;
 LOCAL  int                   simpleZstdLevel;
 LOCAL  int                   simpleFreeOutputBuffers;
 
+// mmap output buffer size: pcapWriteSize plus room for one worst-case record
+// written past the flush threshold: a max packet body (ARKIME_PACKET_MAX_LEN)
+// plus its 16 byte pcap record header.
+#define ARKIME_SIMPLE_BUFSIZE (config.pcapWriteSize + ARKIME_PACKET_MAX_LEN + 16)
+
 // Information about the current file being written to, all items that are constant per file should be here
 typedef struct {
     EVP_CIPHER_CTX      *cipher_ctx;
@@ -70,7 +75,7 @@ typedef struct {
 // NOTE this points to the file structure, kind of backwards
 typedef struct arkimesimple {
     struct arkimesimple *simple_next, *simple_prev;
-    uint8_t             *buf;     // mmap buffer, config.pcapWriteSize + ARKIME_PACKET_MAX_LEN
+    uint8_t             *buf;     // mmap buffer, ARKIME_SIMPLE_BUFSIZE bytes
     ArkimeSimpleFile_t  *file;
     uint32_t             bufpos;  // Where in buf we are writing to
     uint8_t              closing; // This is the last block, close file when done
@@ -150,7 +155,7 @@ LOCAL ArkimeSimple_t *writer_simple_alloc(ArkimeSimple_t *previous)
     if (!info) {
         // Freelist empty, allocate new
         info = ARKIME_TYPE_ALLOC0(ArkimeSimple_t);
-        info->buf = mmap (0, config.pcapWriteSize + ARKIME_PACKET_MAX_LEN, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+        info->buf = mmap (0, ARKIME_SIMPLE_BUFSIZE, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
         if (unlikely(info->buf == MAP_FAILED)) {
             LOGEXIT("ERROR - MMap failure in writer_simple_alloc, %d: %s", errno, strerror(errno));
         }
@@ -200,7 +205,7 @@ LOCAL void writer_simple_free(ArkimeSimple_t *info)
         ARKIME_UNLOCK(freeList);
     } else {
         ARKIME_UNLOCK(freeList);
-        munmap(info->buf, config.pcapWriteSize + ARKIME_PACKET_MAX_LEN);
+        munmap(info->buf, ARKIME_SIMPLE_BUFSIZE);
         ARKIME_TYPE_FREE(ArkimeSimple_t, info);
     }
 }
@@ -226,7 +231,7 @@ LOCAL ArkimeSimple_t *writer_simple_process_buf(int thread, int closing)
         case ARKIME_COMPRESSION_GZIP:
             // Start the gzip buffer after what we copied from previous buffer.
             ninfo->file->z_strm.next_out = (Bytef *) ninfo->buf + ninfo->bufpos;
-            ninfo->file->z_strm.avail_out = config.pcapWriteSize + ARKIME_PACKET_MAX_LEN - ninfo->bufpos;
+            ninfo->file->z_strm.avail_out = ARKIME_SIMPLE_BUFSIZE - ninfo->bufpos;
             break;
 #ifdef HAVE_ZSTD
         case ARKIME_COMPRESSION_ZSTD:
@@ -541,7 +546,7 @@ LOCAL void writer_simple_write(const ArkimeSession_t *const session, ArkimePacke
             compressionArg = "gzip";
 
             info->file->z_strm.next_out = (Bytef *) info->buf;
-            info->file->z_strm.avail_out = config.pcapWriteSize + ARKIME_PACKET_MAX_LEN;
+            info->file->z_strm.avail_out = ARKIME_SIMPLE_BUFSIZE;
             deflateInit2(&info->file->z_strm, simpleGzipLevel, Z_DEFLATED, 16 + 15, 9, Z_DEFAULT_STRATEGY);
             break;
 #ifdef HAVE_ZSTD
@@ -552,7 +557,7 @@ LOCAL void writer_simple_write(const ArkimeSession_t *const session, ArkimePacke
             compressionArg = "zstd";
 
             info->file->zstd_out.dst = info->buf;
-            info->file->zstd_out.size = config.pcapWriteSize + ARKIME_PACKET_MAX_LEN;
+            info->file->zstd_out.size = ARKIME_SIMPLE_BUFSIZE;
             info->file->zstd_out.pos = 0;
             info->file->zstd_completedBlockStart = 0;
             break;

--- a/cont3xt/common/vueapp/vueFilters.js
+++ b/cont3xt/common/vueapp/vueFilters.js
@@ -4,6 +4,25 @@
 import moment from 'moment-timezone';
 
 /**
+ * Returns url if it uses a safe scheme (http(s)/mailto/ftp/tel or relative),
+ * otherwise undefined. Rejects javascript:/data: and similar.
+ *
+ * @param {string} url The url to validate
+ * @returns {string|undefined}
+ */
+export const safeUrl = function (url) {
+  if (typeof url !== 'string') { return undefined; }
+
+  const stripped = url.replace(/[\u0000-\u001F\u007F-\u009F\s]/g, '');
+
+  if (/^[a-z][a-z0-9+.-]*:/i.test(stripped) && !/^(https?|mailto|ftp|tel):/i.test(stripped)) {
+    return undefined;
+  }
+
+  return url;
+};
+
+/**
  * Rounds a number using Math.round
  *
  * @example

--- a/cont3xt/vueapp/src/components/integrations/IntegrationValue.vue
+++ b/cont3xt/vueapp/src/components/integrations/IntegrationValue.vue
@@ -81,7 +81,7 @@ SPDX-License-Identifier: Apache-2.0
       <template v-else-if="field.type === 'externalLink'">
         <v-btn
           target="_blank"
-          :href="value.value"
+          :href="safeUrl(value.value)"
           size="x-small"
           class="integration-external-link-button square-btn-xs"
           variant="outlined"
@@ -94,7 +94,7 @@ SPDX-License-Identifier: Apache-2.0
       <template v-else-if="field.type === 'url'">
         <a
           target="_blank"
-          :href="value.value"
+          :href="safeUrl(value.value)"
           rel="noopener noreferrer"
           data-testid="integration-url">
           <highlightable-text
@@ -146,6 +146,7 @@ import HighlightableText from '@/utils/HighlightableText.vue';
 import { formatPostProcessedValue } from '@/utils/formatValue';
 import DnsRecords from '@/utils/DnsRecords.vue';
 import { clipboardCopyText } from '@/utils/clipboardCopyText';
+import { safeUrl } from '@common/vueFilters';
 import { getHighlightsForValue, getHighlightsForArray } from '@/utils/highlightUtil';
 
 export default {
@@ -265,6 +266,7 @@ export default {
       this.tableFilteredData = newFilteredData;
     },
     /* helpers ------------------------------------------------------------- */
+    safeUrl,
     findValue (data, field) {
       return formatPostProcessedValue(data, field);
     },

--- a/tests/pcap/v6-http.test
+++ b/tests/pcap/v6-http.test
@@ -466,8 +466,6 @@
        "AA"
       ],
       "opcode" : "QUERY",
-      "qc" : "(null)",
-      "qt" : "(null)",
       "queryHost" : "<root>",
       "status" : "NOERROR"
      },


### PR DESCRIPTION
- reader-scheme-s3.c: guard NULL endNext before pointer compare; reset s3Items->done in scheme_s3_load_full_dir so listings and continuation pages aren't skipped
- python.c: add ARKIME_PY_HANDLE guard so invalid opaque handles raise a Python exception instead of dereferencing NULL
- parsers/imap.c: buffer partial lines per-direction to avoid concatenating client/server data under the wrong direction
- parsers/dns.c: emit RFC 3597 CLASS%u/TYPE%u for unknown query class/type and omit reserved 0 instead of printing "(null)"
- writer-simple.c: size the mmap output buffer via ARKIME_SIMPLE_BUFSIZE (pcapWriteSize + max packet + record header)
- parsers/isis.c: use "Msg Type" friendly name for isis.msgType
- reader-scheme-file.c: drop bogus "Receive Error" from the opendir failure message
- arkime.h: type reloadFunc as ArkimePluginReloadFunc to match the definition
- cont3xt: add safeUrl sanitizer and use it for integration external link/url hrefs
- .github/workflows: pass release/snapshot inputs via env vars and validate them to avoid injection
- tests/pcap/v6-http.test: update DNS baseline for the class/type change

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
