### PR TITLE
Rearchitect viewer page layout into an app-shell scroll container

### DIFF
--- a/common/vueapp/arkime-navbar.css
+++ b/common/vueapp/arkime-navbar.css
@@ -25,19 +25,23 @@ SPDX-License-Identifier: Apache-2.0
  *   <div class="navbarOffset" />   <!-- pushes content below the fixed bar -->
  */
 
+:root {
+  --arkime-navbar-height: 36px;
+}
+
 .arkime-navbar {
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  height: 36px;
+  height: var(--arkime-navbar-height);
   z-index: 7;
   background-color: rgb(var(--v-theme-primary-dark));
   color: rgb(var(--v-theme-button-fg));
   padding-left: 0.5rem;
 }
 .navbarOffset {
-  padding-top: 36px;
+  padding-top: var(--arkime-navbar-height);
 }
 
 /* brand (logo) -- router-link, intentionally narrow; the 40px-tall

--- a/common/vueapp/composables/useColumnResize.js
+++ b/common/vueapp/composables/useColumnResize.js
@@ -64,6 +64,7 @@ export function useColumnResize ({
     const cb = commit;
     const delta = w - startW;
     clearGuide();
+    col.classList.remove('col-resizing');
     col = null;
     grip = null;
     commit = null;
@@ -81,6 +82,7 @@ export function useColumnResize ({
     e.preventDefault();
     e.stopPropagation();
     col = columnEl;
+    col.classList.add('col-resizing'); // style hook for the active column
     grip = gripEl;
     startW = parseInt(columnEl.style.width, 10) ||
              columnEl.offsetWidth ||

--- a/viewer/vueapp/src/App.vue
+++ b/viewer/vueapp/src/App.vue
@@ -282,8 +282,11 @@ html {
   position: relative;
   min-height: 100%;
 }
+:root {
+  --arkime-footer-height: 25px;
+}
 #app {
-  padding-bottom: 25px;
+  padding-bottom: var(--arkime-footer-height);
 }
 
 /* global font, colors, and vars */
@@ -306,17 +309,19 @@ body {
   color: rgb(var(--v-theme-neutral));
 }
 
