### PR TITLE
Omit dns qc/qt fields when query class/type is unknown

### DIFF
--- a/capture/parsers/dns.c
+++ b/capture/parsers/dns.c
@@ -1432,8 +1432,13 @@ LOCAL void dns_save(BSB *jbsb, ArkimeFieldObject_t *object, struct arkime_sessio
     BSB_EXPORT_sprintf(*jbsb, "\"opcode\":\"%s\",", dns->query.opcode);
     BSB_EXPORT_sprintf(*jbsb, "\"queryHost\":");
     arkime_db_js0n_str(jbsb, (uint8_t *)dns->query.hostname, TRUE);
-    BSB_EXPORT_sprintf(*jbsb, ",\"qc\":\"%s\",", dns->query.class);
-    BSB_EXPORT_sprintf(*jbsb, "\"qt\":\"%s\",", dns->query.type);
+    if (dns->query.class) {
+        BSB_EXPORT_sprintf(*jbsb, ",\"qc\":\"%s\"", dns->query.class);
+    }
+    if (dns->query.type) {
+        BSB_EXPORT_sprintf(*jbsb, ",\"qt\":\"%s\"", dns->query.type);
+    }
+    BSB_EXPORT_u08(*jbsb, ',');
 
     if (HASH_COUNT(s_, dns->hosts) > 0) {
         SAVE_STRING_HASH(dns->hosts, "host");

--- a/tests/pcap/v6-http.test
+++ b/tests/pcap/v6-http.test
@@ -466,8 +466,6 @@
        "AA"
       ],
       "opcode" : "QUERY",
-      "qc" : "(null)",
-      "qt" : "(null)",
       "queryHost" : "<root>",
       "status" : "NOERROR"
      },


### PR DESCRIPTION
The qc/qt emission added in #4024/#4025 uses an unconditional `%s`, so a root query whose class/type lookup fails prints the literal `(null)` into the session JSON. Guard each field and skip it when unset, and drop the two `(null)` lines from `tests/pcap/v6-http.test` — mirroring arkime/ja4@f18adec1, which already removed them from the ja4 copy of the same expectation.

Found via PR #4029's CI, which was the first run to clone the ja4 repo after that expectation change; dev7's next push would fail the ja4plus job the same way without this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
