### PR TITLE
Add mpacket (DLT_ETHERNET_MPACKET) link layer support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,10 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 6.5.1 2026/07/xx
 ## Release
   - #4048 Node 22.23.0
+## Capture
+  - #4054 Fix GRE keepalive packets adding bogus 00:00:00:00:00:00 MACs
+## Capture/Viewer
+  - #4054 Add mpacket link layer support
 
 6.5.0 2026/06/15
 ## Breaking

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -418,6 +418,34 @@ LOCAL void arkime_packet_process(ArkimePacket_t *packet, int thread)
             if (session->ethertype == 0 && n + 1 < packet->pktlen) {
                 session->ethertype = (pcapData[n] << 8) | pcapData[n + 1];
             }
+        } else if (pcapFileHeader.dlt == DLT_ETHERNET_MPACKET) {
+            // mPacket inner Ethernet frame starts at etherOffset (past the preamble)
+            const uint8_t *ed = packet->pkt + packet->etherOffset;
+            int eavail = (int)packet->pktlen - (int)packet->etherOffset;
+            if (packet->direction == 1) {
+                arkime_field_macoui_add(session, mac1Field, oui1Field, ed);
+                arkime_field_macoui_add(session, mac2Field, oui2Field, ed + 6);
+            } else {
+                arkime_field_macoui_add(session, mac1Field, oui1Field, ed + 6);
+                arkime_field_macoui_add(session, mac2Field, oui2Field, ed);
+            }
+
+            int n = 12;
+            while (n + 3 < eavail &&
+                   ((ed[n] == 0x81 && ed[n + 1] == 0x00) || (ed[n] == 0x88 && ed[n + 1] == 0xa8))) {
+                uint16_t vlan = ((uint16_t)(ed[n + 2] << 8 | ed[n + 3])) & 0xfff;
+                arkime_field_int_add(vlanField, session, vlan);
+                if (ed[n] == 0x81 && ed[n + 1] == 0x00) {
+                    arkime_field_int_add(dot1qField, session, vlan);
+                } else {
+                    arkime_field_int_add(dot1adField, session, vlan);
+                }
+                n += 4;
+            }
+
+            if (session->ethertype == 0 && n + 1 < eavail) {
+                session->ethertype = (ed[n] << 8) | ed[n + 1];
+            }
         }
 
         if (packet->vlan) {
@@ -1491,6 +1519,61 @@ LOCAL ArkimePacketRC arkime_packet_nflog(ArkimePacketBatch_t *batch, ArkimePacke
     return ARKIME_PACKET_CORRUPT;
 }
 /******************************************************************************/
+// IEEE 802.3br Frame Preemption mPacket (DLT_ETHERNET_MPACKET / linktype 274)
+// Layout: [optional 0x50 align octet][0x55... preamble][SMD octet][Ethernet mData][4-byte CRC]
+// SMD (Start mPacket Delimiter) values per IEEE 802.3br (see Wireshark packet-fpp.c)
+LOCAL ArkimePacketRC arkime_packet_mpacket(ArkimePacketBatch_t *batch, ArkimePacket_t *const packet, const uint8_t *data, int len)
+{
+    if (len < 14) {
+#ifdef DEBUG_PACKET
+        LOG("BAD PACKET: Too short %d", len);
+#endif
+        return ARKIME_PACKET_CORRUPT;
+    }
+
+    int offset = 0;
+
+    // An optional leading octet (0x50) carries preamble alignment bits
+    if (data[0] == 0x50)
+        offset = 1;
+
+    // Skip the 0x55 preamble octets, leaving room for the SMD and a frame
+    while (offset + 2 < len && data[offset] == 0x55)
+        offset++;
+
+    switch (data[offset]) {
+    case 0xd5: // SMD-E  Express frame
+    case 0xe6: // SMD-S0 preemptable start / non-fragmented frame
+    case 0x4c: // SMD-S1
+    case 0x7f: // SMD-S2
+    case 0xb3: // SMD-S3
+        offset++;
+        break;
+    default:
+        // SMD-V/SMD-R control frames have no Ethernet payload, and SMD-Cx
+        // continuation fragments require reassembly we don't perform here
+#ifdef DEBUG_PACKET
+        LOG("Unsupported mPacket SMD 0x%02x", data[offset]);
+#endif
+        return ARKIME_PACKET_CORRUPT;
+    }
+
+    // What remains is the Ethernet mData followed by a trailing 4-byte CRC
+    int elen = len - offset - 4;
+    if (elen < 14) {
+#ifdef DEBUG_PACKET
+        LOG("BAD PACKET: Too short after preamble %d", elen);
+#endif
+        return ARKIME_PACKET_CORRUPT;
+    }
+
+    // Treat the inner Ethernet frame as the sole frame: pre-seeding etherOffset
+    // makes arkime_packet_ether set outerEtherOffset == etherOffset, so the
+    // preamble bytes are not mistaken for an outer MAC.
+    packet->etherOffset = offset;
+    return arkime_packet_ether(batch, packet, data + offset, elen);
+}
+/******************************************************************************/
 LOCAL ArkimePacketRC arkime_packet_radiotap(ArkimePacketBatch_t *batch, ArkimePacket_t *const packet, const uint8_t *data, int len)
 {
     if (data[0] != 0 || len < 36)
@@ -1616,11 +1699,16 @@ void arkime_packet_batch(ArkimePacketBatch_t *batch, ArkimePacket_t *const packe
     case DLT_NFLOG: // NFLOG
         rc = arkime_packet_nflog(batch, packet, packet->pkt, packet->pktlen);
         break;
+    case DLT_ETHERNET_MPACKET: // IEEE 802.3br mPackets
+        rc = arkime_packet_mpacket(batch, packet, packet->pkt, packet->pktlen);
+        break;
     default:
         if (config.ignoreErrors)
             rc = ARKIME_PACKET_CORRUPT;
+        else if (config.pcapReadOffline)
+            LOGEXIT("ERROR - Unsupported pcap link type %u in file %s", pcapFileHeader.dlt, offlineInfo[packet->readerPos].filename);
         else
-            LOGEXIT("ERROR - Unsupported pcap link type %u", pcapFileHeader.dlt);
+            LOGEXIT("ERROR - Unsupported pcap link type %u on interface %s", pcapFileHeader.dlt, config.interface ? config.interface[packet->readerPos] : NULL);
     }
 
     if (likely(rc == ARKIME_PACKET_DO_PROCESS) && unlikely(packet->mProtocol == 0)) {

--- a/capture/parsers/gre.c
+++ b/capture/parsers/gre.c
@@ -82,6 +82,14 @@ LOCAL ArkimePacketRC gre_packet_enqueue(ArkimePacketBatch_t *batch, ArkimePacket
     if (BSB_IS_ERROR(bsb))
         return ARKIME_PACKET_CORRUPT;
 
+    // GRE protocol type 0x0000 is reserved and is what GRE keepalive payloads
+    // carry; it is NOT Transparent Ethernet Bridging (0x6558). Don't hand it to
+    // the Ethernet handler, which is registered under ARKIME_ETHERTYPE_ETHER (== 0)
+    // and would otherwise parse the empty/zero keepalive payload as an Ethernet
+    // frame and emit bogus 00:00:00:00:00:00 MAC addresses.
+    if (type == 0)
+        return ARKIME_PACKET_UNKNOWN_ETHER;
+
     // Type I of ERSPAN doesn't have a ERSPAN header
     if (type == 0x88be && (flags_version & 0x1000) == 0) {
         type = ARKIME_ETHERTYPE_ETHER;

--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -975,6 +975,40 @@ class Pcap {
   }
 
   // --------------------------------------------------------------------------
+  // IEEE 802.3br Frame Preemption mPacket (DLT_ETHERNET_MPACKET / 274)
+  // Layout: [optional 0x50 align octet][0x55... preamble][SMD octet][Ethernet mData][4-byte CRC]
+  mpacket (buffer, obj, pos) {
+    let offset = 0;
+
+    // Optional leading octet carrying preamble alignment bits
+    if (buffer[0] === 0x50) { offset = 1; }
+
+    // Skip the 0x55 preamble octets, leaving room for the SMD and a frame
+    while (offset + 2 < buffer.length && buffer[offset] === 0x55) { offset++; }
+
+    // SMD (Start mPacket Delimiter); only express / preemptable-start frames
+    // carry a full Ethernet frame here (see capture/parsers gre/packet.c)
+    switch (buffer[offset]) {
+    case 0xd5: // SMD-E  Express frame
+    case 0xe6: // SMD-S0 preemptable start / non-fragmented frame
+    case 0x4c: // SMD-S1
+    case 0x7f: // SMD-S2
+    case 0xb3: // SMD-S3
+      offset++;
+      break;
+    default:
+      // SMD-V/SMD-R control frames and SMD-Cx continuation fragments have no
+      // standalone Ethernet frame to decode here
+      return;
+    }
+
+    // What remains is the Ethernet mData followed by a trailing 4-byte CRC
+    const end = buffer.length - 4;
+    if (end - offset < 14) { return; }
+    this.ether(buffer.slice(offset, end), obj, pos + offset);
+  }
+
+  // --------------------------------------------------------------------------
   radiotap (buffer, obj, pos) {
     const l = buffer[2] + 24 + 6;
     const ethertype = buffer.readUInt16BE(l);
@@ -1075,6 +1109,9 @@ class Pcap {
       break;
     case 239: // NFLOG
       this.nflog(buffer.slice(16, obj.pcap.incl_len + 16), obj, 16);
+      break;
+    case 274: // IEEE 802.3br mPackets
+      this.mpacket(buffer.slice(16, obj.pcap.incl_len + 16), obj, 16);
       break;
     case 276: // SLL2
       this.ip4(buffer.slice(36, obj.pcap.incl_len + 20), obj, 36);


### PR DESCRIPTION
- capture: decode IEEE 802.3br mPackets (linktype 274), stripping the FPP preamble/CRC and parsing the inner Ethernet frame, MACs, VLAN and ethertype
- capture: include filename (offline) or interface (live) in the unsupported pcap link type error
- viewer/pcap.js: decode mpacket link layer for session packet views
- capture: fix GRE keepalive packets (inner GRE type 0x0000) being dispatched to the Ethernet handler and adding bogus 00:00:00:00:00:00 MACs

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