-/* displaying */
-.fixed-header {
-  z-index: 5;
-  position: fixed;
-  left: 0;
-  right: 0;
+/* toolbar chrome row on PageLayout pages: a normal flow row inside the
+   page shell */
+.page-toolbar {
   background-color: rgb(var(--v-theme-quaternary-lightest));
+  box-shadow: 0 0 16px -2px black;
+}
 
-  -webkit-box-shadow: 0 0 16px -2px black;
-     -moz-box-shadow: 0 0 16px -2px black;
-          box-shadow: 0 0 16px -2px black;
+/* page sub-navbar band: the page-specific control row below the search
+   toolbar — a comfortable fixed-height band with vertically-centered
+   content, matching the Sessions paging bar. */
+.page-shell .page-subnav {
+  align-items: center;
+  min-height: 44px;
 }
 
 /* themed buttons */

--- a/viewer/vueapp/src/components/arkime/Arkime.vue
+++ b/viewer/vueapp/src/components/arkime/Arkime.vue
@@ -3,131 +3,137 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div
-    class="arkime-page"
-    :class="{'hide-tool-bars': !showToolBars}">
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <!-- search navbar -->
-        <arkime-search
-          :hide-actions="true"
-          @change-search="loadSummary"
-          @recalc-collapse="$emit('recalc-collapse')" />
+  <page-layout class="arkime-page">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- search navbar -->
+          <arkime-search
+            :hide-actions="true"
+            @change-search="loadSummary" />
 
-        <!-- toolbar row -->
-        <div class="d-flex justify-start align-center ms-2 m-1 gap-2">
-          <!-- results per widget dropdown -->
-          <v-menu>
-            <template #activator="{ props }">
-              <v-btn
-                v-bind="props"
-                size="large"
-                variant="flat"
-                color="secondary">
-                {{ summaryResultsLimit }}
-                <v-icon
-                  end
-                  icon="mdi-menu-down" />
-              </v-btn>
-            </template>
-            <v-list density="compact">
-              <v-list-item
-                v-for="opt in [10, 20, 50, 100]"
-                :key="opt"
-                :active="summaryResultsLimit === opt"
-                @click="updateSummaryResultsLimit(opt)">
-                <v-list-item-title>{{ opt }}</v-list-item-title>
-              </v-list-item>
-            </v-list>
-          </v-menu>
+          <!-- toolbar row -->
+          <div class="d-flex justify-start align-center ms-2 gap-2 page-subnav">
+            <!-- results per widget dropdown -->
+            <v-menu>
+              <template #activator="{ props }">
+                <v-btn
+                  v-bind="props"
+                  size="large"
+                  variant="flat"
+                  color="secondary">
+                  {{ summaryResultsLimit }}
+                  <v-icon
+                    end
+                    icon="mdi-menu-down" />
+                </v-btn>
+              </template>
+              <v-list density="compact">
+                <v-list-item
+                  v-for="opt in [10, 20, 50, 100]"
+                  :key="opt"
+                  :active="summaryResultsLimit === opt"
+                  @click="updateSummaryResultsLimit(opt)">
+                  <v-list-item-title>{{ opt }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
 
-          <!-- top/bottom results toggle -->
-          <v-menu>
-            <template #activator="{ props }">
-              <v-btn
-                v-bind="props"
-                size="large"
-                variant="flat"
-                color="secondary">
-                {{ summaryOrder === 'asc' ? 'Bottom' : 'Top' }}
-                <v-icon
-                  end
-                  icon="mdi-menu-down" />
-              </v-btn>
-            </template>
-            <v-list density="compact">
-              <v-list-item
-                :active="summaryOrder === 'desc'"
-                @click="updateSummaryOrder('desc')">
-                <v-list-item-title>Top</v-list-item-title>
-              </v-list-item>
-              <v-list-item
-                :active="summaryOrder === 'asc'"
-                @click="updateSummaryOrder('asc')">
-                <v-list-item-title>Bottom</v-list-item-title>
-              </v-list-item>
-            </v-list>
-          </v-menu>
+            <!-- top/bottom results toggle -->
+            <v-menu>
+              <template #activator="{ props }">
+                <v-btn
+                  v-bind="props"
+                  size="large"
+                  variant="flat"
+                  color="secondary">
+                  {{ summaryOrder === 'asc' ? 'Bottom' : 'Top' }}
+                  <v-icon
+                    end
+                    icon="mdi-menu-down" />
+                </v-btn>
+              </template>
+              <v-list density="compact">
+                <v-list-item
+                  :active="summaryOrder === 'desc'"
+                  @click="updateSummaryOrder('desc')">
+                  <v-list-item-title>Top</v-list-item-title>
+                </v-list-item>
+                <v-list-item
+                  :active="summaryOrder === 'asc'"
+                  @click="updateSummaryOrder('asc')">
+                  <v-list-item-title>Bottom</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
 
-          <!-- export all charts as PNG -->
-          <v-btn
-            :aria-label="$t('sessions.summary.exportAllPNG')"
-            size="large"
-            variant="flat"
-            color="secondary"
-            @click="exportAllPNG">
-            <v-icon icon="mdi-download" />
-            <v-tooltip
-              activator="parent"
-              :open-delay="500">
-              {{ $t('sessions.summary.exportAllPNG') }} — {{ $t('sessions.summary.exportPNGTableWarning') }}
-            </v-tooltip>
-          </v-btn>
+            <!-- export all charts as PNG -->
+            <v-btn
+              :aria-label="$t('sessions.summary.exportAllPNG')"
+              size="large"
+              variant="flat"
+              color="secondary"
+              @click="exportAllPNG">
+              <v-icon icon="mdi-download" />
+              <v-tooltip
+                activator="parent"
+                :open-delay="500">
+                {{ $t('sessions.summary.exportAllPNG') }} — {{ $t('sessions.summary.exportPNGTableWarning') }}
+              </v-tooltip>
+            </v-btn>
 
-          <!-- summary field visibility + config group -->
-          <v-btn-group
-            divided
-            density="compact"
-            variant="flat"
-            color="secondary">
-            <FieldSelectDropdown
-              :selected-fields="summaryFields"
-              :tooltip-text="$t('sessions.summary.toggleFields')"
-              :search-placeholder="$t('sessions.summary.searchFields')"
-              :include-summary-fields="true"
-              field-id-key="exp"
-              @toggle="toggleSummaryField"
-              @clear="clearSummaryFields" />
-            <SummaryConfigDropdown
-              :current-config="currentSummaryConfig"
-              @load="loadSummaryConfigFromShareable"
-              @reset="resetSummaryToDefaults"
-              @message="displayMessage" />
-          </v-btn-group>
+            <!-- summary field visibility + config group -->
+            <v-btn-group
+              divided
+              density="compact"
+              variant="flat"
+              color="secondary">
+              <FieldSelectDropdown
+                :selected-fields="summaryFields"
+                :tooltip-text="$t('sessions.summary.toggleFields')"
+                :search-placeholder="$t('sessions.summary.searchFields')"
+                :include-summary-fields="true"
+                field-id-key="exp"
+                @toggle="toggleSummaryField"
+                @clear="clearSummaryFields" />
+              <SummaryConfigDropdown
+                :current-config="currentSummaryConfig"
+                @load="loadSummaryConfigFromShareable"
+                @reset="resetSummaryToDefaults"
+                @message="displayMessage" />
+            </v-btn-group>
 
-          <!-- cancel loading button -->
-          <v-btn
-            v-if="summaryStreaming"
-            size="large"
-            variant="flat"
-            color="warning"
-            @click="cancelSummaryLoading">
-            <v-icon icon="mdi-cancel" />&nbsp;
-            {{ $t('common.cancel') }}
-          </v-btn>
+            <!-- cancel loading button -->
+            <v-btn
+              v-if="summaryStreaming"
+              size="large"
+              variant="flat"
+              color="warning"
+              @click="cancelSummaryLoading">
+              <v-icon icon="mdi-cancel" />&nbsp;
+              {{ $t('common.cancel') }}
+            </v-btn>
+          </div>
         </div>
+      </ArkimeCollapsible>
+      <!-- pinned visualizations land here (teleported from below) -->
+      <div id="viz-pin-anchor" />
+    </template>
 
-      </span>
-    </ArkimeCollapsible>
-
-    <!-- visualizations -->
-    <arkime-visualizations
-      v-if="graphData && showToolBars"
-      :primary="true"
-      :map-data="mapData"
-      :graph-data="graphData"
-      :timeline-data-filters="timelineDataFilters"
-      @spanning-change="reloadSummaryView" />
+    <!-- visualizations: pinned = chrome row above the scroll container,
+         unpinned = scrolls away with the content -->
+    <teleport
+      defer
+      to="#viz-pin-anchor"
+      :disabled="!stickyViz">
+      <arkime-visualizations
+        v-if="graphData && showToolBars"
+        :primary="true"
+        :map-data="mapData"
+        :graph-data="graphData"
+        :timeline-data-filters="timelineDataFilters"
+        @spanning-change="reloadSummaryView" />
+    </teleport> <!-- /visualizations -->
 
     <!-- error message -->
     <v-alert
@@ -152,8 +158,7 @@ SPDX-License-Identifier: Apache-2.0
         @widget-config-changed="updateWidgetConfigs"
         @remove-field="toggleSummaryField"
         @streaming-state="summaryStreaming = $event"
-        @canceled-state="summaryCanceled = $event"
-        @recalc-collapse="$emit('recalc-collapse')" />
+        @canceled-state="summaryCanceled = $event" />
     </div>
 
     <!-- stale data warning after cancellation -->
@@ -180,12 +185,13 @@ SPDX-License-Identifier: Apache-2.0
         {{ $t('sessions.summary.retryAllFailed') }}
       </v-btn>
     </v-alert>
-  </div>
+  </page-layout>
 </template>
 
 <script>
 import ArkimeSearch from '../search/Search.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import ArkimeVisualizations from '../visualizations/Visualizations.vue';
 import ArkimeSummaryView from '../summary/Summary.vue';
 import FieldSelectDropdown from '../utils/FieldSelectDropdown.vue';
@@ -199,12 +205,12 @@ export default {
   components: {
     ArkimeSearch,
     ArkimeCollapsible,
+    PageLayout,
     ArkimeVisualizations,
     ArkimeSummaryView,
     FieldSelectDropdown,
     SummaryConfigDropdown
   },
-  emits: ['recalc-collapse'],
   data: function () {
     return {
       // Summary configuration
@@ -225,6 +231,9 @@ export default {
   computed: {
     showToolBars: function () {
       return this.$store.state.showToolBars;
+    },
+    stickyViz: function () {
+      return this.$store.state.stickyViz;
     },
     user: function () {
       return this.$store.state.user;
@@ -257,6 +266,11 @@ export default {
     }
   },
   watch: {
+    '$store.state.stickyViz': function () {
+      // pin toggle teleports the viz between chrome and scroll content;
+      // charts/map cache geometry, so nudge their resize handling
+      this.$nextTick(() => window.dispatchEvent(new Event('resize')));
+    },
     // Handle browser back/forward navigation for summaryLength
     '$route.query.summaryLength': function (newValue) {
       const newLimit = parseInt(newValue) || 20;
@@ -417,10 +431,6 @@ export default {
 </script>
 
 <style scoped>
-.arkime-page.hide-tool-bars .fixed-header {
-  display: none;
-}
-
 .arkime-content {
   margin-right: 0.5rem;
 }

--- a/viewer/vueapp/src/components/connections/Connections.vue
+++ b/viewer/vueapp/src/components/connections/Connections.vue
@@ -3,312 +3,353 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div class="connections-page">
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <!-- search navbar -->
-        <arkime-search
-          :start="query.start"
-          @change-search="cancelAndLoad(true)"
-          @recalc-collapse="$emit('recalc-collapse')" /> <!-- /search navbar -->
+  <page-layout
+    ref="pageLayout"
+    class="connections-page">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- search navbar -->
+          <arkime-search
+            :start="query.start"
+            @change-search="cancelAndLoad(true)" /> <!-- /search navbar -->
 
-        <!-- connections sub navbar -->
-        <div class="connections-form m-1">
-          <div class="d-flex flex-wrap align-center gap-1">
+          <!-- connections sub navbar -->
+          <div class="connections-form mx-1">
+            <div class="d-flex flex-wrap align-center gap-1 page-subnav">
+              <!-- query size select -->
+              <div class="arkime-input-group">
+                <span
+                  id="querySize"
+                  class="arkime-input-label cursor-help">
+                  {{ $t('connections.querySize') }}
+                </span>
+                <v-tooltip
+                  activator="#querySize"
+                  :open-delay="300">
+                  {{ $t('connections.querySizeTip') }}
+                </v-tooltip>
+                <select
+                  class="arkime-input-control"
+                  :value="query.length"
+                  @change="changeLength(Number($event.target.value))">
+                  <option
+                    v-for="opt in [100, 500, 1000, 5000, 10000, 50000, 100000]"
+                    :key="opt"
+                    :value="opt">
+                    {{ opt }}
+                  </option>
+                </select>
+              </div> <!-- /query size select -->
 
-            <!-- query size select -->
-            <div class="arkime-input-group">
+              <!-- src select -->
+              <div
+                class="connections-field-row"
+                v-if="fields && fields.length && srcFieldTypeahead && fieldHistoryConnectionsSrc">
+                <span
+                  class="connections-legend-cell primary-legend cursor-help"
+                  id="sourceField">
+                  Src:
+                </span>
+                <v-tooltip
+                  activator="#sourceField"
+                  :open-delay="300">
+                  {{ $t('connections.sourceFieldTip') }}
+                </v-tooltip>
+                <arkime-field-typeahead
+                  :fields="fields"
+                  query-param="srcField"
+                  :initial-value="srcFieldTypeahead"
+                  @field-selected="changeSrcField"
+                  :history="fieldHistoryConnectionsSrc"
+                  page="ConnectionsSrc" />
+              </div> <!-- /src select -->
+
+              <!-- dst select -->
+              <div
+                class="connections-field-row"
+                v-if="fields && dstFieldTypeahead && fieldHistoryConnectionsDst">
+                <span
+                  class="connections-legend-cell secondary-legend cursor-help"
+                  id="dstField">
+                  Dst:
+                </span>
+                <v-tooltip
+                  activator="#dstField"
+                  :open-delay="300">
+                  {{ $t('connections.dstFieldTip') }}
+                </v-tooltip>
+                <arkime-field-typeahead
+                  :fields="fields"
+                  query-param="dstField"
+                  :initial-value="dstFieldTypeahead"
+                  @field-selected="changeDstField"
+                  :history="fieldHistoryConnectionsDst"
+                  page="ConnectionsDst" />
+              </div> <!-- /dst select -->
+
+              <!-- src & dst color -->
               <span
-                id="querySize"
-                class="arkime-input-label cursor-help">
-                {{ $t('connections.querySize') }}
+                class="connections-legend-cell connections-legend-standalone tertiary-legend cursor-help"
+                id="srcDstColor">
+                Src &amp; dst
               </span>
               <v-tooltip
-                activator="#querySize"
+                activator="#srcDstColor"
                 :open-delay="300">
-                {{ $t('connections.querySizeTip') }}
-              </v-tooltip>
-              <select
-                class="arkime-input-control"
-                :value="query.length"
-                @change="changeLength(Number($event.target.value))">
-                <option
-                  v-for="opt in [100, 500, 1000, 5000, 10000, 50000, 100000]"
-                  :key="opt"
-                  :value="opt">{{ opt }}</option>
-              </select>
-            </div> <!-- /query size select -->
+                {{ $t('connections.srcDstColorTip') }}
+              </v-tooltip> <!-- /src & dst color -->
 
-            <!-- src select -->
-            <div
-              class="connections-field-row"
-              v-if="fields && fields.length && srcFieldTypeahead && fieldHistoryConnectionsSrc">
-              <span
-                class="connections-legend-cell primary-legend cursor-help"
-                id="sourceField">
-                Src:
-              </span>
-              <v-tooltip
-                activator="#sourceField"
-                :open-delay="300">
-                {{ $t('connections.sourceFieldTip') }}
-              </v-tooltip>
-              <arkime-field-typeahead
-                :fields="fields"
-                query-param="srcField"
-                :initial-value="srcFieldTypeahead"
-                @field-selected="changeSrcField"
-                :history="fieldHistoryConnectionsSrc"
-                page="ConnectionsSrc" />
-            </div> <!-- /src select -->
+              <!-- min connections select -->
+              <div class="arkime-input-group">
+                <span
+                  id="minConn"
+                  class="arkime-input-label help-cursor">
+                  {{ $t('connections.minConn') }}
+                </span>
+                <v-tooltip
+                  activator="#minConn"
+                  :open-delay="300">
+                  {{ $t('connections.minConnTip') }}
+                </v-tooltip>
+                <select
+                  class="arkime-input-control"
+                  :value="query.minConn"
+                  @change="changeMinConn(Number($event.target.value))">
+                  <option
+                    v-for="opt in [1,2,3,4,5]"
+                    :key="opt"
+                    :value="opt">
+                    {{ opt }}
+                  </option>
+                </select>
+              </div> <!-- /min connections select -->
 
-            <!-- dst select -->
-            <div
-              class="connections-field-row"
-              v-if="fields && dstFieldTypeahead && fieldHistoryConnectionsDst">
-              <span
-                class="connections-legend-cell secondary-legend cursor-help"
-                id="dstField">
-                Dst:
-              </span>
-              <v-tooltip
-                activator="#dstField"
-                :open-delay="300">
-                {{ $t('connections.dstFieldTip') }}
-              </v-tooltip>
-              <arkime-field-typeahead
-                :fields="fields"
-                query-param="dstField"
-                :initial-value="dstFieldTypeahead"
-                @field-selected="changeDstField"
-                :history="fieldHistoryConnectionsDst"
-                page="ConnectionsDst" />
-            </div> <!-- /dst select -->
+              <!-- weight select -->
+              <div class="arkime-input-group">
+                <span
+                  class="arkime-input-label help-cursor"
+                  id="weight">
+                  {{ $t('connections.weight') }}
+                </span>
+                <v-tooltip
+                  activator="#weight"
+                  :open-delay="300">
+                  {{ $t('connections.weightTip') }}
+                </v-tooltip>
+                <select
+                  class="arkime-input-control"
+                  :value="weight"
+                  @change="changeWeight($event.target.value)">
+                  <option
+                    value="sessions"
+                    v-i18n-value="'connections.weight-'" />
+                  <option
+                    value="network.packets"
+                    v-i18n-value="'connections.weight-'" />
+                  <option
+                    value="network.bytes"
+                    v-i18n-value="'connections.weight-'" />
+                  <option
+                    value="totDataBytes"
+                    v-i18n-value="'connections.weight-'" />
+                  <option
+                    value=""
+                    v-i18n-value="'connections.weight-'" />
+                </select>
+              </div> <!-- /weight select -->
 
-            <!-- src & dst color -->
-            <span
-              class="connections-legend-cell connections-legend-standalone tertiary-legend cursor-help"
-              id="srcDstColor">
-              Src &amp; dst
-            </span>
-            <v-tooltip
-              activator="#srcDstColor"
-              :open-delay="300">
-              {{ $t('connections.srcDstColorTip') }}
-            </v-tooltip> <!-- /src & dst color -->
-
-            <!-- min connections select -->
-            <div class="arkime-input-group">
-              <span
-                id="minConn"
-                class="arkime-input-label help-cursor">
-                {{ $t('connections.minConn') }}
-              </span>
-              <v-tooltip
-                activator="#minConn"
-                :open-delay="300">
-                {{ $t('connections.minConnTip') }}
-              </v-tooltip>
-              <select
-                class="arkime-input-control"
-                :value="query.minConn"
-                @change="changeMinConn(Number($event.target.value))">
-                <option
-                  v-for="opt in [1,2,3,4,5]"
-                  :key="opt"
-                  :value="opt">{{ opt }}</option>
-              </select>
-            </div> <!-- /min connections select -->
-
-            <!-- weight select -->
-            <div class="arkime-input-group">
-              <span
-                class="arkime-input-label help-cursor"
-                id="weight">
-                {{ $t('connections.weight') }}
-              </span>
-              <v-tooltip
-                activator="#weight"
-                :open-delay="300">
-                {{ $t('connections.weightTip') }}
-              </v-tooltip>
-              <select
-                class="arkime-input-control"
-                :value="weight"
-                @change="changeWeight($event.target.value)">
-                <option
-                  value="sessions"
-                  v-i18n-value="'connections.weight-'" />
-                <option
-                  value="network.packets"
-                  v-i18n-value="'connections.weight-'" />
-                <option
-                  value="network.bytes"
-                  v-i18n-value="'connections.weight-'" />
-                <option
-                  value="totDataBytes"
-                  v-i18n-value="'connections.weight-'" />
-                <option
-                  value=""
-                  v-i18n-value="'connections.weight-'" />
-              </select>
-            </div> <!-- /weight select -->
-
-            <div
-              v-if="!loading"
-              class="d-inline-flex">
-              <!-- node + link field-visibility menus (same shape, kind='node'|'link') -->
-              <template
-                v-for="m in fieldVisMenus"
-                :key="m.kind">
-                <v-menu
-                  v-if="fields && groupedFields && fieldList(m.kind)"
-                  :close-on-content-click="false"
-                  location="bottom start">
-                  <template #activator="{ props: activatorProps }">
-                    <v-btn
-                      v-bind="activatorProps"
-                      variant="flat"
-                      size="large"
-                      color="primary"
-                      class="ms-1 field-vis-trigger"
-                      :id="`${m.kind}Fields`">
-                      <v-icon :icon="m.icon" />
-                      <v-tooltip
-                        activator="parent"
-                        :open-delay="300">
-                        {{ $t(m.tipKey) }}
-                      </v-tooltip>
-                    </v-btn>
-                  </template>
-                  <v-list
-                    density="compact"
-                    class="field-vis-list">
-                    <div class="px-2 py-1">
-                      <div class="arkime-input-group arkime-input-group--fluid">
-                        <span class="arkime-input-label arkime-input-label-fw">
-                          <v-icon icon="mdi-magnify" />
-                        </span>
-                        <input
-                          type="text"
-                          v-model="fieldQuery"
-                          class="arkime-input-control"
-                          :placeholder="$t('common.searchForFields')">
-                      </div>
-                    </div>
-                    <v-divider />
-                    <v-list-item @click.stop.prevent="resetFieldVisibility(m.kind)">
-                      {{ $t('connections.reset') }}
-                    </v-list-item>
-                    <v-divider />
-                    <template
-                      v-for="(group, key) in filteredFields"
-                      :key="key">
-                      <v-list-subheader
-                        v-if="group.length"
-                        class="field-vis-group-header">
-                        {{ key }}
-                      </v-list-subheader>
-                      <template
-                        v-for="(field, k) in group"
-                        :key="key + k + m.kind">
-                        <v-list-item
-                          :data-tip-id="key + k + m.kind"
-                          :active="isFieldVisible(field.dbField, fieldList(m.kind)) >= 0"
-                          @click.stop.prevent="toggleFieldVisibility(field.dbField, fieldList(m.kind))">
-                          {{ field.friendlyName }}
-                          <small>({{ field.exp }})</small>
-                          <v-tooltip
-                            :activator="`[data-tip-id='${key + k + m.kind}']`"
-                            :open-delay="300">
-                            {{ field.help }}
-                          </v-tooltip>
-                        </v-list-item>
-                      </template>
+              <div
+                v-if="!loading"
+                class="d-inline-flex">
+                <!-- node + link field-visibility menus (same shape, kind='node'|'link') -->
+                <template
+                  v-for="m in fieldVisMenus"
+                  :key="m.kind">
+                  <v-menu
+                    v-if="fields && groupedFields && fieldList(m.kind)"
+                    :close-on-content-click="false"
+                    location="bottom start">
+                    <template #activator="{ props: activatorProps }">
+                      <v-btn
+                        v-bind="activatorProps"
+                        variant="flat"
+                        size="large"
+                        color="primary"
+                        class="ms-1 field-vis-trigger"
+                        :id="`${m.kind}Fields`">
+                        <v-icon :icon="m.icon" />
+                        <v-tooltip
+                          activator="parent"
+                          :open-delay="300">
+                          {{ $t(m.tipKey) }}
+                        </v-tooltip>
+                      </v-btn>
                     </template>
-                  </v-list>
-                </v-menu>
-              </template> <!-- /field-visibility menus -->
+                    <v-list
+                      density="compact"
+                      class="field-vis-list">
+                      <div class="px-2 py-1">
+                        <div class="arkime-input-group arkime-input-group--fluid">
+                          <span class="arkime-input-label arkime-input-label-fw">
+                            <v-icon icon="mdi-magnify" />
+                          </span>
+                          <input
+                            type="text"
+                            v-model="fieldQuery"
+                            class="arkime-input-control"
+                            :placeholder="$t('common.searchForFields')">
+                        </div>
+                      </div>
+                      <v-divider />
+                      <v-list-item @click.stop.prevent="resetFieldVisibility(m.kind)">
+                        {{ $t('connections.reset') }}
+                      </v-list-item>
+                      <v-divider />
+                      <template
+                        v-for="(group, key) in filteredFields"
+                        :key="key">
+                        <v-list-subheader
+                          v-if="group.length"
+                          class="field-vis-group-header">
+                          {{ key }}
+                        </v-list-subheader>
+                        <template
+                          v-for="(field, k) in group"
+                          :key="key + k + m.kind">
+                          <v-list-item
+                            :data-tip-id="key + k + m.kind"
+                            :active="isFieldVisible(field.dbField, fieldList(m.kind)) >= 0"
+                            @click.stop.prevent="toggleFieldVisibility(field.dbField, fieldList(m.kind))">
+                            {{ field.friendlyName }}
+                            <small>({{ field.exp }})</small>
+                            <v-tooltip
+                              :activator="`[data-tip-id='${key + k + m.kind}']`"
+                              :open-delay="300">
+                              {{ field.help }}
+                            </v-tooltip>
+                          </v-list-item>
+                        </template>
+                      </template>
+                    </v-list>
+                  </v-menu>
+                </template> <!-- /field-visibility menus -->
+              </div>
+
+              <!-- network baseline time range -->
+              <div class="arkime-input-group">
+                <span
+                  class="arkime-input-label help-cursor"
+                  id="baselineDate">
+                  {{ $t('connections.baselineDate') }}
+                </span>
+                <v-tooltip
+                  activator="#baselineDate"
+                  :open-delay="300">
+                  {{ $t('connections.baselineDateTip') }}
+                </v-tooltip>
+                <select
+                  class="arkime-input-control"
+                  v-model="query.baselineDate"
+                  @change="changeBaselineDate">
+                  <option value="0">
+                    {{ $t('common.optionDisabled') }}
+                  </option>
+                  <option value="1x">
+                    {{ $t('connections.queryRange', 1) }}
+                  </option>
+                  <option value="2x">
+                    {{ $t('connections.queryRange', 2) }}
+                  </option>
+                  <option value="4x">
+                    {{ $t('connections.queryRange', 4) }}
+                  </option>
+                  <option value="6x">
+                    {{ $t('connections.queryRange', 6) }}
+                  </option>
+                  <option value="8x">
+                    {{ $t('connections.queryRange', 8) }}
+                  </option>
+                  <option value="10x">
+                    {{ $t('connections.queryRange', 10) }}
+                  </option>
+                  <option value="1">
+                    {{ $t('common.hourCount', 1) }}
+                  </option>
+                  <option value="6">
+                    {{ $t('common.hourCount', 6) }}
+                  </option>
+                  <option value="24">
+                    {{ $t('common.hourCount', 24) }}
+                  </option>
+                  <option value="48">
+                    {{ $t('common.hourCount', 48) }}
+                  </option>
+                  <option value="72">
+                    {{ $t('common.hourCount', 72) }}
+                  </option>
+                  <option value="168">
+                    {{ $t('common.weekCount', 1) }}
+                  </option>
+                  <option value="336">
+                    {{ $t('common.weekCount', 2) }}
+                  </option>
+                  <option value="720">
+                    {{ $t('common.monthCount', 1) }}
+                  </option>
+                  <option value="1440">
+                    {{ $t('common.monthCount', 2) }}
+                  </option>
+                  <option value="4380">
+                    {{ $t('common.monthCount', 6) }}
+                  </option>
+                  <option value="8760">
+                    {{ $t('common.yearCount', 1) }}
+                  </option>
+                </select>
+              </div> <!-- /network baseline time range -->
+
+              <!-- network baseline node visibility -->
+              <div
+                class="arkime-input-group"
+                v-show="query.baselineDate !== '0'">
+                <span
+                  class="arkime-input-label help-cursor"
+                  id="baselineVis">
+                  {{ $t('connections.baselineVis') }}
+                </span>
+                <v-tooltip
+                  activator="#baselineVis"
+                  :open-delay="300">
+                  {{ $t('connections.baselineVisTip') }}
+                </v-tooltip>
+                <select
+                  class="arkime-input-control"
+                  :disabled="query.baselineDate === '0'"
+                  v-model="query.baselineVis"
+                  @change="changeBaselineVis">
+                  <option
+                    value="all"
+                    v-i18n-value="'connections.baselineVis-'" />
+                  <option
+                    value="actual"
+                    v-i18n-value="'connections.baselineVis-'" />
+                  <option
+                    value="actualold"
+                    v-i18n-value="'connections.baselineVis-'" />
+                  <option
+                    value="new"
+                    v-i18n-value="'connections.baselineVis-'" />
+                  <option
+                    value="old"
+                    v-i18n-value="'connections.baselineVis-'" />
+                </select>
+              </div> <!-- /network baseline node visibility -->
             </div>
-
-            <!-- network baseline time range -->
-            <div class="arkime-input-group">
-              <span
-                class="arkime-input-label help-cursor"
-                id="baselineDate">
-                {{ $t('connections.baselineDate') }}
-              </span>
-              <v-tooltip
-                activator="#baselineDate"
-                :open-delay="300">
-                {{ $t('connections.baselineDateTip') }}
-              </v-tooltip>
-              <select
-                class="arkime-input-control"
-                v-model="query.baselineDate"
-                @change="changeBaselineDate">
-                <option value="0">{{ $t('common.optionDisabled') }}</option>
-                <option value="1x">{{ $t('connections.queryRange', 1) }}</option>
-                <option value="2x">{{ $t('connections.queryRange', 2) }}</option>
-                <option value="4x">{{ $t('connections.queryRange', 4) }}</option>
-                <option value="6x">{{ $t('connections.queryRange', 6) }}</option>
-                <option value="8x">{{ $t('connections.queryRange', 8) }}</option>
-                <option value="10x">{{ $t('connections.queryRange', 10) }}</option>
-                <option value="1">{{ $t('common.hourCount', 1) }}</option>
-                <option value="6">{{ $t('common.hourCount', 6) }}</option>
-                <option value="24">{{ $t('common.hourCount', 24) }}</option>
-                <option value="48">{{ $t('common.hourCount', 48) }}</option>
-                <option value="72">{{ $t('common.hourCount', 72) }}</option>
-                <option value="168">{{ $t('common.weekCount', 1) }}</option>
-                <option value="336">{{ $t('common.weekCount', 2) }}</option>
-                <option value="720">{{ $t('common.monthCount', 1) }}</option>
-                <option value="1440">{{ $t('common.monthCount', 2) }}</option>
-                <option value="4380">{{ $t('common.monthCount', 6) }}</option>
-                <option value="8760">{{ $t('common.yearCount', 1) }}</option>
-              </select>
-            </div> <!-- /network baseline time range -->
-
-            <!-- network baseline node visibility -->
-            <div
-              class="arkime-input-group"
-              v-show="query.baselineDate !== '0'">
-              <span
-                class="arkime-input-label help-cursor"
-                id="baselineVis">
-                {{ $t('connections.baselineVis') }}
-              </span>
-              <v-tooltip
-                activator="#baselineVis"
-                :open-delay="300">
-                {{ $t('connections.baselineVisTip') }}
-              </v-tooltip>
-              <select
-                class="arkime-input-control"
-                :disabled="query.baselineDate === '0'"
-                v-model="query.baselineVis"
-                @change="changeBaselineVis">
-                <option
-                  value="all"
-                  v-i18n-value="'connections.baselineVis-'" />
-                <option
-                  value="actual"
-                  v-i18n-value="'connections.baselineVis-'" />
-                <option
-                  value="actualold"
-                  v-i18n-value="'connections.baselineVis-'" />
-                <option
-                  value="new"
-                  v-i18n-value="'connections.baselineVis-'" />
-                <option
-                  value="old"
-                  v-i18n-value="'connections.baselineVis-'" />
-              </select>
-            </div> <!-- /network baseline node visibility -->
-
-          </div>
-        </div> <!-- /connections sub navbar -->
-      </span>
-    </ArkimeCollapsible>
+          </div> <!-- /connections sub navbar -->
+        </div>
+      </ArkimeCollapsible>
+    </template>
 
     <div class="connections-content">
       <!-- loading overlay -->
@@ -356,11 +397,11 @@ SPDX-License-Identifier: Apache-2.0
             @hide-link="hideLink" />
         </div>
       </div> <!-- /popup area -->
+    </div>
 
+    <template #overlay>
       <!-- Button group -->
-      <div
-        class="connections-buttons d-flex align-center ga-2"
-        :style="[showToolBars ? {'top': '175px'} : {'top': '55px'}]">
+      <div class="connections-buttons d-flex align-center ga-2">
         <!-- unlock + export -->
         <div class="d-flex ga-1">
           <v-btn
@@ -511,8 +552,8 @@ SPDX-License-Identifier: Apache-2.0
           </v-btn>
         </div>
       </div> <!-- /Button group -->
-    </div>
-  </div>
+    </template>
+  </page-layout>
 </template>
 
 <script>
@@ -522,6 +563,7 @@ import ArkimeError from '../utils/Error.vue';
 import ArkimeLoading from '../utils/Loading.vue';
 import ArkimeNoResults from '../utils/NoResults.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import NodePopup from './NodePopup.vue';
 import LinkPopup from './LinkPopup.vue';
 // import services
@@ -608,11 +650,13 @@ function unfocus () {
   link.style('opacity', 1);
 }
 
-// simulation resize helper
-function resize (toolbarDown = true) {
-  const width = $(window).width() - 10;
-  // 36px for navbar + 25px for footer = 61px.
-  const height = $(window).height() - (toolbarDown ? 171 : 61);
+// simulation resize helper: size the canvas to the page scroll container
+// (tracks window resizes AND toolbar collapse via the ResizeObserver below)
+function resize (scrollEl) {
+  if (!svg) { return; }
+
+  const width = (scrollEl ? scrollEl.clientWidth : $(window).width()) - 10;
+  const height = (scrollEl ? scrollEl.clientHeight : $(window).height() - 61) - 4;
 
   // set the width and height of the canvas
   svg.attr('width', width).attr('height', height);
@@ -632,11 +676,11 @@ export default {
     ArkimeLoading,
     ArkimeNoResults,
     ArkimeCollapsible,
+    PageLayout,
     ArkimeFieldTypeahead,
     NodePopup,
     LinkPopup
   },
-  emits: ['recalc-collapse'],
   data: function () {
     return {
       error: '',
@@ -697,10 +741,6 @@ export default {
     },
     user: function () {
       return store.state.user;
-    },
-    // Boolean in the store will remember chosen toggle state for all pages
-    showToolBars: function () {
-      return store.state.showToolBars;
     },
     filteredFields: function () {
       const filteredGroupedFields = {};
@@ -766,13 +806,6 @@ export default {
     },
     '$route.query.dstField': function (newVal, oldVal) {
       this.cancelAndLoad(true);
-    },
-
-    // Resize svg height after toggle is updated and mounted()
-    showToolBars: function () {
-      this.$nextTick(() => {
-        resize(this.showToolBars);
-      });
     }
   },
   mounted () {
@@ -789,8 +822,12 @@ export default {
 
     // close any node/link popups if the user presses escape
     window.addEventListener('keyup', this.closePopupsOnEsc);
-    // resize the simulation with the window
-    window.addEventListener('resize', resize);
+    // resize the simulation with its container (covers window resizes and
+    // the animated toolbar collapse)
+    this._svgResizeObserver = new ResizeObserver(() => {
+      resize(this.$refs.pageLayout?.scrollEl);
+    });
+    this._svgResizeObserver.observe(this.$refs.pageLayout.scrollEl);
   },
   methods: {
     /* exposed page functions ---------------------------------------------- */
@@ -1175,10 +1212,10 @@ export default {
         linkedByIndex[d.source + ',' + d.target] = true;
       });
 
-      // calculate the width and height of the canvas
-      const width = $(window).width() - 10;
-      // 36px for navbar + 25px for footer = 61px.
-      const height = $(window).height() - (this.toolbarDown ? 171 : 61);
+      // calculate the width and height of the canvas from the scroll container
+      const scrollEl = this.$refs.pageLayout?.scrollEl;
+      const width = (scrollEl ? scrollEl.clientWidth : $(window).width()) - 10;
+      const height = (scrollEl ? scrollEl.clientHeight : $(window).height() - 61) - 4;
 
       // get the node and link data
       links = data.links.map(d => Object.create(d));
@@ -1482,7 +1519,7 @@ export default {
     }
 
     // remove listeners
-    window.removeEventListener('resize', resize);
+    this._svgResizeObserver?.disconnect();
     window.removeEventListener('keyup', this.closePopupsOnEsc);
 
     if (d3) {
@@ -1599,9 +1636,11 @@ export default {
   fill: rgb(var(--v-theme-foreground));
 }
 
-/* buttons overlaying the graph */
+/* buttons overlaying the graph (in the page shell's overlay slot, which
+   tracks the content area — no toolbar offset math) */
 .connections-buttons {
-  position: fixed;
+  position: absolute;
+  top: 8px;
   right: 10px;
 }
 </style>
@@ -1612,8 +1651,8 @@ export default {
 .connections-page div.connections-popup {
   position: absolute;
   left: 0;
-  top: 75px;
-  bottom: 24px;
+  top: 8px;
+  bottom: 8px;
   font-size: 0.85rem;
   padding: 4px 8px;
   max-width: 400px;

--- a/viewer/vueapp/src/components/files/Files.vue
+++ b/viewer/vueapp/src/components/files/Files.vue
@@ -3,14 +3,19 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div>
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <div class="files-search p-1">
+  <page-layout>
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="files-search px-1">
           <v-row
             dense
-            justify="start">
-            <v-col cols="auto">
+            align="center"
+            justify="start"
+            class="page-subnav">
+            <v-col
+              cols="auto"
+              align-self="start"
+              class="mt-2">
               <arkime-paging
                 v-if="files"
                 :records-total="recordsTotal"
@@ -57,8 +62,8 @@ SPDX-License-Identifier: Apache-2.0
             </v-col>
           </v-row>
         </div>
-      </span>
-    </ArkimeCollapsible>
+      </ArkimeCollapsible>
+    </template>
 
     <div class="mt-4 px-3">
       <arkime-loading v-if="loading && !error" />
@@ -86,7 +91,7 @@ SPDX-License-Identifier: Apache-2.0
           table-widths-state-name="filesColWidths" />
       </div>
     </div>
-  </div> <!-- /files content -->
+  </page-layout> <!-- /files content -->
 </template>
 
 <script>
@@ -98,6 +103,7 @@ import Clusters from '../utils/Clusters.vue';
 import ArkimeLoading from '../utils/Loading.vue';
 import ArkimePaging from '@common/Pagination.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import Focus from '@common/Focus.vue';
 import { commaString, timezoneDateString } from '@common/vueFilters.js';
 import { resolveMessage } from '@common/resolveI18nMessage';
@@ -112,6 +118,7 @@ export default {
     ArkimeLoading,
     ArkimeTable,
     ArkimeCollapsible,
+    PageLayout,
     Clusters
   },
   directives: { Focus },

--- a/viewer/vueapp/src/components/history/History.vue
+++ b/viewer/vueapp/src/components/history/History.vue
@@ -3,110 +3,114 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div class="history-page">
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <!-- search navbar -->
-        <div class="history-search p-1">
-          <!-- search row: cluster + search expression + search button -->
-          <div class="d-flex align-center gap-1 mb-1">
-            <Clusters />
-            <div class="arkime-input-group arkime-input-group--fluid">
-              <span
-                id="searchHistory"
-                class="arkime-input-label arkime-input-label-fw cursor-help">
-                <v-icon
-                  icon="mdi-magnify"
-                  v-if="!shiftKeyHold" />
+  <page-layout class="history-page">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- search navbar -->
+          <div class="history-search px-1 pt-2 pb-1 d-flex flex-column gap-2">
+            <!-- search row: cluster + search expression + search button -->
+            <div class="d-flex align-center search-row">
+              <Clusters />
+              <div class="arkime-input-group arkime-input-group--fluid me-1">
+                <span
+                  id="searchHistory"
+                  class="arkime-input-label arkime-input-label-fw cursor-help">
+                  <v-icon
+                    icon="mdi-magnify"
+                    v-if="!shiftKeyHold" />
+                  <span
+                    v-else
+                    class="query-shortcut">
+                    Q
+                  </span>
+                  <v-tooltip activator="#searchHistory">
+                    <div v-html="$t('history.searchHistoryTipHtml')" />
+                  </v-tooltip>
+                </span>
+                <input
+                  type="text"
+                  v-model="searchTerm"
+                  class="arkime-input-control"
+                  :placeholder="$t('history.searchHistoryPlaceholder')"
+                  v-focus="focusInput"
+                  @keyup.enter="loadData"
+                  @input="debounceSearch"
+                  @blur="onOffFocus">
+                <v-btn
+                  v-if="searchTerm"
+                  variant="text"
+                  size="x-small"
+                  density="comfortable"
+                  icon
+                  class="arkime-input-append-btn"
+                  :aria-label="$t('common.clear')"
+                  @click="clear">
+                  <v-icon icon="mdi-close" />
+                </v-btn>
+              </div>
+              <v-btn
+                variant="flat"
+                size="small"
+                density="comfortable"
+                color="tertiary"
+                @click="loadData">
+                <span v-if="!shiftKeyHold">
+                  Search
+                </span>
                 <span
                   v-else
-                  class="query-shortcut">
-                  Q
+                  class="enter-icon">
+                  <v-icon
+                    icon="mdi-arrow-left"
+                    size="small" />
+                  <div class="enter-arm" />
                 </span>
-                <v-tooltip activator="#searchHistory">
-                  <div v-html="$t('history.searchHistoryTipHtml')" />
-                </v-tooltip>
-              </span>
-              <input
-                type="text"
-                v-model="searchTerm"
-                class="arkime-input-control"
-                :placeholder="$t('history.searchHistoryPlaceholder')"
-                v-focus="focusInput"
-                @keyup.enter="loadData"
-                @input="debounceSearch"
-                @blur="onOffFocus">
-              <v-btn
-                v-if="searchTerm"
-                variant="text"
-                size="x-small"
-                density="comfortable"
-                icon
-                class="arkime-input-append-btn"
-                :aria-label="$t('common.clear')"
-                @click="clear">
-                <v-icon icon="mdi-close" />
               </v-btn>
-            </div>
-            <v-btn
-              variant="flat"
-              size="large"
-              color="tertiary"
-              @click="loadData">
-              <span v-if="!shiftKeyHold">
-                Search
-              </span>
-              <span
-                v-else
-                class="enter-icon">
+              <v-btn
+                id="seeAllHistoryBtn"
+                class="ms-1"
+                variant="flat"
+                size="small"
+                density="comfortable"
+                color="primary"
+                v-has-role="{user:user,roles:'arkimeAdmin'}"
+                @click="toggleSeeAll">
                 <v-icon
-                  icon="mdi-arrow-left"
-                  size="small" />
-                <div class="enter-arm" />
-              </span>
-            </v-btn>
-            <v-btn
-              id="seeAllHistoryBtn"
-              class="ms-1"
-              variant="flat"
-              size="large"
-              color="primary"
-              v-has-role="{user:user,roles:'arkimeAdmin'}"
-              @click="toggleSeeAll">
-              <v-icon
-                class="me-1"
-                icon="mdi-account-circle" />
-              See {{ seeAll ? ' MY ' : ' ALL ' }} History
-              <v-tooltip activator="#seeAllHistoryBtn">
-                {{ seeAll ? $t('history.seeMyHistoryTip') : $t('history.seeAllHistoryTip') }}
-              </v-tooltip>
-            </v-btn>
-          </div> <!-- /search row -->
+                  class="me-1"
+                  icon="mdi-account-circle" />
+                See {{ seeAll ? ' MY ' : ' ALL ' }} History
+                <v-tooltip activator="#seeAllHistoryBtn">
+                  {{ seeAll ? $t('history.seeMyHistoryTip') : $t('history.seeAllHistoryTip') }}
+                </v-tooltip>
+              </v-btn>
+            </div> <!-- /search row -->
 
-          <!-- time row -->
-          <arkime-time
-            :timezone="user.settings.timezone"
-            @time-change="loadData"
-            :hide-bounding="true"
-            :hide-interval="true" />
-        </div> <!-- /search navbar -->
+            <!-- time row -->
+            <arkime-time
+              :timezone="user.settings.timezone"
+              @time-change="loadData"
+              :hide-bounding="true"
+              :hide-interval="true" />
+          </div> <!-- /search navbar -->
 
-        <!-- paging navbar -->
-        <div class="history-paging pt-1">
-          <arkime-paging
-            class="ms-1 d-inline"
-            :length-default="100"
-            :records-total="recordsTotal"
-            :records-filtered="recordsFiltered"
-            @change-paging="changePaging" />
-          <arkime-toast
-            class="ms-2 mb-3 mt-1 d-inline"
-            :message="msg"
-            :type="msgType"
-            :done="messageDone" />
-        </div> <!-- /paging navbar -->
-      </span>
-    </ArkimeCollapsible>
+          <!-- paging navbar -->
+          <div class="history-paging page-subnav">
+            <arkime-paging
+              class="ms-1 d-inline"
+              :length-default="100"
+              :records-total="recordsTotal"
+              :records-filtered="recordsFiltered"
+              @change-paging="changePaging" />
+            <arkime-toast
+              class="ms-2 mb-3 mt-1 d-inline"
+              :message="msg"
+              :type="msgType"
+              :done="messageDone" />
+          </div> <!-- /paging navbar -->
+        </div>
+      </ArkimeCollapsible>
+    </template>
 
     <table
       v-if="!error"
@@ -395,7 +399,7 @@ SPDX-License-Identifier: Apache-2.0
     <div style="display:none;">
       {{ expandedLogs }}
     </div>
-  </div>
+  </page-layout>
 </template>
 
 <script>
@@ -410,6 +414,7 @@ import ArkimePaging from '@common/Pagination.vue';
 import HistoryService from './HistoryService';
 import Focus from '@common/Focus.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import ToggleBtn from '@common/ToggleBtn.vue';
 import { timezoneDateString, readableTime } from '@common/vueFilters.js';
 import { resolveMessage } from '@common/resolveI18nMessage';
@@ -426,6 +431,7 @@ export default {
     ToggleBtn,
     ArkimeToast,
     ArkimeCollapsible,
+    PageLayout,
     Clusters
   },
   directives: { Focus },
@@ -689,10 +695,17 @@ export default {
   -webkit-appearance: none;
 }
 
+/* match the main Search.vue search row: pin the search/see-all buttons to
+   the 32px input-group height so they don't tower over the inputs */
+.history-page .search-row > :deep(.v-btn) {
+  height: 32px;
+}
+
 /* navbar with pagination */
 .history-page .history-paging {
   z-index: 4;
-  height: 40px;
+  display: flex;
+  align-items: center;
 }
 
 .history-page .history-table {

--- a/viewer/vueapp/src/components/hunt/Hunt.vue
+++ b/viewer/vueapp/src/components/hunt/Hunt.vue
@@ -3,469 +3,511 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div class="packet-search-page ms-2 me-2">
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <!-- search navbar -->
-        <arkime-search
-          v-if="user.settings"
-          :start="sessionsQuery.start"
-          :hide-actions="true"
-          :hide-interval="true"
-          @change-search="cancelAndLoad(true)"
-          @recalc-collapse="$emit('recalc-collapse')" /> <!-- /search navbar -->
+  <page-layout class="packet-search-page">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- search navbar -->
+          <arkime-search
+            v-if="user.settings"
+            :start="sessionsQuery.start"
+            :hide-actions="true"
+            :hide-interval="true"
+            @change-search="cancelAndLoad(true)" /> <!-- /search navbar -->
 
-        <!-- hunt create navbar -->
-        <v-row
-          class="g-1 hunt-create-navbar ps-2 pe-2 py-2 justify-space-between align-center"
-          style="min-height: 44px;">
-          <v-col cols="auto">
-            <span v-if="loadingSessions">
-              <div
-                class="mt-1"
-                style="display:inline-block;">
-                <v-icon
-                  icon="mdi-loading"
-                  class="mdi-spin" />
-                {{ $t('common.loading') }}
-              </div>
+          <!-- hunt create navbar -->
+          <v-row class="g-1 hunt-create-navbar ps-2 pe-2 justify-space-between align-center page-subnav">
+            <v-col cols="auto">
+              <span v-if="loadingSessions">
+                <div
+                  class="mt-1"
+                  style="display:inline-block;">
+                  <v-icon
+                    icon="mdi-loading"
+                    class="mdi-spin" />
+                  {{ $t('common.loading') }}
+                </div>
+                <v-btn
+                  color="warning"
+                  variant="flat"
+                  size="small"
+                  density="comfortable"
+                  class="ms-3"
+                  @click="cancelAndLoad">
+                  <v-icon icon="mdi-cancel" />&nbsp;
+                  {{ $t('common.cancel') }}
+                </v-btn>
+              </span>
+              <span v-else-if="loadingSessionsError">
+                <div
+                  class="mt-1"
+                  style="display:inline-block;">
+                  <v-icon
+                    icon="mdi-alert"
+                    class="text-danger" />
+                  {{ loadingSessionsError }}
+                </div>
+              </span>
+              <span v-else-if="!loadingSessions && !loadingSessionsError">
+                <div
+                  class="mt-1"
+                  style="display:inline-block;">
+                  <span v-html="$t('hunts.createMsgHtml', { count: commaString(sessions.recordsFiltered) })" />
+                </div>
+              </span>
+            </v-col>
+            <v-col cols="auto">
+              <v-btn
+                variant="flat"
+                size="small"
+                density="comfortable"
+                :style="tertiaryBtnStyle"
+                :disabled="loadingSessions"
+                v-if="!createFormOpened"
+                @click="createFormOpened = true">
+                {{ $t('hunts.createJob') }}
+              </v-btn>
               <v-btn
                 color="warning"
                 variant="flat"
                 size="small"
                 density="comfortable"
-                class="ms-3"
-                @click="cancelAndLoad">
+                v-if="createFormOpened && loadingSessionsDetailError"
+                @click="createFormOpened = false">
                 <v-icon icon="mdi-cancel" />&nbsp;
                 {{ $t('common.cancel') }}
               </v-btn>
-            </span>
-            <span v-else-if="loadingSessionsError">
-              <div
-                class="mt-1"
-                style="display:inline-block;">
-                <v-icon
-                  icon="mdi-alert"
-                  class="text-danger" />
-                {{ loadingSessionsError }}
-              </div>
-            </span>
-            <span v-else-if="!loadingSessions && !loadingSessionsError">
-              <div
-                class="mt-1"
-                style="display:inline-block;">
-                <span v-html="$t('hunts.createMsgHtml', { count: commaString(sessions.recordsFiltered) })" />
-              </div>
-            </span>
-          </v-col>
-          <v-col cols="auto">
-            <v-btn
-              variant="flat"
-              size="small"
-              density="comfortable"
-              :style="tertiaryBtnStyle"
-              :disabled="loadingSessions"
-              v-if="!createFormOpened"
-              @click="createFormOpened = true">
-              {{ $t('hunts.createJob') }}
-            </v-btn>
-            <v-btn
-              color="warning"
-              variant="flat"
-              size="small"
-              density="comfortable"
-              v-if="createFormOpened && loadingSessionsDetailError"
-              @click="createFormOpened = false">
-              <v-icon icon="mdi-cancel" />&nbsp;
-              {{ $t('common.cancel') }}
-            </v-btn>
-          </v-col>
-        </v-row> <!-- /hunt create navbar -->
-      </span>
-    </ArkimeCollapsible>
+            </v-col>
+          </v-row> <!-- /hunt create navbar -->
+        </div>
+      </ArkimeCollapsible>
+    </template>
 
-    <!-- loading overlay -->
-    <arkime-loading
-      v-if="loading" /> <!-- /loading overlay -->
+    <div class="ms-2 me-2">
+      <!-- loading overlay -->
+      <arkime-loading
+        v-if="loading" /> <!-- /loading overlay -->
 
-    <!-- page error -->
-    <arkime-error
-      v-if="loadingSessionsDetailError && createFormOpened"
-      :message="loadingSessionsDetailError"
-      class="mt-2 mb-2" /> <!-- /page error -->
+      <!-- page error -->
+      <arkime-error
+        v-if="loadingSessionsDetailError && createFormOpened"
+        :message="loadingSessionsDetailError"
+        class="mt-2 mb-2" /> <!-- /page error -->
 
-    <!-- configuration error -->
-    <v-alert
-      v-if="nodeInfo && !nodeInfo.node"
-      type="error"
-      variant="tonal"
-      density="compact"
-      style="z-index: 2000;"
-      class="position-fixed fixed-bottom m-0 rounded-0">
-      <v-icon
-        icon="mdi-alert"
-        class="me-2" />
-      <span v-html="$t('hunts.notConfiguredHtml')" />
-    </v-alert> <!-- /configuration error -->
-
-    <!-- permission error -->
-    <v-alert
-      v-if="permissionDenied"
-      type="error"
-      variant="tonal"
-      density="compact"
-      class="mt-4">
-      <p class="mb-0">
+      <!-- configuration error -->
+      <v-alert
+        v-if="nodeInfo && !nodeInfo.node"
+        type="error"
+        variant="tonal"
+        density="compact"
+        style="z-index: 2000;"
+        class="position-fixed fixed-bottom m-0 rounded-0">
         <v-icon
           icon="mdi-alert"
           class="me-2" />
-        <strong>{{ $t('common.permisionDenied') }}</strong>
-      </p>
-      <p class="mb-0">
-        <v-icon
-          icon="mdi-information"
-          class="me-2" />
-        <template v-if="user.roles.includes('usersAdmin')">
-          {{ $t('hunts.selfEnable') }}
-        </template>
-        <template v-else>
-          {{ $t('hunts.adminEnable') }}
-        </template>
-      </p>
-    </v-alert> <!-- /permission error -->
+        <span v-html="$t('hunts.notConfiguredHtml')" />
+      </v-alert> <!-- /configuration error -->
 
-    <!-- packet search jobs content -->
-    <div
-      v-if="!permissionDenied"
-      class="packet-search-content ms-2 me-2">
-      <!-- create new packet search job -->
-      <div class="mb-3">
-        <transition name="slide">
-          <v-card
-            v-if="createFormOpened && !loadingSessionsDetailError"
-            variant="outlined">
-            <form
-              class="pa-3"
-              @keyup.enter="createJob">
-              <v-row>
-                <v-col cols="12">
-                  <v-alert
-                    :type="sessions.recordsFiltered >= huntWarn ? 'error' : 'info'"
-                    :icon="false"
-                    variant="tonal"
-                    density="compact">
-                    <em v-if="sessions.recordsFiltered > huntWarn && !loadingSessions">
-                      <span v-html="$t('hunts.lotOfSessionsHtml')" />
-                      <br>
-                    </em>
-                    <em v-if="loadingSessions">
-                      <v-icon
-                        icon="mdi-loading"
-                        class="mdi-spin me-1" />
-                      {{ $t('hunts.waitForCalculation') }}
-                      <br>
-                    </em>
-                    <span v-if="!loadingSessions">
-                      <v-icon
-                        icon="mdi-alert"
-                        class="me-1" />
-                      {{ $t('hunts.doubleCheckSessions') }}
-                    </span>
-                    <span v-if="multiviewer">
-                      <br>
-                      <v-icon
-                        icon="mdi-information"
-                        class="me-2" />
-                      {{ $t('hunts.multiViewerHtml', { cluster: selectedCluster[0] }) }}
-                    </span>
-                  </v-alert>
-                </v-col>
-              </v-row>
-              <v-row class="g-1">
-                <v-col
-                  cols="auto"
-                  class="mb-2 flex-grow-1">
-                  <!-- packet search job name -->
-                  <div class="arkime-input-group arkime-input-group--fluid">
-                    <span
-                      id="jobName"
-                      class="arkime-input-label cursor-help">
-                      {{ $t('hunts.jobName') }}
-                      <v-tooltip activator="#jobName">
-                        {{ $t('hunts.jobNameTip') }}
-                      </v-tooltip>
-                    </span>
-                    <input
-                      type="text"
-                      v-model="jobName"
-                      v-focus="true"
-                      class="arkime-input-control"
-                      :placeholder="$t('hunts.jobNamePlaceholder')"
-                      maxlength="40">
-                  </div> <!-- /packet search job name -->
-                </v-col>
-                <!-- packet search size -->
-                <v-col cols="auto">
-                  <div class="arkime-input-group arkime-input-group--fluid">
-                    <span class="arkime-input-label">
-                      {{ $t('hunts.jobSize') }}
-                    </span>
-                    <select
-                      class="arkime-input-control"
-                      v-model="jobSize">
-                      <option
-                        v-for="size in [50, 500, 5000, 10000]"
-                        :key="size"
-                        :value="size">
-                        {{ size }}
-                      </option>
-                    </select>
-                  </div>
-                </v-col> <!-- /packet search size -->
-                <!-- notifier -->
-                <v-col cols="auto">
-                  <NotifierDropdown
-                    :notifiers="notifiers"
-                    :selected-notifiers="jobNotifier"
-                    @selected-notifiers-updated="updateJobNotifiers"
-                    :display-text="jobNotifier.length > 0 ? undefined : $t('settings.cron.selectNotifier')" />
-                </v-col> <!-- /notifier -->
-              </v-row>
-              <v-row class="g-1 mb-2">
-                <v-col cols="auto">
-                  <div class="arkime-input-group arkime-input-group--fluid">
-                    <span
-                      id="jobDescription"
-                      class="arkime-input-label cursor-help">
-                      {{ $t('hunts.jobDescription') }}
-                      <v-tooltip activator="#jobDescription">
-                        {{ $t('hunts.jobDescriptionTip') }}
-                      </v-tooltip>
-                    </span>
-                    <input
-                      type="text"
-                      class="arkime-input-control"
-                      v-model="jobDescription"
-                      :placeholder="$t('hunts.jobDescriptionPlaceholder')">
-                  </div>
-                </v-col>
-              </v-row>
-              <v-row>
-                <v-col cols="auto">
-                  <div class="arkime-input-group arkime-input-group--fluid">
-                    <span
-                      id="jobSearch"
-                      class="arkime-input-label cursor-help">
-                      <v-icon icon="mdi-magnify" />
-                      <v-tooltip activator="#jobSearch">
-                        {{ $t('hunts.jobSearchTip') }}
-                      </v-tooltip>
-                    </span>
-                    <input
-                      type="text"
-                      v-model="jobSearch"
-                      :placeholder="$t('hunts.jobSearchPlaceholder')"
-                      class="arkime-input-control">
-                  </div>
-                </v-col>
-              </v-row>
-              <v-row class="g-1 justify-start">
-                <!-- packet search text & text type -->
-                <v-col cols="auto">
-                  <v-btn-toggle
-                    class="d-inline-flex"
-                    density="compact"
-                    divided
-                    variant="outlined"
-                    color="secondary"
-                    v-model="jobSearchType"
-                    mandatory>
-                    <v-btn value="ascii">
-                      ascii
-                    </v-btn>
-                    <v-btn value="asciicase">
-                      ascii (case sensitive)
-                    </v-btn>
-                    <v-btn value="hex">
-                      hex
-                    </v-btn>
-                    <v-btn value="regex">
-                      safe regex
-                    </v-btn>
-                    <v-btn value="hexregex">
-                      safe hex regex
-                    </v-btn>
-                  </v-btn-toggle>
-                  <a
-                    href="https://github.com/google/re2/wiki/Syntax"
-                    target="_blank"
-                    id="safeRegexHelp"
-                    class="ms-2">
-                    <v-icon
-                      icon="mdi-help-circle"
-                      size="small" />
-                    <v-tooltip activator="#safeRegexHelp">{{ $t('hunts.safeRegexHelpTip') }}</v-tooltip>
-                  </a>
-                </v-col>
-              </v-row>
-              <v-row class="g-1">
-                <!-- packet search direction -->
-                <v-col
-                  cols="12"
-                  lg="3"
-                  md="12">
-                  <v-checkbox
-                    :model-value="jobSrc"
-                    @update:model-value="jobSrc = $event"
-                    :label="$t('hunts.jobSrc')"
-                    density="compact"
-                    hide-details
-                    color="primary" />
-                  <v-checkbox
-                    :model-value="jobDst"
-                    @update:model-value="jobDst = $event"
-                    :label="$t('hunts.jobDst')"
-                    density="compact"
-                    hide-details
-                    color="primary" />
-                </v-col> <!-- /packet search direction -->
-                <!-- packet search type -->
-                <v-col
-                  cols="12"
-                  lg="3"
-                  md="12">
-                  <v-radio-group
-                    :model-value="jobType"
-                    @update:model-value="setJobType($event)"
-                    density="compact"
-                    hide-details>
-                    <v-radio
-                      :label="$t('hunts.jobType-raw')"
-                      value="raw"
-                      color="primary" />
-                    <v-radio
-                      :label="$t('hunts.jobType-reassembled')"
-                      value="reassembled"
-                      color="primary" />
-                  </v-radio-group>
-                </v-col> <!-- /packet search type -->
-                <!-- sharing with users/roles -->
-                <v-col
-                  cols="12"
-                  lg="6"
-                  md="12"
-                  class="d-flex"
-                  v-if="!anonymousMode">
-                  <div class="align-self-start">
-                    <RoleDropdown
-                      size="large"
-                      :roles="roles"
-                      :selected-roles="jobRoles"
-                      :display-text="$t('common.shareWithRoles')"
-                      @selected-roles-updated="updateNewJobRoles" />
-                  </div>
-                  <div class="flex-grow-1 ms-2">
+      <!-- permission error -->
+      <v-alert
+        v-if="permissionDenied"
+        type="error"
+        variant="tonal"
+        density="compact"
+        class="mt-4">
+        <p class="mb-0">
+          <v-icon
+            icon="mdi-alert"
+            class="me-2" />
+          <strong>{{ $t('common.permisionDenied') }}</strong>
+        </p>
+        <p class="mb-0">
+          <v-icon
+            icon="mdi-information"
+            class="me-2" />
+          <template v-if="user.roles.includes('usersAdmin')">
+            {{ $t('hunts.selfEnable') }}
+          </template>
+          <template v-else>
+            {{ $t('hunts.adminEnable') }}
+          </template>
+        </p>
+      </v-alert> <!-- /permission error -->
+
+      <!-- packet search jobs content -->
+      <div
+        v-if="!permissionDenied"
+        class="packet-search-content ms-2 me-2">
+        <!-- create new packet search job -->
+        <div class="mb-3">
+          <transition name="slide">
+            <v-card
+              v-if="createFormOpened && !loadingSessionsDetailError"
+              variant="outlined">
+              <form
+                class="pa-3"
+                @keyup.enter="createJob">
+                <v-row>
+                  <v-col cols="12">
+                    <v-alert
+                      :type="sessions.recordsFiltered >= huntWarn ? 'error' : 'info'"
+                      :icon="false"
+                      variant="tonal"
+                      density="compact">
+                      <em v-if="sessions.recordsFiltered > huntWarn && !loadingSessions">
+                        <span v-html="$t('hunts.lotOfSessionsHtml')" />
+                        <br>
+                      </em>
+                      <em v-if="loadingSessions">
+                        <v-icon
+                          icon="mdi-loading"
+                          class="mdi-spin me-1" />
+                        {{ $t('hunts.waitForCalculation') }}
+                        <br>
+                      </em>
+                      <span v-if="!loadingSessions">
+                        <v-icon
+                          icon="mdi-alert"
+                          class="me-1" />
+                        {{ $t('hunts.doubleCheckSessions') }}
+                      </span>
+                      <span v-if="multiviewer">
+                        <br>
+                        <v-icon
+                          icon="mdi-information"
+                          class="me-2" />
+                        {{ $t('hunts.multiViewerHtml', { cluster: selectedCluster[0] }) }}
+                      </span>
+                    </v-alert>
+                  </v-col>
+                </v-row>
+                <v-row class="g-1">
+                  <v-col
+                    cols="auto"
+                    class="mb-2 flex-grow-1">
+                    <!-- packet search job name -->
                     <div class="arkime-input-group arkime-input-group--fluid">
                       <span
-                        id="jobUsers"
+                        id="jobName"
                         class="arkime-input-label cursor-help">
-                        <v-icon icon="mdi-account" />
-                        <v-tooltip activator="#jobUsers">
-                          {{ $t('hunts.jobUsersTip') }}
+                        {{ $t('hunts.jobName') }}
+                        <v-tooltip activator="#jobName">
+                          {{ $t('hunts.jobNameTip') }}
                         </v-tooltip>
                       </span>
                       <input
                         type="text"
-                        v-model="jobUsers"
-                        :placeholder="$t('hunts.jobUsersPlaceholder')"
+                        v-model="jobName"
+                        v-focus="true"
+                        class="arkime-input-control"
+                        :placeholder="$t('hunts.jobNamePlaceholder')"
+                        maxlength="40">
+                    </div> <!-- /packet search job name -->
+                  </v-col>
+                  <!-- packet search size -->
+                  <v-col cols="auto">
+                    <div class="arkime-input-group arkime-input-group--fluid">
+                      <span class="arkime-input-label">
+                        {{ $t('hunts.jobSize') }}
+                      </span>
+                      <select
+                        class="arkime-input-control"
+                        v-model="jobSize">
+                        <option
+                          v-for="size in [50, 500, 5000, 10000]"
+                          :key="size"
+                          :value="size">
+                          {{ size }}
+                        </option>
+                      </select>
+                    </div>
+                  </v-col> <!-- /packet search size -->
+                  <!-- notifier -->
+                  <v-col cols="auto">
+                    <NotifierDropdown
+                      :notifiers="notifiers"
+                      :selected-notifiers="jobNotifier"
+                      @selected-notifiers-updated="updateJobNotifiers"
+                      :display-text="jobNotifier.length > 0 ? undefined : $t('settings.cron.selectNotifier')" />
+                  </v-col> <!-- /notifier -->
+                </v-row>
+                <v-row class="g-1 mb-2">
+                  <v-col cols="auto">
+                    <div class="arkime-input-group arkime-input-group--fluid">
+                      <span
+                        id="jobDescription"
+                        class="arkime-input-label cursor-help">
+                        {{ $t('hunts.jobDescription') }}
+                        <v-tooltip activator="#jobDescription">
+                          {{ $t('hunts.jobDescriptionTip') }}
+                        </v-tooltip>
+                      </span>
+                      <input
+                        type="text"
+                        class="arkime-input-control"
+                        v-model="jobDescription"
+                        :placeholder="$t('hunts.jobDescriptionPlaceholder')">
+                    </div>
+                  </v-col>
+                </v-row>
+                <v-row>
+                  <v-col cols="auto">
+                    <div class="arkime-input-group arkime-input-group--fluid">
+                      <span
+                        id="jobSearch"
+                        class="arkime-input-label cursor-help">
+                        <v-icon icon="mdi-magnify" />
+                        <v-tooltip activator="#jobSearch">
+                          {{ $t('hunts.jobSearchTip') }}
+                        </v-tooltip>
+                      </span>
+                      <input
+                        type="text"
+                        v-model="jobSearch"
+                        :placeholder="$t('hunts.jobSearchPlaceholder')"
                         class="arkime-input-control">
                     </div>
-                  </div>
-                </v-col> <!-- /sharing with users/roles -->
-              </v-row>
-              <v-row>
-                <v-col
-                  cols="12"
-                  class="mt-1 d-flex align-center gap-2">
-                  <v-alert
-                    v-if="createFormError"
-                    type="error"
-                    variant="tonal"
-                    density="compact"
-                    class="flex-grow-1">
-                    <v-icon icon="mdi-alert" />&nbsp;
-                    {{ createFormError }}
-                  </v-alert>
-                  <v-spacer v-else />
-                  <!-- cancel create search job button -->
+                  </v-col>
+                </v-row>
+                <v-row class="g-1 justify-start">
+                  <!-- packet search text & text type -->
+                  <v-col cols="auto">
+                    <v-btn-toggle
+                      class="d-inline-flex"
+                      density="compact"
+                      divided
+                      variant="outlined"
+                      color="secondary"
+                      v-model="jobSearchType"
+                      mandatory>
+                      <v-btn value="ascii">
+                        ascii
+                      </v-btn>
+                      <v-btn value="asciicase">
+                        ascii (case sensitive)
+                      </v-btn>
+                      <v-btn value="hex">
+                        hex
+                      </v-btn>
+                      <v-btn value="regex">
+                        safe regex
+                      </v-btn>
+                      <v-btn value="hexregex">
+                        safe hex regex
+                      </v-btn>
+                    </v-btn-toggle>
+                    <a
+                      href="https://github.com/google/re2/wiki/Syntax"
+                      target="_blank"
+                      id="safeRegexHelp"
+                      class="ms-2">
+                      <v-icon
+                        icon="mdi-help-circle"
+                        size="small" />
+                      <v-tooltip activator="#safeRegexHelp">{{ $t('hunts.safeRegexHelpTip') }}</v-tooltip>
+                    </a>
+                  </v-col>
+                </v-row>
+                <v-row class="g-1">
+                  <!-- packet search direction -->
+                  <v-col
+                    cols="12"
+                    lg="3"
+                    md="12">
+                    <v-checkbox
+                      :model-value="jobSrc"
+                      @update:model-value="jobSrc = $event"
+                      :label="$t('hunts.jobSrc')"
+                      density="compact"
+                      hide-details
+                      color="primary" />
+                    <v-checkbox
+                      :model-value="jobDst"
+                      @update:model-value="jobDst = $event"
+                      :label="$t('hunts.jobDst')"
+                      density="compact"
+                      hide-details
+                      color="primary" />
+                  </v-col> <!-- /packet search direction -->
+                  <!-- packet search type -->
+                  <v-col
+                    cols="12"
+                    lg="3"
+                    md="12">
+                    <v-radio-group
+                      :model-value="jobType"
+                      @update:model-value="setJobType($event)"
+                      density="compact"
+                      hide-details>
+                      <v-radio
+                        :label="$t('hunts.jobType-raw')"
+                        value="raw"
+                        color="primary" />
+                      <v-radio
+                        :label="$t('hunts.jobType-reassembled')"
+                        value="reassembled"
+                        color="primary" />
+                    </v-radio-group>
+                  </v-col> <!-- /packet search type -->
+                  <!-- sharing with users/roles -->
+                  <v-col
+                    cols="12"
+                    lg="6"
+                    md="12"
+                    class="d-flex"
+                    v-if="!anonymousMode">
+                    <div class="align-self-start">
+                      <RoleDropdown
+                        size="large"
+                        :roles="roles"
+                        :selected-roles="jobRoles"
+                        :display-text="$t('common.shareWithRoles')"
+                        @selected-roles-updated="updateNewJobRoles" />
+                    </div>
+                    <div class="flex-grow-1 ms-2">
+                      <div class="arkime-input-group arkime-input-group--fluid">
+                        <span
+                          id="jobUsers"
+                          class="arkime-input-label cursor-help">
+                          <v-icon icon="mdi-account" />
+                          <v-tooltip activator="#jobUsers">
+                            {{ $t('hunts.jobUsersTip') }}
+                          </v-tooltip>
+                        </span>
+                        <input
+                          type="text"
+                          v-model="jobUsers"
+                          :placeholder="$t('hunts.jobUsersPlaceholder')"
+                          class="arkime-input-control">
+                      </div>
+                    </div>
+                  </v-col> <!-- /sharing with users/roles -->
+                </v-row>
+                <v-row>
+                  <v-col
+                    cols="12"
+                    class="mt-1 d-flex align-center gap-2">
+                    <v-alert
+                      v-if="createFormError"
+                      type="error"
+                      variant="tonal"
+                      density="compact"
+                      class="flex-grow-1">
+                      <v-icon icon="mdi-alert" />&nbsp;
+                      {{ createFormError }}
+                    </v-alert>
+                    <v-spacer v-else />
+                    <!-- cancel create search job button -->
+                    <v-btn
+                      color="warning"
+                      variant="flat"
+                      size="small"
+                      density="comfortable"
+                      @click="cancelCreateForm"
+                      title="Cancel creating this hunt">
+                      <v-icon icon="mdi-cancel" />&nbsp;
+                      {{ $t('common.cancel') }}
+                    </v-btn> <!-- /cancel create search job button -->
+                    <!-- create search job button -->
+                    <v-btn
+                      variant="flat"
+                      size="small"
+                      density="comfortable"
+                      :style="tertiaryBtnStyle"
+                      @click="createJob"
+                      :disabled="loadingSessions || !!loadingSessionsError"
+                      title="Create this hunt">
+                      <v-icon icon="mdi-plus" />&nbsp;
+                      {{ $t('common.create') }}
+                    </v-btn> <!-- /create search job button -->
+                  </v-col>
+                </v-row>
+              </form>
+            </v-card>
+          </transition>
+        </div> <!-- /create new packet search job -->
+
+        <!-- running job -->
+        <transition name="slide">
+          <v-card
+            v-if="runningJob"
+            variant="outlined"
+            class="mb-3">
+            <div class="pa-3">
+              <h5 class="d-flex align-center gap-1 mb-2">
+                <span class="flex-grow-1">
+                  {{ $t('hunts.runningHuntJob', { name: runningJob.name, user: runningJob.userId }) }}
+                </span>
+                <template v-if="canEdit">
                   <v-btn
+                    :id="`pause${runningJob.id}`"
+                    @click="pauseJob(runningJob)"
+                    :disabled="runningJob.loading"
+                    :aria-label="$t('hunts.pauseTip')"
+                    icon
                     color="warning"
                     variant="flat"
                     size="small"
                     density="comfortable"
-                    @click="cancelCreateForm"
-                    title="Cancel creating this hunt">
-                    <v-icon icon="mdi-cancel" />&nbsp;
-                    {{ $t('common.cancel') }}
-                  </v-btn> <!-- /cancel create search job button -->
-                  <!-- create search job button -->
+                    class="ms-1">
+                    <v-icon
+                      icon="mdi-pause"
+                      v-if="!runningJob.loading" />
+                    <v-icon
+                      icon="mdi-loading"
+                      class="mdi-spin"
+                      v-else />
+                    <v-tooltip :activator="`[id='pause${runningJob.id}']`">
+                      {{ $t('hunts.pauseTip') }}
+                    </v-tooltip>
+                  </v-btn>
                   <v-btn
+                    :id="`cancel${runningJob.id}`"
+                    @click="cancelJob(runningJob)"
+                    :disabled="runningJob.disabled"
+                    :aria-label="$t('hunts.cancelTip')"
+                    icon
+                    color="error"
                     variant="flat"
                     size="small"
                     density="comfortable"
-                    :style="tertiaryBtnStyle"
-                    @click="createJob"
-                    :disabled="loadingSessions || !!loadingSessionsError"
-                    title="Create this hunt">
-                    <v-icon icon="mdi-plus" />&nbsp;
-                    {{ $t('common.create') }}
-                  </v-btn> <!-- /create search job button -->
-                </v-col>
-              </v-row>
-            </form>
-          </v-card>
-        </transition>
-      </div> <!-- /create new packet search job -->
-
-      <!-- running job -->
-      <transition name="slide">
-        <v-card
-          v-if="runningJob"
-          variant="outlined"
-          class="mb-3">
-          <div class="pa-3">
-            <h5 class="d-flex align-center gap-1 mb-2">
-              <span class="flex-grow-1">
-                {{ $t('hunts.runningHuntJob', { name: runningJob.name, user: runningJob.userId }) }}
-              </span>
-              <template v-if="canEdit">
+                    class="ms-1">
+                    <v-icon
+                      icon="mdi-cancel"
+                      v-if="!runningJob.loading" />
+                    <v-icon
+                      icon="mdi-loading"
+                      class="mdi-spin"
+                      v-else />
+                    <v-tooltip :activator="`[id='cancel${runningJob.id}']`">
+                      {{ $t('hunts.cancelTip') }}
+                    </v-tooltip>
+                  </v-btn>
+                </template>
+                <template v-if="canView">
+                  <v-btn
+                    @click="openSessions(runningJob)"
+                    v-if="runningJob.matchedSessions"
+                    :id="`openresults${runningJob.id}`"
+                    :aria-label="$t('common.open')"
+                    icon
+                    variant="flat"
+                    size="small"
+                    density="comfortable"
+                    :style="primaryBtnStyle"
+                    class="ms-1">
+                    <v-icon icon="mdi-folder-open" />
+                    <v-tooltip :activator="`[id='openresults${runningJob.id}']`">
+                      <span v-html="$t('hunts.openResultsTipHtml')" />
+                    </v-tooltip>
+                  </v-btn>
+                </template>
                 <v-btn
-                  :id="`pause${runningJob.id}`"
-                  @click="pauseJob(runningJob)"
-                  :disabled="runningJob.loading"
-                  :aria-label="$t('hunts.pauseTip')"
-                  icon
-                  color="warning"
-                  variant="flat"
-                  size="small"
-                  density="comfortable"
-                  class="ms-1">
-                  <v-icon
-                    icon="mdi-pause"
-                    v-if="!runningJob.loading" />
-                  <v-icon
-                    icon="mdi-loading"
-                    class="mdi-spin"
-                    v-else />
-                  <v-tooltip :activator="`[id='pause${runningJob.id}']`">
-                    {{ $t('hunts.pauseTip') }}
-                  </v-tooltip>
-                </v-btn>
-                <v-btn
-                  :id="`cancel${runningJob.id}`"
-                  @click="cancelJob(runningJob)"
+                  v-if="canEdit"
+                  :id="`remove${runningJob.id}`"
+                  @click="removeJob(runningJob, 'results')"
                   :disabled="runningJob.disabled"
-                  :aria-label="$t('hunts.cancelTip')"
+                  :aria-label="$t('hunts.removeHuntTip')"
                   icon
                   color="error"
                   variant="flat"
@@ -473,338 +515,129 @@ SPDX-License-Identifier: Apache-2.0
                   density="comfortable"
                   class="ms-1">
                   <v-icon
-                    icon="mdi-cancel"
+                    icon="mdi-trash-can-outline"
                     v-if="!runningJob.loading" />
                   <v-icon
                     icon="mdi-loading"
                     class="mdi-spin"
                     v-else />
-                  <v-tooltip :activator="`[id='cancel${runningJob.id}']`">
-                    {{ $t('hunts.cancelTip') }}
+                  <v-tooltip :activator="`[id='remove${runningJob.id}']`">
+                    {{ $t('hunts.cancelAndRemoveTip') }}
                   </v-tooltip>
                 </v-btn>
-              </template>
-              <template v-if="canView">
-                <v-btn
-                  @click="openSessions(runningJob)"
-                  v-if="runningJob.matchedSessions"
-                  :id="`openresults${runningJob.id}`"
-                  :aria-label="$t('common.open')"
-                  icon
-                  variant="flat"
-                  size="small"
-                  density="comfortable"
-                  :style="primaryBtnStyle"
-                  class="ms-1">
-                  <v-icon icon="mdi-folder-open" />
-                  <v-tooltip :activator="`[id='openresults${runningJob.id}']`">
-                    <span v-html="$t('hunts.openResultsTipHtml')" />
-                  </v-tooltip>
-                </v-btn>
-              </template>
-              <v-btn
-                v-if="canEdit"
-                :id="`remove${runningJob.id}`"
-                @click="removeJob(runningJob, 'results')"
-                :disabled="runningJob.disabled"
-                :aria-label="$t('hunts.removeHuntTip')"
-                icon
-                color="error"
-                variant="flat"
-                size="small"
-                density="comfortable"
-                class="ms-1">
-                <v-icon
-                  icon="mdi-trash-can-outline"
-                  v-if="!runningJob.loading" />
-                <v-icon
-                  icon="mdi-loading"
-                  class="mdi-spin"
-                  v-else />
-                <v-tooltip :activator="`[id='remove${runningJob.id}']`">
-                  {{ $t('hunts.cancelAndRemoveTip') }}
-                </v-tooltip>
-              </v-btn>
-            </h5>
-            <div>
-              <v-row>
-                <v-col
-                  cols="auto"
-                  class="d-flex align-center gap-2">
-                  <toggle-btn
-                    v-if="canView"
-                    :opened="runningJob.expanded"
-                    @toggle="toggleJobDetail(runningJob)" />
-                  <v-progress-linear
-                    id="runningJob"
-                    color="success"
-                    striped
-                    height="26"
-                    :model-value="runningJob.progress"
-                    class="cursor-help flex-grow-1">
-                    <template #default>
-                      {{ round(runningJob.progress, 1) }}%
-                    </template>
-                  </v-progress-linear>
-                  <v-tooltip activator="#runningJob">
-                    <div class="mt-2">
-                      <span v-html="$t('hunts.runningJob-headHtml', { matched: commaString(runningJob.matchedSessions) })" />
-                      <span
-                        v-if="canView"
-                        v-html="$t('hunts.runningJob-canViewHtml', { search: escapeHtml(runningJob.search), searchType: runningJob.searchType })" />
-                      <span
-                        v-if="runningJob.failedSessionIds && runningJob.failedSessionIds.length"
-                        v-html="$t('hunts.runningJob-outOfHtml', {
-                          searched: commaString(runningJob.searchedSessions - runningJob.failedSessionIds.length),
-                          remaining: commaString(runningJob.totalSessions - runningJob.searchedSessions + runningJob.failedSessionIds.length),
-                          totalSessions: commaString(runningJob.totalSessions)})" />
-                      <span
-                        v-else
-                        v-html="$t('hunts.runningJob-outOfHtml', {
-                          searched: commaString(runningJob.searchedSessions),
-                          remaining: commaString(runningJob.totalSessions - runningJob.searchedSessions),
-                          totalSessions: commaString(runningJob.totalSessions)})" />
-                    </div>
-                  </v-tooltip>
-                </v-col>
-              </v-row>
-              <transition name="grow">
-                <div
-                  v-if="runningJob.expanded"
-                  class="mt-3">
-                  <v-row>
-                    <v-col cols="12">
-                      <v-icon icon="mdi-card-account-details" />&nbsp;
-                      {{ $t('hunts.huntJobId', { id: runningJob.id }) }}:
-                    </v-col>
-                  </v-row>
-                  <hunt-data
-                    :job="runningJob"
-                    @remove-user="removeUser"
-                    @add-users="addUsers"
-                    :user="user"
-                    @update-hunt="updateHunt" />
-                </div>
-              </transition>
+              </h5>
+              <div>
+                <v-row>
+                  <v-col
+                    cols="auto"
+                    class="d-flex align-center gap-2">
+                    <toggle-btn
+                      v-if="canView"
+                      :opened="runningJob.expanded"
+                      @toggle="toggleJobDetail(runningJob)" />
+                    <v-progress-linear
+                      id="runningJob"
+                      color="success"
+                      striped
+                      height="26"
+                      :model-value="runningJob.progress"
+                      class="cursor-help flex-grow-1">
+                      <template #default>
+                        {{ round(runningJob.progress, 1) }}%
+                      </template>
+                    </v-progress-linear>
+                    <v-tooltip activator="#runningJob">
+                      <div class="mt-2">
+                        <span v-html="$t('hunts.runningJob-headHtml', { matched: commaString(runningJob.matchedSessions) })" />
+                        <span
+                          v-if="canView"
+                          v-html="$t('hunts.runningJob-canViewHtml', { search: escapeHtml(runningJob.search), searchType: runningJob.searchType })" />
+                        <span
+                          v-if="runningJob.failedSessionIds && runningJob.failedSessionIds.length"
+                          v-html="$t('hunts.runningJob-outOfHtml', {
+                            searched: commaString(runningJob.searchedSessions - runningJob.failedSessionIds.length),
+                            remaining: commaString(runningJob.totalSessions - runningJob.searchedSessions + runningJob.failedSessionIds.length),
+                            totalSessions: commaString(runningJob.totalSessions)})" />
+                        <span
+                          v-else
+                          v-html="$t('hunts.runningJob-outOfHtml', {
+                            searched: commaString(runningJob.searchedSessions),
+                            remaining: commaString(runningJob.totalSessions - runningJob.searchedSessions),
+                            totalSessions: commaString(runningJob.totalSessions)})" />
+                      </div>
+                    </v-tooltip>
+                  </v-col>
+                </v-row>
+                <transition name="grow">
+                  <div
+                    v-if="runningJob.expanded"
+                    class="mt-3">
+                    <v-row>
+                      <v-col cols="12">
+                        <v-icon icon="mdi-card-account-details" />&nbsp;
+                        {{ $t('hunts.huntJobId', { id: runningJob.id }) }}:
+                      </v-col>
+                    </v-row>
+                    <hunt-data
+                      :job="runningJob"
+                      @remove-user="removeUser"
+                      @add-users="addUsers"
+                      :user="user"
+                      @update-hunt="updateHunt" />
+                  </div>
+                </transition>
+              </div>
             </div>
-          </div>
-        </v-card>
-      </transition> <!-- /running job -->
+          </v-card>
+        </transition> <!-- /running job -->
 
-      <h4 v-if="results.length">
-        <v-icon icon="mdi-format-list-numbered" />&nbsp;
-        {{ $t('hunts.huntJobQueue') }}:
-      </h4>
-
-      <!-- hunt job queue errors -->
-      <v-alert
-        v-if="queuedListError"
-        type="error"
-        variant="tonal"
-        density="compact">
-        {{ queuedListError }}
-      </v-alert>
-      <v-alert
-        v-if="queuedListLoadingError"
-        type="error"
-        variant="tonal"
-        density="compact">
-        {{ $t('hunts.errorLoadingQueue') }}:
-        {{ queuedListLoadingError }}
-      </v-alert> <!-- /hunt job queue errors -->
-
-      <table
-        v-if="results.length"
-        class="arkime-table mb-4">
-        <thead>
-          <tr>
-            <th width="40px">
-&nbsp;
-            </th>
-            <th>
-              {{ $t('hunts.jobStatus') }}
-            </th>
-            <th>
-              {{ $t('hunts.jobMatches') }}
-            </th>
-            <th>
-              {{ $t('hunts.jobName') }}
-            </th>
-            <th>
-              {{ $t('hunts.jobUser') }}
-            </th>
-            <th>
-              {{ $t('hunts.jobSearch') }}
-            </th>
-            <th>
-              {{ $t('common.created') }}
-            </th>
-            <th>
-              ID
-            </th>
-            <th width="260px">
-&nbsp;
-            </th>
-          </tr>
-        </thead>
-        <transition-group
-          name="list"
-          tag="tbody">
-          <!-- packet search jobs -->
-          <template
-            v-for="job in results"
-            :key="`${job.id}-row`">
-            <hunt-row
-              :job="job"
-              :user="user"
-              :can-rerun="true"
-              :can-repeat="true"
-              :can-cancel="true"
-              array-name="results"
-              @play-job="playJob"
-              @rerun-job="rerunJob"
-              @repeat-job="repeatJob"
-              @pause-job="pauseJob"
-              @cancel-job="cancelJob"
-              @remove-job="removeJob"
-              @toggle="toggleJobDetail"
-              @open-sessions="openSessions" />
-            <tr
-              :key="`${job.id}-detail`"
-              v-if="job.expanded">
-              <td colspan="10">
-                <hunt-data
-                  :job="job"
-                  @remove-user="removeUser"
-                  @add-users="addUsers"
-                  :user="user"
-                  @update-hunt="updateHunt" />
-              </td>
-            </tr>
-          </template> <!-- /packet search jobs -->
-        </transition-group>
-      </table>
-
-      <!-- hunt job history errors -->
-      <v-alert
-        v-if="historyListError"
-        type="error"
-        variant="tonal"
-        density="compact">
-        <v-icon
-          icon="mdi-alert"
-          class="me-2" />
-        {{ historyListError }}
-      </v-alert>
-      <v-alert
-        v-if="historyListLoadingError"
-        type="error"
-        variant="tonal"
-        density="compact">
-        <v-icon
-          icon="mdi-alert"
-          class="me-2" />
-        {{ $t('hunts.errorLoadingHistory') }}:
-        {{ historyListLoadingError }}
-      </v-alert> <!-- /hunt job history errors -->
-
-      <template v-if="!historyListLoadingError">
-        <h4>
-          <v-icon
-            icon="mdi-clock-outline"
-            class="me-2" />
-          {{ $t('hunts.title') }}
+        <h4 v-if="results.length">
+          <v-icon icon="mdi-format-list-numbered" />&nbsp;
+          {{ $t('hunts.huntJobQueue') }}:
         </h4>
-        <v-row class="g-1 justify-start">
-          <v-col cols="auto">
-            <!-- search packet search jobs -->
-            <div class="arkime-input-group arkime-input-group--fluid">
-              <span class="arkime-input-label arkime-input-label-fw">
-                <v-icon icon="mdi-magnify" />
-              </span>
-              <input
-                type="text"
-                v-model="query.searchTerm"
-                @input="debounceSearch"
-                :placeholder="$t('hunts.querySearchTermPlaceholder')"
-                class="arkime-input-control">
-              <v-btn
-                v-if="query.searchTerm"
-                variant="text"
-                size="x-small"
-                density="comfortable"
-                icon
-                class="arkime-input-append-btn"
-                :disabled="!query.searchTerm"
-                @click="clear">
-                <v-icon icon="mdi-close" />
-              </v-btn>
-            </div> <!-- /search packet search jobs -->
-          </v-col>
-          <v-col cols="auto">
-            <!-- job history paging -->
-            <arkime-paging
-              :records-total="historyResults.recordsTotal"
-              :records-filtered="historyResults.recordsFiltered"
-              @change-paging="changePaging" /> <!-- /job history paging -->
-          </v-col>
-        </v-row>
 
-        <table class="arkime-table">
+        <!-- hunt job queue errors -->
+        <v-alert
+          v-if="queuedListError"
+          type="error"
+          variant="tonal"
+          density="compact">
+          {{ queuedListError }}
+        </v-alert>
+        <v-alert
+          v-if="queuedListLoadingError"
+          type="error"
+          variant="tonal"
+          density="compact">
+          {{ $t('hunts.errorLoadingQueue') }}:
+          {{ queuedListLoadingError }}
+        </v-alert> <!-- /hunt job queue errors -->
+
+        <table
+          v-if="results.length"
+          class="arkime-table mb-4">
           <thead>
             <tr>
               <th width="40px">
 &nbsp;
               </th>
-              <th
-                class="cursor-pointer"
-                @click="columnClick('status')">
+              <th>
                 {{ $t('hunts.jobStatus') }}
-                <v-icon
-                  icon="mdi-chevron-up"
-                  v-show="query.sortField === 'status' && !query.desc" />
-                <v-icon
-                  icon="mdi-chevron-down"
-                  v-show="query.sortField === 'status' && query.desc" />
               </th>
               <th>
                 {{ $t('hunts.jobMatches') }}
               </th>
-              <th
-                class="cursor-pointer"
-                @click="columnClick('name')">
+              <th>
                 {{ $t('hunts.jobName') }}
-                <v-icon
-                  icon="mdi-chevron-up"
-                  v-show="query.sortField === 'name' && !query.desc" />
-                <v-icon
-                  icon="mdi-chevron-down"
-                  v-show="query.sortField === 'name' && query.desc" />
               </th>
-              <th
-                class="cursor-pointer no-wrap"
-                @click="columnClick('userId')">
+              <th>
                 {{ $t('hunts.jobUser') }}
-                <v-icon
-                  icon="mdi-chevron-up"
-                  v-show="query.sortField === 'userId' && !query.desc" />
-                <v-icon
-                  icon="mdi-chevron-down"
-                  v-show="query.sortField === 'userId' && query.desc" />
               </th>
               <th>
                 {{ $t('hunts.jobSearch') }}
               </th>
-              <th
-                class="cursor-pointer"
-                @click="columnClick('created')">
+              <th>
                 {{ $t('common.created') }}
-                <v-icon
-                  icon="mdi-chevron-up"
-                  v-show="query.sortField === 'created' && !query.desc" />
-                <v-icon
-                  icon="mdi-chevron-down"
-                  v-show="query.sortField === 'created' && query.desc" />
               </th>
               <th>
                 ID
@@ -819,30 +652,29 @@ SPDX-License-Identifier: Apache-2.0
             tag="tbody">
             <!-- packet search jobs -->
             <template
-              v-for="job in historyResults.data"
+              v-for="job in results"
               :key="`${job.id}-row`">
               <hunt-row
                 :job="job"
                 :user="user"
                 :can-rerun="true"
                 :can-repeat="true"
-                array-name="historyResults"
-                :can-remove-from-sessions="true"
+                :can-cancel="true"
+                array-name="results"
                 @play-job="playJob"
-                @pause-job="pauseJob"
                 @rerun-job="rerunJob"
                 @repeat-job="repeatJob"
+                @pause-job="pauseJob"
+                @cancel-job="cancelJob"
                 @remove-job="removeJob"
                 @toggle="toggleJobDetail"
-                @open-sessions="openSessions"
-                @remove-from-sessions="removeFromSessions" />
+                @open-sessions="openSessions" />
               <tr
                 :key="`${job.id}-detail`"
                 v-if="job.expanded">
                 <td colspan="10">
                   <hunt-data
                     :job="job"
-                    @remove-job="removeJob"
                     @remove-user="removeUser"
                     @add-users="addUsers"
                     :user="user"
@@ -853,61 +685,230 @@ SPDX-License-Identifier: Apache-2.0
           </transition-group>
         </table>
 
-        <!-- no results -->
-        <div
-          v-if="!loading && !historyResults.data.length"
-          class="ms-1 me-1">
-          <div class="mb-5 info-area horizontal-center">
-            <div>
-              <v-icon
-                icon="mdi-folder-open"
-                size="x-large"
-                class="text-muted-more" />&nbsp;
-              <span v-if="!query.searchTerm">
-                {{ $t('hunts.emptyHistory') }}
-                <span v-if="!results.length">
-                  <br>
-                  {{ $t('hunts.noHunts') }}
-                </span>
-              </span>
-              <span v-else>
-                {{ $t('hunts.noMatchHistory') }}
-              </span>
-            </div>
-          </div>
-        </div> <!-- /no results -->
-      </template>
-    </div> <!-- /packet search jobs content -->
+        <!-- hunt job history errors -->
+        <v-alert
+          v-if="historyListError"
+          type="error"
+          variant="tonal"
+          density="compact">
+          <v-icon
+            icon="mdi-alert"
+            class="me-2" />
+          {{ historyListError }}
+        </v-alert>
+        <v-alert
+          v-if="historyListLoadingError"
+          type="error"
+          variant="tonal"
+          density="compact">
+          <v-icon
+            icon="mdi-alert"
+            class="me-2" />
+          {{ $t('hunts.errorLoadingHistory') }}:
+          {{ historyListLoadingError }}
+        </v-alert> <!-- /hunt job history errors -->
 
-    <!-- floating error -->
-    <transition name="slide-fade">
-      <v-card
-        v-if="floatingError || floatingSuccess"
-        variant="outlined"
-        class="floating-msg">
-        <div class="pa-3">
-          <a
-            @click="floatingError = false; floatingSuccess = false"
-            id="dismissError"
-            class="no-decoration cursor-pointer float-right">
-            <v-icon icon="mdi-close" />
-            <v-tooltip activator="#dismissError">{{ $t('common.dismiss') }}</v-tooltip>
-          </a>
-          <span :class="floatingError ? 'text-danger' : 'text-success'">
+        <template v-if="!historyListLoadingError">
+          <h4>
             <v-icon
-              icon="mdi-alert"
-              class="me-2"
-              v-if="floatingError" />
-            <v-icon
-              icon="mdi-check"
-              class="me-2"
-              v-else />
-            {{ floatingError || floatingSuccess }}
-          </span>
-        </div>
-      </v-card>
-    </transition> <!-- /floating error -->
-  </div>
+              icon="mdi-clock-outline"
+              class="me-2" />
+            {{ $t('hunts.title') }}
+          </h4>
+          <v-row class="g-1 justify-start">
+            <v-col cols="auto">
+              <!-- search packet search jobs -->
+              <div class="arkime-input-group arkime-input-group--fluid">
+                <span class="arkime-input-label arkime-input-label-fw">
+                  <v-icon icon="mdi-magnify" />
+                </span>
+                <input
+                  type="text"
+                  v-model="query.searchTerm"
+                  @input="debounceSearch"
+                  :placeholder="$t('hunts.querySearchTermPlaceholder')"
+                  class="arkime-input-control">
+                <v-btn
+                  v-if="query.searchTerm"
+                  variant="text"
+                  size="x-small"
+                  density="comfortable"
+                  icon
+                  class="arkime-input-append-btn"
+                  :disabled="!query.searchTerm"
+                  @click="clear">
+                  <v-icon icon="mdi-close" />
+                </v-btn>
+              </div> <!-- /search packet search jobs -->
+            </v-col>
+            <v-col cols="auto">
+              <!-- job history paging -->
+              <arkime-paging
+                :records-total="historyResults.recordsTotal"
+                :records-filtered="historyResults.recordsFiltered"
+                @change-paging="changePaging" /> <!-- /job history paging -->
+            </v-col>
+          </v-row>
+
+          <table class="arkime-table">
+            <thead>
+              <tr>
+                <th width="40px">
+&nbsp;
+                </th>
+                <th
+                  class="cursor-pointer"
+                  @click="columnClick('status')">
+                  {{ $t('hunts.jobStatus') }}
+                  <v-icon
+                    icon="mdi-chevron-up"
+                    v-show="query.sortField === 'status' && !query.desc" />
+                  <v-icon
+                    icon="mdi-chevron-down"
+                    v-show="query.sortField === 'status' && query.desc" />
+                </th>
+                <th>
+                  {{ $t('hunts.jobMatches') }}
+                </th>
+                <th
+                  class="cursor-pointer"
+                  @click="columnClick('name')">
+                  {{ $t('hunts.jobName') }}
+                  <v-icon
+                    icon="mdi-chevron-up"
+                    v-show="query.sortField === 'name' && !query.desc" />
+                  <v-icon
+                    icon="mdi-chevron-down"
+                    v-show="query.sortField === 'name' && query.desc" />
+                </th>
+                <th
+                  class="cursor-pointer no-wrap"
+                  @click="columnClick('userId')">
+                  {{ $t('hunts.jobUser') }}
+                  <v-icon
+                    icon="mdi-chevron-up"
+                    v-show="query.sortField === 'userId' && !query.desc" />
+                  <v-icon
+                    icon="mdi-chevron-down"
+                    v-show="query.sortField === 'userId' && query.desc" />
+                </th>
+                <th>
+                  {{ $t('hunts.jobSearch') }}
+                </th>
+                <th
+                  class="cursor-pointer"
+                  @click="columnClick('created')">
+                  {{ $t('common.created') }}
+                  <v-icon
+                    icon="mdi-chevron-up"
+                    v-show="query.sortField === 'created' && !query.desc" />
+                  <v-icon
+                    icon="mdi-chevron-down"
+                    v-show="query.sortField === 'created' && query.desc" />
+                </th>
+                <th>
+                  ID
+                </th>
+                <th width="260px">
+&nbsp;
+                </th>
+              </tr>
+            </thead>
+            <transition-group
+              name="list"
+              tag="tbody">
+              <!-- packet search jobs -->
+              <template
+                v-for="job in historyResults.data"
+                :key="`${job.id}-row`">
+                <hunt-row
+                  :job="job"
+                  :user="user"
+                  :can-rerun="true"
+                  :can-repeat="true"
+                  array-name="historyResults"
+                  :can-remove-from-sessions="true"
+                  @play-job="playJob"
+                  @pause-job="pauseJob"
+                  @rerun-job="rerunJob"
+                  @repeat-job="repeatJob"
+                  @remove-job="removeJob"
+                  @toggle="toggleJobDetail"
+                  @open-sessions="openSessions"
+                  @remove-from-sessions="removeFromSessions" />
+                <tr
+                  :key="`${job.id}-detail`"
+                  v-if="job.expanded">
+                  <td colspan="10">
+                    <hunt-data
+                      :job="job"
+                      @remove-job="removeJob"
+                      @remove-user="removeUser"
+                      @add-users="addUsers"
+                      :user="user"
+                      @update-hunt="updateHunt" />
+                  </td>
+                </tr>
+              </template> <!-- /packet search jobs -->
+            </transition-group>
+          </table>
+
+          <!-- no results -->
+          <div
+            v-if="!loading && !historyResults.data.length"
+            class="ms-1 me-1">
+            <div class="mb-5 info-area horizontal-center">
+              <div>
+                <v-icon
+                  icon="mdi-folder-open"
+                  size="x-large"
+                  class="text-muted-more" />&nbsp;
+                <span v-if="!query.searchTerm">
+                  {{ $t('hunts.emptyHistory') }}
+                  <span v-if="!results.length">
+                    <br>
+                    {{ $t('hunts.noHunts') }}
+                  </span>
+                </span>
+                <span v-else>
+                  {{ $t('hunts.noMatchHistory') }}
+                </span>
+              </div>
+            </div>
+          </div> <!-- /no results -->
+        </template>
+      </div> <!-- /packet search jobs content -->
+
+      <!-- floating error -->
+      <transition name="slide-fade">
+        <v-card
+          v-if="floatingError || floatingSuccess"
+          variant="outlined"
+          class="floating-msg">
+          <div class="pa-3">
+            <a
+              @click="floatingError = false; floatingSuccess = false"
+              id="dismissError"
+              class="no-decoration cursor-pointer float-right">
+              <v-icon icon="mdi-close" />
+              <v-tooltip activator="#dismissError">{{ $t('common.dismiss') }}</v-tooltip>
+            </a>
+            <span :class="floatingError ? 'text-danger' : 'text-success'">
+              <v-icon
+                icon="mdi-alert"
+                class="me-2"
+                v-if="floatingError" />
+              <v-icon
+                icon="mdi-check"
+                class="me-2"
+                v-else />
+              {{ floatingError || floatingSuccess }}
+            </span>
+          </div>
+        </v-card>
+      </transition> <!-- /floating error -->
+    </div>
+  </page-layout>
 </template>
 
 <script>
@@ -923,6 +924,7 @@ import ArkimeError from '../utils/Error.vue';
 import ArkimeLoading from '../utils/Loading.vue';
 import ArkimePaging from '@common/Pagination.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import Focus from '@common/Focus.vue';
 import HuntData from './HuntData.vue';
 import HuntRow from './HuntRow.vue';
@@ -946,6 +948,7 @@ export default {
     ArkimeSearch,
     ArkimeLoading,
     ArkimeCollapsible,
+    PageLayout,
     ArkimePaging,
     HuntData,
     HuntRow,
@@ -953,7 +956,6 @@ export default {
     NotifierDropdown
   },
   directives: { Focus },
-  emits: ['recalc-collapse'],
   data: function () {
     return {
       queuedListError: '',
@@ -1543,7 +1545,6 @@ export default {
 
 .hunt-create-navbar {
   z-index: 4;
-  height: 38px;
   background-color: rgb(var(--v-theme-quaternary-lightest));
 
   -webkit-box-shadow: 0 0 16px -2px black;

--- a/viewer/vueapp/src/components/search/Search.vue
+++ b/viewer/vueapp/src/components/search/Search.vue
@@ -604,7 +604,6 @@ export default {
   },
   emits: [
     'changeSearch',
-    'recalc-collapse',
     'setView',
     'setColumns'
   ],
@@ -702,9 +701,6 @@ export default {
     },
     issueSearch: function (newVal, oldVal) {
       if (newVal) { this.applyParams(); }
-    },
-    actionForm: function () {
-      this.$emit('recalc-collapse');
     }
   },
   created: function () {
@@ -721,7 +717,6 @@ export default {
     messageDone: function () {
       this.message = undefined;
       this.messageType = undefined;
-      this.$emit('recalc-collapse');
     },
     applyExpression: function (expression) {
       if (!this.expression) { this.expression = undefined; }
@@ -1004,10 +999,12 @@ form {
   min-width: 0;
 }
 
-/* viz options button position above viz in nav */
+/* viz options gear: docked under the right end of the search form (its
+   position-relative parent) so it follows the toolbar chrome in flow */
 .viz-options-btn-container {
-  top: 128px;
+  position: absolute;
+  top: 108%; /* a nudge past the form bottom centers it in the paging bar */
   right: 4px;
-  position: fixed;
+  z-index: 5;
 }
 </style>

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -3,73 +3,63 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div
-    class="sessions-page"
-    :class="{'hide-tool-bars': !showToolBars}">
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <!-- search navbar -->
-        <arkime-search
-          :fields="headers"
-          :open-sessions="stickySessions"
-          :num-visible-sessions="query.length"
-          :num-matching-sessions="sessions.recordsFiltered"
-          :start="query.start"
-          @change-search="cancelAndLoad(true)"
-          @set-view="loadNewView"
-          @set-columns="loadColumns"
-          @recalc-collapse="$emit('recalc-collapse')" /> <!-- /search navbar -->
+  <page-layout
+    ref="pageLayout"
+    class="sessions-page">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- search navbar -->
+          <arkime-search
+            :fields="headers"
+            :open-sessions="stickySessions"
+            :num-visible-sessions="query.length"
+            :num-matching-sessions="sessions.recordsFiltered"
+            :start="query.start"
+            @change-search="cancelAndLoad(true)"
+            @set-view="loadNewView"
+            @set-columns="loadColumns" /> <!-- /search navbar -->
 
-        <!-- paging navbar -->
-        <div class="d-flex justify-start align-baseline m-1">
-          <arkime-paging
-            style="height: 32px;"
-            :records-total="sessions.recordsTotal"
-            :records-filtered="sessions.recordsFiltered"
-            @change-paging="changePaging" />
-        </div> <!-- /paging navbar -->
-      </span>
-    </ArkimeCollapsible>
+          <!-- paging navbar -->
+          <div class="d-flex justify-start align-center paging-navbar">
+            <arkime-paging
+              :records-total="sessions.recordsTotal"
+              :records-filtered="sessions.recordsFiltered"
+              @change-paging="changePaging" />
+          </div> <!-- /paging navbar -->
+        </div>
+      </ArkimeCollapsible>
+      <!-- pinned visualizations land here (teleported from below) -->
+      <div id="viz-pin-anchor" />
+    </template>
 
-    <!-- visualizations -->
-    <arkime-visualizations
-      v-if="graphData && showToolBars"
-      :primary="true"
-      :map-data="mapData"
-      :graph-data="graphData"
-      @fetch-map-data="fetchMapData"
-      @spanning-change="loadData"
-      :timeline-data-filters="timelineDataFilters" />
-    <!-- /visualizations -->
+    <!-- visualizations: pinned = chrome row above the scroll container,
+         unpinned = scrolls away with the content -->
+    <teleport
+      defer
+      to="#viz-pin-anchor"
+      :disabled="!stickyViz">
+      <arkime-visualizations
+        v-if="graphData && showToolBars"
+        :primary="true"
+        :map-data="mapData"
+        :graph-data="graphData"
+        @fetch-map-data="fetchMapData"
+        @spanning-change="loadData"
+        :timeline-data-filters="timelineDataFilters" />
+    </teleport> <!-- /visualizations -->
 
-    <div
-      class="sessions-content ms-2"
-      id="sessions-content"
-      ref="sessionsContent">
+    <div class="sessions-content ms-2">
       <!-- table view -->
       <div>
-        <!-- sticky (opened) sessions -->
-        <transition name="leave">
-          <arkime-sticky-sessions
-            class="sticky-sessions"
-            v-if="stickySessions.length"
-            :ms="user.settings.ms"
-            :sessions="stickySessions"
-            @close-session="closeSession"
-            @close-all-sessions="closeAllSessions" />
-        </transition> <!-- /sticky (opened) sessions -->
-
         <!-- sessions results -->
         <table
           class="sessions-table"
           :style="`width:${tableWidth}px`"
-          :class="{'sticky-header':stickyHeader}"
+          :class="{'sticky-header':stickyViz}"
           ref="sessionsTable"
           id="sessionsTable">
-          <thead
-            ref="tableHeader"
-            id="sessions-table-header"
-            style="overflow:scroll">
+          <thead>
             <tr ref="draggableColumns">
               <!-- table options: single dropdown collapsing five separate
                    controls (open/close all, fit, toggle columns, save
@@ -636,6 +626,12 @@ SPDX-License-Identifier: Apache-2.0
                     </div>
                     <div class="header-text">
                       {{ header.friendlyName }}
+                      <v-tooltip
+                        activator="parent"
+                        location="top"
+                        open-delay="500">
+                        {{ header.friendlyName }}
+                      </v-tooltip>
                     </div>
                   </span> <!-- /sortable column -->
                 </th> <!-- /table headers -->
@@ -643,16 +639,13 @@ SPDX-License-Identifier: Apache-2.0
             </tr>
           </thead>
 
-          <tbody
-            class="small"
-            id="sessions-table-body">
+          <tbody class="small">
             <!-- session + detail -->
             <template
-              v-for="(session, index) of sessions.data"
+              v-for="session of sessions.data"
               :key="session.id">
               <tr
                 class="sessions-scroll-margin"
-                :ref="`tableRow${index}`"
                 :id="`session${session.id}`">
                 <!-- toggle button and ip protocol -->
                 <td class="ignore-element">
@@ -761,7 +754,20 @@ SPDX-License-Identifier: Apache-2.0
       :timeout="5000">
       {{ configSnackbar.text }}
     </v-snackbar>
-  </div>
+
+    <template #overlay>
+      <!-- sticky (opened) sessions -->
+      <transition name="leave">
+        <arkime-sticky-sessions
+          class="sticky-sessions"
+          v-if="stickySessions.length"
+          :ms="user.settings.ms"
+          :sessions="stickySessions"
+          @close-session="closeSession"
+          @close-all-sessions="closeAllSessions" />
+      </transition> <!-- /sticky (opened) sessions -->
+    </template>
+  </page-layout>
 </template>
 
 <script>
@@ -781,6 +787,7 @@ import ArkimeLoading from '../utils/Loading.vue';
 import ArkimeNoResults from '../utils/NoResults.vue';
 import ArkimeSessionDetail from './SessionDetail.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import ArkimeVisualizations from '../visualizations/Visualizations.vue';
 import ArkimeStickySessions from './StickySessions.vue';
 import FieldActions from './FieldActions.vue';
@@ -819,22 +826,6 @@ const defaultColWidths = {
 
 const MIN_COL_WIDTH = 70;
 
-// fired when a scroll event is captured on this page
-// scrolls the table header and body together if the header is sticky
-function docScroll (e, vueThis) {
-  if (!vueThis.stickyHeader) { return; }
-
-  let sibling;
-  if (e.target.id === 'sessions-content') {
-    sibling = vueThis.$refs.tableHeader;
-  } else if (e.target.id === 'sessions-table-header') {
-    sibling = vueThis.$refs.sessionsContent;
-  } else {
-    return;
-  }
-  sibling.scrollLeft = e.target.scrollLeft;
-}
-
 // save a pending promise to be able to cancel it
 let pendingPromise;
 
@@ -851,10 +842,10 @@ export default {
     ArkimeVisualizations,
     ArkimeStickySessions,
     ArkimeCollapsible,
+    PageLayout,
     FieldActions,
     FieldSelectDropdown
   },
-  emits: ['recalc-collapse'],
   data: function () {
     return {
       loading: true,
@@ -874,8 +865,6 @@ export default {
       infoFields: customCols.info.children,
       colVisMenuOpen: false,
       infoFieldVisMenuOpen: false,
-      stickyHeader: false,
-      tableHeaderOverflow: undefined,
       showFitButton: false,
       tableWidth: window.innerWidth - 20, // account for margins
       filteredFields: [],
@@ -920,7 +909,7 @@ export default {
     windowResizeEvent = () => {
       // Surface the Fit Table button when the viewport shrinks past the content.
       // Cheap; runs every resize event so the affordance appears immediately.
-      if (Math.abs((this.tableWidth || 0) - window.innerWidth) > 15) {
+      if (Math.abs((this.tableWidth || 0) - this.availableTableWidth()) > 15) {
         this.showFitButton = true;
       }
       if (resizeTimeout) { clearTimeout(resizeTimeout); }
@@ -1000,6 +989,9 @@ export default {
     showToolBars: function () {
       return this.$store.state.showToolBars;
     },
+    stickyViz: function () {
+      return this.$store.state.stickyViz;
+    },
     fields: function () {
       return this.$store.state.fieldsMap;
     },
@@ -1069,8 +1061,9 @@ export default {
   },
   watch: {
     '$store.state.stickyViz': function () {
-      this.stickyHeader = this.$store.state.stickyViz;
-      this.toggleStickyHeader();
+      // pin toggle teleports the viz between chrome and scroll content;
+      // charts/map cache geometry, so nudge their resize handling
+      this.$nextTick(() => window.dispatchEvent(new Event('resize')));
     },
     '$store.state.fetchGraphData': function (value) {
       if (value) { this.fetchGraphData(); }
@@ -1084,23 +1077,13 @@ export default {
       this.tableState = JSON.parse(JSON.stringify(colConfig));
       this.loadData(true);
     },
-    /* show the overflow when a dropdown in a column header is shown. otherwise,
-     * the dropdown is cut off and scrolls vertically in the column header */
-    dropdownShowListener: function (bvEvent) {
-      if (!this.stickyHeader) { return; }
-      const target = $(bvEvent.target);
-      if (!target) { return; }
-      if (!target.parent().hasClass('col-dropdown')) { return; }
-      $('thead').css('overflow', 'visible');
-    },
-    /* when the column header dropdown is hidden, go back to the default scroll
-     * behavior so that the table can overflow the window width */
-    dropdownHideListener: function (bvEvent) {
-      if (!this.stickyHeader) { return; }
-      const target = $(bvEvent.target);
-      if (!target) { return; }
-      if (!target.parent().hasClass('col-dropdown')) { return; }
-      $('thead').css('overflow', 'scroll');
+    /* Width available to the table inside the page scroll container */
+    availableTableWidth: function () {
+      const scrollEl = this.$refs.pageLayout?.scrollEl;
+      if (scrollEl && scrollEl.clientWidth) {
+        return scrollEl.clientWidth - 20; // account for margins
+      }
+      return window.innerWidth - 20; // pre-mount fallback
     },
     /* exposed page functions ---------------------------------------------- */
     /* SESSIONS DATA */
@@ -1173,8 +1156,6 @@ export default {
         const index = this.stickySessions.indexOf(session);
         if (index >= 0) { this.stickySessions.splice(index, 1); }
       }
-
-      this.$store.commit('setStickySessionsBtn', !!this.stickySessions.length);
     },
     expandSessionDetail: function (session) {
       if (session.expanded) { return; }
@@ -1195,7 +1176,6 @@ export default {
         if (session.id === sessionId) {
           session.expanded = false;
           this.stickySessions.splice(i, 1);
-          this.$store.commit('setStickySessionsBtn', !!this.stickySessions.length);
           return;
         }
       }
@@ -1692,10 +1672,10 @@ export default {
       customCols.info.children = this.infoFields;
       UserService.saveSettings(this.user.settings);
     },
-    /* Fits the table to the width of the current window size */
+    /* Fits the table to the width of the page scroll container */
     fitTable: function () {
-      const windowWidth = window.innerWidth - 20; // account for margins
-      const leftoverWidth = windowWidth - this.sumOfColWidths;
+      const targetWidth = this.availableTableWidth();
+      const leftoverWidth = targetWidth - this.sumOfColWidths;
       const percentChange = 1 + (leftoverWidth / this.sumOfColWidths);
 
       for (let i = 0, len = this.headers.length; i < len; ++i) {
@@ -1706,13 +1686,12 @@ export default {
         this.colWidths[header.dbField] = newWidth;
       }
 
-      this.tableWidth = windowWidth;
+      this.tableWidth = targetWidth;
       this.showFitButton = false;
 
-      this.$refs.sessionsTable.style.width = `${windowWidth}px`;
+      this.$refs.sessionsTable.style.width = `${targetWidth}px`;
 
       this.saveColumnWidths();
-      this.toggleStickyHeader();
     },
     /**
      * Returns the list of field targets a column-context menu should render
@@ -2062,7 +2041,6 @@ export default {
       this.sumOfColWidths = Math.round(this.sumOfColWidths);
 
       this.calculateInfoColumnWidth(defaultColWidths.info);
-      this.toggleStickyHeader();
     },
     /* Opens up to 50 session details in the table */
     openAll: function () {
@@ -2163,17 +2141,11 @@ export default {
           this.loading = false;
         }
       });
-      this._docScrollHandler = (e) => docScroll(e, this);
-      document.addEventListener('scroll', this._docScrollHandler, true);
     },
     destroyColResizable () {
       if (this._gripAttachment) {
         this._gripAttachment.detach();
         this._gripAttachment = null;
-      }
-      if (this._docScrollHandler) {
-        document.removeEventListener('scroll', this._docScrollHandler, true);
-        this._docScrollHandler = null;
       }
       this._colResizeInitialized = false;
     },
@@ -2204,10 +2176,10 @@ export default {
       this.showFitButton = false;
       if (!this.colWidths) { return; }
 
-      const windowWidth = window.innerWidth - 20; // account for margins
+      const availableWidth = this.availableTableWidth();
 
       if (this.tableState.visibleHeaders.indexOf('info') >= 0) {
-        const fillWithInfoCol = windowWidth - this.sumOfColWidths;
+        const fillWithInfoCol = availableWidth - this.sumOfColWidths;
         let newTableWidth = this.sumOfColWidths;
         for (let i = 0, len = this.headers.length; i < len; ++i) {
           if (this.headers[i].dbField === 'info') {
@@ -2219,52 +2191,11 @@ export default {
         this.tableWidth = newTableWidth;
       } else {
         this.tableWidth = this.sumOfColWidths;
-        // display a button to fit the table to the width of the window
-        // if the table is more than 10 pixels larger or smaller than the window
-        if (Math.abs(this.tableWidth - windowWidth) > 10) {
+        // display a button to fit the table to the width of the container
+        // if the table is more than 10 pixels larger or smaller than it
+        if (Math.abs(this.tableWidth - availableWidth) > 10) {
           this.showFitButton = true;
         }
-      }
-    },
-    /* Toggles the sticky table header */
-    toggleStickyHeader: function () {
-      // Guard check: ensure refs are available before proceeding
-      if (!this.$refs.draggableColumns || !this.$refs.tableHeader || !this.$refs.tableRow0) {
-        return;
-      }
-
-      const firstTableRow = this.$refs.tableRow0;
-      if (this.stickyHeader) {
-        // calculate the height of the header row
-        const height = this.$refs.draggableColumns.clientHeight + 6;
-        const windowWidth = window.innerWidth - 20; // account for margins
-        // calculate how much the header row is under or overflowing the window
-        const tableHeaderOverflow = windowWidth - this.tableWidth;
-        if (tableHeaderOverflow !== 0) { // if it's overflowing the window
-          this.tableHeaderOverflow = tableHeaderOverflow;
-          // set the right style to the amount of the overflow
-          if (tableHeaderOverflow < 0) {
-            this.$refs.tableHeader.style.width = `${window.innerWidth}px`;
-            this.$refs.draggableColumns.style.width = `${table.clientWidth}px`;
-          }
-        } else { // otherwise unset it (default = auto, see css)
-          this.tableHeaderOverflow = undefined;
-          this.$refs.tableHeader.style = undefined;
-          this.$refs.draggableColumns.style = undefined;
-        }
-        if (firstTableRow && firstTableRow.length > 0) { // if there is a table row in the body
-          // set the margin top to the height of the header so it renders below it
-          firstTableRow[0].style.marginTop = `${height}px`;
-        }
-        // set the overflow to scroll so that the header can scroll horizontally
-        $('thead').css('overflow', 'scroll');
-      } else { // if the header is not sticky
-        if (firstTableRow && firstTableRow.length > 0) { // and there is a table row in the body
-          // unset the top margin because the table header won't overlay it
-          firstTableRow[0].style = undefined;
-        }
-        // set the overflow to visible so that the dropdowns overflow the header
-        $('thead').css('overflow', 'visible');
       }
     },
     /* event handlers ------------------------------------------------------ */
@@ -2289,6 +2220,8 @@ export default {
     }
 
     if (timeout) { clearTimeout(timeout); }
+    if (resizeTimeout) { clearTimeout(resizeTimeout); }
+    if (filterFieldsTimeout) { clearTimeout(filterFieldsTimeout); }
 
     this.destroyColResizable();
 
@@ -2387,33 +2320,26 @@ table.sessions-table thead tr th.sessions-options-cell {
   margin-left: 0;
 }
 
-/* clear the box shadow above the sticky column headers */
-.sessions-page .sticky-viz .viz-container {
-  box-shadow: none !important;
-}
 </style>
 
 <style scoped>
-.sessions-page {
-  overflow: hidden;
+/* paging sub-navbar: fixed band height, controls centered within it */
+.paging-navbar {
+  height: 44px;
+  padding: 0 4px;
 }
 
 .sessions-content {
-  margin-top: -12px;
   min-height: 500px;
-}
-
-/* only pad above the table when the sticky-viz sibling is present;
-   otherwise the gap looks like dead space at the top of the page */
-.sticky-viz ~ .sessions-content {
-  padding-top: 30px;
-  margin-top: 10px;
 }
 
 /* sessions table styles --------------------- */
 table.sessions-table {
   margin-bottom: 20px;
   table-layout: fixed;
+  /* separate borders so they travel with the sticky header cells */
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 /* borders for header */
@@ -2428,10 +2354,6 @@ table.sessions-table thead tr th:first-child {
   border-right: none;
   padding: 0;
   vertical-align: middle;
-}
-/* remove scrollbar from table header */
-table.sessions-table thead::-webkit-scrollbar {
-  display: none;
 }
 
 /* alternate-row striping */
@@ -2467,40 +2389,25 @@ table.sessions-table tbody tr td.ignore-element {
 }
 
 /* sticky table header ----------------------- */
-table.sessions-table.sticky-header > thead {
-  left: 0;
+/* native sticky: the page-scroll container is the one scroller for both
+   axes, so the header pins vertically and stays aligned horizontally with
+   the body for free */
+table.sessions-table.sticky-header > thead th {
+  position: sticky;
+  top: 0;
   z-index: 2;
-  /* need to unset right because sometimes the header overflows the window */
-  right: auto;
-  position: fixed;
-  margin-top: -50px;
-  padding-top: 5px;
-  /* need x overflow for the table to be able to overflow the window width */
-  overflow-x: scroll;
-  padding-left: 8px;
   box-shadow: 0 6px 9px -6px black;
   background-color: rgb(var(--v-theme-background));
 }
-table.sessions-table.sticky-header > thead > tr {
-  display: table;
-  /* need x overflow for the table to be able to overflow the window width */
-  overflow-x: scroll;
-  table-layout: fixed;
+/* each sticky th is its own stacking context; lift the dragged cell so
+   the grip's guide line isn't painted under the following cells */
+table.sessions-table.sticky-header > thead th.col-resizing {
+  z-index: 3;
 }
-/* need this to make sure that the body cells are the correct width */
-table.sessions-table.sticky-header > tbody > tr {
-  display: table;
-  table-layout: fixed;
-}
-/* need this when reloading the page with sticky headers */
-table.sessions-table.sticky-header > tbody {
-  display: block;
-  margin-top: -50px;
-}
-/* Disabled-aggregations variant: pull tbody up under the sticky thead so it
-   lands flush when the info column is showing and rows are pinned. */
-.sticky-viz.disabled-msg ~ .sessions-content table.sessions-table.sticky-header > tbody {
-  margin-top: -50px;
+/* keep the grip fully inside its cell — the overhanging half would
+   hit-test under the next (opaque) sticky th */
+table.sessions-table thead .grip {
+  right: 0;
 }
 
 /* table column headers -------------------- */
@@ -2528,6 +2435,10 @@ table.sessions-table.sticky-header > tbody {
 .arkime-col-header .header-text {
   display: inline-block;
   width: calc(100% - 24px);
+  /* one line max so the header height stays within scroll-margin-top */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .arkime-col-header .header-sort {
@@ -2569,12 +2480,8 @@ table.sessions-table.sticky-header > tbody {
   opacity: 0;
 }
 
-/* set scroll margin offset for scrolling to sessions */
+/* keep scrolled-to sessions clear of the sticky column headers */
 .sessions-scroll-margin {
-  scroll-margin: 115px;
-}
-/* if there are no toolbars, there is no offset */
-.hide-tool-bars .sessions-scroll-margin {
-  scroll-margin: 0px;
+  scroll-margin-top: 40px;
 }
 </style>

--- a/viewer/vueapp/src/components/sessions/StickySessions.vue
+++ b/viewer/vueapp/src/components/sessions/StickySessions.vue
@@ -3,34 +3,36 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div
-    class="bounce"
-    ref="stickyContainer"
-    :class="{
-      'hide-toolbars': !showToolBars,
-      'show-sticky-sessions-btn': sortedSessions && sortedSessions.length
-    }">
-    <!-- toggle button -->
-    <div
-      class="sticky-session-btn"
-      @click="toggleStickySessions"
-      v-if="sortedSessions && sortedSessions.length > 0">
-      <v-icon
-        icon="mdi-chevron-double-left"
-        v-if="!open" /><v-icon
-          icon="mdi-chevron-double-right"
-          v-else />&nbsp;
-      <small>{{ sortedSessions.length }}</small>
-      <v-tooltip activator="parent">
-        {{ $t('sessions.sticky.toggleOpenTip') }}
-      </v-tooltip>
-    </div> <!-- /toggle button -->
+  <div>
+    <!-- toggle button: teleported to body so it escapes the page
+         overlay's stacking context and paints over the toolbar chrome
+         (z-tie with .page-chrome, later in DOM = on top, like the
+         legacy .fixed-header tie) -->
+    <teleport to="body">
+      <div
+        class="sticky-session-btn bounce"
+        :style="showToolBars ? null : { top: '4px', zIndex: 8 }"
+        ref="stickyContainer"
+        @click="toggleStickySessions"
+        v-if="sortedSessions && sortedSessions.length > 0">
+        <v-icon
+          icon="mdi-chevron-double-left"
+          v-if="!open" /><v-icon
+            icon="mdi-chevron-double-right"
+            v-else />&nbsp;
+        <small>{{ sortedSessions.length }}</small>
+        <v-tooltip activator="parent">
+          {{ $t('sessions.sticky.toggleOpenTip') }}
+        </v-tooltip>
+      </div>
+    </teleport> <!-- /toggle button -->
 
     <!-- sticky sessions content -->
     <transition name="slide">
       <div
         v-if="open"
-        class="sticky-session-detail">
+        class="sticky-session-detail"
+        :style="showToolBars ? null : { top: '35px' }">
         <!-- sticky sessions list -->
         <ul class="sticky-list">
           <li class="sticky-list-item sticky-list-header">
@@ -137,9 +139,6 @@ SPDX-License-Identifier: Apache-2.0
 <script>
 import { timezoneDateString, protocol } from '@common/vueFilters.js';
 
-let stickyContainer;
-let oldLength = 1;
-
 export default {
   name: 'ArkimeStickySessions',
   emits: ['closeSession', 'closeAllSessions'],
@@ -157,7 +156,8 @@ export default {
     return {
       open: false,
       sortBy: '', // use the order sessions are opened
-      sortOrder: 'desc'
+      sortOrder: 'desc',
+      oldLength: this.sessions.length
     };
   },
   watch: {
@@ -166,33 +166,29 @@ export default {
       handler (newVal, oldVal) {
         const newLength = newVal.length;
 
-        this.$store.commit('setStickySessionsBtn', !!newLength);
-
         // only sort changed, nothing to do
-        if (newLength === oldLength) { return; }
+        if (newLength === this.oldLength) { return; }
 
         if (!newLength) {
           this.open = false;
           return;
         }
 
-        if (newLength > oldLength) {
-          if (!stickyContainer) {
-            stickyContainer = this.$refs.stickyContainer;
+        if (newLength > this.oldLength) {
+          const btn = this.$refs.stickyContainer;
+          if (btn) {
+            btn.classList.remove('bounce');
+            setTimeout(() => btn.classList.add('bounce'));
           }
-
-          stickyContainer.classList.remove('bounce');
-
-          setTimeout(() => {
-            stickyContainer.classList.add('bounce');
-          });
         }
 
-        oldLength = newLength;
+        this.oldLength = newLength;
       }
     }
   },
   computed: {
+    // store toggle (shared across pages); collapsed toolbar rides the
+    // button/panel up to the top
     showToolBars: function () {
       return this.$store.state.showToolBars;
     },
@@ -251,7 +247,6 @@ export default {
     closeAll: function () {
       this.open = false;
       this.$emit('closeAllSessions');
-      this.$store.commit('setStickySessionsBtn', false);
     },
     /**
      * Scrolls to specified session
@@ -266,6 +261,9 @@ export default {
 </script>
 
 <style scoped>
+/* viewport-fixed: the button (body-teleported) paints over the toolbar
+   chrome; the panel stays in the overlay and slides under it (chrome z5 >
+   overlay z4). When the toolbar collapses, :style rides both up to the top. */
 .sticky-session-btn {
   width: 100px;
   display: block;
@@ -275,17 +273,11 @@ export default {
   z-index: 5;
   margin-right: -50px;
   overflow: hidden;
-  padding: 1px 10px 2px 12px;
+  padding: 1px 0px 1px 0px;
   border-radius: 4px 0 0 4px;
   cursor: pointer;
   background-color: rgb(var(--v-theme-quaternary));
   color: rgb(var(--v-theme-button-fg));
-}
-
-/* move the sticky session button up when the toolbars are hidden */
-.hide-toolbars.show-sticky-sessions-btn .sticky-session-btn {
-  top: 4px;
-  z-index: 8;
 }
 
 .sort-by-select {
@@ -295,7 +287,7 @@ export default {
 .sticky-session-detail {
   overflow-y: auto;
   position: fixed;
-  top: 160px;
+  top: 168px;
   right: 0;
   bottom: 0;
   z-index: 4;
@@ -308,11 +300,6 @@ export default {
           box-shadow: 0 0 16px -2px black;
 }
 
-/* move the sticky session detail up when the toolbars are hidden */
-.hide-toolbars.show-sticky-sessions-btn .sticky-session-detail {
-  top: 35px;
-}
-
 .sticky-session-detail .sticky-list {
   margin-bottom: 0;
   padding-left: 0;
@@ -321,7 +308,7 @@ export default {
 
 .sticky-session-detail .sticky-list-item {
   display: block;
-  border-top: 1px solid rgb(var(--v-theme-neutral-light)));
+  border-top: 1px solid rgb(var(--v-theme-neutral-light));
   padding: 4px 8px;
   background-color: rgb(var(--v-theme-background));
   color: rgb(var(--v-theme-foreground));
@@ -346,7 +333,7 @@ a.sticky-list-item:focus {
 
 /* ANIMATIONS ---------------------- */
 /* bounce the sticky sessions button */
-.bounce .sticky-session-btn {
+.sticky-session-btn.bounce {
   -webkit-animation: bounce 1000ms linear both;
      -moz-animation: bounce 1000ms linear both;
           animation: bounce 1000ms linear both;

--- a/viewer/vueapp/src/components/spigraph/Spigraph.vue
+++ b/viewer/vueapp/src/components/spigraph/Spigraph.vue
@@ -3,148 +3,167 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div class="spigraph-page">
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <!-- search navbar -->
-        <arkime-search
-          :num-matching-sessions="filtered"
-          @change-search="cancelAndLoad(true)"
-          @recalc-collapse="$emit('recalc-collapse')" /> <!-- /search navbar -->
+  <page-layout class="spigraph-page">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- search navbar -->
+          <arkime-search
+            :num-matching-sessions="filtered"
+            @change-search="cancelAndLoad(true)" /> <!-- /search navbar -->
 
-        <!-- spigraph sub navbar -->
-        <div class="spigraph-form m-1">
-          <div class="d-flex flex-wrap align-center gap-1">
-            <!-- field select -->
-            <div
-              class="arkime-input-group"
-              v-if="fields && fields.length && fieldTypeahead">
-              <span class="arkime-input-label">
-                {{ $t('spigraph.field') }}:
-              </span>
-              <arkime-field-typeahead
-                :fields="fields"
-                query-param="exp"
-                :initial-value="fieldTypeahead"
-                @field-selected="changeField"
-                page="Spigraph" />
-            </div> <!-- /field select -->
+          <!-- spigraph sub navbar -->
+          <div class="spigraph-form mx-1">
+            <div class="d-flex flex-wrap align-center gap-1 page-subnav">
+              <!-- field select -->
+              <div
+                class="arkime-input-group"
+                v-if="fields && fields.length && fieldTypeahead">
+                <span class="arkime-input-label">
+                  {{ $t('spigraph.field') }}:
+                </span>
+                <arkime-field-typeahead
+                  :fields="fields"
+                  query-param="exp"
+                  :initial-value="fieldTypeahead"
+                  @field-selected="changeField"
+                  page="Spigraph" />
+              </div> <!-- /field select -->
 
-            <!-- maxElements select -->
-            <div class="arkime-input-group">
-              <span
-                id="maxElements"
-                class="arkime-input-label cursor-help">
-                {{ $t('spigraph.maxElements') }}:
-              </span>
-              <v-tooltip activator="#maxElements">
-                {{ $t('spigraph.maxElementsTip') }}
-              </v-tooltip>
-              <select
-                class="arkime-input-control"
-                :value="query.size"
-                @change="changeMaxElements(Number($event.target.value))">
-                <option
-                  v-for="opt in maxElementsOptions"
-                  :key="opt"
-                  :value="opt">{{ opt }}</option>
-              </select>
-            </div> <!-- /maxElements select -->
+              <!-- maxElements select -->
+              <div class="arkime-input-group">
+                <span
+                  id="maxElements"
+                  class="arkime-input-label cursor-help">
+                  {{ $t('spigraph.maxElements') }}:
+                </span>
+                <v-tooltip activator="#maxElements">
+                  {{ $t('spigraph.maxElementsTip') }}
+                </v-tooltip>
+                <select
+                  class="arkime-input-control"
+                  :value="query.size"
+                  @change="changeMaxElements(Number($event.target.value))">
+                  <option
+                    v-for="opt in maxElementsOptions"
+                    :key="opt"
+                    :value="opt">
+                    {{ opt }}
+                  </option>
+                </select>
+              </div> <!-- /maxElements select -->
 
-            <!-- main graph type select -->
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">
-                {{ $t('spigraph.graphType') }}:
-              </span>
-              <select
-                class="arkime-input-control"
-                :value="spiGraphType"
-                @change="changeSpiGraphType($event.target.value)">
-                <option
-                  v-for="t in graphTypeOptions"
-                  :key="t"
-                  :value="t"
-                  v-i18n-value="'spigraph.graphType-'" />
-              </select>
-            </div> <!-- /main graph type select -->
+              <!-- main graph type select -->
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">
+                  {{ $t('spigraph.graphType') }}:
+                </span>
+                <select
+                  class="arkime-input-control"
+                  :value="spiGraphType"
+                  @change="changeSpiGraphType($event.target.value)">
+                  <option
+                    v-for="t in graphTypeOptions"
+                    :key="t"
+                    :value="t"
+                    v-i18n-value="'spigraph.graphType-'" />
+                </select>
+              </div> <!-- /main graph type select -->
 
-            <!-- sort select (not shown for the pie graph) -->
-            <div
-              class="arkime-input-group"
-              v-if="spiGraphType === 'default'">
-              <span class="arkime-input-label">
-                {{ $t('spigraph.sortBy') }}:
-              </span>
-              <select
-                class="arkime-input-control"
-                :value="sortBy"
-                @change="changeSortBy($event.target.value)">
-                <option value="name">{{ $t('spigraph.sortBy-name') }}</option>
-                <option value="graph">{{ $t('spigraph.sortBy-graph') }}</option>
-              </select>
-            </div> <!-- /sort select -->
+              <!-- sort select (not shown for the pie graph) -->
+              <div
+                class="arkime-input-group"
+                v-if="spiGraphType === 'default'">
+                <span class="arkime-input-label">
+                  {{ $t('spigraph.sortBy') }}:
+                </span>
+                <select
+                  class="arkime-input-control"
+                  :value="sortBy"
+                  @change="changeSortBy($event.target.value)">
+                  <option value="name">
+                    {{ $t('spigraph.sortBy-name') }}
+                  </option>
+                  <option value="graph">
+                    {{ $t('spigraph.sortBy-graph') }}
+                  </option>
+                </select>
+              </div> <!-- /sort select -->
 
-            <!-- refresh input (not shown for pie) -->
-            <div
-              class="arkime-input-group"
-              v-if="spiGraphType === 'default'">
-              <span class="arkime-input-label">
-                {{ $t('spigraph.refreshEvery') }}:
-              </span>
-              <select
-                class="arkime-input-control"
-                :value="refresh"
-                @change="changeRefreshInterval(Number($event.target.value))">
-                <option
-                  v-for="opt in refreshOptions"
-                  :key="opt"
-                  :value="opt">{{ opt }}</option>
-              </select>
-              <span class="arkime-input-label">
-                {{ $t('common.seconds') }}
-              </span>
-            </div> <!-- /refresh input-->
+              <!-- refresh input (not shown for pie) -->
+              <div
+                class="arkime-input-group"
+                v-if="spiGraphType === 'default'">
+                <span class="arkime-input-label">
+                  {{ $t('spigraph.refreshEvery') }}:
+                </span>
+                <select
+                  class="arkime-input-control"
+                  :value="refresh"
+                  @change="changeRefreshInterval(Number($event.target.value))">
+                  <option
+                    v-for="opt in refreshOptions"
+                    :key="opt"
+                    :value="opt">
+                    {{ opt }}
+                  </option>
+                </select>
+                <span class="arkime-input-label">
+                  {{ $t('common.seconds') }}
+                </span>
+              </div> <!-- /refresh input-->
 
-            <!-- page info -->
-            <div
-              class="records-display align-self-center"
-              v-if="spiGraphType === 'default'">
-              <strong
-                class="text-theme-accent"
-                v-if="!error && recordsFiltered !== undefined">
-                {{ $t('common.showingAllTip', { count: commaString(recordsFiltered), total: commaString(recordsTotal) }) }}
-              </strong>
-            </div> <!-- /page info -->
+              <!-- page info -->
+              <div
+                class="records-display align-self-center"
+                v-if="spiGraphType === 'default'">
+                <strong
+                  class="text-theme-accent"
+                  v-if="!error && recordsFiltered !== undefined">
+                  {{ $t('common.showingAllTip', { count: commaString(recordsFiltered), total: commaString(recordsTotal) }) }}
+                </strong>
+              </div> <!-- /page info -->
 
-            <!-- export button-->
-            <v-btn
-              v-if="spiGraphType !== 'default' && spiGraphType !== 'sankey'"
-              variant="outlined"
-              size="small"
-              density="comfortable"
-              icon
-              class="ms-1"
-              :aria-label="$t('spigraph.exportCSVSPIGraphTip')"
-              @click.stop.prevent="exportCSV">
-              <v-icon icon="mdi-download" />
-              <v-tooltip activator="parent">{{ $t('spigraph.exportCSVSPIGraphTip') }}</v-tooltip>
-            </v-btn> <!-- /export button-->
+              <!-- export button-->
+              <v-btn
+                v-if="spiGraphType !== 'default' && spiGraphType !== 'sankey'"
+                variant="outlined"
+                size="small"
+                density="comfortable"
+                icon
+                class="ms-1"
+                :aria-label="$t('spigraph.exportCSVSPIGraphTip')"
+                @click.stop.prevent="exportCSV">
+                <v-icon icon="mdi-download" />
+                <v-tooltip activator="parent">
+                  {{ $t('spigraph.exportCSVSPIGraphTip') }}
+                </v-tooltip>
+              </v-btn> <!-- /export button-->
+            </div>
           </div>
         </div>
-      </span>
-    </ArkimeCollapsible>
+      </ArkimeCollapsible>
+      <!-- pinned ("Pin top") visualizations land here (teleported from below) -->
+      <div id="viz-pin-anchor" />
+    </template>
 
-    <!-- main visualization -->
-    <div v-if="spiGraphType === 'default' && mapData && graphData && fieldObj && showToolBars">
-      <arkime-visualizations
-        id="primary"
-        :graph-data="graphData"
-        :map-data="mapData"
-        :primary="true"
-        :timeline-data-filters="timelineDataFilters"
-        @fetch-map-data="cancelAndLoad(true)"
-        @spanning-change="cancelAndLoad(true)" />
-    </div> <!-- /main visualization -->
+    <!-- main visualization: pinned = chrome row above the scroll container,
+         unpinned = scrolls away with the content -->
+    <teleport
+      defer
+      to="#viz-pin-anchor"
+      :disabled="!stickyViz">
+      <div v-if="spiGraphType === 'default' && mapData && graphData && fieldObj && showToolBars">
+        <arkime-visualizations
+          id="primary"
+          :graph-data="graphData"
+          :map-data="mapData"
+          :primary="true"
+          :timeline-data-filters="timelineDataFilters"
+          @fetch-map-data="cancelAndLoad(true)"
+          @spanning-change="cancelAndLoad(true)" />
+      </div>
+    </teleport> <!-- /main visualization -->
 
     <div class="spigraph-content">
       <!-- pie graph type -->
@@ -224,7 +243,7 @@ SPDX-License-Identifier: Apache-2.0
         :records-total="recordsTotal"
         :view="query.view" /> <!-- /no results -->
     </div>
-  </div>
+  </page-layout>
 </template>
 
 <script>
@@ -240,6 +259,7 @@ import ArkimeNoResults from '../utils/NoResults.vue';
 import ArkimeFieldTypeahead from '../utils/FieldTypeahead.vue';
 import ArkimeVisualizations from '../visualizations/Visualizations.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import ArkimePie from './Hierarchy.vue';
 import { commaString } from '@common/vueFilters.js';
 import { resolveMessage } from '@common/resolveI18nMessage';
@@ -260,9 +280,9 @@ export default {
     ArkimeFieldTypeahead,
     ArkimeVisualizations,
     ArkimeCollapsible,
+    PageLayout,
     ArkimePie
   },
-  emits: ['recalc-collapse'],
   data: function () {
     return {
       error: '',
@@ -327,11 +347,19 @@ export default {
     showToolBars: function () {
       return this.$store.state.showToolBars;
     },
+    stickyViz: function () {
+      return this.$store.state.stickyViz;
+    },
     fields: function () {
       return FieldService.addIpDstPortField(this.$store.state.fieldsArr);
     }
   },
   watch: {
+    '$store.state.stickyViz': function () {
+      // pin toggle teleports the viz between chrome and scroll content;
+      // charts/map cache geometry, so nudge their resize handling
+      this.$nextTick(() => window.dispatchEvent(new Event('resize')));
+    },
     '$route.query' (newVal, oldVal) {
       if (newVal.size !== this.query.size) {
         this.query.size = newVal.size || 20;

--- a/viewer/vueapp/src/components/spiview/Spiview.vue
+++ b/viewer/vueapp/src/components/spiview/Spiview.vue
@@ -3,197 +3,206 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div class="spiview-page">
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <!-- search navbar -->
-        <arkime-search
-          @change-search="changeSearch"
-          :num-matching-sessions="filtered"
-          @recalc-collapse="$emit('recalc-collapse')" /> <!-- /search navbar -->
+  <page-layout class="spiview-page">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- search navbar -->
+          <arkime-search
+            @change-search="changeSearch"
+            :num-matching-sessions="filtered" /> <!-- /search navbar -->
 
-        <!-- info navbar -->
-        <div class="d-flex align-center info-nav m-1 gap-2">
-          <div v-if="!dataLoading">
-            <!-- field config save button -->
-            <v-menu
-              :close-on-content-click="false"
-              location="bottom start">
-              <template #activator="{ props: activatorProps }">
-                <v-btn
-                  v-bind="activatorProps"
-                  variant="flat"
-                  size="large"
-                  color="secondary"
-                  class="field-config-trigger">
-                  <v-icon icon="mdi-view-column" />
-                  <v-tooltip
-                    activator="parent"
-                    location="right">
-                    {{ $t('spiview.spiViewFieldConfigTip') }}
-                  </v-tooltip>
-                </v-btn>
-              </template>
-              <v-list
-                density="compact"
-                class="field-config-list">
-                <div class="px-2 py-1">
-                  <div class="arkime-input-group">
-                    <input
-                      autofocus
-                      @click.stop
-                      maxlength="30"
-                      type="text"
-                      class="arkime-input-control"
-                      @input="debounceNewFieldConfigName"
-                      v-model.lazy="newFieldConfigName"
-                      :placeholder="$t('spiview.newConfigPlaceholder')"
-                      @keydown.enter.stop.prevent="saveFieldConfiguration">
-                    <v-btn
-                      :aria-label="$t('common.save')"
-                      variant="flat"
-                      size="small"
-                      density="comfortable"
-                      icon
-                      class="arkime-input-append-btn"
-                      :style="secondaryBtnStyle"
-                      :disabled="!newFieldConfigName"
-                      @click.stop.prevent="saveFieldConfiguration">
-                      <v-icon icon="mdi-content-save" />
-                      <v-tooltip
-                        activator="parent"
-                        location="right">
-                        {{ $t('spiview.spiViewFieldConfigSaveTip') }}
-                      </v-tooltip>
-                    </v-btn>
+          <!-- info navbar -->
+          <div class="d-flex align-center info-nav mx-1 gap-2 page-subnav">
+            <div v-if="!dataLoading">
+              <!-- field config save button -->
+              <v-menu
+                :close-on-content-click="false"
+                location="bottom start">
+                <template #activator="{ props: activatorProps }">
+                  <v-btn
+                    v-bind="activatorProps"
+                    variant="flat"
+                    size="large"
+                    color="secondary"
+                    class="field-config-trigger">
+                    <v-icon icon="mdi-view-column" />
+                    <v-tooltip
+                      activator="parent"
+                      location="right">
+                      {{ $t('spiview.spiViewFieldConfigTip') }}
+                    </v-tooltip>
+                  </v-btn>
+                </template>
+                <v-list
+                  density="compact"
+                  class="field-config-list">
+                  <div class="px-2 py-1">
+                    <div class="arkime-input-group">
+                      <input
+                        autofocus
+                        @click.stop
+                        maxlength="30"
+                        type="text"
+                        class="arkime-input-control"
+                        @input="debounceNewFieldConfigName"
+                        v-model.lazy="newFieldConfigName"
+                        :placeholder="$t('spiview.newConfigPlaceholder')"
+                        @keydown.enter.stop.prevent="saveFieldConfiguration">
+                      <v-btn
+                        :aria-label="$t('common.save')"
+                        variant="flat"
+                        size="small"
+                        density="comfortable"
+                        icon
+                        class="arkime-input-append-btn"
+                        :style="secondaryBtnStyle"
+                        :disabled="!newFieldConfigName"
+                        @click.stop.prevent="saveFieldConfiguration">
+                        <v-icon icon="mdi-content-save" />
+                        <v-tooltip
+                          activator="parent"
+                          location="right">
+                          {{ $t('spiview.spiViewFieldConfigSaveTip') }}
+                        </v-tooltip>
+                      </v-btn>
+                    </div>
                   </div>
-                </div>
-                <v-divider />
-                <v-list-item
-                  key="config-default"
-                  @click.stop.prevent="loadFieldConfiguration(-1)">
-                  {{ $t('spiview.arkimeDefault') }}
-                  <v-tooltip
-                    activator="parent"
-                    location="end">
-                    {{ $t('spiview.spiViewConfigDefaultTip') }}
-                  </v-tooltip>
-                </v-list-item>
-                <v-list-item
-                  v-for="(config, key) in fieldConfigs"
-                  :key="config.name"
-                  @click.self.stop.prevent="loadFieldConfiguration(key)">
-                  <div
-                    class="d-flex align-center w-100"
-                    @click.self="loadFieldConfiguration(key)">
-                    <span
-                      class="flex-grow-1"
-                      @click="loadFieldConfiguration(key)">
-                      {{ config.name }}
-                    </span>
-                    <v-btn
-                      :id="`updateFieldConfig${key}`"
-                      color="warning"
-                      variant="flat"
-                      size="small"
-                      density="comfortable"
-                      icon
-                      class="ms-1"
-                      :aria-label="$t('common.save')"
-                      @click.stop.prevent="updateFieldConfiguration(config.name, key)">
-                      <v-icon icon="mdi-content-save" />
-                      <v-tooltip
-                        :activator="`[id='updateFieldConfig${key}']`"
-                        location="end">
-                        Update this field configuration with the currently visible fields
-                      </v-tooltip>
-                    </v-btn>
-                    <v-btn
-                      color="error"
-                      variant="flat"
-                      size="small"
-                      density="comfortable"
-                      icon
-                      class="ms-1"
-                      :aria-label="$t('common.delete')"
-                      @click.stop.prevent="deleteFieldConfiguration(config.name, key)">
-                      <v-icon icon="mdi-trash-can-outline" />
-                    </v-btn>
-                  </div>
-                </v-list-item>
-              </v-list>
-              <v-alert
-                v-if="fieldConfigError"
-                density="compact"
-                variant="tonal"
-                type="error"
-                class="ma-1">
-                {{ fieldConfigError }}
-              </v-alert>
-              <v-alert
-                v-if="fieldConfigSuccess"
-                density="compact"
-                variant="tonal"
-                type="success"
-                class="ma-1">
-                {{ fieldConfigSuccess }}
-              </v-alert>
-            </v-menu> <!-- /field config save button -->
-          </div>
-          <div class="info-nav-count">
-            <strong
-              class="text-theme-accent"
-              v-if="!dataLoading && !error && filtered !== undefined">
-              {{ $t('common.showingAllTip', { count: commaString(filtered), total: commaString(total) }) }}
-            </strong>
-          </div>
-          <div
-            v-if="dataLoading"
-            class="info-nav-loading">
-            <v-icon
-              icon="mdi-loading"
-              size="small"
-              class="mdi-spin" />&nbsp;
-            <em>
-              {{ $t('common.loading') }}
-            </em>
-            <v-btn
-              :class="{'disabled-aggregations':disabledAggregations}"
-              color="warning"
-              variant="flat"
-              size="large"
-              class="ms-2"
-              @click="cancelLoading">
+                  <v-divider />
+                  <v-list-item
+                    key="config-default"
+                    @click.stop.prevent="loadFieldConfiguration(-1)">
+                    {{ $t('spiview.arkimeDefault') }}
+                    <v-tooltip
+                      activator="parent"
+                      location="end">
+                      {{ $t('spiview.spiViewConfigDefaultTip') }}
+                    </v-tooltip>
+                  </v-list-item>
+                  <v-list-item
+                    v-for="(config, key) in fieldConfigs"
+                    :key="config.name"
+                    @click.self.stop.prevent="loadFieldConfiguration(key)">
+                    <div
+                      class="d-flex align-center w-100"
+                      @click.self="loadFieldConfiguration(key)">
+                      <span
+                        class="flex-grow-1"
+                        @click="loadFieldConfiguration(key)">
+                        {{ config.name }}
+                      </span>
+                      <v-btn
+                        :id="`updateFieldConfig${key}`"
+                        color="warning"
+                        variant="flat"
+                        size="small"
+                        density="comfortable"
+                        icon
+                        class="ms-1"
+                        :aria-label="$t('common.save')"
+                        @click.stop.prevent="updateFieldConfiguration(config.name, key)">
+                        <v-icon icon="mdi-content-save" />
+                        <v-tooltip
+                          :activator="`[id='updateFieldConfig${key}']`"
+                          location="end">
+                          Update this field configuration with the currently visible fields
+                        </v-tooltip>
+                      </v-btn>
+                      <v-btn
+                        color="error"
+                        variant="flat"
+                        size="small"
+                        density="comfortable"
+                        icon
+                        class="ms-1"
+                        :aria-label="$t('common.delete')"
+                        @click.stop.prevent="deleteFieldConfiguration(config.name, key)">
+                        <v-icon icon="mdi-trash-can-outline" />
+                      </v-btn>
+                    </div>
+                  </v-list-item>
+                </v-list>
+                <v-alert
+                  v-if="fieldConfigError"
+                  density="compact"
+                  variant="tonal"
+                  type="error"
+                  class="ma-1">
+                  {{ fieldConfigError }}
+                </v-alert>
+                <v-alert
+                  v-if="fieldConfigSuccess"
+                  density="compact"
+                  variant="tonal"
+                  type="success"
+                  class="ma-1">
+                  {{ fieldConfigSuccess }}
+                </v-alert>
+              </v-menu> <!-- /field config save button -->
+            </div>
+            <div class="info-nav-count">
+              <strong
+                class="text-theme-accent"
+                v-if="!dataLoading && !error && filtered !== undefined">
+                {{ $t('common.showingAllTip', { count: commaString(filtered), total: commaString(total) }) }}
+              </strong>
+            </div>
+            <div
+              v-if="dataLoading"
+              class="info-nav-loading">
               <v-icon
-                icon="mdi-cancel"
-                class="me-1" />
-              {{ $t('common.cancel') }}
-            </v-btn>
-          </div>
-        </div> <!-- /info navbar -->
-      </span>
+                icon="mdi-loading"
+                size="small"
+                class="mdi-spin" />&nbsp;
+              <em>
+                {{ $t('common.loading') }}
+              </em>
+              <v-btn
+                :class="{'disabled-aggregations':disabledAggregations}"
+                color="warning"
+                variant="flat"
+                size="large"
+                class="ms-2"
+                @click="cancelLoading">
+                <v-icon
+                  icon="mdi-cancel"
+                  class="me-1" />
+                {{ $t('common.cancel') }}
+              </v-btn>
+            </div>
+          </div> <!-- /info navbar -->
+        </div>
 
-      <!-- warning navbar -->
-      <div
-        class="text-theme-accent"
-        v-if="staleData && !dataLoading">
-        <v-icon icon="mdi-alert" />&nbsp;<span v-html="$t('spiview.cancelWarningHtml')" />
-        <v-icon
-          icon="mdi-close"
-          class="cursor-pointer"
-          @click="staleData = false" />
-      </div> <!-- /warning navbar -->
-    </ArkimeCollapsible>
+        <!-- warning navbar -->
+        <div
+          class="text-theme-accent"
+          v-if="staleData && !dataLoading">
+          <v-icon icon="mdi-alert" />&nbsp;<span v-html="$t('spiview.cancelWarningHtml')" />
+          <v-icon
+            icon="mdi-close"
+            class="cursor-pointer"
+            @click="staleData = false" />
+        </div> <!-- /warning navbar -->
+      </ArkimeCollapsible>
+      <!-- pinned visualizations land here (teleported from below) -->
+      <div id="viz-pin-anchor" />
+    </template>
 
-    <!-- visualizations -->
-    <arkime-visualizations
-      v-if="mapData && graphData && showToolBars"
-      :primary="true"
-      :map-data="mapData"
-      :graph-data="graphData"
-      @fetch-map-data="fetchVizData"
-      @spanning-change="issueQueries"
-      :timeline-data-filters="timelineDataFilters" /> <!-- /visualizations -->
+    <!-- visualizations: pinned = chrome row above the scroll container,
+         unpinned = scrolls away with the content -->
+    <teleport
+      defer
+      to="#viz-pin-anchor"
+      :disabled="!stickyViz">
+      <arkime-visualizations
+        v-if="mapData && graphData && showToolBars"
+        :primary="true"
+        :map-data="mapData"
+        :graph-data="graphData"
+        @fetch-map-data="fetchVizData"
+        @spanning-change="issueQueries"
+        :timeline-data-filters="timelineDataFilters" />
+    </teleport> <!-- /visualizations -->
 
     <div class="spiview-content me-1 ms-1">
       <!-- page error -->
@@ -463,7 +472,7 @@ SPDX-License-Identifier: Apache-2.0
         </div>
       </div> <!-- /spiview panels -->
     </div>
-  </div>
+  </page-layout>
 </template>
 
 <script>
@@ -478,6 +487,7 @@ import ArkimeError from '../utils/Error.vue';
 import ArkimeSearch from '../search/Search.vue';
 import ArkimeVisualizations from '../visualizations/Visualizations.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import FieldActions from '../sessions/FieldActions.vue';
 import { commaString, searchFields, buildExpression } from '@common/vueFilters.js';
 import { resolveMessage } from '@common/resolveI18nMessage';
@@ -505,9 +515,9 @@ export default {
     ArkimeSearch,
     ArkimeVisualizations,
     ArkimeCollapsible,
+    PageLayout,
     FieldActions
   },
-  emits: ['recalc-collapse'],
   data: function () {
     return {
       error: '',
@@ -565,6 +575,9 @@ export default {
     showToolBars: function () {
       return this.$store.state.showToolBars;
     },
+    stickyViz: function () {
+      return this.$store.state.stickyViz;
+    },
     fields: function () {
       return this.$store.state.fieldsArr;
     },
@@ -573,6 +586,11 @@ export default {
     }
   },
   watch: {
+    '$store.state.stickyViz': function () {
+      // pin toggle teleports the viz between chrome and scroll content;
+      // charts/map cache geometry, so nudge their resize handling
+      this.$nextTick(() => window.dispatchEvent(new Event('resize')));
+    },
     '$store.state.fetchGraphData': function (value) {
       if (value) { this.fetchGraphData(); }
     }
@@ -1546,7 +1564,6 @@ export default {
 
 /* info navbar --------------------- */
 .spiview-page .info-nav {
-  height: 32px;
   background-color: rgb(var(--v-theme-quaternary-lightest));
 }
 

--- a/viewer/vueapp/src/components/stats/Stats.vue
+++ b/viewer/vueapp/src/components/stats/Stats.vue
@@ -3,556 +3,589 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div class="stats-content">
-    <ArkimeCollapsible>
-      <span class="fixed-header">
-        <!-- stats sub navbar -->
-        <v-row
-          class="g-1 stats-form p-1 align-center justify-start"
-          :class="{ 'stats-form--empty': tabIndex === 7 }">
-
-          <v-col
-            cols="auto"
-            class="flex-grow-1"
-            v-if="tabIndex !== 7">
-            <div class="arkime-input-group arkime-input-group--fluid">
-              <span class="arkime-input-label arkime-input-label-fw">
-                <v-icon
-                  icon="mdi-loading"
-                  class="mdi-spin text-theme-accent"
-                  v-if="loadingData" />
-                <v-icon
-                  icon="mdi-magnify"
-                  v-else-if="!shiftKeyHold" />
-                <span
-                  v-else-if="shiftKeyHold"
-                  class="query-shortcut">
-                  Q
+  <page-layout class="stats-content">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- stats sub navbar -->
+          <v-row class="g-1 stats-form p-1 align-center justify-start page-subnav">
+            <v-col
+              cols="auto"
+              class="flex-grow-1"
+              v-if="tabIndex !== 7">
+              <div class="arkime-input-group arkime-input-group--fluid">
+                <span class="arkime-input-label arkime-input-label-fw">
+                  <v-icon
+                    icon="mdi-loading"
+                    class="mdi-spin text-theme-accent"
+                    v-if="loadingData" />
+                  <v-icon
+                    icon="mdi-magnify"
+                    v-else-if="!shiftKeyHold" />
+                  <span
+                    v-else-if="shiftKeyHold"
+                    class="query-shortcut">
+                    Q
+                  </span>
                 </span>
-              </span>
-              <input
-                type="text"
-                class="arkime-input-control"
-                v-model="searchTerm"
-                v-focus="focusInput"
-                @blur="onOffFocus"
-                @input="debounceSearchInput"
-                @keydown.stop.prevent.enter="debounceSearchInput"
-                :placeholder="$t('stats.filterPlaceholder')">
+                <input
+                  type="text"
+                  class="arkime-input-control"
+                  v-model="searchTerm"
+                  v-focus="focusInput"
+                  @blur="onOffFocus"
+                  @input="debounceSearchInput"
+                  @keydown.stop.prevent.enter="debounceSearchInput"
+                  :placeholder="$t('stats.filterPlaceholder')">
+                <v-btn
+                  v-if="searchTerm"
+                  variant="outlined"
+                  size="x-small"
+                  density="comfortable"
+                  icon
+                  :disabled="!searchTerm"
+                  @click="clear">
+                  <v-icon icon="mdi-close" />
+                </v-btn>
+              </div>
+            </v-col>
+
+            <!-- graph type select -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex === 0">
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">
+                  {{ $t('stats.graphType') }}
+                </span>
+                <select
+                  class="arkime-input-control"
+                  v-model="statsType"
+                  @change="statsTypeChange">
+                  <option
+                    value="deltaPacketsPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaBytesPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaBitsPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaSessionsPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaDroppedPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="monitoring"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="tcpSessions"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="udpSessions"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="icmpSessions"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="sctpSessions"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="espSessions"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="usedSpaceM"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="freeSpaceM"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="freeSpaceP"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="memory"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="memoryP"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="cpu"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="diskQueue"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="esQueue"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaESDroppedPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="esHealthMS"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="packetQueue"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="closeQueue"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="needSave"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="frags"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaFragsDroppedPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaOverloadDroppedPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaDupDroppedPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaTotalDroppedPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaSessionBytesPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="sessionSizePerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaWrittenBytesPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                  <option
+                    value="deltaUnwrittenBytesPerSec"
+                    v-i18n-value="'stats.cstats.'" />
+                </select>
+              </div>
+            </v-col> <!-- /graph type select -->
+
+            <!-- graph interval select -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex === 0">
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">
+                  {{ $t('stats.graphInterval') }}
+                </span>
+                <select
+                  class="arkime-input-control"
+                  v-model="graphInterval"
+                  @change="graphIntervalChange">
+                  <option value="5">
+                    {{ $t('common.secondCount', 5) }}
+                  </option>
+                  <option value="60">
+                    {{ $t('common.minuteCount', 1) }}
+                  </option>
+                  <option value="600">
+                    {{ $t('common.minuteCount', 10) }}
+                  </option>
+                </select>
+              </div>
+            </v-col> <!-- /graph interval select -->
+
+            <!-- graph hide select -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex === 0 || tabIndex === 1">
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">{{ $t('stats.graphHide') }}</span>
+                <select
+                  class="arkime-input-control"
+                  v-model="graphHide"
+                  @change="graphHideChange">
+                  <option
+                    value="none"
+                    v-i18n-value="'stats.graphHide-'" />
+                  <option
+                    value="old"
+                    v-i18n-value="'stats.graphHide-'" />
+                  <option
+                    value="nosession"
+                    v-i18n-value="'stats.graphHide-'" />
+                  <option
+                    value="both"
+                    v-i18n-value="'stats.graphHide-'" />
+                </select>
+              </div>
+            </v-col> <!-- /graph hide select -->
+
+            <!-- graph sort select -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex === 0">
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">{{ $t('stats.graphSort') }}</span>
+                <select
+                  class="arkime-input-control"
+                  v-model="graphSort">
+                  <option
+                    value="asc"
+                    v-i18n-value="'stats.graphSort-'" />
+                  <option
+                    value="desc"
+                    v-i18n-value="'stats.graphSort-'" />
+                </select>
+              </div>
+            </v-col> <!-- /graph sort select -->
+
+            <!-- page size select -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex === 4">
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">{{ $t('stats.pageSize') }}</span>
+                <select
+                  class="arkime-input-control"
+                  v-model="pageSize"
+                  @change="pageSizeChange">
+                  <option value="100">
+                    {{ $t('common.perPage', 100) }}
+                  </option>
+                  <option value="200">
+                    {{ $t('common.perPage', 200) }}
+                  </option>
+                  <option value="500">
+                    {{ $t('common.perPage', 500) }}
+                  </option>
+                  <option value="1000">
+                    {{ $t('common.perPage', {count: "1,000"}) }}
+                  </option>
+                  <option value="5000">
+                    {{ $t('common.perPage', {count: "5,000"}) }}
+                  </option>
+                  <option value="10000">
+                    {{ $t('common.perPage', {count: "10,000"}) }}
+                  </option>
+                </select>
+              </div>
+            </v-col><!-- /page size select -->
+
+            <!-- table data interval select -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex !== 0 && tabIndex !== 7">
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">{{ $t('stats.refreshEvery') }}</span>
+                <select
+                  class="arkime-input-control"
+                  v-model="dataInterval"
+                  @change="dataIntervalChange">
+                  <option value="5000">
+                    {{ $t('common.secondCount', 5) }}
+                  </option>
+                  <option value="15000">
+                    {{ $t('common.secondCount', 15) }}
+                  </option>
+                  <option value="30000">
+                    {{ $t('common.secondCount', 30) }}
+                  </option>
+                  <option value="60000">
+                    {{ $t('common.minuteCount', 1) }}
+                  </option>
+                  <option value="600000">
+                    {{ $t('common.minuteCount', 10) }}
+                  </option>
+                  <option value="0">
+                    {{ $t('common.never') }}
+                  </option>
+                </select>
+              </div>
+            </v-col> <!-- /table data interval select -->
+
+            <!-- shards show select -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex === 5">
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">{{ $t('stats.shardsShow') }}</span>
+                <select
+                  class="arkime-input-control"
+                  v-model="shardsShow"
+                  @change="shardsShowChange">
+                  <option
+                    value="all"
+                    v-i18n-value="'stats.shardsShow-'" />
+                  <option
+                    value="UNASSIGNED"
+                    v-i18n-value="'stats.shardsShow-'" />
+                  <option
+                    value="RELOCATING"
+                    v-i18n-value="'stats.shardsShow-'" />
+                  <option
+                    value="INITIALIZING"
+                    v-i18n-value="'stats.shardsShow-'" />
+                  <option
+                    value="notstarted"
+                    v-i18n-value="'stats.shardsShow-'" />
+                </select>
+              </div>
+            </v-col> <!-- /shards show select -->
+
+            <!-- recovery show select -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex === 6">
+              <div class="arkime-input-group">
+                <span class="arkime-input-label">{{ $t('stats.recoveryShow') }}</span>
+                <select
+                  class="arkime-input-control"
+                  v-model="recoveryShow"
+                  @change="recoveryShowChange">
+                  <option
+                    value="all"
+                    v-i18n-value="'stats.recoveryShow-'" />
+                  <option
+                    value="notdone"
+                    v-i18n-value="'stats.recoveryShow-'" />
+                </select>
+              </div>
+            </v-col> <!-- /recovery show select -->
+
+            <!-- refresh button -->
+            <v-col
+              cols="auto"
+              v-if="tabIndex !== 0 && tabIndex !== 7">
               <v-btn
-                v-if="searchTerm"
-                variant="outlined"
-                size="x-small"
+                variant="flat"
+                size="large"
                 density="comfortable"
-                icon
-                :disabled="!searchTerm"
-                @click="clear">
-                <v-icon icon="mdi-close" />
+                :style="tertiaryBtnStyle"
+                @click="loadData">
+                <span v-if="!shiftKeyHold">
+                  {{ $t('common.refresh') }}
+                </span>
+                <span
+                  v-else
+                  class="enter-icon">
+                  <v-icon
+                    icon="mdi-arrow-left"
+                    size="small" />
+                  <div class="enter-arm" />
+                </span>
               </v-btn>
-            </div>
-          </v-col>
+            </v-col> <!-- /refresh button -->
 
-          <!-- graph type select -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex === 0">
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">
-                {{ $t('stats.graphType') }}
-              </span>
-              <select
-                class="arkime-input-control"
-                v-model="statsType"
-                @change="statsTypeChange">
-                <option
-                  value="deltaPacketsPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaBytesPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaBitsPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaSessionsPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaDroppedPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="monitoring"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="tcpSessions"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="udpSessions"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="icmpSessions"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="sctpSessions"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="espSessions"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="usedSpaceM"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="freeSpaceM"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="freeSpaceP"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="memory"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="memoryP"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="cpu"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="diskQueue"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="esQueue"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaESDroppedPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="esHealthMS"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="packetQueue"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="closeQueue"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="needSave"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="frags"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaFragsDroppedPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaOverloadDroppedPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaDupDroppedPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaTotalDroppedPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaSessionBytesPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="sessionSizePerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaWrittenBytesPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-                <option
-                  value="deltaUnwrittenBytesPerSec"
-                  v-i18n-value="'stats.cstats.'" />
-              </select>
-            </div>
-          </v-col> <!-- /graph type select -->
+            <v-col cols="auto">
+              <!-- confirm button -->
+              <transition name="buttons">
+                <v-btn
+                  v-if="confirmMessage"
+                  color="error"
+                  variant="flat"
+                  size="small"
+                  density="comfortable"
+                  class="ms-2"
+                  @click="confirmed">
+                  <v-icon
+                    icon="mdi-check"
+                    class="me-1" />
+                  {{ confirmMessage }}
+                </v-btn>
+              </transition> <!-- /confirm button -->
 
-          <!-- graph interval select -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex === 0">
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">
-                {{ $t('stats.graphInterval') }}
-              </span>
-              <select
-                class="arkime-input-control"
-                v-model="graphInterval"
-                @change="graphIntervalChange">
-                <option value="5">{{ $t('common.secondCount', 5) }}</option>
-                <option value="60">{{ $t('common.minuteCount', 1) }}</option>
-                <option value="600">{{ $t('common.minuteCount', 10) }}</option>
-              </select>
-            </div>
-          </v-col> <!-- /graph interval select -->
+              <!-- cancel confirm button -->
+              <transition name="buttons">
+                <v-btn
+                  v-if="confirmMessage"
+                  color="warning"
+                  variant="flat"
+                  size="small"
+                  density="comfortable"
+                  class="ms-2"
+                  @click="cancelConfirm">
+                  <v-icon
+                    icon="mdi-cancel"
+                    class="me-1" />
+                  {{ $t('common.cancel') }}
+                </v-btn>
+              </transition> <!-- /cancel confirm button -->
+            </v-col>
 
-          <!-- graph hide select -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex === 0 || tabIndex === 1">
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">{{ $t('stats.graphHide') }}</span>
-              <select
-                class="arkime-input-control"
-                v-model="graphHide"
-                @change="graphHideChange">
-                <option
-                  value="none"
-                  v-i18n-value="'stats.graphHide-'" />
-                <option
-                  value="old"
-                  v-i18n-value="'stats.graphHide-'" />
-                <option
-                  value="nosession"
-                  v-i18n-value="'stats.graphHide-'" />
-                <option
-                  value="both"
-                  v-i18n-value="'stats.graphHide-'" />
-              </select>
-            </div>
-          </v-col> <!-- /graph hide select -->
+            <!-- error (from child component) -->
+            <v-alert
+              v-if="childError"
+              type="error"
+              density="compact"
+              variant="tonal"
+              closable
+              class="ms-2"
+              @click:close="childError = ''">
+              {{ childError }}
+            </v-alert> <!-- /error (from child component) -->
 
-          <!-- graph sort select -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex === 0">
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">{{ $t('stats.graphSort') }}</span>
-              <select
-                class="arkime-input-control"
-                v-model="graphSort">
-                <option
-                  value="asc"
-                  v-i18n-value="'stats.graphSort-'" />
-                <option
-                  value="desc"
-                  v-i18n-value="'stats.graphSort-'" />
-              </select>
-            </div>
-          </v-col> <!-- /graph sort select -->
-
-          <!-- page size select -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex === 4">
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">{{ $t('stats.pageSize') }}</span>
-              <select
-                class="arkime-input-control"
-                v-model="pageSize"
-                @change="pageSizeChange">
-                <option value="100">{{ $t('common.perPage', 100) }}</option>
-                <option value="200">{{ $t('common.perPage', 200) }}</option>
-                <option value="500">{{ $t('common.perPage', 500) }}</option>
-                <option value="1000">{{ $t('common.perPage', {count: "1,000"}) }}</option>
-                <option value="5000">{{ $t('common.perPage', {count: "5,000"}) }}</option>
-                <option value="10000">{{ $t('common.perPage', {count: "10,000"}) }}</option>
-              </select>
-            </div>
-          </v-col><!-- /page size select -->
-
-          <!-- table data interval select -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex !== 0 && tabIndex !== 7">
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">{{ $t('stats.refreshEvery') }}</span>
-              <select
-                class="arkime-input-control"
-                v-model="dataInterval"
-                @change="dataIntervalChange">
-                <option value="5000">{{ $t('common.secondCount', 5) }}</option>
-                <option value="15000">{{ $t('common.secondCount', 15) }}</option>
-                <option value="30000">{{ $t('common.secondCount', 30) }}</option>
-                <option value="60000">{{ $t('common.minuteCount', 1) }}</option>
-                <option value="600000">{{ $t('common.minuteCount', 10) }}</option>
-                <option value="0">{{ $t('common.never') }}</option>
-              </select>
-            </div>
-          </v-col> <!-- /table data interval select -->
-
-          <!-- shards show select -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex === 5">
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">{{ $t('stats.shardsShow') }}</span>
-              <select
-                class="arkime-input-control"
-                v-model="shardsShow"
-                @change="shardsShowChange">
-                <option
-                  value="all"
-                  v-i18n-value="'stats.shardsShow-'" />
-                <option
-                  value="UNASSIGNED"
-                  v-i18n-value="'stats.shardsShow-'" />
-                <option
-                  value="RELOCATING"
-                  v-i18n-value="'stats.shardsShow-'" />
-                <option
-                  value="INITIALIZING"
-                  v-i18n-value="'stats.shardsShow-'" />
-                <option
-                  value="notstarted"
-                  v-i18n-value="'stats.shardsShow-'" />
-              </select>
-            </div>
-          </v-col> <!-- /shards show select -->
-
-          <!-- recovery show select -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex === 6">
-            <div class="arkime-input-group">
-              <span class="arkime-input-label">{{ $t('stats.recoveryShow') }}</span>
-              <select
-                class="arkime-input-control"
-                v-model="recoveryShow"
-                @change="recoveryShowChange">
-                <option
-                  value="all"
-                  v-i18n-value="'stats.recoveryShow-'" />
-                <option
-                  value="notdone"
-                  v-i18n-value="'stats.recoveryShow-'" />
-              </select>
-            </div>
-          </v-col> <!-- /recovery show select -->
-
-          <!-- refresh button -->
-          <v-col
-            cols="auto"
-            v-if="tabIndex !== 0 && tabIndex !== 7">
-            <v-btn
-              variant="flat"
-              size="large"
-              density="comfortable"
-              :style="tertiaryBtnStyle"
-              @click="loadData">
-              <span v-if="!shiftKeyHold">
-                {{ $t('common.refresh') }}
-              </span>
-              <span
-                v-else
-                class="enter-icon">
-                <v-icon
-                  icon="mdi-arrow-left"
-                  size="small" />
-                <div class="enter-arm" />
-              </span>
-            </v-btn>
-          </v-col> <!-- /refresh button -->
-
-          <v-col cols="auto">
-            <!-- confirm button -->
-            <transition name="buttons">
+            <!-- shrink index -->
+            <div
+              v-if="shrinkIndex"
+              class="ms-4 d-flex align-center">
+              <strong>
+                {{ $t('stats.shrink') }}  {{ shrinkIndex.index }}
+              </strong>
+              <!-- new # shards -->
+              <div class="arkime-input-group ms-2">
+                <span class="arkime-input-label">
+                  {{ $t('stats.numShards') }}
+                </span>
+                <select
+                  v-model="shrinkFactor"
+                  class="arkime-input-control"
+                  style="-webkit-appearance:none;">
+                  <option
+                    v-for="factor in shrinkFactors"
+                    :key="factor"
+                    :value="factor">
+                    {{ factor }}
+                  </option>
+                </select>
+              </div> <!-- /new # shards -->
+              <!-- temporary node -->
+              <div
+                v-if="nodes && temporaryNode"
+                class="arkime-input-group ms-2">
+                <span class="arkime-input-label">
+                  {{ $t('stats.temporaryNode') }}
+                </span>
+                <select
+                  v-model="temporaryNode"
+                  class="arkime-input-control"
+                  style="-webkit-appearance:none;">
+                  <option
+                    v-for="node in nodes"
+                    :key="node.name"
+                    :value="node.name">
+                    {{ node.name }}
+                  </option>
+                </select>
+              </div> <!-- /new shards input -->
+              <!-- ok button -->
               <v-btn
-                v-if="confirmMessage"
-                color="error"
+                color="success"
                 variant="flat"
                 size="small"
                 density="comfortable"
-                class="ms-2"
-                @click="confirmed">
-                <v-icon
-                  icon="mdi-check"
-                  class="me-1" />
-                {{ confirmMessage }}
-              </v-btn>
-            </transition> <!-- /confirm button -->
-
-            <!-- cancel confirm button -->
-            <transition name="buttons">
+                icon
+                class="float-right ms-2"
+                :aria-label="$t('common.apply')"
+                @click="executeShrink(shrinkIndex)">
+                <v-icon icon="mdi-check" />
+              </v-btn> <!-- /ok button -->
+              <!-- cancel button -->
               <v-btn
-                v-if="confirmMessage"
                 color="warning"
                 variant="flat"
                 size="small"
                 density="comfortable"
-                class="ms-2"
-                @click="cancelConfirm">
-                <v-icon
-                  icon="mdi-cancel"
-                  class="me-1" />
-                {{ $t('common.cancel') }}
-              </v-btn>
-            </transition> <!-- /cancel confirm button -->
-          </v-col>
+                icon
+                class="float-right ms-2"
+                :aria-label="$t('common.cancel')"
+                @click="cancelShrink">
+                <v-icon icon="mdi-cancel" />
+              </v-btn> <!-- /cancel button -->
+            </div>
+            <span
+              v-if="shrinkIndex && shrinkError"
+              class="text-danger ms-2">
+              {{ shrinkError }}
+            </span> <!-- /shrink index -->
 
-          <!-- error (from child component) -->
-          <v-alert
-            v-if="childError"
-            type="error"
-            density="compact"
-            variant="tonal"
-            closable
-            class="ms-2"
-            @click:close="childError = ''">
-            {{ childError }}
-          </v-alert> <!-- /error (from child component) -->
+            <!-- select cluster(s) -->
+            <v-col
+              cols="auto"
+              v-if="multiviewer">
+              <Clusters
+                @update-cluster="updateCluster"
+                :select-one="clusterParamOverride && tabIndex > 1" />
+            </v-col> <!-- /select cluster(s) -->
 
-          <!-- shrink index -->
-          <div
-            v-if="shrinkIndex"
-            class="ms-4 d-flex align-center">
-            <strong>
-              {{ $t('stats.shrink') }}  {{ shrinkIndex.index }}
-            </strong>
-            <!-- new # shards -->
-            <div class="arkime-input-group ms-2">
-              <span class="arkime-input-label">
-                {{ $t('stats.numShards') }}
-              </span>
-              <select
-                v-model="shrinkFactor"
-                class="arkime-input-control"
-                style="-webkit-appearance:none;">
-                <option
-                  v-for="factor in shrinkFactors"
-                  :key="factor"
-                  :value="factor">
-                  {{ factor }}
-                </option>
-              </select>
-            </div> <!-- /new # shards -->
-            <!-- temporary node -->
-            <div
-              v-if="nodes && temporaryNode"
-              class="arkime-input-group ms-2">
-              <span class="arkime-input-label">
-                {{ $t('stats.temporaryNode') }}
-              </span>
-              <select
-                v-model="temporaryNode"
-                class="arkime-input-control"
-                style="-webkit-appearance:none;">
-                <option
-                  v-for="node in nodes"
-                  :key="node.name"
-                  :value="node.name">
-                  {{ node.name }}
-                </option>
-              </select>
-            </div> <!-- /new shards input -->
-            <!-- ok button -->
-            <v-btn
-              color="success"
-              variant="flat"
-              size="small"
-              density="comfortable"
-              icon
-              class="float-right ms-2"
-              :aria-label="$t('common.apply')"
-              @click="executeShrink(shrinkIndex)">
-              <v-icon icon="mdi-check" />
-            </v-btn> <!-- /ok button -->
-            <!-- cancel button -->
-            <v-btn
-              color="warning"
-              variant="flat"
-              size="small"
-              density="comfortable"
-              icon
-              class="float-right ms-2"
-              :aria-label="$t('common.cancel')"
-              @click="cancelShrink">
-              <v-icon icon="mdi-cancel" />
-            </v-btn> <!-- /cancel button -->
-          </div>
-          <span
-            v-if="shrinkIndex && shrinkError"
-            class="text-danger ms-2">
-            {{ shrinkError }}
-          </span> <!-- /shrink index -->
-
-          <!-- select cluster(s) -->
-          <v-col
-            cols="auto"
-            v-if="multiviewer">
-            <Clusters
-              @update-cluster="updateCluster"
-              :select-one="clusterParamOverride && tabIndex > 1" />
-          </v-col> <!-- /select cluster(s) -->
-
-          <!-- spacer on esAdmin so the sub-navbar keeps the same height
+            <!-- spacer on esAdmin so the sub-navbar keeps the same height
                as on other tabs (all real controls are v-if-hidden when
                tabIndex === 7); without this the row collapses and leaves
                a gap above the tab strip. -->
-          <v-col
-            v-if="tabIndex === 7"
-            cols="auto">
+            <v-col
+              v-if="tabIndex === 7"
+              cols="auto">
             &nbsp;
-          </v-col>
+            </v-col>
+          </v-row> <!-- /stats sub navbar -->
+        </div>
+      </ArkimeCollapsible>
 
-        </v-row> <!-- /stats sub navbar -->
-      </span>
-    </ArkimeCollapsible>
+      <!-- tab strip: chrome row outside the collapsible so the tabs stay
+           visible when the toolbar is collapsed -->
+      <div class="stats-tabs">
+        <div class="stats-tab-bar">
+          <v-btn-toggle
+            :model-value="tabIndex"
+            @update:model-value="tabIndexChange($event)"
+            density="compact"
+            variant="text"
+            color="primary"
+            mandatory
+            class="stats-tab-strip">
+            <v-btn :value="0">
+              <v-icon
+                start
+                icon="mdi-chart-areaspline" />
+              {{ $t('stats.nav.captureGraphs') }}
+            </v-btn>
+            <v-btn :value="1">
+              <v-icon
+                start
+                icon="mdi-speedometer" />
+              {{ $t('stats.nav.captureStats') }}
+            </v-btn>
+            <span class="stats-tab-divider" />
+            <v-btn :value="2">
+              <v-icon
+                start
+                icon="mdi-server" />
+              {{ $t('stats.nav.esNodes') }}
+            </v-btn>
+            <v-btn :value="3">
+              <v-icon
+                start
+                icon="mdi-database" />
+              {{ $t('stats.nav.esIndices') }}
+            </v-btn>
+            <v-btn :value="4">
+              <v-icon
+                start
+                icon="mdi-format-list-checks" />
+              {{ $t('stats.nav.esTasks') }}
+            </v-btn>
+            <v-btn :value="5">
+              <v-icon
+                start
+                icon="mdi-sitemap" />
+              {{ $t('stats.nav.esShards') }}
+            </v-btn>
+            <v-btn :value="6">
+              <v-icon
+                start
+                icon="mdi-lifebuoy" />
+              {{ $t('stats.nav.esRecovery') }}
+            </v-btn>
+            <v-btn
+              v-if="user.esAdminUser"
+              :value="7">
+              <v-icon
+                start
+                icon="mdi-cog-outline" />
+              {{ $t('stats.nav.esAdmin') }}
+            </v-btn>
+          </v-btn-toggle>
+        </div>
+      </div>
+    </template>
 
     <!-- stats content -->
     <div class="stats-tabs">
-      <div class="stats-tab-bar">
-        <v-btn-toggle
-          :model-value="tabIndex"
-          @update:model-value="tabIndexChange($event)"
-          density="compact"
-          variant="text"
-          color="primary"
-          mandatory
-          class="stats-tab-strip">
-          <v-btn :value="0">
-            <v-icon
-              start
-              icon="mdi-chart-areaspline" />
-            {{ $t('stats.nav.captureGraphs') }}
-          </v-btn>
-          <v-btn :value="1">
-            <v-icon
-              start
-              icon="mdi-speedometer" />
-            {{ $t('stats.nav.captureStats') }}
-          </v-btn>
-          <span class="stats-tab-divider" />
-          <v-btn :value="2">
-            <v-icon
-              start
-              icon="mdi-server" />
-            {{ $t('stats.nav.esNodes') }}
-          </v-btn>
-          <v-btn :value="3">
-            <v-icon
-              start
-              icon="mdi-database" />
-            {{ $t('stats.nav.esIndices') }}
-          </v-btn>
-          <v-btn :value="4">
-            <v-icon
-              start
-              icon="mdi-format-list-checks" />
-            {{ $t('stats.nav.esTasks') }}
-          </v-btn>
-          <v-btn :value="5">
-            <v-icon
-              start
-              icon="mdi-sitemap" />
-            {{ $t('stats.nav.esShards') }}
-          </v-btn>
-          <v-btn :value="6">
-            <v-icon
-              start
-              icon="mdi-lifebuoy" />
-            {{ $t('stats.nav.esRecovery') }}
-          </v-btn>
-          <v-btn
-            v-if="user.esAdminUser"
-            :value="7">
-            <v-icon
-              start
-              icon="mdi-cog-outline" />
-            {{ $t('stats.nav.esAdmin') }}
-          </v-btn>
-        </v-btn-toggle>
-      </div>
       <!-- Lazy-mount each tab pane via v-if so child components only initialize
            when their tab is active. -->
       <div class="stats-tab-content">
@@ -623,7 +656,7 @@ SPDX-License-Identifier: Apache-2.0
           :cluster="cluster" />
       </div>
     </div> <!-- /stats content -->
-  </div>
+  </page-layout>
 </template>
 
 <script>
@@ -636,6 +669,7 @@ import EsAdmin from './EsAdmin.vue';
 import CaptureGraphs from './CaptureGraphs.vue';
 import CaptureStats from './CaptureStats.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+import PageLayout from '../utils/PageLayout.vue';
 import Utils from '../utils/utils';
 import Focus from '@common/Focus.vue';
 import Clusters from '../utils/Clusters.vue';
@@ -656,6 +690,7 @@ export default {
     EsRecovery,
     EsAdmin,
     ArkimeCollapsible,
+    PageLayout,
     Clusters
   },
   directives: { Focus },
@@ -893,10 +928,6 @@ export default {
    (the search/cluster/refresh row above) but uses a different theme
    tint so the two rows read as separate strata. */
 .stats-tabs .stats-tab-bar {
-  position: fixed;
-  left: 0;
-  right: 0;
-  z-index: 4;
   padding: 6px 12px;
   background-color: rgb(var(--v-theme-secondary-lightest));
   border-bottom: 1px solid rgb(var(--v-theme-neutral-light));
@@ -960,9 +991,6 @@ export default {
   margin: 0 8px;
   background-color: rgb(var(--v-theme-neutral-light));
 }
-.stats-tabs .stats-tab-content {
-  padding-top: 50px;
-}
 
 /* shrink the column header font on stats tables one notch so that the
    long headers (Sessions/s, Packet Q, Free Space, etc.) fit without
@@ -978,12 +1006,6 @@ export default {
 .stats-form {
   z-index : 6;
   background-color: rgb(var(--v-theme-quaternary-lightest));
-}
-/* Lock the height ONLY when the form has no controls (esAdmin tab) so
-   it doesn't collapse and leave a gap above the fixed tab strip. Other
-   tabs let their form controls drive the row height naturally. */
-.stats-form.stats-form--empty {
-  min-height: 44px;
 }
 
 /* remove browser styles on select box (mostly for border-radius) */

--- a/viewer/vueapp/src/components/summary/Summary.vue
+++ b/viewer/vueapp/src/components/summary/Summary.vue
@@ -193,7 +193,7 @@
 
 <script setup>
 // external dependencies
-import { ref, onMounted, onBeforeUnmount, computed, watch, nextTick } from 'vue';
+import { ref, inject, onMounted, onBeforeUnmount, computed, watch, nextTick } from 'vue';
 import { themedColor } from '@common/themes/themedColor.js';
 import { useRoute } from 'vue-router';
 import { useStore } from 'vuex';
@@ -266,6 +266,8 @@ const summary = ref(null);
 const loading = ref(true);
 const error = ref('');
 const widgetContainer = ref(null);
+// scroll container provided by the page shell (PageLayout)
+const pageScrollEl = inject('pageScrollEl', null);
 const canceled = ref(false);
 const streaming = ref(false);
 
@@ -945,13 +947,16 @@ const initializeDragDrop = () => {
   const minScrollSpeed = 50;
   const maxScrollSpeed = 300;
 
+  // the page shell's scroll container is the scroller (not the document)
+  const scrollTarget = () => pageScrollEl?.value || document.documentElement;
+
   sortableInstance = Sortable.create(widgetContainer.value, {
     animation: 100,
     handle: '.widget-handle',
     draggable: '.widget-wrapper',
     ghostClass: 'widget-ghost',
     chosenClass: 'widget-chosen',
-    scroll: document.documentElement,
+    scroll: scrollTarget(),
     scrollSensitivity,
     bubbleScroll: true,
     forceFallback: true,
@@ -960,18 +965,19 @@ const initializeDragDrop = () => {
       // Custom scroll function for dynamic speed based on cursor proximity to edge
       // offsetY is negative when near top, positive when near bottom
       if (offsetY !== 0 && originalEvent) {
-        const viewportHeight = window.innerHeight;
+        const el = scrollTarget();
+        const rect = el.getBoundingClientRect();
         const cursorY = originalEvent.clientY;
 
-        // Calculate distance from the edge being scrolled toward
-        const distanceFromEdge = offsetY < 0 ? cursorY : viewportHeight - cursorY;
+        // Calculate distance from the scroller edge being scrolled toward
+        const distanceFromEdge = offsetY < 0 ? cursorY - rect.top : rect.bottom - cursorY;
 
         // Calculate speed: closer to edge = faster scroll
         const ratio = 1 - (distanceFromEdge / scrollSensitivity);
         const speed = minScrollSpeed + (ratio * (maxScrollSpeed - minScrollSpeed));
 
         // Apply scroll in the appropriate direction
-        document.documentElement.scrollTop += offsetY > 0 ? speed : -speed;
+        el.scrollTop += offsetY > 0 ? speed : -speed;
       }
     },
     onSort: (evt) => {

--- a/viewer/vueapp/src/components/utils/CollapsibleWrapper.vue
+++ b/viewer/vueapp/src/components/utils/CollapsibleWrapper.vue
@@ -3,66 +3,21 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
+  <!-- chrome is normal-flow inside a PageLayout shell, so collapsing is
+       plain reflow — no measurement, spacer, or position juggling -->
   <v-expand-transition>
     <div v-show="showToolBars">
-      <span ref="collapseBox">
-        <slot />
-      </span>
-      <div :style="{ paddingTop: offset + 'px'}" />
+      <slot />
     </div>
   </v-expand-transition>
 </template>
 
 <script>
 export default {
-  data: function () {
-    return {
-      offset: 0
-    };
-  },
-  mounted: function () {
-    this.getOffset();
-  },
   computed: {
     // Boolean in the store will remember chosen toggle state for all pages
     showToolBars: function () {
       return this.$store.state.showToolBars;
-    }
-  },
-  methods: {
-    // Dynamically sets the height of the wrapper component to the total of inner components
-    getOffset: function () {
-      this.$nextTick(() => {
-        // Could give odd results passing in a mix of position:fixed and others
-        // Vue 3 compatible: Check if ref exists and has children
-        if (this.$refs.collapseBox && this.$refs.collapseBox.children) {
-          this.offset = Array.from(this.$refs.collapseBox.children)
-            .reduce((total, el) => (el.offsetHeight) ? el.offsetHeight + total : total, 0);
-        }
-      });
-    }
-  },
-  watch: {
-    // Check offset height after toggle is updated and mounted()
-    showToolBars: function () {
-      this.$nextTick(() => {
-        // Momentarily override toolbars position so animation can occur
-        // WARNING: inline position or non-scoped css position will be modified
-        // Vue 3 compatible: Check if ref exists and has children
-        if (this.$refs.collapseBox && this.$refs.collapseBox.children) {
-          Array.from(this.$refs.collapseBox.children).map((el) => {
-            const position = (this.showToolBars) ? '' : 'static';
-            el.style.position = position;
-            return position;
-          });
-        }
-
-        // Recalculate offset after position changes are complete
-        // Use setTimeout to ensure the position changes have taken effect
-        setTimeout(() => {
-          this.getOffset();
-        }, 50);
-      });
     }
   }
 };

--- a/viewer/vueapp/src/components/utils/Navbar.vue
+++ b/viewer/vueapp/src/components/utils/Navbar.vue
@@ -3,11 +3,7 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <span
-    :class="{
-      'hide-tool-bars': !showToolBars,
-      'show-sticky-sessions-btn': stickySessionsBtn
-    }">
+  <span>
     <nav class="arkime-navbar d-flex align-center pe-2">
 
       <router-link
@@ -221,9 +217,6 @@ export default {
     },
     shiftKeyHold: function () {
       return this.$store.state.shiftKeyHold;
-    },
-    stickySessionsBtn: function () {
-      return this.$store.state.stickySessionsBtn;
     },
     timezone: function () {
       return this.$store.state?.user?.settings?.timezone || 'gmt';

--- a/viewer/vueapp/src/components/utils/PageLayout.vue
+++ b/viewer/vueapp/src/components/utils/PageLayout.vue
@@ -1,0 +1,106 @@
+<!--
+Copyright Yahoo Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+<template>
+  <div class="page-shell">
+    <div class="page-chrome">
+      <slot name="chrome" />
+    </div>
+    <div class="page-body">
+      <div
+        class="page-scroll"
+        ref="scrollEl"
+        tabindex="-1">
+        <slot />
+      </div>
+      <div
+        v-if="$slots.overlay"
+        class="page-overlay"
+        :style="{ right: `${gutter.v}px`, bottom: `${gutter.h}px` }">
+        <slot name="overlay" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, reactive, provide, onMounted, onBeforeUnmount } from 'vue';
+
+// App-shell layout: chrome rows (toolbar, paging, pinned viz) live in normal
+// flow above a single scroll container, so collapsing the toolbar is plain
+// reflow — no fixed positioning, no measured offsets. The overlay slot floats
+// content (sticky sessions panel, etc.) over the scroll area without
+// viewport-coordinate math.
+const scrollEl = ref(null);
+provide('pageScrollEl', scrollEl);
+defineExpose({ scrollEl });
+
+// inset the overlay so it doesn't cover the scroller's scrollbars
+// (classic scrollbars render inside .page-scroll, not at the window edge)
+const gutter = reactive({ v: 0, h: 0 });
+let gutterObserver;
+
+onMounted(() => {
+  const el = scrollEl.value;
+  const measure = () => {
+    gutter.v = el.offsetWidth - el.clientWidth;
+    gutter.h = el.offsetHeight - el.clientHeight;
+  };
+  measure();
+  gutterObserver = new ResizeObserver(measure);
+  gutterObserver.observe(el);
+  // the document no longer scrolls, so give keyboard scrolling
+  // (PageDown/Space/arrows) a target on load
+  if (document.activeElement === document.body) {
+    el.focus({ preventScroll: true });
+  }
+});
+
+onBeforeUnmount(() => gutterObserver?.disconnect());
+</script>
+
+<style scoped>
+.page-shell {
+  display: flex;
+  flex-direction: column;
+  /* navbar is fixed (`.navbarOffset` spacer sits above us) and the footer is
+     html-absolute with #app padding-bottom reserving it — subtracting both
+     lands total flow height at exactly 100vh, so no document scrollbar. */
+  height: calc(100vh - var(--arkime-navbar-height, 36px) - var(--arkime-footer-height, 25px));
+  overflow: hidden;
+}
+/* z-index matches the legacy .fixed-header: the chrome and its shadow
+   paint over the overlay, so overlay panels slide under the nav (this
+   also keeps an expanded map in the pinned viz above the overlay) */
+.page-chrome {
+  position: relative;
+  z-index: 5;
+  flex: 0 0 auto;
+}
+.page-body {
+  position: relative;
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+}
+.page-scroll {
+  flex: 1 1 0;
+  min-width: 0;
+  overflow: auto;
+  position: relative;
+  /* always reserve the vertical scrollbar gutter so clientWidth doesn't
+     shift when rows arrive (pages measure table width against it) */
+  scrollbar-gutter: stable;
+  outline: none;
+}
+.page-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  pointer-events: none;
+}
+.page-overlay > :deep(*) {
+  pointer-events: auto;
+}
+</style>

--- a/viewer/vueapp/src/components/visualizations/Visualizations.vue
+++ b/viewer/vueapp/src/components/visualizations/Visualizations.vue
@@ -919,23 +919,15 @@ export default {
   z-index: 0;
 }
 
-/* sticky visualizations styles --------------- */
-/* 195 = 8 viz-container padding-top + 186 chart/map (TimelineGraph host
-   180 + wrapper padding-top 6; map matches at .inline-map > .map). +1
-   keeps the overflow-hidden clip off antialiased chart edges.
-   padding-bottom 200 = height + 5 gap below viz. */
-.sticky-viz {
-  padding-bottom: 200px;
-}
-
+/* sticky ("pinned") visualizations --------------- */
+/* The pinned viz is a normal-flow chrome row inside the page shell, so
+   no fixed positioning and no reserved flow space. 195 = 8 viz-container
+   padding-top + 186 chart/map (TimelineGraph host 180 + wrapper
+   padding-top 6; map matches at .inline-map > .map). +1 keeps the
+   overflow-hidden clip off antialiased chart edges. */
 .sticky-viz .viz-container {
-  left: 0;
-  right: 0;
-  z-index: 3;
   height: 195px;
-  position: fixed;
   overflow: hidden;
-  box-shadow: 0 0 16px -2px black;
   background-color: rgb(var(--v-theme-background));
 }
 
@@ -954,36 +946,16 @@ export default {
 }
 
 /* Disabled-aggregations variant: chart is replaced by a compact v-alert
-   info card (~80px with title + body). 90/95 preserves the normal-
-   variant spacing ratio so the thead still lands flush below the viz. */
-.sticky-viz.disabled-msg {
-  padding-bottom: 95px;
-}
+   info card (~80px with title + body). */
 .sticky-viz.disabled-msg .viz-container {
   height: 90px;
-}
-
-/* viz options button styles ----------------- */
-.viz-options-btn-container {
-  z-index: 5;
-  position: relative;
-}
-.viz-options-btn {
-  right: 8px;
-  display: block;
-  position: fixed;
-  margin-top: -35px;
 }
 
 /* hide visualization styles ----------------- */
 .hide-viz .viz-container {
   height: auto;
 }
-.hide-viz.sticky-viz {
-  padding-bottom: 0px;
-}
 .hide-viz.sticky-viz .viz-container {
-  z-index: 4;
   overflow: visible;
   box-shadow: none !important;
   background-color: transparent;

--- a/viewer/vueapp/src/store.js
+++ b/viewer/vueapp/src/store.js
@@ -49,7 +49,6 @@ const store = createStore({
     loadingData: false,
     sorts: [['firstPacket', 'desc']],
     sortsParam: 'firstPacket:desc',
-    stickySessionsBtn: false,
     showCapStartTimes: true,
     capStartTimes: [{ nodeName: 'none', startTime: 1 }],
     roles: [],
@@ -194,9 +193,6 @@ const store = createStore({
     },
     setSelectedCluster (state, value) {
       state.esCluster.selectedCluster = value;
-    },
-    setStickySessionsBtn (state, value) {
-      state.stickySessionsBtn = value;
     },
     setShowCapStartTimes (state, value) {
       state.showCapStartTimes = value;


### PR DESCRIPTION
Rearchitects the viewer's per-page layout into an app-shell scroll container, replacing the Vue2-era `position:fixed`-without-`top` chrome (toolbar, sticky viz, sticky table header) that desynced on toolbar toggle. Chrome rows now live in normal flow above a single `overflow:auto` scroll container, so collapsing the toolbar is plain reflow with zero offset math.

See the commit message for the full breakdown. Highlights:

- **`PageLayout.vue`** shell: chrome / scroll / overlay slots, provides `pageScrollEl`, height `calc(100vh - navbar - footer)`.
- All **9 toolbar pages** converted (Sessions, Arkime, Connections, Files, History, Hunt, Spigraph, Spiview, Stats).
- **Sessions**: native `position:sticky` thead, viz pinned via Teleport, width math off the scroll container; deletes `docScroll` / `toggleStickyHeader` / the `-50px` margin hacks / the last jQuery.
- **Connections**: graph svg sized from the scroll container via `ResizeObserver`. **Summary**: SortableJS autoscroll retargeted to `pageScrollEl`. **StickySessions**: button teleported to body, panel in the overlay slot.
- Adds `--arkime-navbar-height` / `--arkime-footer-height` CSS vars; reduces `CollapsibleWrapper` to a flow-only `v-expand-transition`.

**Review fixes folded in (post-commit):**
- Sessions: added the `$store.state.stickyViz` resize-nudge watcher for parity with Spigraph/Spiview/Arkime (charts/map cache geometry on pin toggle).
- StickySessions: restored toolbar-collapse tracking for the button/panel (they ride up when the toolbar collapses) — done via `:style` rather than `:class` so the `bounce` animation's manual `classList` handling isn't clobbered by class patching.

**Rebase note:** branched off current dev7 and resolved one conflict in `Sessions.vue` — kept the app-shell `#overlay` structure and folded in #4034's save/load-config `<v-snackbar>`. App.vue and Spiview.vue auto-merged. Lint + viewer bundle build pass.
