### PR TITLE
Fold Connections into SPIGraph as a graph type

### DIFF
--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -115,7 +115,6 @@
     "settings": "Einstellungen",
     "spiview": "SPI-Ansicht",
     "spigraph": "SPI-Grafik",
-    "connections": "Verbindungen",
     "hunt": "Jagd",
     "stats": "Statistik",
     "files": "Dateien",
@@ -1361,7 +1360,8 @@
     "v7Item2": "Neue Sitzungsansicht (Details/Pakete/tshark)",
     "v7Item3": "Mehr Internationalisierung",
     "v7Item4": "Mehr Visualisierungen",
-    "v7Item5": "Und vieles mehr"
+    "v7Item5": "Verbindungen wurden in die SPI-Grafik verschoben",
+    "v7Item6": "Und vieles mehr"
   },
   "helpNotes": {
     "learnMore": "Mehr erfahren",
@@ -1377,9 +1377,6 @@
     },
     "spigraph": {
       "text": "Die SPI-Grafik stellt die häufigsten Werte eines beliebigen Feldes über die Zeit dar — probieren Sie verschiedene Felder und Diagrammtypen aus."
-    },
-    "connections": {
-      "text": "Die Seite Verbindungen zeigt, wie Quellen und Ziele miteinander kommunizieren — ziehen, zoomen und klicken Sie auf Knoten, um tiefer einzusteigen."
     },
     "hunt": {
       "text": "Jagden durchsuchen die Roh-Pakete selbst, nicht nur Sitzungs-Metadaten. Erstellen Sie einen Paketsuchauftrag, um zu finden, was die Indizierung übersehen hat."
@@ -1412,10 +1409,12 @@
     "graphType-table": "Tabelle",
     "graphType-treemap": "Baumkarte",
     "graphType-sankey": "Sankey",
+    "graphType-connections": "Verbindungen",
     "sortBy": "Sortieren nach",
     "sortBy-name": "Alphabetisch",
     "sortBy-graph": "Anzahl",
     "refreshEvery": "Alle aktualisieren",
+    "exportCSV": "CSV exportieren",
     "exportCSVSPIGraphTip": "Diese Daten als CSV-Datei exportieren"
   },
   "utils": {

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -115,7 +115,6 @@
     "settings": "Settings",
     "spiview": "SPIView",
     "spigraph": "SPIGraph",
-    "connections": "Connections",
     "hunt": "Hunt",
     "stats": "Stats",
     "files": "Files",
@@ -1361,7 +1360,8 @@
     "v7Item2": "New session view (detail/packets/tshark)",
     "v7Item3": "More internationalization",
     "v7Item4": "More visualizations",
-    "v7Item5": "And many more"
+    "v7Item5": "Connections moved into SPI Graph",
+    "v7Item6": "And many more"
   },
   "helpNotes": {
     "learnMore": "Learn more",
@@ -1376,10 +1376,7 @@
       "text": "SPI View shows captured field values grouped by category, so you can scan what's in your data at a glance."
     },
     "spigraph": {
-      "text": "SPI Graph charts the top values of any field over time — try different fields and graph types."
-    },
-    "connections": {
-      "text": "The Connections page maps how sources and destinations talk to each other — drag, zoom, and click nodes to dig in."
+      "text": "SPI Graph charts the top values of any field over time — try different fields and graph types, including the connections network graph."
     },
     "hunt": {
       "text": "Hunts search inside raw packets, not just session metadata. Create a packet search job to find what indexing missed."
@@ -1407,15 +1404,17 @@
     "maxElements": "Max Elements",
     "maxElementsTip": "Maximum number of elements returned (for the first field selected)",
     "graphType": "Graph Type",
-    "graphType-default": "timeline/map",
-    "graphType-pie": "donut",
-    "graphType-table": "table",
-    "graphType-treemap": "treemap",
-    "graphType-sankey": "sankey",
+    "graphType-default": "Timeline/Map",
+    "graphType-pie": "Donut",
+    "graphType-table": "Table",
+    "graphType-treemap": "Treemap",
+    "graphType-sankey": "Sankey",
+    "graphType-connections": "Connections",
     "sortBy": "Sort by",
     "sortBy-name": "Alphabetically",
     "sortBy-graph": "Count",
     "refreshEvery": "Refresh every",
+    "exportCSV": "Export CSV",
     "exportCSVSPIGraphTip": "Export this data as a CSV file"
   },
   "utils": {

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -115,7 +115,6 @@
     "settings": "Configuración",
     "spiview": "Vista SPI",
     "spigraph": "Gráfico SPI",
-    "connections": "Conexiones",
     "hunt": "Búsqueda",
     "stats": "Estadísticas",
     "files": "Archivos",
@@ -1361,7 +1360,8 @@
     "v7Item2": "Nueva vista de sesión (detalle/paquetes/tshark)",
     "v7Item3": "Más internacionalización",
     "v7Item4": "Más visualizaciones",
-    "v7Item5": "Y mucho más"
+    "v7Item5": "Conexiones se movió a Gráfico SPI",
+    "v7Item6": "Y mucho más"
   },
   "helpNotes": {
     "learnMore": "Más información",
@@ -1377,9 +1377,6 @@
     },
     "spigraph": {
       "text": "El Gráfico SPI muestra los valores principales de cualquier campo a lo largo del tiempo — prueba distintos campos y tipos de gráfico."
-    },
-    "connections": {
-      "text": "La página de Conexiones muestra cómo se comunican los orígenes y los destinos — arrastra, haz zoom y haz clic en los nodos para profundizar."
     },
     "hunt": {
       "text": "Las búsquedas (Hunt) examinan el interior de los paquetes sin procesar, no solo los metadatos de sesión. Crea un trabajo de búsqueda de paquetes para encontrar lo que la indexación pasó por alto."
@@ -1407,15 +1404,17 @@
     "maxElements": "Elementos máximos",
     "maxElementsTip": "Número máximo de elementos devueltos (para el primer campo seleccionado)",
     "graphType": "Tipo de gráfico",
-    "graphType-default": "línea de tiempo/mapa",
-    "graphType-pie": "dona",
-    "graphType-table": "tabla",
-    "graphType-treemap": "mapa de árbol",
-    "graphType-sankey": "sankey",
+    "graphType-default": "Línea de tiempo/mapa",
+    "graphType-pie": "Dona",
+    "graphType-table": "Tabla",
+    "graphType-treemap": "Mapa de árbol",
+    "graphType-sankey": "Sankey",
+    "graphType-connections": "Conexiones",
     "sortBy": "Ordenar por",
     "sortBy-name": "Alfabéticamente",
     "sortBy-graph": "Conteo",
     "refreshEvery": "Actualizar cada",
+    "exportCSV": "Exportar CSV",
     "exportCSVSPIGraphTip": "Exportar estos datos como archivo CSV"
   },
   "utils": {

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -115,7 +115,6 @@
     "settings": "Seaded",
     "spiview": "SPI Vaade",
     "spigraph": "SPI Graafik",
-    "connections": "Ühendused",
     "hunt": "Jaht",
     "stats": "Statistika",
     "files": "Failid",
@@ -1361,7 +1360,8 @@
     "v7Item2": "Uus seansivaade (üksikasjad/paketid/tshark)",
     "v7Item3": "Rohkem rahvusvahelistamist",
     "v7Item4": "Rohkem visualiseeringuid",
-    "v7Item5": "Ja palju muud"
+    "v7Item5": "Ühendused on nüüd SPI Graafikus",
+    "v7Item6": "Ja palju muud"
   },
   "helpNotes": {
     "learnMore": "Loe lähemalt",
@@ -1377,9 +1377,6 @@
     },
     "spigraph": {
       "text": "SPI Graafik kuvab mis tahes välja populaarseimad väärtused ajas — proovi erinevaid välju ja graafikutüüpe."
-    },
-    "connections": {
-      "text": "Ühenduste leht näitab, kuidas allikad ja sihtkohad omavahel suhtlevad — lohista, suumi ja klõpsa sõlmedel, et lähemalt uurida."
     },
     "hunt": {
       "text": "Jahid otsivad toorpakettide seest, mitte ainult seansi metaandmetest. Loo paketiotsingu töö, et leida see, mis indekseerimisel märkamata jäi."
@@ -1407,15 +1404,17 @@
     "maxElements": "Maksimaalne elementide arv",
     "maxElementsTip": "Tagastatud elementide maksimaalne arv (esimese valitud välja jaoks)",
     "graphType": "Graafiku tüüp",
-    "graphType-default": "ajajoon/kaart",
-    "graphType-pie": "sõõrik",
-    "graphType-table": "tabel",
-    "graphType-treemap": "puukaart",
-    "graphType-sankey": "sankey",
+    "graphType-default": "Ajajoon/kaart",
+    "graphType-pie": "Sõõrik",
+    "graphType-table": "Tabel",
+    "graphType-treemap": "Puukaart",
+    "graphType-sankey": "Sankey",
+    "graphType-connections": "Ühendused",
     "sortBy": "Sorteeri",
     "sortBy-name": "Tähestikuliselt",
     "sortBy-graph": "Loendus",
     "refreshEvery": "Värskenda iga",
+    "exportCSV": "Ekspordi CSV",
     "exportCSVSPIGraphTip": "Ekspordi SPI graafiku andmed CSV kujul"
   },
   "utils": {

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -115,7 +115,6 @@
     "settings": "Paramètres",
     "spiview": "Vue SPI",
     "spigraph": "Graphique SPI",
-    "connections": "Connexions",
     "hunt": "Chasse",
     "stats": "Statistiques",
     "files": "Fichiers",
@@ -1361,7 +1360,8 @@
     "v7Item2": "Nouvelle vue de session (détail/paquets/tshark)",
     "v7Item3": "Plus d'internationalisation",
     "v7Item4": "Plus de visualisations",
-    "v7Item5": "Et bien plus encore"
+    "v7Item5": "Connexions a été déplacé dans Graphique SPI",
+    "v7Item6": "Et bien plus encore"
   },
   "helpNotes": {
     "learnMore": "En savoir plus",
@@ -1377,9 +1377,6 @@
     },
     "spigraph": {
       "text": "Le Graphique SPI trace les principales valeurs de n'importe quel champ dans le temps — essayez différents champs et types de graphiques."
-    },
-    "connections": {
-      "text": "La page Connexions cartographie les échanges entre sources et destinations — déplacez, zoomez et cliquez sur les nœuds pour approfondir."
     },
     "hunt": {
       "text": "Les chasses recherchent dans les paquets bruts, pas seulement dans les métadonnées de session. Créez une tâche de recherche de paquets pour trouver ce que l'indexation a manqué."
@@ -1407,15 +1404,17 @@
     "maxElements": "Max. éléments",
     "maxElementsTip": "Nombre maximum d'éléments retournés (pour le premier champ sélectionné)",
     "graphType": "Type de graphique",
-    "graphType-default": "chronologie/carte",
-    "graphType-pie": "beignet",
-    "graphType-table": "tableau",
-    "graphType-treemap": "treemap",
-    "graphType-sankey": "sankey",
+    "graphType-default": "Chronologie/carte",
+    "graphType-pie": "Beignet",
+    "graphType-table": "Tableau",
+    "graphType-treemap": "Treemap",
+    "graphType-sankey": "Sankey",
+    "graphType-connections": "Connexions",
     "sortBy": "Trier par",
     "sortBy-name": "Alphabétiquement",
     "sortBy-graph": "Compte",
     "refreshEvery": "Actualiser toutes les",
+    "exportCSV": "Exporter CSV",
     "exportCSVSPIGraphTip": "Exporter les données du graphique SPI au format CSV"
   },
   "utils": {

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -115,7 +115,6 @@
     "settings": "設定",
     "spiview": "SPI View",
     "spigraph": "SPI Graph",
-    "connections": "コネクション",
     "hunt": "ハント",
     "stats": "統計",
     "files": "ファイル",
@@ -1361,7 +1360,8 @@
     "v7Item2": "新しいセッションビュー（詳細/パケット/tshark）",
     "v7Item3": "国際化対応の強化",
     "v7Item4": "ビジュアライゼーションの追加",
-    "v7Item5": "その他多数の改善"
+    "v7Item5": "コネクションは SPI Graph に移動しました",
+    "v7Item6": "その他多数の改善"
   },
   "helpNotes": {
     "learnMore": "詳細を見る",
@@ -1377,9 +1377,6 @@
     },
     "spigraph": {
       "text": "SPI Graph は任意のフィールドの上位値を時系列でグラフ化します。さまざまなフィールドやグラフタイプを試してみてください。"
-    },
-    "connections": {
-      "text": "コネクションページは送信元と宛先がどのように通信しているかをマップ表示します。ドラッグ、ズーム、ノードのクリックで詳しく調べられます。"
     },
     "hunt": {
       "text": "ハントはセッションのメタデータだけでなく、生のパケットの中身を検索します。パケット検索ジョブを作成して、インデックス化で漏れたものを見つけましょう。"
@@ -1412,10 +1409,12 @@
     "graphType-table": "テーブル",
     "graphType-treemap": "ツリーマップ",
     "graphType-sankey": "サンキー",
+    "graphType-connections": "コネクション",
     "sortBy": "ソート順",
     "sortBy-name": "アルファベット順",
     "sortBy-graph": "カウント順",
     "refreshEvery": "更新間隔",
+    "exportCSV": "CSV をエクスポート",
     "exportCSVSPIGraphTip": "このデータを CSV ファイルとしてエクスポート"
   },
   "utils": {

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -115,7 +115,6 @@
     "settings": "설정",
     "spiview": "SPI 뷰",
     "spigraph": "SPI 그래프",
-    "connections": "연결",
     "hunt": "사냥(Hunt)",
     "stats": "통계",
     "files": "파일",
@@ -1361,7 +1360,8 @@
     "v7Item2": "새로운 세션 보기 (상세/패킷/tshark)",
     "v7Item3": "국제화 지원 강화",
     "v7Item4": "더 많은 시각화",
-    "v7Item5": "그 외 다양한 개선"
+    "v7Item5": "연결이 SPI 그래프로 이동되었습니다",
+    "v7Item6": "그 외 다양한 개선"
   },
   "helpNotes": {
     "learnMore": "더 알아보기",
@@ -1377,9 +1377,6 @@
     },
     "spigraph": {
       "text": "SPI 그래프는 어떤 필드든 상위 값을 시간에 따라 차트로 보여줍니다. 다양한 필드와 그래프 유형을 시도해 보세요."
-    },
-    "connections": {
-      "text": "연결 페이지는 소스와 대상이 어떻게 통신하는지 보여줍니다. 드래그, 확대/축소, 노드 클릭으로 자세히 살펴보세요."
     },
     "hunt": {
       "text": "사냥(Hunt)은 세션 메타데이터뿐 아니라 원시 패킷 내부를 검색합니다. 패킷 검색 작업을 만들어 인덱싱에서 놓친 것을 찾아보세요."
@@ -1412,10 +1409,12 @@
     "graphType-table": "테이블",
     "graphType-treemap": "트리맵",
     "graphType-sankey": "생키(Sankey)",
+    "graphType-connections": "연결",
     "sortBy": "정렬 기준",
     "sortBy-name": "사전순",
     "sortBy-graph": "개수",
     "refreshEvery": "새로고침 주기",
+    "exportCSV": "CSV 내보내기",
     "exportCSVSPIGraphTip": "이 데이터를 CSV 파일로 내보내기"
   },
   "utils": {

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -115,7 +115,6 @@
     "settings": "Configurações",
     "spiview": "Visualização SPI",
     "spigraph": "Gráfico SPI",
-    "connections": "Conexões",
     "hunt": "Caça",
     "stats": "Estatísticas",
     "files": "Arquivos",
@@ -1361,7 +1360,8 @@
     "v7Item2": "Nova visualização de sessão (detalhes/pacotes/tshark)",
     "v7Item3": "Mais internacionalização",
     "v7Item4": "Mais visualizações",
-    "v7Item5": "E muito mais"
+    "v7Item5": "Conexões foi movido para o Gráfico SPI",
+    "v7Item6": "E muito mais"
   },
   "helpNotes": {
     "learnMore": "Saiba mais",
@@ -1377,9 +1377,6 @@
     },
     "spigraph": {
       "text": "O Gráfico SPI mostra os principais valores de qualquer campo ao longo do tempo — experimente diferentes campos e tipos de gráfico."
-    },
-    "connections": {
-      "text": "A página de Conexões mapeia como origens e destinos se comunicam — arraste, amplie e clique nos nós para explorar."
     },
     "hunt": {
       "text": "Caças pesquisam dentro dos pacotes brutos, não apenas nos metadados de sessão. Crie um trabalho de busca de pacotes para encontrar o que a indexação deixou passar."
@@ -1407,15 +1404,17 @@
     "maxElements": "Máx de Elementos",
     "maxElementsTip": "Número máximo de elementos retornados (para o primeiro campo selecionado)",
     "graphType": "Tipo de Gráfico",
-    "graphType-default": "linha do tempo/mapa",
-    "graphType-pie": "rosca",
-    "graphType-table": "tabela",
-    "graphType-treemap": "treemap",
-    "graphType-sankey": "sankey",
+    "graphType-default": "Linha do tempo/mapa",
+    "graphType-pie": "Rosca",
+    "graphType-table": "Tabela",
+    "graphType-treemap": "Treemap",
+    "graphType-sankey": "Sankey",
+    "graphType-connections": "Conexões",
     "sortBy": "Ordenar por",
     "sortBy-name": "Alfabeticamente",
     "sortBy-graph": "Contagem",
     "refreshEvery": "Atualizar a cada",
+    "exportCSV": "Exportar CSV",
     "exportCSVSPIGraphTip": "Exportar estes dados como arquivo CSV"
   },
   "utils": {

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -116,7 +116,6 @@
     "settings": "Ettingssay",
     "spiview": "PIsay Iewvay",
     "spigraph": "PIsay Raphgray",
-    "connections": "Onnectionscay",
     "hunt": "Unthay",
     "stats": "Atssay",
     "files": "Ilesfay",
@@ -1362,7 +1361,8 @@
     "v7Item2": "Ewnay essionsay iewvay (etailday/acketspay/sharktay)",
     "v7Item3": "Oremay internationalizationway",
     "v7Item4": "Oremay isualizationsvay",
-    "v7Item5": "Andway anymay oremay"
+    "v7Item5": "Onnectionscay ovedmay intoway PIsay Raphgray",
+    "v7Item6": "Andway anymay oremay"
   },
   "helpNotes": {
     "learnMore": "Earnlay oremay",
@@ -1378,9 +1378,6 @@
     },
     "spigraph": {
       "text": "PIsay Raphgray artschay ethay optay aluesvay ofway anyway ieldfay overway imetay — ytray ifferentday ieldsfay andway aphgray ypestay."
-    },
-    "connections": {
-      "text": "Ethay Onnectionscay agepay apsmay owhay ourcessay andway estinationsday alktay otay eachway otherway — agdray, oomzay, andway ickclay odesnay otay igday inway."
     },
     "hunt": {
       "text": "Untshay earchsay insideway awray acketspay, otnay ustjay essionsay etadatamay. Eatecray away acketpay earchsay objay otay indfay atwhay indexingway issedmay."
@@ -1408,15 +1405,17 @@
     "maxElements": "Axmay Elementsway",
     "maxElementsTip": "Aximummay umbernay ofway elementsway eturnedray (orfay ethay irtsfay ieldfay electedsay)",
     "graphType": "Raphgray Ypetay",
-    "graphType-default": "imelinetay/apmay",
-    "graphType-pie": "onutday",
-    "graphType-table": "abletay",
-    "graphType-treemap": "eemaptray",
-    "graphType-sankey": "ankeysay",
+    "graphType-default": "Imelinetay/apmay",
+    "graphType-pie": "Onutday",
+    "graphType-table": "Abletay",
+    "graphType-treemap": "Eemaptray",
+    "graphType-sankey": "Ankeysay",
+    "graphType-connections": "Onnectionscay",
     "sortBy": "Ortsay ybay",
     "sortBy-name": "Alphabeticallyway",
     "sortBy-graph": "Ountcay",
     "refreshEvery": "Efreshrway everyway",
+    "exportCSV": "Exportway SVCAY",
     "exportCSVSPIGraphTip": "Exportway isthay ataday asway away SVCAY ilefay"
   },
   "utils": {

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -115,7 +115,6 @@
     "settings": "设置",
     "spiview": "SPI 视图",
     "spigraph": "SPI 图",
-    "connections": "连接",
     "hunt": "捕获任务",
     "stats": "统计",
     "files": "文件",
@@ -1361,7 +1360,8 @@
     "v7Item2": "全新会话视图（详情/数据包/tshark）",
     "v7Item3": "更完善的国际化支持",
     "v7Item4": "更多可视化功能",
-    "v7Item5": "以及更多改进"
+    "v7Item5": "连接已移至 SPI 图",
+    "v7Item6": "以及更多改进"
   },
   "helpNotes": {
     "learnMore": "了解更多",
@@ -1377,9 +1377,6 @@
     },
     "spigraph": {
       "text": "SPI 图按时间绘制任意字段的最高频值——尝试不同的字段和图表类型。"
-    },
-    "connections": {
-      "text": "连接页面展示源和目标之间的通信关系——拖动、缩放并点击节点深入查看。"
     },
     "hunt": {
       "text": "捕获任务可搜索原始数据包内部，而不仅仅是会话元数据。创建数据包搜索任务，找出索引遗漏的内容。"
@@ -1412,10 +1409,12 @@
     "graphType-table": "表格",
     "graphType-treemap": "树状图",
     "graphType-sankey": "桑基图",
+    "graphType-connections": "连接",
     "sortBy": "排序方式",
     "sortBy-name": "按字母顺序",
     "sortBy-graph": "按计数",
     "refreshEvery": "每隔多久刷新一次",
+    "exportCSV": "导出 CSV",
     "exportCSVSPIGraphTip": "以 CSV 格式导出 SPI 图表数据"
   },
   "utils": {

--- a/viewer/vueapp/src/App.vue
+++ b/viewer/vueapp/src/App.vue
@@ -30,7 +30,7 @@ SPDX-License-Identifier: Apache-2.0
         <br>
         <code>'G'</code> - jump to the SPI Graph page
         <br>
-        <code>'C'</code> - jump to the Connections page
+        <code>'C'</code> - jump to the Connections graph (SPI Graph)
         <br>
         <code>'H'</code> - jump to the Arkime Help page
         <br>
@@ -174,9 +174,17 @@ export default {
         }
         break;
       case 'c': // c
-        // open connections page if not on connections page
-        if (this.$route.name !== 'Connections') {
-          this.routeTo('/connections');
+        // open the connections graph (a Spigraph view) if not already there
+        if (this.$route.name !== 'Spigraph' || this.$route.query.spiGraphType !== 'connections') {
+          this.$router.push({
+            path: '/spigraph',
+            query: {
+              ...this.$route.query,
+              spiGraphType: 'connections',
+              expression: this.$store.state.expression
+            },
+            hash: this.$route.hash
+          });
         }
         break;
       case 'h': // h

--- a/viewer/vueapp/src/components/connections/ConnectionsGraph.vue
+++ b/viewer/vueapp/src/components/connections/ConnectionsGraph.vue
@@ -2,568 +2,560 @@
 Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
+<!--
+  Connections force-directed graph (the `connections` SPIGraph type).
+  Teleports its controls + overlay buttons into anchors the host exposes.
+-->
 <template>
-  <page-layout
-    ref="pageLayout"
-    class="connections-page">
-    <template #chrome>
-      <ArkimeCollapsible>
-        <div class="page-toolbar">
-          <!-- search navbar -->
-          <arkime-search
-            :start="query.start"
-            @change-search="cancelAndLoad(true)" /> <!-- /search navbar -->
+  <!-- sub-navbar controls -->
+  <teleport
+    defer
+    to="#connections-controls-anchor">
+    <!-- query size select -->
+    <div class="arkime-input-group">
+      <span
+        id="querySize"
+        class="arkime-input-label cursor-help">
+        {{ $t('connections.querySize') }}
+      </span>
+      <v-tooltip
+        activator="#querySize"
+        :open-delay="300">
+        {{ $t('connections.querySizeTip') }}
+      </v-tooltip>
+      <select
+        class="arkime-input-control"
+        :value="query.length"
+        @change="changeLength(Number($event.target.value))">
+        <option
+          v-for="opt in [100, 500, 1000, 5000, 10000, 50000, 100000]"
+          :key="opt"
+          :value="opt">
+          {{ opt }}
+        </option>
+      </select>
+    </div> <!-- /query size select -->
 
-          <!-- connections sub navbar -->
-          <div class="connections-form mx-1">
-            <div class="d-flex flex-wrap align-center gap-1 page-subnav">
-              <!-- query size select -->
-              <div class="arkime-input-group">
-                <span
-                  id="querySize"
-                  class="arkime-input-label cursor-help">
-                  {{ $t('connections.querySize') }}
-                </span>
-                <v-tooltip
-                  activator="#querySize"
-                  :open-delay="300">
-                  {{ $t('connections.querySizeTip') }}
-                </v-tooltip>
-                <select
-                  class="arkime-input-control"
-                  :value="query.length"
-                  @change="changeLength(Number($event.target.value))">
-                  <option
-                    v-for="opt in [100, 500, 1000, 5000, 10000, 50000, 100000]"
-                    :key="opt"
-                    :value="opt">
-                    {{ opt }}
-                  </option>
-                </select>
-              </div> <!-- /query size select -->
+    <!-- src select -->
+    <div
+      class="connections-field-row"
+      v-if="fields && fields.length && srcFieldTypeahead && fieldHistoryConnectionsSrc">
+      <span
+        class="connections-legend-cell primary-legend cursor-help"
+        id="sourceField">
+        Src:
+      </span>
+      <v-tooltip
+        activator="#sourceField"
+        :open-delay="300">
+        {{ $t('connections.sourceFieldTip') }}
+      </v-tooltip>
+      <arkime-field-typeahead
+        :fields="fields"
+        query-param="srcField"
+        :initial-value="srcFieldTypeahead"
+        @field-selected="changeSrcField"
+        :history="fieldHistoryConnectionsSrc"
+        page="ConnectionsSrc" />
+    </div> <!-- /src select -->
 
-              <!-- src select -->
-              <div
-                class="connections-field-row"
-                v-if="fields && fields.length && srcFieldTypeahead && fieldHistoryConnectionsSrc">
-                <span
-                  class="connections-legend-cell primary-legend cursor-help"
-                  id="sourceField">
-                  Src:
-                </span>
-                <v-tooltip
-                  activator="#sourceField"
-                  :open-delay="300">
-                  {{ $t('connections.sourceFieldTip') }}
-                </v-tooltip>
-                <arkime-field-typeahead
-                  :fields="fields"
-                  query-param="srcField"
-                  :initial-value="srcFieldTypeahead"
-                  @field-selected="changeSrcField"
-                  :history="fieldHistoryConnectionsSrc"
-                  page="ConnectionsSrc" />
-              </div> <!-- /src select -->
+    <!-- dst select -->
+    <div
+      class="connections-field-row"
+      v-if="fields && dstFieldTypeahead && fieldHistoryConnectionsDst">
+      <span
+        class="connections-legend-cell secondary-legend cursor-help"
+        id="dstField">
+        Dst:
+      </span>
+      <v-tooltip
+        activator="#dstField"
+        :open-delay="300">
+        {{ $t('connections.dstFieldTip') }}
+      </v-tooltip>
+      <arkime-field-typeahead
+        :fields="fields"
+        query-param="dstField"
+        :initial-value="dstFieldTypeahead"
+        @field-selected="changeDstField"
+        :history="fieldHistoryConnectionsDst"
+        page="ConnectionsDst" />
+    </div> <!-- /dst select -->
 
-              <!-- dst select -->
-              <div
-                class="connections-field-row"
-                v-if="fields && dstFieldTypeahead && fieldHistoryConnectionsDst">
-                <span
-                  class="connections-legend-cell secondary-legend cursor-help"
-                  id="dstField">
-                  Dst:
-                </span>
-                <v-tooltip
-                  activator="#dstField"
-                  :open-delay="300">
-                  {{ $t('connections.dstFieldTip') }}
-                </v-tooltip>
-                <arkime-field-typeahead
-                  :fields="fields"
-                  query-param="dstField"
-                  :initial-value="dstFieldTypeahead"
-                  @field-selected="changeDstField"
-                  :history="fieldHistoryConnectionsDst"
-                  page="ConnectionsDst" />
-              </div> <!-- /dst select -->
+    <!-- src & dst color -->
+    <span
+      class="connections-legend-cell connections-legend-standalone tertiary-legend cursor-help"
+      id="srcDstColor">
+      Src &amp; dst
+    </span>
+    <v-tooltip
+      activator="#srcDstColor"
+      :open-delay="300">
+      {{ $t('connections.srcDstColorTip') }}
+    </v-tooltip> <!-- /src & dst color -->
 
-              <!-- src & dst color -->
-              <span
-                class="connections-legend-cell connections-legend-standalone tertiary-legend cursor-help"
-                id="srcDstColor">
-                Src &amp; dst
-              </span>
+    <!-- min connections select -->
+    <div class="arkime-input-group">
+      <span
+        id="minConn"
+        class="arkime-input-label help-cursor">
+        {{ $t('connections.minConn') }}
+      </span>
+      <v-tooltip
+        activator="#minConn"
+        :open-delay="300">
+        {{ $t('connections.minConnTip') }}
+      </v-tooltip>
+      <select
+        class="arkime-input-control"
+        :value="query.minConn"
+        @change="changeMinConn(Number($event.target.value))">
+        <option
+          v-for="opt in [1,2,3,4,5]"
+          :key="opt"
+          :value="opt">
+          {{ opt }}
+        </option>
+      </select>
+    </div> <!-- /min connections select -->
+
+    <!-- weight select -->
+    <div class="arkime-input-group">
+      <span
+        class="arkime-input-label help-cursor"
+        id="weight">
+        {{ $t('connections.weight') }}
+      </span>
+      <v-tooltip
+        activator="#weight"
+        :open-delay="300">
+        {{ $t('connections.weightTip') }}
+      </v-tooltip>
+      <select
+        class="arkime-input-control"
+        :value="weight"
+        @change="changeWeight($event.target.value)">
+        <option
+          value="sessions"
+          v-i18n-value="'connections.weight-'" />
+        <option
+          value="network.packets"
+          v-i18n-value="'connections.weight-'" />
+        <option
+          value="network.bytes"
+          v-i18n-value="'connections.weight-'" />
+        <option
+          value="totDataBytes"
+          v-i18n-value="'connections.weight-'" />
+        <option
+          value=""
+          v-i18n-value="'connections.weight-'" />
+      </select>
+    </div> <!-- /weight select -->
+
+    <div
+      v-if="!loading"
+      class="d-inline-flex">
+      <!-- node + link field-visibility menus (same shape, kind='node'|'link') -->
+      <template
+        v-for="m in fieldVisMenus"
+        :key="m.kind">
+        <v-menu
+          v-if="fields && groupedFields && fieldList(m.kind)"
+          :close-on-content-click="false"
+          location="bottom start">
+          <template #activator="{ props: activatorProps }">
+            <v-btn
+              v-bind="activatorProps"
+              variant="flat"
+              size="large"
+              color="primary"
+              class="ms-1 field-vis-trigger"
+              :id="`${m.kind}Fields`">
+              <v-icon :icon="m.icon" />
               <v-tooltip
-                activator="#srcDstColor"
+                activator="parent"
                 :open-delay="300">
-                {{ $t('connections.srcDstColorTip') }}
-              </v-tooltip> <!-- /src & dst color -->
-
-              <!-- min connections select -->
-              <div class="arkime-input-group">
-                <span
-                  id="minConn"
-                  class="arkime-input-label help-cursor">
-                  {{ $t('connections.minConn') }}
+                {{ $t(m.tipKey) }}
+              </v-tooltip>
+            </v-btn>
+          </template>
+          <v-list
+            density="compact"
+            class="field-vis-list">
+            <div class="px-2 py-1">
+              <div class="arkime-input-group arkime-input-group--fluid">
+                <span class="arkime-input-label arkime-input-label-fw">
+                  <v-icon icon="mdi-magnify" />
                 </span>
-                <v-tooltip
-                  activator="#minConn"
-                  :open-delay="300">
-                  {{ $t('connections.minConnTip') }}
-                </v-tooltip>
-                <select
+                <input
+                  type="text"
+                  v-model="fieldQuery"
                   class="arkime-input-control"
-                  :value="query.minConn"
-                  @change="changeMinConn(Number($event.target.value))">
-                  <option
-                    v-for="opt in [1,2,3,4,5]"
-                    :key="opt"
-                    :value="opt">
-                    {{ opt }}
-                  </option>
-                </select>
-              </div> <!-- /min connections select -->
-
-              <!-- weight select -->
-              <div class="arkime-input-group">
-                <span
-                  class="arkime-input-label help-cursor"
-                  id="weight">
-                  {{ $t('connections.weight') }}
-                </span>
-                <v-tooltip
-                  activator="#weight"
-                  :open-delay="300">
-                  {{ $t('connections.weightTip') }}
-                </v-tooltip>
-                <select
-                  class="arkime-input-control"
-                  :value="weight"
-                  @change="changeWeight($event.target.value)">
-                  <option
-                    value="sessions"
-                    v-i18n-value="'connections.weight-'" />
-                  <option
-                    value="network.packets"
-                    v-i18n-value="'connections.weight-'" />
-                  <option
-                    value="network.bytes"
-                    v-i18n-value="'connections.weight-'" />
-                  <option
-                    value="totDataBytes"
-                    v-i18n-value="'connections.weight-'" />
-                  <option
-                    value=""
-                    v-i18n-value="'connections.weight-'" />
-                </select>
-              </div> <!-- /weight select -->
-
-              <div
-                v-if="!loading"
-                class="d-inline-flex">
-                <!-- node + link field-visibility menus (same shape, kind='node'|'link') -->
-                <template
-                  v-for="m in fieldVisMenus"
-                  :key="m.kind">
-                  <v-menu
-                    v-if="fields && groupedFields && fieldList(m.kind)"
-                    :close-on-content-click="false"
-                    location="bottom start">
-                    <template #activator="{ props: activatorProps }">
-                      <v-btn
-                        v-bind="activatorProps"
-                        variant="flat"
-                        size="large"
-                        color="primary"
-                        class="ms-1 field-vis-trigger"
-                        :id="`${m.kind}Fields`">
-                        <v-icon :icon="m.icon" />
-                        <v-tooltip
-                          activator="parent"
-                          :open-delay="300">
-                          {{ $t(m.tipKey) }}
-                        </v-tooltip>
-                      </v-btn>
-                    </template>
-                    <v-list
-                      density="compact"
-                      class="field-vis-list">
-                      <div class="px-2 py-1">
-                        <div class="arkime-input-group arkime-input-group--fluid">
-                          <span class="arkime-input-label arkime-input-label-fw">
-                            <v-icon icon="mdi-magnify" />
-                          </span>
-                          <input
-                            type="text"
-                            v-model="fieldQuery"
-                            class="arkime-input-control"
-                            :placeholder="$t('common.searchForFields')">
-                        </div>
-                      </div>
-                      <v-divider />
-                      <v-list-item @click.stop.prevent="resetFieldVisibility(m.kind)">
-                        {{ $t('connections.reset') }}
-                      </v-list-item>
-                      <v-divider />
-                      <template
-                        v-for="(group, key) in filteredFields"
-                        :key="key">
-                        <v-list-subheader
-                          v-if="group.length"
-                          class="field-vis-group-header">
-                          {{ key }}
-                        </v-list-subheader>
-                        <template
-                          v-for="(field, k) in group"
-                          :key="key + k + m.kind">
-                          <v-list-item
-                            :data-tip-id="key + k + m.kind"
-                            :active="isFieldVisible(field.dbField, fieldList(m.kind)) >= 0"
-                            @click.stop.prevent="toggleFieldVisibility(field.dbField, fieldList(m.kind))">
-                            {{ field.friendlyName }}
-                            <small>({{ field.exp }})</small>
-                            <v-tooltip
-                              :activator="`[data-tip-id='${key + k + m.kind}']`"
-                              :open-delay="300">
-                              {{ field.help }}
-                            </v-tooltip>
-                          </v-list-item>
-                        </template>
-                      </template>
-                    </v-list>
-                  </v-menu>
-                </template> <!-- /field-visibility menus -->
+                  :placeholder="$t('common.searchForFields')">
               </div>
-
-              <!-- network baseline time range -->
-              <div class="arkime-input-group">
-                <span
-                  class="arkime-input-label help-cursor"
-                  id="baselineDate">
-                  {{ $t('connections.baselineDate') }}
-                </span>
-                <v-tooltip
-                  activator="#baselineDate"
-                  :open-delay="300">
-                  {{ $t('connections.baselineDateTip') }}
-                </v-tooltip>
-                <select
-                  class="arkime-input-control"
-                  v-model="query.baselineDate"
-                  @change="changeBaselineDate">
-                  <option value="0">
-                    {{ $t('common.optionDisabled') }}
-                  </option>
-                  <option value="1x">
-                    {{ $t('connections.queryRange', 1) }}
-                  </option>
-                  <option value="2x">
-                    {{ $t('connections.queryRange', 2) }}
-                  </option>
-                  <option value="4x">
-                    {{ $t('connections.queryRange', 4) }}
-                  </option>
-                  <option value="6x">
-                    {{ $t('connections.queryRange', 6) }}
-                  </option>
-                  <option value="8x">
-                    {{ $t('connections.queryRange', 8) }}
-                  </option>
-                  <option value="10x">
-                    {{ $t('connections.queryRange', 10) }}
-                  </option>
-                  <option value="1">
-                    {{ $t('common.hourCount', 1) }}
-                  </option>
-                  <option value="6">
-                    {{ $t('common.hourCount', 6) }}
-                  </option>
-                  <option value="24">
-                    {{ $t('common.hourCount', 24) }}
-                  </option>
-                  <option value="48">
-                    {{ $t('common.hourCount', 48) }}
-                  </option>
-                  <option value="72">
-                    {{ $t('common.hourCount', 72) }}
-                  </option>
-                  <option value="168">
-                    {{ $t('common.weekCount', 1) }}
-                  </option>
-                  <option value="336">
-                    {{ $t('common.weekCount', 2) }}
-                  </option>
-                  <option value="720">
-                    {{ $t('common.monthCount', 1) }}
-                  </option>
-                  <option value="1440">
-                    {{ $t('common.monthCount', 2) }}
-                  </option>
-                  <option value="4380">
-                    {{ $t('common.monthCount', 6) }}
-                  </option>
-                  <option value="8760">
-                    {{ $t('common.yearCount', 1) }}
-                  </option>
-                </select>
-              </div> <!-- /network baseline time range -->
-
-              <!-- network baseline node visibility -->
-              <div
-                class="arkime-input-group"
-                v-show="query.baselineDate !== '0'">
-                <span
-                  class="arkime-input-label help-cursor"
-                  id="baselineVis">
-                  {{ $t('connections.baselineVis') }}
-                </span>
-                <v-tooltip
-                  activator="#baselineVis"
-                  :open-delay="300">
-                  {{ $t('connections.baselineVisTip') }}
-                </v-tooltip>
-                <select
-                  class="arkime-input-control"
-                  :disabled="query.baselineDate === '0'"
-                  v-model="query.baselineVis"
-                  @change="changeBaselineVis">
-                  <option
-                    value="all"
-                    v-i18n-value="'connections.baselineVis-'" />
-                  <option
-                    value="actual"
-                    v-i18n-value="'connections.baselineVis-'" />
-                  <option
-                    value="actualold"
-                    v-i18n-value="'connections.baselineVis-'" />
-                  <option
-                    value="new"
-                    v-i18n-value="'connections.baselineVis-'" />
-                  <option
-                    value="old"
-                    v-i18n-value="'connections.baselineVis-'" />
-                </select>
-              </div> <!-- /network baseline node visibility -->
             </div>
-          </div> <!-- /connections sub navbar -->
-        </div>
-      </ArkimeCollapsible>
-    </template>
-
-    <div class="connections-content">
-      <!-- loading overlay -->
-      <arkime-loading
-        :can-cancel="true"
-        v-if="loading && !error"
-        @cancel="cancelAndLoad" /> <!-- /loading overlay -->
-
-      <!-- page error -->
-      <arkime-error
-        v-if="error"
-        :message="error"
-        class="mt-5" /> <!-- /page error -->
-
-      <!-- no results -->
-      <arkime-no-results
-        v-if="!error && !loading && recordsFiltered === 0"
-        class="mt-5"
-        :view="query.view" /> <!-- /no results -->
-
-      <!-- connections graph container -->
-      <svg
-        class="connections-graph"
-        v-if="!error" /> <!-- /connections graph container -->
-
-      <!-- popup area -->
-      <div
-        ref="infoPopup"
-        v-if="showPopup">
-        <div class="connections-popup">
-          <NodePopup
-            v-if="dataNode"
-            :data-node="dataNode"
-            :fields="fieldsMap"
-            :node-fields="nodeFields"
-            :baseline-date="query.baselineDate"
-            @close="closePopups"
-            @hide-node="hideNode" />
-          <LinkPopup
-            v-if="dataLink"
-            :data-link="dataLink"
-            :fields="fieldsMap"
-            :link-fields="linkFields"
-            @close="closePopups"
-            @hide-link="hideLink" />
-        </div>
-      </div> <!-- /popup area -->
+            <v-divider />
+            <v-list-item @click.stop.prevent="resetFieldVisibility(m.kind)">
+              {{ $t('connections.reset') }}
+            </v-list-item>
+            <v-divider />
+            <template
+              v-for="(group, key) in filteredFields"
+              :key="key">
+              <v-list-subheader
+                v-if="group.length"
+                class="field-vis-group-header">
+                {{ key }}
+              </v-list-subheader>
+              <template
+                v-for="(field, k) in group"
+                :key="key + k + m.kind">
+                <v-list-item
+                  :data-tip-id="key + k + m.kind"
+                  :active="isFieldVisible(field.dbField, fieldList(m.kind)) >= 0"
+                  @click.stop.prevent="toggleFieldVisibility(field.dbField, fieldList(m.kind))">
+                  {{ field.friendlyName }}
+                  <small>({{ field.exp }})</small>
+                  <v-tooltip
+                    :activator="`[data-tip-id='${key + k + m.kind}']`"
+                    :open-delay="300">
+                    {{ field.help }}
+                  </v-tooltip>
+                </v-list-item>
+              </template>
+            </template>
+          </v-list>
+        </v-menu>
+      </template> <!-- /field-visibility menus -->
     </div>
 
-    <template #overlay>
-      <!-- Button group -->
-      <div class="connections-buttons d-flex align-center ga-2">
-        <!-- unlock + export -->
-        <div class="d-flex ga-1">
-          <v-btn
-            variant="outlined"
-            size="small"
-            density="comfortable"
-            icon
-            id="unlockNodes"
-            :aria-label="$t('connections.unlockNodesTip')"
-            @click.stop.prevent="unlock">
-            <v-icon icon="mdi-lock-open" />
-            <v-tooltip
-              activator="parent"
-              location="bottom"
-              :open-delay="300">
-              {{ $t('connections.unlockNodesTip') }}
-            </v-tooltip>
-          </v-btn>
-          <v-btn
-            variant="outlined"
-            size="small"
-            density="comfortable"
-            icon
-            id="exportGraph"
-            :aria-label="$t('connections.exportGraphTip')"
-            @click.stop.prevent="exportPng">
-            <v-icon icon="mdi-download" />
-            <v-tooltip
-              activator="parent"
-              location="bottom"
-              :open-delay="300">
-              {{ $t('connections.exportGraphTip') }}
-            </v-tooltip>
-          </v-btn>
-        </div>
+    <!-- network baseline time range -->
+    <div class="arkime-input-group">
+      <span
+        class="arkime-input-label help-cursor"
+        id="baselineDate">
+        {{ $t('connections.baselineDate') }}
+      </span>
+      <v-tooltip
+        activator="#baselineDate"
+        :open-delay="300">
+        {{ $t('connections.baselineDateTip') }}
+      </v-tooltip>
+      <select
+        class="arkime-input-control"
+        v-model="query.baselineDate"
+        @change="changeBaselineDate">
+        <option value="0">
+          {{ $t('common.optionDisabled') }}
+        </option>
+        <option value="1x">
+          {{ $t('connections.queryRange', 1) }}
+        </option>
+        <option value="2x">
+          {{ $t('connections.queryRange', 2) }}
+        </option>
+        <option value="4x">
+          {{ $t('connections.queryRange', 4) }}
+        </option>
+        <option value="6x">
+          {{ $t('connections.queryRange', 6) }}
+        </option>
+        <option value="8x">
+          {{ $t('connections.queryRange', 8) }}
+        </option>
+        <option value="10x">
+          {{ $t('connections.queryRange', 10) }}
+        </option>
+        <option value="1">
+          {{ $t('common.hourCount', 1) }}
+        </option>
+        <option value="6">
+          {{ $t('common.hourCount', 6) }}
+        </option>
+        <option value="24">
+          {{ $t('common.hourCount', 24) }}
+        </option>
+        <option value="48">
+          {{ $t('common.hourCount', 48) }}
+        </option>
+        <option value="72">
+          {{ $t('common.hourCount', 72) }}
+        </option>
+        <option value="168">
+          {{ $t('common.weekCount', 1) }}
+        </option>
+        <option value="336">
+          {{ $t('common.weekCount', 2) }}
+        </option>
+        <option value="720">
+          {{ $t('common.monthCount', 1) }}
+        </option>
+        <option value="1440">
+          {{ $t('common.monthCount', 2) }}
+        </option>
+        <option value="4380">
+          {{ $t('common.monthCount', 6) }}
+        </option>
+        <option value="8760">
+          {{ $t('common.yearCount', 1) }}
+        </option>
+      </select>
+    </div> <!-- /network baseline time range -->
 
-        <!-- node distance -->
-        <div class="d-flex ga-1">
-          <v-btn
-            id="nodeDistUp"
-            :aria-label="$t('connections.nodeDistUpTip')"
-            variant="outlined"
-            size="small"
-            density="comfortable"
-            icon
-            :disabled="query.nodeDist >= 200"
-            @click="changeNodeDist(10)">
-            <v-icon icon="mdi-plus-network" />
-            <v-tooltip
-              activator="parent"
-              location="bottom"
-              :open-delay="300">
-              {{ $t('connections.nodeDistUpTip') }}
-            </v-tooltip>
-          </v-btn>
-          <v-btn
-            id="nodeDistDown"
-            :aria-label="$t('connections.nodeDistDownTip')"
-            variant="outlined"
-            size="small"
-            density="comfortable"
-            icon
-            :disabled="query.nodeDist <= 10"
-            @click="changeNodeDist(-10)">
-            <v-icon icon="mdi-minus-network" />
-            <v-tooltip
-              activator="parent"
-              location="bottom"
-              :open-delay="300">
-              {{ $t('connections.nodeDistDownTip') }}
-            </v-tooltip>
-          </v-btn>
-        </div>
+    <!-- network baseline node visibility -->
+    <div
+      class="arkime-input-group"
+      v-show="query.baselineDate !== '0'">
+      <span
+        class="arkime-input-label help-cursor"
+        id="baselineVis">
+        {{ $t('connections.baselineVis') }}
+      </span>
+      <v-tooltip
+        activator="#baselineVis"
+        :open-delay="300">
+        {{ $t('connections.baselineVisTip') }}
+      </v-tooltip>
+      <select
+        class="arkime-input-control"
+        :disabled="query.baselineDate === '0'"
+        v-model="query.baselineVis"
+        @change="changeBaselineVis">
+        <option
+          value="all"
+          v-i18n-value="'connections.baselineVis-'" />
+        <option
+          value="actual"
+          v-i18n-value="'connections.baselineVis-'" />
+        <option
+          value="actualold"
+          v-i18n-value="'connections.baselineVis-'" />
+        <option
+          value="new"
+          v-i18n-value="'connections.baselineVis-'" />
+        <option
+          value="old"
+          v-i18n-value="'connections.baselineVis-'" />
+      </select>
+    </div> <!-- /network baseline node visibility -->
+  </teleport> <!-- /sub-navbar controls -->
 
-        <!-- text size increase/decrease -->
-        <div class="d-flex ga-1">
-          <v-btn
-            id="textSizeUp"
-            :aria-label="$t('connections.textSizeUpTip')"
-            variant="outlined"
-            size="small"
-            density="comfortable"
-            icon
-            :disabled="fontSize >= 1"
-            @click="updateTextSize(0.1)">
-            <v-icon icon="mdi-format-font-size-increase" />
-            <v-tooltip
-              activator="parent"
-              location="bottom"
-              :open-delay="300">
-              {{ $t('connections.textSizeUpTip') }}
-            </v-tooltip>
-          </v-btn>
-          <v-btn
-            id="textSizeDown"
-            :aria-label="$t('connections.textSizeDownTip')"
-            variant="outlined"
-            size="small"
-            density="comfortable"
-            icon
-            :disabled="fontSize <= 0.2"
-            @click="updateTextSize(-0.1)">
-            <v-icon icon="mdi-format-font-size-decrease" />
-            <v-tooltip
-              activator="parent"
-              location="bottom"
-              :open-delay="300">
-              {{ $t('connections.textSizeDownTip') }}
-            </v-tooltip>
-          </v-btn>
-        </div>
+  <!-- graph + popups -->
+  <div
+    ref="graphContainer"
+    class="connections-page connections-graph-host">
+    <!-- loading overlay -->
+    <arkime-loading
+      :can-cancel="true"
+      v-if="loading && !error"
+      @cancel="cancelAndLoad" /> <!-- /loading overlay -->
 
-        <!-- zoom in/out -->
-        <div class="d-flex ga-1">
-          <v-btn
-            id="zoomIn"
-            :aria-label="$t('connections.zoomInTip')"
-            variant="outlined"
-            size="small"
-            density="comfortable"
-            icon
-            :disabled="zoomLevel >= 4"
-            @click="zoomConnections(2)">
-            <v-icon icon="mdi-magnify-plus" />
-            <v-tooltip
-              activator="parent"
-              location="bottom"
-              :open-delay="300">
-              {{ $t('connections.zoomInTip') }}
-            </v-tooltip>
-          </v-btn>
-          <v-btn
-            id="zoomOut"
-            :aria-label="$t('connections.zoomOutTip')"
-            variant="outlined"
-            size="small"
-            density="comfortable"
-            icon
-            :disabled="zoomLevel <= 0.0625"
-            @click="zoomConnections(0.5)">
-            <v-icon icon="mdi-magnify-minus" />
-            <v-tooltip
-              activator="parent"
-              location="bottom"
-              :open-delay="300">
-              {{ $t('connections.zoomOutTip') }}
-            </v-tooltip>
-          </v-btn>
-        </div>
-      </div> <!-- /Button group -->
-    </template>
-  </page-layout>
+    <!-- page error -->
+    <arkime-error
+      v-if="error"
+      :message="error"
+      class="mt-5" /> <!-- /page error -->
+
+    <!-- no results -->
+    <arkime-no-results
+      v-if="!error && !loading && recordsFiltered === 0"
+      class="mt-5"
+      :view="query.view" /> <!-- /no results -->
+
+    <!-- connections graph container -->
+    <svg
+      ref="svgEl"
+      class="connections-graph"
+      v-if="!error" /> <!-- /connections graph container -->
+
+    <!-- popup area -->
+    <div
+      v-if="showPopup">
+      <div class="connections-popup-host">
+        <NodePopup
+          v-if="dataNode"
+          :data-node="dataNode"
+          :fields="fieldsMap"
+          :node-fields="nodeFields"
+          :baseline-date="query.baselineDate"
+          @close="closePopups"
+          @hide-node="hideNode" />
+        <LinkPopup
+          v-if="dataLink"
+          :data-link="dataLink"
+          :fields="fieldsMap"
+          :link-fields="linkFields"
+          @close="closePopups"
+          @hide-link="hideLink" />
+      </div>
+    </div> <!-- /popup area -->
+  </div>
+
+  <!-- floating overlay buttons -->
+  <teleport
+    defer
+    to="#connections-overlay-anchor">
+    <!-- Button group -->
+    <div class="connections-buttons d-flex align-center ga-2">
+      <!-- unlock + export -->
+      <div class="d-flex ga-1">
+        <v-btn
+          variant="outlined"
+          size="small"
+          density="comfortable"
+          icon
+          id="unlockNodes"
+          :aria-label="$t('connections.unlockNodesTip')"
+          @click.stop.prevent="unlock">
+          <v-icon icon="mdi-lock-open" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :open-delay="300">
+            {{ $t('connections.unlockNodesTip') }}
+          </v-tooltip>
+        </v-btn>
+        <v-btn
+          variant="outlined"
+          size="small"
+          density="comfortable"
+          icon
+          id="exportGraph"
+          :aria-label="$t('connections.exportGraphTip')"
+          @click.stop.prevent="exportPng">
+          <v-icon icon="mdi-download" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :open-delay="300">
+            {{ $t('connections.exportGraphTip') }}
+          </v-tooltip>
+        </v-btn>
+      </div>
+
+      <!-- node distance -->
+      <div class="d-flex ga-1">
+        <v-btn
+          id="nodeDistUp"
+          :aria-label="$t('connections.nodeDistUpTip')"
+          variant="outlined"
+          size="small"
+          density="comfortable"
+          icon
+          :disabled="query.nodeDist >= 200"
+          @click="changeNodeDist(10)">
+          <v-icon icon="mdi-plus-network" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :open-delay="300">
+            {{ $t('connections.nodeDistUpTip') }}
+          </v-tooltip>
+        </v-btn>
+        <v-btn
+          id="nodeDistDown"
+          :aria-label="$t('connections.nodeDistDownTip')"
+          variant="outlined"
+          size="small"
+          density="comfortable"
+          icon
+          :disabled="query.nodeDist <= 10"
+          @click="changeNodeDist(-10)">
+          <v-icon icon="mdi-minus-network" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :open-delay="300">
+            {{ $t('connections.nodeDistDownTip') }}
+          </v-tooltip>
+        </v-btn>
+      </div>
+
+      <!-- text size increase/decrease -->
+      <div class="d-flex ga-1">
+        <v-btn
+          id="textSizeUp"
+          :aria-label="$t('connections.textSizeUpTip')"
+          variant="outlined"
+          size="small"
+          density="comfortable"
+          icon
+          :disabled="fontSize >= 1"
+          @click="updateTextSize(0.1)">
+          <v-icon icon="mdi-format-font-size-increase" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :open-delay="300">
+            {{ $t('connections.textSizeUpTip') }}
+          </v-tooltip>
+        </v-btn>
+        <v-btn
+          id="textSizeDown"
+          :aria-label="$t('connections.textSizeDownTip')"
+          variant="outlined"
+          size="small"
+          density="comfortable"
+          icon
+          :disabled="fontSize <= 0.2"
+          @click="updateTextSize(-0.1)">
+          <v-icon icon="mdi-format-font-size-decrease" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :open-delay="300">
+            {{ $t('connections.textSizeDownTip') }}
+          </v-tooltip>
+        </v-btn>
+      </div>
+
+      <!-- zoom in/out -->
+      <div class="d-flex ga-1">
+        <v-btn
+          id="zoomIn"
+          :aria-label="$t('connections.zoomInTip')"
+          variant="outlined"
+          size="small"
+          density="comfortable"
+          icon
+          :disabled="zoomLevel >= 4"
+          @click="zoomConnections(2)">
+          <v-icon icon="mdi-magnify-plus" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :open-delay="300">
+            {{ $t('connections.zoomInTip') }}
+          </v-tooltip>
+        </v-btn>
+        <v-btn
+          id="zoomOut"
+          :aria-label="$t('connections.zoomOutTip')"
+          variant="outlined"
+          size="small"
+          density="comfortable"
+          icon
+          :disabled="zoomLevel <= 0.0625"
+          @click="zoomConnections(0.5)">
+          <v-icon icon="mdi-magnify-minus" />
+          <v-tooltip
+            activator="parent"
+            location="bottom"
+            :open-delay="300">
+            {{ $t('connections.zoomOutTip') }}
+          </v-tooltip>
+        </v-btn>
+      </div>
+    </div> <!-- /Button group -->
+  </teleport> <!-- /floating overlay buttons -->
 </template>
 
 <script>
 // import components
-import ArkimeSearch from '../search/Search.vue';
 import ArkimeError from '../utils/Error.vue';
 import ArkimeLoading from '../utils/Loading.vue';
 import ArkimeNoResults from '../utils/NoResults.vue';
-import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
-import PageLayout from '../utils/PageLayout.vue';
 import NodePopup from './NodePopup.vue';
 import LinkPopup from './LinkPopup.vue';
 // import services
@@ -669,14 +661,11 @@ const defaultNodeFields = ['network.bytes', 'totDataBytes', 'network.packets', '
 
 // vue definition ---------------------------------------------------------- */
 export default {
-  name: 'Connections',
+  name: 'ConnectionsGraph',
   components: {
-    ArkimeSearch,
     ArkimeError,
     ArkimeLoading,
     ArkimeNoResults,
-    ArkimeCollapsible,
-    PageLayout,
     ArkimeFieldTypeahead,
     NodePopup,
     LinkPopup
@@ -689,6 +678,7 @@ export default {
       recordsFiltered: 0,
       fieldsMap: {},
       fieldQuery: '',
+      scrollEl: undefined, // scroll container (sizes the svg)
       srcFieldTypeahead: undefined,
       dstFieldTypeahead: undefined,
       groupedFields: undefined,
@@ -809,6 +799,10 @@ export default {
     }
   },
   mounted () {
+    // the host PageLayout wraps us in a .page-scroll container; size the
+    // graph svg against it (covers window resizes and toolbar collapse)
+    this.scrollEl = this.$refs.graphContainer?.closest('.page-scroll');
+
     // IMPORTANT: this kicks off loading data and drawing the graph
     this.cancelAndLoad(true);
 
@@ -824,10 +818,12 @@ export default {
     window.addEventListener('keyup', this.closePopupsOnEsc);
     // resize the simulation with its container (covers window resizes and
     // the animated toolbar collapse)
-    this._svgResizeObserver = new ResizeObserver(() => {
-      resize(this.$refs.pageLayout?.scrollEl);
-    });
-    this._svgResizeObserver.observe(this.$refs.pageLayout.scrollEl);
+    if (this.scrollEl) {
+      this._svgResizeObserver = new ResizeObserver(() => {
+        resize(this.scrollEl);
+      });
+      this._svgResizeObserver.observe(this.scrollEl);
+    }
   },
   methods: {
     /* exposed page functions ---------------------------------------------- */
@@ -1213,7 +1209,7 @@ export default {
       });
 
       // calculate the width and height of the canvas from the scroll container
-      const scrollEl = this.$refs.pageLayout?.scrollEl;
+      const scrollEl = this.scrollEl;
       const width = (scrollEl ? scrollEl.clientWidth : $(window).width()) - 10;
       const height = (scrollEl ? scrollEl.clientHeight : $(window).height() - 61) - 4;
 
@@ -1243,8 +1239,8 @@ export default {
         .force('y', d3.forceY());
 
       if (!svg) {
-        // set the width and height of the canvas
-        svg = d3.select('svg')
+        // scope to our own svg ref, never another viz's svg
+        svg = d3.select(this.$refs.svgEl)
           .attr('width', width)
           .attr('height', height)
           .attr('id', 'graphSvg');
@@ -1440,11 +1436,11 @@ export default {
         switch (n.inresult) {
         case 2:
           // "old" (in baseline, not in actual result set)
-          val = ' 🚫';
+          val = ' 🚫';
           break;
         case 1:
           // "new" (in actual, not in baseline result set)
-          val = ' ✨';
+          val = ' ✨';
           break;
         }
       }
@@ -1550,19 +1546,19 @@ export default {
       svg.remove();
     }
 
-    setTimeout(() => {
-      // clean up global vars
-      svg = undefined;
-      zoom = undefined;
-      node = undefined;
-      link = undefined;
-      nodeFillColors = undefined;
-      container = undefined;
-      nodeLabel = undefined;
-      popupTimer = undefined;
-      simulation = undefined;
-      draggingNode = undefined;
-    });
+    // listeners/elements are detached above, so reset the module-level d3
+    // state synchronously -- a remount then always rebuilds cleanly
+    if (simulation) { simulation.stop(); }
+    svg = undefined;
+    zoom = undefined;
+    node = undefined;
+    link = undefined;
+    nodeFillColors = undefined;
+    container = undefined;
+    nodeLabel = undefined;
+    popupTimer = undefined;
+    simulation = undefined;
+    draggingNode = undefined;
   }
 };
 </script>
@@ -1574,22 +1570,16 @@ export default {
 </style>
 
 <style scoped>
+/* graph host: positioning context for the absolutely-placed popup */
+.connections-graph-host {
+  position: relative;
+}
+
 .connections-graph {
   /* don't allow selecting text */
   -webkit-user-select: none;
   -moz-user-select: none;
   user-select: none;
-}
-
-/* position the subnavbar */
-.connections-page .connections-form {
-  z-index: 4;
-  background-color: rgb(var(--v-theme-quaternary-lightest));
-}
-
-/* remove select box styles */
-.connections-page .connections-form select {
-  -webkit-appearance: none;
 }
 
 /* connections-field-row: label-cell + FieldTypeahead pair. No outer
@@ -1646,34 +1636,42 @@ export default {
 </style>
 
 <style>
-/* this needs to not be scoped because it's a child component */
-/* node/link data popup */
-.connections-page div.connections-popup {
+/* not scoped: targets child popup components */
+/* popup host: positions the card; no overflow clip so its shadow can spill */
+.connections-page div.connections-popup-host {
   position: absolute;
   left: 0;
   top: 8px;
-  bottom: 8px;
-  font-size: 0.85rem;
-  padding: 4px 8px;
-  max-width: 400px;
+  z-index: 5;
   min-width: 280px;
-  border: solid 1px rgb(var(--v-theme-neutral));
-  background: rgb(var(--v-theme-primary-lightest));
-  white-space: nowrap;
-  overflow-x: visible;
+  max-width: 400px;
+}
+/* the card caps its height, scrolls, and uses a louder shadow than Vuetify's */
+.connections-page .connections-popup.v-card {
+  max-height: calc(100vh - 200px);
   overflow-y: auto;
-  text-overflow: ellipsis;
+  box-shadow: 0 8px 30px -4px rgba(0, 0, 0, 0.55) !important;
 }
-.connections-page div.connections-popup .dl-horizontal {
-  margin-bottom: var(--px-md) !important;
+
+/* label / value grid */
+.connections-page .connections-popup-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 16px;
+  row-gap: 6px;
+  margin: 0;
+  font-size: 0.8125rem;
+  align-items: baseline;
 }
-.connections-page div.connections-popup .dl-horizontal dt {
-  width: 100px !important;
-  text-align: left;
+.connections-page .connections-popup-grid dt {
+  font-weight: 500;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+  white-space: nowrap;
 }
-.connections-page div.connections-popup .dl-horizontal dd {
-  margin-left: 105px !important;
+.connections-page .connections-popup-grid dd {
+  margin: 0;
   white-space: normal;
+  word-break: break-word;
 }
 
 /* Field-vis menu trigger -- the round node/link icon buttons that open

--- a/viewer/vueapp/src/components/connections/LinkPopup.vue
+++ b/viewer/vueapp/src/components/connections/LinkPopup.vue
@@ -1,80 +1,114 @@
+<!--
+Copyright Yahoo Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
 <template>
-  <div class="connections-popup">
-    <div class="mb-2 mt-2">
-      <strong>Link</strong>
-      <a
-        class="float-right cursor-pointer no-decoration"
-        @click="$emit('close')">
-        <v-icon icon="mdi-close" />
-      </a>
-    </div>
-    <div>
-      <arkime-session-field
-        :value="dataLink.source.id"
-        :session="dataLink"
-        :expr="dataLink.srcExp"
-        :field="fields[dataLink.srcDbField]"
-        :pull-left="true" />
-    </div>
-    <div class="mb-2">
-      <arkime-session-field
-        :value="dataLink.target.id"
-        :session="dataLink"
-        :expr="dataLink.dstExp"
-        :field="fields[dataLink.dstDbField]"
-        :pull-left="true" />
+  <v-card
+    class="connections-popup"
+    elevation="8"
+    rounded="lg">
+    <!-- header -->
+    <div class="connections-popup-header d-flex align-center ga-2 px-3 py-2">
+      <v-icon
+        icon="mdi-vector-polyline"
+        color="primary"
+        size="small" />
+      <strong class="flex-grow-1 text-body-2">
+        Link
+      </strong>
+      <v-btn
+        icon="mdi-close"
+        size="x-small"
+        variant="text"
+        density="comfortable"
+        aria-label="Close"
+        @click="$emit('close')" />
     </div>
 
-    <dl class="dl-horizontal">
+    <v-divider />
+
+    <!-- endpoints: source over target, each on its own line so long
+         values never wrap around the connector -->
+    <div class="connections-popup-endpoints px-3 py-2">
+      <div class="connections-popup-endpoint">
+        <span class="connections-popup-endpoint-label text-primary">Source</span>
+        <arkime-session-field
+          :value="dataLink.source.id"
+          :session="dataLink"
+          :expr="dataLink.srcExp"
+          :field="fields[dataLink.srcDbField]"
+          :pull-left="true" />
+      </div>
+      <v-icon
+        icon="mdi-arrow-down-thin"
+        size="small"
+        class="text-medium-emphasis connections-popup-arrow" />
+      <div class="connections-popup-endpoint">
+        <span class="connections-popup-endpoint-label text-secondary">Target</span>
+        <arkime-session-field
+          :value="dataLink.target.id"
+          :session="dataLink"
+          :expr="dataLink.dstExp"
+          :field="fields[dataLink.dstDbField]"
+          :pull-left="true" />
+      </div>
+    </div>
+
+    <v-divider />
+
+    <!-- key / value details -->
+    <dl class="connections-popup-grid px-3 py-2">
       <dt>{{ $t('common.sessions') }}</dt>
-      <dd>{{ dataLink.value }}&nbsp;</dd>
+      <dd>{{ commaString(dataLink.value) }}</dd>
 
-      <span
+      <template
         v-for="field in linkFields"
         :key="field">
         <template v-if="fields[field]">
-          <dt>
-            {{ fields[field].friendlyName }}
-          </dt>
+          <dt>{{ fields[field].friendlyName }}</dt>
           <dd>
-            <span v-if="!Array.isArray(dataLink[field])">
+            <template v-if="!Array.isArray(dataLink[field])">
               <arkime-session-field
                 :value="dataLink[field]"
                 :session="dataLink"
                 :expr="fields[field].exp"
                 :field="fields[field]"
                 :pull-left="true" />
-            </span>
-            <span
-              v-else
-              v-for="value in dataLink[field]"
-              :key="`${field}-${value}`">
+            </template>
+            <template v-else>
               <arkime-session-field
+                v-for="value in dataLink[field]"
+                :key="`${field}-${value}`"
                 :value="value"
                 :session="dataLink"
                 :expr="fields[field].exp"
                 :field="fields[field]"
                 :pull-left="true" />
-            </span>&nbsp;
+            </template>
           </dd>
         </template>
-      </span>
+      </template>
     </dl>
 
-    <a
-      class="cursor-pointer no-decoration"
-      href="javascript:void(0)"
-      @click="$emit('hideLink')">
-      <v-icon
-        icon="mdi-eye-off"
-        class="me-2" />
-      {{ $t('connections.hideLink') }}
-    </a>
-  </div>
+    <v-divider />
+
+    <!-- actions -->
+    <div class="px-2 py-1">
+      <v-btn
+        variant="text"
+        size="small"
+        color="primary"
+        prepend-icon="mdi-eye-off"
+        @click.stop.prevent="$emit('hideLink')">
+        {{ $t('connections.hideLink') }}
+      </v-btn>
+    </div>
+  </v-card>
 </template>
 
 <script setup>
 import ArkimeSessionField from '../sessions/SessionField.vue';
+import { commaString } from '@common/vueFilters.js';
 
 // Define Props
 defineProps({
@@ -95,3 +129,28 @@ defineProps({
 // Define Emits
 defineEmits(['hideLink', 'close']);
 </script>
+
+<style scoped>
+.connections-popup-endpoints {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+.connections-popup-endpoint {
+  font-weight: 600;
+  min-width: 0;
+  max-width: 100%;
+}
+.connections-popup-endpoint-label {
+  display: block;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 1px;
+}
+.connections-popup-arrow {
+  margin-left: 2px;
+}
+</style>

--- a/viewer/vueapp/src/components/connections/NodePopup.vue
+++ b/viewer/vueapp/src/components/connections/NodePopup.vue
@@ -1,7 +1,19 @@
+<!--
+Copyright Yahoo Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
 <template>
-  <div class="connections-popup">
-    <div class="mb-2 mt-2">
-      <strong>
+  <v-card
+    class="connections-popup"
+    elevation="8"
+    rounded="lg">
+    <!-- header: node identity + close -->
+    <div class="connections-popup-header d-flex align-center ga-2 px-3 py-2">
+      <v-icon
+        :icon="typeIcon"
+        :color="typeColor"
+        size="small" />
+      <strong class="flex-grow-1 text-truncate text-body-2">
         <arkime-session-field
           :value="dataNode.id"
           :session="dataNode"
@@ -9,38 +21,51 @@
           :field="fields[dataNode.dbField]"
           :pull-left="true" />
       </strong>
-      <a
-        class="float-right cursor-pointer no-decoration"
-        @click="$emit('close')">
-        <v-icon icon="mdi-close" />
-      </a>
+      <v-btn
+        icon="mdi-close"
+        size="x-small"
+        variant="text"
+        density="comfortable"
+        aria-label="Close"
+        @click="$emit('close')" />
     </div>
 
-    <dl class="dl-horizontal">
-      <dt>{{ $t('connections.type') }}</dt>
-      <dd>{{ ['','Source','Target','Both'][dataNode.type] }}</dd>
-      <dt>{{ $t('connections.links') }}</dt>
-      <dd>{{ dataNode.weight || dataNode.cnt }}&nbsp;</dd>
-      <dt>{{ $t('common.sessions') }}</dt>
-      <dd>{{ dataNode.sessions }}&nbsp;</dd>
+    <v-divider />
 
-      <span
+    <!-- key / value details -->
+    <dl class="connections-popup-grid px-3 py-2">
+      <dt>{{ $t('connections.type') }}</dt>
+      <dd>
+        <v-chip
+          :color="typeColor"
+          size="x-small"
+          variant="tonal"
+          label>
+          {{ ['', 'Source', 'Target', 'Both'][dataNode.type] }}
+        </v-chip>
+      </dd>
+
+      <dt>{{ $t('connections.links') }}</dt>
+      <dd>{{ commaString(dataNode.weight || dataNode.cnt) }}</dd>
+
+      <dt>{{ $t('common.sessions') }}</dt>
+      <dd>{{ commaString(dataNode.sessions) }}</dd>
+
+      <template
         v-for="fieldKey in nodeFields"
         :key="fieldKey">
         <template v-if="fields[fieldKey]">
-          <dt>
-            {{ fields[fieldKey].friendlyName }}
-          </dt>
+          <dt>{{ fields[fieldKey].friendlyName }}</dt>
           <dd>
-            <span v-if="!Array.isArray(dataNode[fieldKey])">
+            <template v-if="!Array.isArray(dataNode[fieldKey])">
               <arkime-session-field
                 :value="dataNode[fieldKey]"
                 :session="dataNode"
                 :expr="fields[fieldKey].exp"
                 :field="fields[fieldKey]"
                 :pull-left="true" />
-            </span>
-            <span v-else>
+            </template>
+            <template v-else>
               <arkime-session-field
                 v-for="(value, index) in dataNode[fieldKey]"
                 :key="`${fieldKey}-${index}`"
@@ -49,34 +74,40 @@
                 :expr="fields[fieldKey].exp"
                 :field="fields[fieldKey]"
                 :pull-left="true" />
-            </span>&nbsp;
+            </template>
           </dd>
         </template>
-      </span>
+      </template>
 
-      <div v-if="baselineDate !== '0'">
+      <template v-if="baselineDate !== '0'">
         <dt>{{ $t('connections.resultSet') }}</dt>
-        <dd>{{ ['','✨Actual','🚫 Baseline','Both'][dataNode.inresult] }}</dd>
-      </div>
+        <dd>{{ ['', '✨ Actual', '🚫 Baseline', 'Both'][dataNode.inresult] }}</dd>
+      </template>
     </dl>
 
-    <a
-      class="cursor-pointer no-decoration"
-      href="javascript:void(0)"
-      @click.stop.prevent="$emit('hideNode')">
-      <v-icon
-        icon="mdi-eye-off"
-        class="me-2" />
-      {{ $t('connections.hideNode') }}
-    </a>
-  </div>
+    <v-divider />
+
+    <!-- actions -->
+    <div class="px-2 py-1">
+      <v-btn
+        variant="text"
+        size="small"
+        color="primary"
+        prepend-icon="mdi-eye-off"
+        @click.stop.prevent="$emit('hideNode')">
+        {{ $t('connections.hideNode') }}
+      </v-btn>
+    </div>
+  </v-card>
 </template>
 
 <script setup>
+import { computed } from 'vue';
 import ArkimeSessionField from '../sessions/SessionField.vue';
+import { commaString } from '@common/vueFilters.js';
 
 // Define Props
-defineProps({
+const props = defineProps({
   dataNode: {
     type: Object,
     required: true
@@ -97,4 +128,18 @@ defineProps({
 
 // Define Emits
 defineEmits(['hideNode', 'close']);
+
+// type 1 = source, 2 = target, 3 = both -- mirror the graph/legend colors
+const typeColor = computed(() => ['', 'primary', 'secondary', 'tertiary'][props.dataNode.type] || 'primary');
+const typeIcon = computed(() => ({
+  1: 'mdi-ray-start-arrow',
+  2: 'mdi-ray-end-arrow',
+  3: 'mdi-ray-start-end'
+}[props.dataNode.type] || 'mdi-circle-medium'));
 </script>
+
+<style scoped>
+.connections-popup-header strong {
+  min-width: 0;
+}
+</style>

--- a/viewer/vueapp/src/components/search/Search.vue
+++ b/viewer/vueapp/src/components/search/Search.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
     <!-- viz options button -->
     <div
       class="viz-options-btn-container"
-      v-if="!actionForm && (basePath === 'spigraph' || basePath === 'sessions' || basePath === 'spiview' || basePath === 'arkime')">
+      v-if="!actionForm && (basePath === 'sessions' || basePath === 'spiview' || basePath === 'arkime')">
       <!-- Split-button vs single-dropdown depending on whether the gear
            has a meaningful primary action. When viz is hidden or there
            are no disabled aggregations to fetch, the gear has nothing
@@ -75,7 +75,7 @@ SPDX-License-Identifier: Apache-2.0
             </v-list-item>
             <v-divider />
             <v-list-item @click="toggleStickyViz">
-              {{ !stickyViz ? 'Pin' : 'Unpin' }}{{ basePath && basePath === 'spigraph' ? ' top' : '' }} {{ basePath && basePath === 'sessions' ? 'graph, map, and column headers' : 'graph and map' }}
+              {{ !stickyViz ? 'Pin' : 'Unpin' }} {{ basePath && basePath === 'sessions' ? 'graph, map, and column headers' : 'graph and map' }}
             </v-list-item>
             <v-list-item
               id="hideViz"
@@ -114,7 +114,7 @@ SPDX-License-Identifier: Apache-2.0
             {{ $t('search.disableVis') }}
           </v-list-item>
           <v-list-item @click="toggleStickyViz">
-            {{ !stickyViz ? 'Pin' : 'Unpin' }}{{ basePath && basePath === 'spigraph' ? ' top' : '' }} {{ basePath && basePath === 'sessions' ? 'graph, map, and column headers' : 'graph and map' }}
+            {{ !stickyViz ? 'Pin' : 'Unpin' }} {{ basePath && basePath === 'sessions' ? 'graph, map, and column headers' : 'graph and map' }}
           </v-list-item>
           <v-list-item
             id="hideViz"

--- a/viewer/vueapp/src/components/sessions/SessionField.vue
+++ b/viewer/vueapp/src/components/sessions/SessionField.vue
@@ -695,6 +695,7 @@ export default {
   max-width: 98%;
   line-height: 1.3;
   font-size: 14px;
+  white-space: nowrap;
 }
 
 .field:not(.time-field) {

--- a/viewer/vueapp/src/components/spigraph/Hierarchy.vue
+++ b/viewer/vueapp/src/components/spigraph/Hierarchy.vue
@@ -4,30 +4,33 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <template>
   <div class="spigraph-pie">
-    <!-- field select -->
-    <div
-      class="d-flex flex-row ps-1"
-      :class="{'position-absolute': !!tableData.length}">
-      <div
-        class="d-inline"
-        v-if="fields && fields.length">
-        <div class="arkime-input-group me-2">
-          <span class="arkime-input-label">
-            {{ $t('spigraph.addAnotherField') }}:
-          </span>
-          <arkime-field-typeahead
-            :fields="fields"
-            @field-selected="changeField"
-            page="SpigraphSubfield" />
+    <!-- field select: teleported into the spigraph sub-navbar, alongside the
+         other controls (same pattern as the connections view) -->
+    <teleport
+      defer
+      to="#spigraph-subfield-anchor">
+      <div class="d-flex flex-row align-center">
+        <div
+          class="d-inline"
+          v-if="fields && fields.length">
+          <div class="arkime-input-group subfield-group">
+            <span class="arkime-input-label">
+              {{ $t('spigraph.addAnotherField') }}:
+            </span>
+            <arkime-field-typeahead
+              :fields="fields"
+              @field-selected="changeField"
+              page="SpigraphSubfield" />
+          </div>
+        </div>
+        <div class="d-inline ms-1">
+          <drag-list
+            :list="this.fieldTypeaheadList"
+            @reorder="reorderFields"
+            @remove="removeField" />
         </div>
       </div>
-      <div class="d-inline ms-1">
-        <drag-list
-          :list="this.fieldTypeaheadList"
-          @reorder="reorderFields"
-          @remove="removeField" />
-      </div>
-    </div> <!-- /field select -->
+    </teleport> <!-- /field select -->
 
     <!-- info area -->
     <div
@@ -49,21 +52,19 @@ SPDX-License-Identifier: Apache-2.0
     <!-- treemap area -->
     <div
       id="treemap-area"
-      class="pt-3"
       v-show="spiGraphType === 'treemap' && vizData && vizData.children.length" />
     <!-- /treemap area -->
 
     <!-- sankey area -->
     <div
       id="sankey-area"
-      class="pt-4"
       v-show="spiGraphType === 'sankey' && sankeyData && sankeyData.nodes && sankeyData.nodes.length" />
     <!-- /sankey area -->
 
     <!-- table area -->
     <div
       v-show="spiGraphType === 'table' && tableData.length && fieldList.length"
-      class="m-1 pt-5">
+      class="m-1 pt-1">
       <table
         class="spigraph-table"
         id="spigraphTable"
@@ -235,25 +236,36 @@ let radius = getRadius();
 
 // page treemap variables -------------------------------------------------- //
 let gtree, newBox;
-const treemapMargin = 10;
+const treemapMargin = 4;
 let treemapWidth = getTreemapWidth();
 let treemapHeight = getTreemapHeight();
 
 // page sankey variables -------------------------------------------------- //
 let gsankey;
-const sankeyMargin = { top: 10, right: 10, bottom: 10, left: 10 };
+const sankeyMargin = { top: 2, right: 2, bottom: 2, left: 2 };
 let sankeyWidth = getSankeyWidth();
 let sankeyHeight = getSankeyHeight();
 
 const MIN_COL_WIDTH = 70;
 
 // pie functions ----------------------------------------------------------- //
-function getWindowWidth () {
-  return window.innerWidth;
+// the scroll container is the real drawing area; measure it directly
+function getContentEl () {
+  return document.querySelector('.spigraph-page .page-scroll');
 }
 
-function getWindowHeight (toolbarDown = true) {
-  return window.innerHeight - 184; // height - (footer + headers + padding)
+function getWindowWidth () {
+  const el = getContentEl();
+  return (el ? el.clientWidth : window.innerWidth) - 8;
+}
+
+function getWindowHeight () {
+  const el = getContentEl();
+  if (!el) { return window.innerHeight - 184; }
+  // measure the live scroll container, not a guessed fixed header height
+  const area = el.querySelector('.spigraph-pie');
+  const offsetTop = area ? (area.getBoundingClientRect().top - el.getBoundingClientRect().top) : 0;
+  return el.clientHeight - offsetTop - 8;
 }
 
 function getRadius () {
@@ -296,11 +308,11 @@ function getUid (d) {
 }
 
 function getTreemapWidth () {
-  return getWindowWidth() - (treemapMargin * 2);
+  return getWindowWidth();
 }
 
 function getTreemapHeight () {
-  return getWindowHeight() - (treemapMargin * 2);
+  return getWindowHeight() + 6;
 }
 
 function mouseoverBox (d, self) {
@@ -319,11 +331,11 @@ function fillBoxText (d) {
 
 // sankey functions ------------------------------------------------------- //
 function getSankeyWidth () {
-  return window.innerWidth - (sankeyMargin.left + sankeyMargin.right);
+  return getWindowWidth();
 }
 
 function getSankeyHeight () {
-  return window.innerHeight - 200 - (sankeyMargin.top + sankeyMargin.bottom);
+  return getWindowHeight() + 6;
 }
 
 // common functions -------------------------------------------------------- //
@@ -517,10 +529,9 @@ export default {
     resize: function () {
       if (resizeTimer) { clearTimeout(resizeTimer); }
       resizeTimer = setTimeout(() => {
-        // recalculate width, height, and radius
+        // recalculate from the live scroll container
         width = getWindowWidth();
-        // re-add the header space if collapsed
-        height = getWindowHeight() + (this.showToolBars ? 0 : 113);
+        height = getWindowHeight();
         radius = getRadius();
 
         // set the new width and height of the pie
@@ -764,6 +775,15 @@ export default {
      * @param {Object} data The data to construct the pie
      */
     initializeGraphs: function (data) {
+      // size to the live scroll container before creating the svgs
+      width = getWindowWidth();
+      height = getWindowHeight();
+      radius = getRadius();
+      treemapWidth = getTreemapWidth();
+      treemapHeight = getTreemapHeight();
+      sankeyWidth = getSankeyWidth();
+      sankeyHeight = getSankeyHeight();
+
       g = d3.select('#pie-area')
         .append('svg')
         .attr('viewBox', `${-width / 2} ${-height / 2} ${width} ${height}`)
@@ -911,12 +931,13 @@ export default {
         .sum((d) => { return d.size; }); // sum each node's children
 
       const treemap = d3.treemap() // organize data into treemap
-        .size([treemapWidth - 12, treemapHeight - 12])
-        .paddingTop(18) // padding between children and parent
-        .paddingLeft(8)
-        .paddingRight(8)
-        .paddingBottom(8)
-        .paddingInner(4) // padding between children
+        .size([treemapWidth - (treemapMargin * 2), treemapHeight - (treemapMargin * 2)])
+        // root label is hidden, so reserve no top band for it
+        .paddingTop((d) => d.depth === 0 ? 2 : 18)
+        .paddingLeft(2)
+        .paddingRight(2)
+        .paddingBottom(2)
+        .paddingInner(3) // padding between children
         .round(true); // round the width/height numbers
 
       // combine treemap var (data structure) with the root node (the actual data)
@@ -1024,7 +1045,7 @@ export default {
         .nodeId(d => d.id)
         .nodeWidth(15)
         .nodePadding(10)
-        .extent([[1, 1], [sankeyWidth - sankeyMargin.left - sankeyMargin.right - 1, sankeyHeight - sankeyMargin.top - sankeyMargin.bottom - 6]]);
+        .extent([[1, 1], [sankeyWidth - sankeyMargin.left - sankeyMargin.right - 1, sankeyHeight - sankeyMargin.top - sankeyMargin.bottom - 2]]);
 
       // Generate the sankey layout
       const graph = sankeyLayout(data);
@@ -1324,6 +1345,15 @@ export default {
 </script>
 
 <style>
+/* not scoped: teleported into the spigraph sub-navbar */
+/* widen the "Add another field" typeahead so its placeholder isn't clipped */
+.subfield-group {
+  flex: 0 1 auto;
+}
+.subfield-group input {
+  min-width: 280px;
+}
+
 /* styling for the lines connecting the labels to the slices
    make sure they are lines, not triangles (no fill) */
 .spigraph-pie polyline {

--- a/viewer/vueapp/src/components/spigraph/Spigraph.vue
+++ b/viewer/vueapp/src/components/spigraph/Spigraph.vue
@@ -10,15 +10,36 @@ SPDX-License-Identifier: Apache-2.0
           <!-- search navbar -->
           <arkime-search
             :num-matching-sessions="filtered"
-            @change-search="cancelAndLoad(true)" /> <!-- /search navbar -->
+            @change-search="onSearch" /> <!-- /search navbar -->
 
           <!-- spigraph sub navbar -->
           <div class="spigraph-form mx-1">
             <div class="d-flex flex-wrap align-center gap-1 page-subnav">
+              <!-- main graph type switcher -->
+              <div class="d-flex align-center spigraph-type-switcher">
+                <v-btn-toggle
+                  :model-value="spiGraphType"
+                  @update:model-value="changeSpiGraphType"
+                  mandatory
+                  divided
+                  density="comfortable"
+                  variant="outlined"
+                  color="primary"
+                  class="spigraph-type-toggle">
+                  <v-btn
+                    v-for="t in graphTypeOptions"
+                    :key="t"
+                    :value="t"
+                    size="small">
+                    {{ $t(`spigraph.graphType-${t}`) }}
+                  </v-btn>
+                </v-btn-toggle>
+              </div> <!-- /main graph type switcher -->
+
               <!-- field select -->
               <div
                 class="arkime-input-group"
-                v-if="fields && fields.length && fieldTypeahead">
+                v-if="spiGraphType !== 'connections' && fields && fields.length && fieldTypeahead">
                 <span class="arkime-input-label">
                   {{ $t('spigraph.field') }}:
                 </span>
@@ -31,7 +52,9 @@ SPDX-License-Identifier: Apache-2.0
               </div> <!-- /field select -->
 
               <!-- maxElements select -->
-              <div class="arkime-input-group">
+              <div
+                class="arkime-input-group"
+                v-if="spiGraphType !== 'connections'">
                 <span
                   id="maxElements"
                   class="arkime-input-label cursor-help">
@@ -53,22 +76,11 @@ SPDX-License-Identifier: Apache-2.0
                 </select>
               </div> <!-- /maxElements select -->
 
-              <!-- main graph type select -->
-              <div class="arkime-input-group">
-                <span class="arkime-input-label">
-                  {{ $t('spigraph.graphType') }}:
-                </span>
-                <select
-                  class="arkime-input-control"
-                  :value="spiGraphType"
-                  @change="changeSpiGraphType($event.target.value)">
-                  <option
-                    v-for="t in graphTypeOptions"
-                    :key="t"
-                    :value="t"
-                    v-i18n-value="'spigraph.graphType-'" />
-                </select>
-              </div> <!-- /main graph type select -->
+              <!-- connections controls anchor -->
+              <div
+                v-if="spiGraphType === 'connections'"
+                id="connections-controls-anchor"
+                class="connections-controls-anchor d-flex flex-wrap align-center gap-1 mt-1 mb-1" />
 
               <!-- sort select (not shown for the pie graph) -->
               <div
@@ -126,46 +138,45 @@ SPDX-License-Identifier: Apache-2.0
 
               <!-- export button-->
               <v-btn
-                v-if="spiGraphType !== 'default' && spiGraphType !== 'sankey'"
+                v-if="spiGraphType !== 'default' && spiGraphType !== 'sankey' && spiGraphType !== 'connections'"
                 variant="outlined"
                 size="small"
                 density="comfortable"
-                icon
                 class="ms-1"
-                :aria-label="$t('spigraph.exportCSVSPIGraphTip')"
+                prepend-icon="mdi-download"
                 @click.stop.prevent="exportCSV">
-                <v-icon icon="mdi-download" />
+                {{ $t('spigraph.exportCSV') }}
                 <v-tooltip activator="parent">
                   {{ $t('spigraph.exportCSVSPIGraphTip') }}
                 </v-tooltip>
               </v-btn> <!-- /export button-->
+
+              <!-- hierarchy "add another field" anchor (own full-width row) -->
+              <div
+                v-if="['pie', 'table', 'treemap', 'sankey'].includes(spiGraphType)"
+                id="spigraph-subfield-anchor"
+                class="spigraph-subfield-anchor d-flex flex-wrap align-center gap-1 mt-1" />
             </div>
           </div>
         </div>
       </ArkimeCollapsible>
-      <!-- pinned ("Pin top") visualizations land here (teleported from below) -->
-      <div id="viz-pin-anchor" />
     </template>
 
-    <!-- main visualization: pinned = chrome row above the scroll container,
-         unpinned = scrolls away with the content -->
-    <teleport
-      defer
-      to="#viz-pin-anchor"
-      :disabled="!stickyViz">
-      <div v-if="spiGraphType === 'default' && mapData && graphData && fieldObj && showToolBars">
-        <arkime-visualizations
-          id="primary"
-          :graph-data="graphData"
-          :map-data="mapData"
-          :primary="true"
-          :timeline-data-filters="timelineDataFilters"
-          @fetch-map-data="cancelAndLoad(true)"
-          @spanning-change="cancelAndLoad(true)" />
-      </div>
-    </teleport> <!-- /main visualization -->
+    <!-- main visualization (timeline/map): always inline, scrolls with content -->
+    <div v-if="spiGraphType === 'default' && mapData && graphData && fieldObj && showToolBars">
+      <arkime-visualizations
+        id="primary"
+        :graph-data="graphData"
+        :map-data="mapData"
+        :primary="true"
+        :timeline-data-filters="timelineDataFilters"
+        @fetch-map-data="cancelAndLoad(true)"
+        @spanning-change="cancelAndLoad(true)" />
+    </div> <!-- /main visualization -->
 
-    <div class="spigraph-content">
+    <div
+      class="spigraph-content"
+      v-if="spiGraphType !== 'connections'">
       <!-- pie graph type -->
       <div v-if="spiGraphType !== 'default'">
         <arkime-pie
@@ -243,6 +254,19 @@ SPDX-License-Identifier: Apache-2.0
         :records-total="recordsTotal"
         :view="query.view" /> <!-- /no results -->
     </div>
+
+    <!-- connections network graph type (self-contained: owns its own
+         /api/connections fetch, controls, and overlay buttons) -->
+    <arkime-connections-graph
+      v-else
+      ref="connectionsGraph" /> <!-- /connections graph type -->
+
+    <!-- overlay anchor: connections floating buttons teleport here -->
+    <template
+      v-if="spiGraphType === 'connections'"
+      #overlay>
+      <div id="connections-overlay-anchor" />
+    </template>
   </page-layout>
 </template>
 
@@ -261,6 +285,7 @@ import ArkimeVisualizations from '../visualizations/Visualizations.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
 import PageLayout from '../utils/PageLayout.vue';
 import ArkimePie from './Hierarchy.vue';
+import ArkimeConnectionsGraph from '../connections/ConnectionsGraph.vue';
 import { commaString } from '@common/vueFilters.js';
 import { resolveMessage } from '@common/resolveI18nMessage';
 // import utils
@@ -281,7 +306,8 @@ export default {
     ArkimeVisualizations,
     ArkimeCollapsible,
     PageLayout,
-    ArkimePie
+    ArkimePie,
+    ArkimeConnectionsGraph
   },
   data: function () {
     return {
@@ -307,7 +333,7 @@ export default {
       // <option> blocks into one.
       maxElementsOptions: [5, 10, 15, 20, 30, 50, 100, 200, 500],
       refreshOptions: [0, 5, 10, 15, 30, 45, 60],
-      graphTypeOptions: ['default', 'pie', 'table', 'treemap', 'sankey']
+      graphTypeOptions: ['default', 'pie', 'table', 'treemap', 'sankey', 'connections']
     };
   },
   computed: {
@@ -347,19 +373,11 @@ export default {
     showToolBars: function () {
       return this.$store.state.showToolBars;
     },
-    stickyViz: function () {
-      return this.$store.state.stickyViz;
-    },
     fields: function () {
       return FieldService.addIpDstPortField(this.$store.state.fieldsArr);
     }
   },
   watch: {
-    '$store.state.stickyViz': function () {
-      // pin toggle teleports the viz between chrome and scroll content;
-      // charts/map cache geometry, so nudge their resize handling
-      this.$nextTick(() => window.dispatchEvent(new Event('resize')));
-    },
     '$route.query' (newVal, oldVal) {
       if (newVal.size !== this.query.size) {
         this.query.size = newVal.size || 20;
@@ -369,6 +387,11 @@ export default {
       }
       if (newVal.spiGraphType !== this.spiGraphType) {
         this.spiGraphType = newVal.spiGraphType || 'default';
+        if (this.spiGraphType === 'connections') {
+          // connections owns its data; stop spigraph refresh
+          this.refresh = 0;
+          this.changeRefreshInterval(0);
+        }
       }
     },
     // watch graph type and update sort
@@ -384,13 +407,26 @@ export default {
       this.fieldTypeahead = field.friendlyName;
       this.baseField = field.exp;
       this.query.exp = field.exp;
+    }
 
+    if (this.spiGraphType === 'connections') {
+      // the connections child runs its own /api/connections load on mount
+      this.loading = false;
+    } else if (field) {
       this.cancelAndLoad(true);
       this.changeRefreshInterval(0);
     }
   },
   methods: {
     commaString,
+    /* Search bar change: connections reloads via its child, others here. */
+    onSearch: function () {
+      if (this.spiGraphType === 'connections') {
+        this.$refs.connectionsGraph?.cancelAndLoad(true);
+        return;
+      }
+      this.cancelAndLoad(true);
+    },
     /* exposed page functions ---------------------------------------------- */
     /**
      * Cancels the pending session query (if it's still pending) and runs a new
@@ -464,6 +500,7 @@ export default {
       }
     },
     changeSpiGraphType: function (spiGraphType) {
+      const leavingConnections = this.spiGraphType === 'connections';
       this.spiGraphType = spiGraphType;
       if (this.spiGraphType === 'pie' ||
         this.spiGraphType === 'table' || this.spiGraphType === 'treemap' || this.spiGraphType === 'sankey') {
@@ -472,6 +509,10 @@ export default {
         }
         this.sortBy = 'graph'; // set default sort to count (graph)
         this.query.sort = this.graphType;
+        this.refresh = 0;
+        this.changeRefreshInterval(0);
+      } else if (this.spiGraphType === 'connections') {
+        // connections owns its data; stop spigraph refresh
         this.refresh = 0;
         this.changeRefreshInterval(0);
       }
@@ -483,6 +524,10 @@ export default {
           spiGraphType: this.spiGraphType
         }
       });
+      if (leavingConnections && this.spiGraphType !== 'connections') {
+        // load spigraph data skipped while connections was active
+        this.cancelAndLoad(true);
+      }
     },
     fetchedResults: function (tableResults, fieldTypeaheadList, baseFieldObj) {
       this.fieldTypeaheadList = fieldTypeaheadList;
@@ -552,6 +597,12 @@ export default {
     async loadData () {
       respondedAt = undefined;
 
+      // connections loads via its own child
+      if (this.spiGraphType === 'connections') {
+        this.loading = false;
+        return;
+      }
+
       if (!Utils.checkClusterSelection(this.query.cluster, this.$store.state.esCluster.availableCluster.active, this).valid) {
         this.items = [];
         pendingPromise = null;
@@ -617,6 +668,26 @@ export default {
 .spigraph-page .spigraph-form .records-display  {
   font-size: 0.85rem;
   font-weight: 400;
+}
+
+/* primary view switcher: a prominent segmented toggle (not a buried
+   dropdown) sized to the 32px subnav band */
+.spigraph-page .spigraph-type-toggle {
+  height: 32px;
+}
+.spigraph-page .spigraph-type-toggle :deep(.v-btn) {
+  height: 32px;
+  text-transform: none;
+  letter-spacing: normal;
+}
+/* symmetric band padding: even spacing for single-row vs multi-row subnavs */
+.spigraph-page .page-subnav {
+  padding-block: 6px;
+}
+/* "add another field" on its own row: full-width forces a flex-wrap break */
+.spigraph-page .spigraph-subfield-anchor {
+  flex: 1 0 100%;
+  padding-bottom: 6px;
 }
 
 /* field typeahead */

--- a/viewer/vueapp/src/components/utils/DragList.vue
+++ b/viewer/vueapp/src/components/utils/DragList.vue
@@ -72,7 +72,7 @@ export default {
 .arkime-drag-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0.3rem 0.5rem;
+  padding: 0.45rem 0.5rem;
   font-size: 0.875rem;
   font-weight: 600;
   line-height: 1;

--- a/viewer/vueapp/src/components/utils/HelpNotes.vue
+++ b/viewer/vueapp/src/components/utils/HelpNotes.vue
@@ -49,7 +49,7 @@ SPDX-License-Identifier: Apache-2.0
           {{ $t('welcome.v7Intro') }}
           <ul class="v7-list ms-4 mt-1">
             <li
-              v-for="n in 5"
+              v-for="n in 6"
               :key="n">
               {{ $t(`welcome.v7Item${n}`) }}
             </li>

--- a/viewer/vueapp/src/components/utils/Navbar.vue
+++ b/viewer/vueapp/src/components/utils/Navbar.vue
@@ -102,7 +102,7 @@ export default {
     return {
       path: this.$constants.PATH,
       menuOrder: [
-        'arkime', 'sessions', 'spiview', 'spigraph', 'connections', 'hunt',
+        'arkime', 'sessions', 'spiview', 'spigraph', 'hunt',
         'files', 'stats', 'history', 'upload', 'settings', 'users', 'roles'
       ],
       // active-pill colors -- use Arkime CSS vars so the pill flips
@@ -127,7 +127,6 @@ export default {
         sessions: { title: this.$t('navigation.sessions'), link: 'sessions', hotkey: ['Sessions'], name: 'Sessions' },
         spiview: { title: this.$t('navigation.spiview'), link: 'spiview', hotkey: ['SPI ', 'View'], name: 'Spiview' },
         spigraph: { title: this.$t('navigation.spigraph'), link: 'spigraph', hotkey: ['SPI ', 'Graph'], name: 'Spigraph' },
-        connections: { title: this.$t('navigation.connections'), link: 'connections', hotkey: ['Connections'], name: 'Connections' },
         files: { title: this.$t('navigation.files'), link: 'files', permission: 'hideFiles', reverse: true, name: 'Files' },
         stats: { title: this.$t('navigation.stats'), link: 'stats', permission: 'hideStats', reverse: true, name: 'Stats' },
         upload: { title: this.$t('navigation.upload'), link: 'upload', permission: 'canUpload', name: 'Upload' },

--- a/viewer/vueapp/src/components/utils/helpNotes.js
+++ b/viewer/vueapp/src/components/utils/helpNotes.js
@@ -10,7 +10,6 @@ export default [
   { id: 'sessions', route: 'Sessions', anchor: '#sessions' },
   { id: 'spiview', route: 'Spiview', anchor: '#spiview' },
   { id: 'spigraph', route: 'Spigraph', anchor: '#spigraph' },
-  { id: 'connections', route: 'Connections', anchor: '#connections' },
   { id: 'hunt', route: 'Hunt', anchor: '#hunt' },
   { id: 'files', route: 'Files', anchor: '#files' },
   { id: 'stats', route: 'Stats', anchor: '#stats' },

--- a/viewer/vueapp/src/components/visualizations/WorldMap.vue
+++ b/viewer/vueapp/src/components/visualizations/WorldMap.vue
@@ -169,7 +169,7 @@ export default {
     },
     async loadDeps () {
       // Lazy-load d3 / topojson / world-atlas — mirrors the
-      // Connections.vue / Hierarchy.vue precedent so the deps don't
+      // ConnectionsGraph.vue / Hierarchy.vue precedent so the deps don't
       // bloat the main bundle and the topojson is only fetched when
       // the map actually mounts.
       const [d3, topojson, world] = await Promise.all([

--- a/viewer/vueapp/src/router.js
+++ b/viewer/vueapp/src/router.js
@@ -10,7 +10,6 @@ import ArkimeHistory from '@/components/history/History.vue';
 import Sessions from '@/components/sessions/Sessions.vue';
 import Spiview from '@/components/spiview/Spiview.vue';
 import Spigraph from '@/components/spigraph/Spigraph.vue';
-import Connections from '@/components/connections/Connections.vue';
 import Settings from '@/components/settings/Settings.vue';
 import Upload from '@/components/upload/Upload.vue';
 import Hunt from '@/components/hunt/Hunt.vue';
@@ -88,9 +87,13 @@ const router = createRouter({
       component: Spigraph
     },
     {
+      // Connections folded into Spigraph as a graph type; keep old
+      // bookmarks/links working by redirecting (query params preserved).
       path: '/connections',
-      name: 'Connections',
-      component: Connections
+      redirect: to => ({
+        path: '/spigraph',
+        query: { ...to.query, spiGraphType: 'connections' }
+      })
     },
     {
       path: '/settings',


### PR DESCRIPTION
Folds the standalone Connections page into SPIGraph as a sixth graph type, so all the top-values visualizations live behind one prominent switcher.

## Highlights
- **New `connections` SPIGraph type** — `ConnectionsGraph.vue` (renamed from `Connections.vue`) is now a child of `Spigraph.vue` that teleports its controls into the sub-navbar and its floating buttons into the page overlay slot. It still owns its own `/api/connections` fetch.
- **Segmented graph-type toggle** replaces the buried dropdown; the SPIGraph viz-options gear and the pin are removed.
- **Backward compatible** — `/connections` redirects to `/spigraph?spiGraphType=connections` (query params preserved) and the `c` hotkey is repointed.
- **Redesigned node/link popups** as Vuetify cards.
- **Sizing** — donut/treemap/sankey are measured against the scroll container so they fill it.
- **v7 help card** announces the move in the "what's new" list (all 10 locales).
- misc polish and cleanup folded in

🤖 Generated with [Claude Code](https://claude.com/claude-code) and greatly reduced by @31453 
