### PR TITLE
Fold Summary/Sessions/SPIView/SPIGraph into one tabbed Explore page

### DIFF
--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "Erkunden",
+    "summary": "Zusammenfassung",
     "sessions": "Sitzungen",
     "settings": "Einstellungen",
     "spiview": "SPI-Ansicht",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "Explore",
+    "summary": "Summary",
     "sessions": "Sessions",
     "settings": "Settings",
     "spiview": "SPIView",

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "Explorar",
+    "summary": "Resumen",
     "sessions": "Sesiones",
     "settings": "Configuración",
     "spiview": "Vista SPI",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "Uuri",
+    "summary": "Kokkuvõte",
     "sessions": "Seansid",
     "settings": "Seaded",
     "spiview": "SPI Vaade",

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "Explorer",
+    "summary": "Résumé",
     "sessions": "Sessions",
     "settings": "Paramètres",
     "spiview": "Vue SPI",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "探索",
+    "summary": "サマリー",
     "sessions": "セッション",
     "settings": "設定",
     "spiview": "SPI View",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "탐색",
+    "summary": "요약",
     "sessions": "세션",
     "settings": "설정",
     "spiview": "SPI 뷰",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "Explorar",
+    "summary": "Resumo",
     "sessions": "Sessões",
     "settings": "Configurações",
     "spiview": "Visualização SPI",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -112,6 +112,8 @@
   },
   "navigation": {
     "arkime": "Arkimeway",
+    "explore": "Exploreway",
+    "summary": "Ummarysay",
     "sessions": "Essionssay",
     "settings": "Ettingssay",
     "spiview": "PIsay Iewvay",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -111,6 +111,8 @@
   },
   "navigation": {
     "arkime": "Arkime",
+    "explore": "浏览",
+    "summary": "摘要",
     "sessions": "会话",
     "settings": "设置",
     "spiview": "SPI 视图",

--- a/viewer/vueapp/src/components/arkime/Arkime.vue
+++ b/viewer/vueapp/src/components/arkime/Arkime.vue
@@ -3,122 +3,114 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <page-layout class="arkime-page">
-    <template #chrome>
-      <ArkimeCollapsible>
-        <div class="page-toolbar">
-          <!-- search navbar -->
-          <arkime-search
-            :hide-actions="true"
-            @change-search="loadSummary" />
-
-          <!-- toolbar row -->
-          <div class="d-flex justify-start align-center ms-2 gap-2 page-subnav">
-            <!-- results per widget dropdown -->
-            <v-menu>
-              <template #activator="{ props }">
-                <v-btn
-                  v-bind="props"
-                  size="large"
-                  variant="flat"
-                  color="secondary">
-                  {{ summaryResultsLimit }}
-                  <v-icon
-                    end
-                    icon="mdi-menu-down" />
-                </v-btn>
-              </template>
-              <v-list density="compact">
-                <v-list-item
-                  v-for="opt in [10, 20, 50, 100]"
-                  :key="opt"
-                  :active="summaryResultsLimit === opt"
-                  @click="updateSummaryResultsLimit(opt)">
-                  <v-list-item-title>{{ opt }}</v-list-item-title>
-                </v-list-item>
-              </v-list>
-            </v-menu>
-
-            <!-- top/bottom results toggle -->
-            <v-menu>
-              <template #activator="{ props }">
-                <v-btn
-                  v-bind="props"
-                  size="large"
-                  variant="flat"
-                  color="secondary">
-                  {{ summaryOrder === 'asc' ? 'Bottom' : 'Top' }}
-                  <v-icon
-                    end
-                    icon="mdi-menu-down" />
-                </v-btn>
-              </template>
-              <v-list density="compact">
-                <v-list-item
-                  :active="summaryOrder === 'desc'"
-                  @click="updateSummaryOrder('desc')">
-                  <v-list-item-title>Top</v-list-item-title>
-                </v-list-item>
-                <v-list-item
-                  :active="summaryOrder === 'asc'"
-                  @click="updateSummaryOrder('asc')">
-                  <v-list-item-title>Bottom</v-list-item-title>
-                </v-list-item>
-              </v-list>
-            </v-menu>
-
-            <!-- export all charts as PNG -->
+  <div class="arkime-page">
+    <!-- summary toolbar teleports into the host toolbar -->
+    <teleport
+      defer
+      to="#tab-subnav-anchor">
+      <!-- toolbar row -->
+      <div class="d-flex justify-start align-center ms-2 gap-2 page-subnav">
+        <!-- results per widget dropdown -->
+        <v-menu>
+          <template #activator="{ props }">
             <v-btn
-              :aria-label="$t('sessions.summary.exportAllPNG')"
+              v-bind="props"
               size="large"
-              variant="flat"
-              color="secondary"
-              @click="exportAllPNG">
-              <v-icon icon="mdi-download" />
-              <v-tooltip
-                activator="parent"
-                :open-delay="500">
-                {{ $t('sessions.summary.exportAllPNG') }} — {{ $t('sessions.summary.exportPNGTableWarning') }}
-              </v-tooltip>
-            </v-btn>
-
-            <!-- summary field visibility + config group -->
-            <v-btn-group
-              divided
-              density="compact"
               variant="flat"
               color="secondary">
-              <FieldSelectDropdown
-                :selected-fields="summaryFields"
-                :tooltip-text="$t('sessions.summary.toggleFields')"
-                :search-placeholder="$t('sessions.summary.searchFields')"
-                :include-summary-fields="true"
-                field-id-key="exp"
-                @toggle="toggleSummaryField"
-                @clear="clearSummaryFields" />
-              <SummaryConfigDropdown
-                :current-config="currentSummaryConfig"
-                @load="loadSummaryConfigFromShareable"
-                @reset="resetSummaryToDefaults"
-                @message="displayMessage" />
-            </v-btn-group>
+              {{ summaryResultsLimit }}
+              <v-icon
+                end
+                icon="mdi-menu-down" />
+            </v-btn>
+          </template>
+          <v-list density="compact">
+            <v-list-item
+              v-for="opt in [10, 20, 50, 100]"
+              :key="opt"
+              :active="summaryResultsLimit === opt"
+              @click="updateSummaryResultsLimit(opt)">
+              <v-list-item-title>{{ opt }}</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
 
-            <!-- cancel loading button -->
+        <!-- top/bottom results toggle -->
+        <v-menu>
+          <template #activator="{ props }">
             <v-btn
-              v-if="summaryStreaming"
+              v-bind="props"
               size="large"
               variant="flat"
-              color="warning"
-              @click="cancelSummaryLoading">
-              <v-icon icon="mdi-cancel" />&nbsp;
-              {{ $t('common.cancel') }}
+              color="secondary">
+              {{ summaryOrder === 'asc' ? 'Bottom' : 'Top' }}
+              <v-icon
+                end
+                icon="mdi-menu-down" />
             </v-btn>
-          </div>
-        </div>
-      </ArkimeCollapsible>
-      <!-- pinned visualizations land here (teleported from below) -->
-      <div id="viz-pin-anchor" />
-    </template>
+          </template>
+          <v-list density="compact">
+            <v-list-item
+              :active="summaryOrder === 'desc'"
+              @click="updateSummaryOrder('desc')">
+              <v-list-item-title>Top</v-list-item-title>
+            </v-list-item>
+            <v-list-item
+              :active="summaryOrder === 'asc'"
+              @click="updateSummaryOrder('asc')">
+              <v-list-item-title>Bottom</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+
+        <!-- export all charts as PNG -->
+        <v-btn
+          :aria-label="$t('sessions.summary.exportAllPNG')"
+          size="large"
+          variant="flat"
+          color="secondary"
+          @click="exportAllPNG">
+          <v-icon icon="mdi-download" />
+          <v-tooltip
+            activator="parent"
+            :open-delay="500">
+            {{ $t('sessions.summary.exportAllPNG') }} — {{ $t('sessions.summary.exportPNGTableWarning') }}
+          </v-tooltip>
+        </v-btn>
+
+        <!-- summary field visibility + config group -->
+        <v-btn-group
+          divided
+          density="compact"
+          variant="flat"
+          color="secondary">
+          <FieldSelectDropdown
+            :selected-fields="summaryFields"
+            :tooltip-text="$t('sessions.summary.toggleFields')"
+            :search-placeholder="$t('sessions.summary.searchFields')"
+            :include-summary-fields="true"
+            field-id-key="exp"
+            @toggle="toggleSummaryField"
+            @clear="clearSummaryFields" />
+          <SummaryConfigDropdown
+            :current-config="currentSummaryConfig"
+            @load="loadSummaryConfigFromShareable"
+            @reset="resetSummaryToDefaults"
+            @message="displayMessage" />
+        </v-btn-group>
+
+        <!-- cancel loading button -->
+        <v-btn
+          v-if="summaryStreaming"
+          size="large"
+          variant="flat"
+          color="warning"
+          @click="cancelSummaryLoading">
+          <v-icon icon="mdi-cancel" />&nbsp;
+          {{ $t('common.cancel') }}
+        </v-btn>
+      </div>
+    </teleport>
 
     <!-- visualizations: pinned = chrome row above the scroll container,
          unpinned = scrolls away with the content -->
@@ -185,13 +177,10 @@ SPDX-License-Identifier: Apache-2.0
         {{ $t('sessions.summary.retryAllFailed') }}
       </v-btn>
     </v-alert>
-  </page-layout>
+  </div>
 </template>
 
 <script>
-import ArkimeSearch from '../search/Search.vue';
-import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
-import PageLayout from '../utils/PageLayout.vue';
 import ArkimeVisualizations from '../visualizations/Visualizations.vue';
 import ArkimeSummaryView from '../summary/Summary.vue';
 import FieldSelectDropdown from '../utils/FieldSelectDropdown.vue';
@@ -203,9 +192,6 @@ import UserService from '../users/UserService';
 export default {
   name: 'Arkime',
   components: {
-    ArkimeSearch,
-    ArkimeCollapsible,
-    PageLayout,
     ArkimeVisualizations,
     ArkimeSummaryView,
     FieldSelectDropdown,
@@ -296,6 +282,10 @@ export default {
     this.loadSummaryConfig();
   },
   methods: {
+    // host delegates the shared search bar's change-search here
+    onSearch: function () {
+      this.loadSummary();
+    },
     /**
      * Loads summary data when search is triggered
      */

--- a/viewer/vueapp/src/components/explore/Explore.vue
+++ b/viewer/vueapp/src/components/explore/Explore.vue
@@ -1,0 +1,188 @@
+<!--
+Copyright Yahoo Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+<!--
+  Explore host: one page, four tabs (Summary / Sessions / SPIView / SPIGraph)
+  sharing a single search bar, time range, and visualization. Each tab body is
+  a self-contained component that teleports its own subnav into
+  #tab-subnav-anchor, its viz into #viz-pin-anchor, and any overlay into
+  #explore-overlay-anchor (same pattern as ConnectionsGraph in #4039). The
+  active tab comes from $route.meta.tab, so the URL, navbar, tab strip, and
+  keyboard shortcuts stay in sync off a single source of truth.
+-->
+<template>
+  <page-layout
+    ref="pageLayout"
+    class="explore-page">
+    <template #chrome>
+      <ArkimeCollapsible>
+        <div class="page-toolbar">
+          <!-- search navbar (keyed per tab so Search re-reads the route in
+               created: basePath + per-tab sticky/hide-viz localStorage) -->
+          <arkime-search
+            :key="activeTab"
+            v-bind="searchMeta"
+            @change-search="onSearch"
+            @set-view="onSetView"
+            @set-columns="onSetColumns" /> <!-- /search navbar -->
+
+          <!-- tab strip -->
+          <v-tabs
+            :model-value="activeTab"
+            :height="36"
+            density="compact"
+            class="explore-tabs ms-2 mt-1">
+            <v-tab
+              value="arkime"
+              :to="tabTo('arkime')">
+              {{ $t('navigation.summary') }}
+            </v-tab>
+            <v-tab
+              value="sessions"
+              :to="tabTo('sessions')">
+              {{ $t('navigation.sessions') }}
+            </v-tab>
+            <v-tab
+              value="spiview"
+              :to="tabTo('spiview')">
+              {{ $t('navigation.spiview') }}
+            </v-tab>
+            <v-tab
+              value="spigraph"
+              :to="tabTo('spigraph')">
+              {{ $t('navigation.spigraph') }}
+            </v-tab>
+          </v-tabs> <!-- /tab strip -->
+
+          <!-- active tab teleports its page-specific subnav here -->
+          <div id="tab-subnav-anchor" />
+        </div>
+      </ArkimeCollapsible>
+      <!-- active tab teleports its pinned visualizations here -->
+      <div id="viz-pin-anchor" />
+    </template>
+
+    <!-- only the active tab body mounts (v-if semantics via :is), so there is
+         never more than one teleport into each shared anchor -->
+    <component
+      :is="activeBodyComponent"
+      ref="body"
+      @search-meta="searchMeta = $event" />
+
+    <!-- active tab teleports floating overlay content here -->
+    <template #overlay>
+      <div id="explore-overlay-anchor" />
+    </template>
+  </page-layout>
+</template>
+
+<script>
+import ArkimeSearch from '../search/Search.vue';
+import PageLayout from '../utils/PageLayout.vue';
+import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
+
+import ArkimeSummary from '../arkime/Arkime.vue';
+import ArkimeSessions from '../sessions/Sessions.vue';
+import ArkimeSpiview from '../spiview/Spiview.vue';
+import ArkimeSpigraph from '../spigraph/Spigraph.vue';
+
+const TAB_TO_COMPONENT = {
+  arkime: 'ArkimeSummary',
+  sessions: 'ArkimeSessions',
+  spiview: 'ArkimeSpiview',
+  spigraph: 'ArkimeSpigraph'
+};
+
+export default {
+  name: 'Explore',
+  components: {
+    ArkimeSearch,
+    PageLayout,
+    ArkimeCollapsible,
+    ArkimeSummary,
+    ArkimeSessions,
+    ArkimeSpiview,
+    ArkimeSpigraph
+  },
+  data: function () {
+    return {
+      // per-tab props the active body feeds up to the shared search bar
+      searchMeta: {}
+    };
+  },
+  computed: {
+    activeTab: function () {
+      return this.$route.meta?.tab || 'sessions';
+    },
+    activeBodyComponent: function () {
+      return TAB_TO_COMPONENT[this.activeTab] || 'ArkimeSessions';
+    }
+  },
+  watch: {
+    activeTab: function () {
+      // drop the previous tab's search-bar props until the new body emits
+      this.searchMeta = {};
+    }
+  },
+  methods: {
+    tabTo: function (tab) {
+      return { path: `/${tab}`, query: this.$route.query };
+    },
+    onSearch: function () {
+      this.$refs.body?.onSearch?.();
+    },
+    onSetView: function (...args) {
+      this.$refs.body?.loadNewView?.(...args);
+    },
+    onSetColumns: function (...args) {
+      this.$refs.body?.loadColumns?.(...args);
+    }
+  }
+};
+</script>
+
+<style scoped>
+/* the tab strip is its own tinted band so it reads as a distinct layer
+   between the dark navbar above and the content below; inactive tabs are
+   dimmed, the active tab is full-strength, bold, and accent-colored with a
+   matching underline */
+.explore-tabs {
+  min-height: 0;
+  background-color: rgb(var(--v-theme-neutral-light));
+  border-radius: 4px;
+}
+.explore-tabs :deep(.v-tab) {
+  text-transform: none;
+  letter-spacing: normal;
+  opacity: 0.7;
+}
+.explore-tabs :deep(.v-tab--selected) {
+  opacity: 1;
+  font-weight: 700;
+}
+/* selected tab uses the theme accent token (foreground-accent — the same
+   --v-theme-* the app's .text-theme-accent utility uses, so it tracks each
+   theme's accent); !important beats Vuetify's default v-tab text color.
+   cover the content node + the slider underline too */
+.explore-tabs :deep(.v-tab--selected),
+.explore-tabs :deep(.v-tab--selected .v-btn__content) {
+  color: rgb(var(--v-theme-foreground-accent)) !important;
+}
+.explore-tabs :deep(.v-tab__slider) {
+  height: 3px;
+  opacity: 1;
+  background-color: rgb(var(--v-theme-foreground-accent)) !important;
+}
+/* #explore-overlay-anchor uses display:contents so its box is removed and the
+   teleported panel (sticky sessions / connections buttons) lays out + positions
+   directly against PageLayout's .page-overlay, exactly as before. PageLayout's
+   ".page-overlay > *" pointer-events rule only reaches the anchor (its direct
+   child), so re-grant pointer-events to the teleported content here. */
+#explore-overlay-anchor {
+  display: contents;
+}
+#explore-overlay-anchor > :deep(*) {
+  pointer-events: auto;
+}
+</style>

--- a/viewer/vueapp/src/components/search/Time.vue
+++ b/viewer/vueapp/src/components/search/Time.vue
@@ -919,11 +919,11 @@ export default {
           this.localStartTime = moment(start * 1000);
           this.time.startTime = start;
         } else { // if we can't parse stop or start time, set default
-          this.timeRange = this.$constants.DEFAULT_TIME_RANGE ?? '1'; // default to config or 1 hour
+          this.timeRange = this.$constants.DEFAULT_TIME_RANGE ?? '0.25'; // default to config or 15 minutes
         }
       } else {
         // there are no time query parameters, so set defaults
-        this.timeRange = this.$constants.DEFAULT_TIME_RANGE ?? '1'; // default to config or 1 hour
+        this.timeRange = this.$constants.DEFAULT_TIME_RANGE ?? '0.25'; // default to config or 15 minutes
       }
     },
     /* watch for the url parameters to change and update the page */

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -3,35 +3,18 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <page-layout
-    ref="pageLayout"
-    class="sessions-page">
-    <template #chrome>
-      <ArkimeCollapsible>
-        <div class="page-toolbar">
-          <!-- search navbar -->
-          <arkime-search
-            :fields="headers"
-            :open-sessions="stickySessions"
-            :num-visible-sessions="query.length"
-            :num-matching-sessions="sessions.recordsFiltered"
-            :start="query.start"
-            @change-search="cancelAndLoad(true)"
-            @set-view="loadNewView"
-            @set-columns="loadColumns" /> <!-- /search navbar -->
-
-          <!-- paging navbar -->
-          <div class="d-flex justify-start align-center paging-navbar">
-            <arkime-paging
-              :records-total="sessions.recordsTotal"
-              :records-filtered="sessions.recordsFiltered"
-              @change-paging="changePaging" />
-          </div> <!-- /paging navbar -->
-        </div>
-      </ArkimeCollapsible>
-      <!-- pinned visualizations land here (teleported from below) -->
-      <div id="viz-pin-anchor" />
-    </template>
+  <div class="sessions-page">
+    <!-- paging navbar teleports into the host toolbar -->
+    <teleport
+      defer
+      to="#tab-subnav-anchor">
+      <div class="d-flex justify-start align-center paging-navbar">
+        <arkime-paging
+          :records-total="sessions.recordsTotal"
+          :records-filtered="sessions.recordsFiltered"
+          @change-paging="changePaging" />
+      </div>
+    </teleport> <!-- /paging navbar -->
 
     <!-- visualizations: pinned = chrome row above the scroll container,
          unpinned = scrolls away with the content -->
@@ -755,8 +738,10 @@ SPDX-License-Identifier: Apache-2.0
       {{ configSnackbar.text }}
     </v-snackbar>
 
-    <template #overlay>
-      <!-- sticky (opened) sessions -->
+    <!-- sticky (opened) sessions float over the host overlay -->
+    <teleport
+      defer
+      to="#explore-overlay-anchor">
       <transition name="leave">
         <arkime-sticky-sessions
           class="sticky-sessions"
@@ -766,8 +751,8 @@ SPDX-License-Identifier: Apache-2.0
           @close-session="closeSession"
           @close-all-sessions="closeAllSessions" />
       </transition> <!-- /sticky (opened) sessions -->
-    </template>
-  </page-layout>
+    </teleport> <!-- /sticky (opened) sessions -->
+  </div>
 </template>
 
 <script>
@@ -778,7 +763,6 @@ import UserService from '../users/UserService';
 import ConfigService from '../utils/ConfigService';
 import Utils from '../utils/utils';
 // import components
-import ArkimeSearch from '../search/Search.vue';
 import customCols from './customCols.json';
 import ArkimePaging from '@common/Pagination.vue';
 import ToggleBtn from '@common/ToggleBtn.vue';
@@ -786,8 +770,6 @@ import ArkimeError from '../utils/Error.vue';
 import ArkimeLoading from '../utils/Loading.vue';
 import ArkimeNoResults from '../utils/NoResults.vue';
 import ArkimeSessionDetail from './SessionDetail.vue';
-import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
-import PageLayout from '../utils/PageLayout.vue';
 import ArkimeVisualizations from '../visualizations/Visualizations.vue';
 import ArkimeStickySessions from './StickySessions.vue';
 import FieldActions from './FieldActions.vue';
@@ -832,7 +814,6 @@ let pendingPromise;
 export default {
   name: 'Sessions',
   components: {
-    ArkimeSearch,
     ArkimePaging,
     ToggleBtn,
     ArkimeError,
@@ -841,11 +822,11 @@ export default {
     ArkimeSessionDetail,
     ArkimeVisualizations,
     ArkimeStickySessions,
-    ArkimeCollapsible,
-    PageLayout,
     FieldActions,
     FieldSelectDropdown
   },
+  inject: ['pageScrollEl'],
+  emits: ['search-meta'],
   data: function () {
     return {
       loading: true,
@@ -925,6 +906,16 @@ export default {
     });
   },
   computed: {
+    /* props the shared (host-owned) search bar needs while this tab is active */
+    searchBarProps: function () {
+      return {
+        fields: this.headers,
+        openSessions: this.stickySessions,
+        numVisibleSessions: this.query.length,
+        numMatchingSessions: this.sessions.recordsFiltered,
+        start: this.query.start
+      };
+    },
     /* name of the currently loaded column config (if it still exists) */
     loadedColConfig: function () {
       const configName = this.tableState.colConfigName;
@@ -1060,6 +1051,11 @@ export default {
     }
   },
   watch: {
+    // feed the host-owned search bar this tab's props
+    searchBarProps: {
+      handler: function (val) { this.$emit('search-meta', val); },
+      immediate: true
+    },
     '$store.state.stickyViz': function () {
       // pin toggle teleports the viz between chrome and scroll content;
       // charts/map cache geometry, so nudge their resize handling
@@ -1070,6 +1066,10 @@ export default {
     }
   },
   methods: {
+    // host delegates the shared search bar's change-search here
+    onSearch: function () {
+      this.cancelAndLoad(true);
+    },
     loadNewView: function () {
       this.viewChanged = true;
     },
@@ -1079,7 +1079,7 @@ export default {
     },
     /* Width available to the table inside the page scroll container */
     availableTableWidth: function () {
-      const scrollEl = this.$refs.pageLayout?.scrollEl;
+      const scrollEl = this.pageScrollEl?.value;
       if (scrollEl && scrollEl.clientWidth) {
         return scrollEl.clientWidth - 20; // account for margins
       }

--- a/viewer/vueapp/src/components/spigraph/Spigraph.vue
+++ b/viewer/vueapp/src/components/spigraph/Spigraph.vue
@@ -3,164 +3,158 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <page-layout class="spigraph-page">
-    <template #chrome>
-      <ArkimeCollapsible>
-        <div class="page-toolbar">
-          <!-- search navbar -->
-          <arkime-search
-            :num-matching-sessions="filtered"
-            @change-search="onSearch" /> <!-- /search navbar -->
-
-          <!-- spigraph sub navbar -->
-          <div class="spigraph-form mx-1">
-            <div class="d-flex flex-wrap align-center gap-1 page-subnav">
-              <!-- main graph type switcher -->
-              <div class="d-flex align-center spigraph-type-switcher">
-                <v-btn-toggle
-                  :model-value="spiGraphType"
-                  @update:model-value="changeSpiGraphType"
-                  mandatory
-                  divided
-                  density="comfortable"
-                  variant="outlined"
-                  color="primary"
-                  class="spigraph-type-toggle">
-                  <v-btn
-                    v-for="t in graphTypeOptions"
-                    :key="t"
-                    :value="t"
-                    size="small">
-                    {{ $t(`spigraph.graphType-${t}`) }}
-                  </v-btn>
-                </v-btn-toggle>
-              </div> <!-- /main graph type switcher -->
-
-              <!-- field select -->
-              <div
-                class="arkime-input-group"
-                v-if="spiGraphType !== 'connections' && fields && fields.length && fieldTypeahead">
-                <span class="arkime-input-label">
-                  {{ $t('spigraph.field') }}:
-                </span>
-                <arkime-field-typeahead
-                  :fields="fields"
-                  query-param="exp"
-                  :initial-value="fieldTypeahead"
-                  @field-selected="changeField"
-                  page="Spigraph" />
-              </div> <!-- /field select -->
-
-              <!-- maxElements select -->
-              <div
-                class="arkime-input-group"
-                v-if="spiGraphType !== 'connections'">
-                <span
-                  id="maxElements"
-                  class="arkime-input-label cursor-help">
-                  {{ $t('spigraph.maxElements') }}:
-                </span>
-                <v-tooltip activator="#maxElements">
-                  {{ $t('spigraph.maxElementsTip') }}
-                </v-tooltip>
-                <select
-                  class="arkime-input-control"
-                  :value="query.size"
-                  @change="changeMaxElements(Number($event.target.value))">
-                  <option
-                    v-for="opt in maxElementsOptions"
-                    :key="opt"
-                    :value="opt">
-                    {{ opt }}
-                  </option>
-                </select>
-              </div> <!-- /maxElements select -->
-
-              <!-- connections controls anchor -->
-              <div
-                v-if="spiGraphType === 'connections'"
-                id="connections-controls-anchor"
-                class="connections-controls-anchor d-flex flex-wrap align-center gap-1 mt-1 mb-1" />
-
-              <!-- sort select (not shown for the pie graph) -->
-              <div
-                class="arkime-input-group"
-                v-if="spiGraphType === 'default'">
-                <span class="arkime-input-label">
-                  {{ $t('spigraph.sortBy') }}:
-                </span>
-                <select
-                  class="arkime-input-control"
-                  :value="sortBy"
-                  @change="changeSortBy($event.target.value)">
-                  <option value="name">
-                    {{ $t('spigraph.sortBy-name') }}
-                  </option>
-                  <option value="graph">
-                    {{ $t('spigraph.sortBy-graph') }}
-                  </option>
-                </select>
-              </div> <!-- /sort select -->
-
-              <!-- refresh input (not shown for pie) -->
-              <div
-                class="arkime-input-group"
-                v-if="spiGraphType === 'default'">
-                <span class="arkime-input-label">
-                  {{ $t('spigraph.refreshEvery') }}:
-                </span>
-                <select
-                  class="arkime-input-control"
-                  :value="refresh"
-                  @change="changeRefreshInterval(Number($event.target.value))">
-                  <option
-                    v-for="opt in refreshOptions"
-                    :key="opt"
-                    :value="opt">
-                    {{ opt }}
-                  </option>
-                </select>
-                <span class="arkime-input-label">
-                  {{ $t('common.seconds') }}
-                </span>
-              </div> <!-- /refresh input-->
-
-              <!-- page info -->
-              <div
-                class="records-display align-self-center"
-                v-if="spiGraphType === 'default'">
-                <strong
-                  class="text-theme-accent"
-                  v-if="!error && recordsFiltered !== undefined">
-                  {{ $t('common.showingAllTip', { count: commaString(recordsFiltered), total: commaString(recordsTotal) }) }}
-                </strong>
-              </div> <!-- /page info -->
-
-              <!-- export button-->
+  <div class="spigraph-page">
+    <!-- spigraph sub navbar teleports into the host toolbar -->
+    <teleport
+      defer
+      to="#tab-subnav-anchor">
+      <!-- spigraph sub navbar -->
+      <div class="spigraph-form mx-1">
+        <div class="d-flex flex-wrap gap-1">
+          <!-- main graph type switcher -->
+          <div class="d-flex align-center spigraph-type-switcher">
+            <v-btn-toggle
+              :model-value="spiGraphType"
+              @update:model-value="changeSpiGraphType"
+              mandatory
+              divided
+              density="comfortable"
+              variant="outlined"
+              color="primary"
+              class="spigraph-type-toggle">
               <v-btn
-                v-if="spiGraphType !== 'default' && spiGraphType !== 'sankey' && spiGraphType !== 'connections'"
-                variant="outlined"
-                size="small"
-                density="comfortable"
-                class="ms-1"
-                prepend-icon="mdi-download"
-                @click.stop.prevent="exportCSV">
-                {{ $t('spigraph.exportCSV') }}
-                <v-tooltip activator="parent">
-                  {{ $t('spigraph.exportCSVSPIGraphTip') }}
-                </v-tooltip>
-              </v-btn> <!-- /export button-->
+                v-for="t in graphTypeOptions"
+                :key="t"
+                :value="t"
+                size="small">
+                {{ $t(`spigraph.graphType-${t}`) }}
+              </v-btn>
+            </v-btn-toggle>
+          </div> <!-- /main graph type switcher -->
 
-              <!-- hierarchy "add another field" anchor (own full-width row) -->
-              <div
-                v-if="['pie', 'table', 'treemap', 'sankey'].includes(spiGraphType)"
-                id="spigraph-subfield-anchor"
-                class="spigraph-subfield-anchor d-flex flex-wrap align-center gap-1 mt-1" />
-            </div>
-          </div>
+          <!-- field select -->
+          <div
+            class="arkime-input-group"
+            v-if="spiGraphType !== 'connections' && fields && fields.length && fieldTypeahead">
+            <span class="arkime-input-label">
+              {{ $t('spigraph.field') }}:
+            </span>
+            <arkime-field-typeahead
+              :fields="fields"
+              query-param="exp"
+              :initial-value="fieldTypeahead"
+              @field-selected="changeField"
+              page="Spigraph" />
+          </div> <!-- /field select -->
+
+          <!-- maxElements select -->
+          <div
+            class="arkime-input-group"
+            v-if="spiGraphType !== 'connections'">
+            <span
+              id="maxElements"
+              class="arkime-input-label cursor-help">
+              {{ $t('spigraph.maxElements') }}:
+            </span>
+            <v-tooltip activator="#maxElements">
+              {{ $t('spigraph.maxElementsTip') }}
+            </v-tooltip>
+            <select
+              class="arkime-input-control"
+              :value="query.size"
+              @change="changeMaxElements(Number($event.target.value))">
+              <option
+                v-for="opt in maxElementsOptions"
+                :key="opt"
+                :value="opt">
+                {{ opt }}
+              </option>
+            </select>
+          </div> <!-- /maxElements select -->
+
+          <!-- connections controls anchor -->
+          <div
+            v-if="spiGraphType === 'connections'"
+            id="connections-controls-anchor"
+            class="connections-controls-anchor d-flex flex-wrap align-center gap-1 mt-1 mb-1" />
+
+          <!-- sort select (not shown for the pie graph) -->
+          <div
+            class="arkime-input-group"
+            v-if="spiGraphType === 'default'">
+            <span class="arkime-input-label">
+              {{ $t('spigraph.sortBy') }}:
+            </span>
+            <select
+              class="arkime-input-control"
+              :value="sortBy"
+              @change="changeSortBy($event.target.value)">
+              <option value="name">
+                {{ $t('spigraph.sortBy-name') }}
+              </option>
+              <option value="graph">
+                {{ $t('spigraph.sortBy-graph') }}
+              </option>
+            </select>
+          </div> <!-- /sort select -->
+
+          <!-- refresh input (not shown for pie) -->
+          <div
+            class="arkime-input-group"
+            v-if="spiGraphType === 'default'">
+            <span class="arkime-input-label">
+              {{ $t('spigraph.refreshEvery') }}:
+            </span>
+            <select
+              class="arkime-input-control"
+              :value="refresh"
+              @change="changeRefreshInterval(Number($event.target.value))">
+              <option
+                v-for="opt in refreshOptions"
+                :key="opt"
+                :value="opt">
+                {{ opt }}
+              </option>
+            </select>
+            <span class="arkime-input-label">
+              {{ $t('common.seconds') }}
+            </span>
+          </div> <!-- /refresh input-->
+
+          <!-- page info -->
+          <div
+            class="records-display align-self-center"
+            v-if="spiGraphType === 'default'">
+            <strong
+              class="text-theme-accent"
+              v-if="!error && recordsFiltered !== undefined">
+              {{ $t('common.showingAllTip', { count: commaString(recordsFiltered), total: commaString(recordsTotal) }) }}
+            </strong>
+          </div> <!-- /page info -->
+
+          <!-- export button-->
+          <v-btn
+            v-if="spiGraphType !== 'default' && spiGraphType !== 'sankey' && spiGraphType !== 'connections'"
+            variant="outlined"
+            size="small"
+            density="comfortable"
+            class="ms-1"
+            prepend-icon="mdi-download"
+            @click.stop.prevent="exportCSV">
+            {{ $t('spigraph.exportCSV') }}
+            <v-tooltip activator="parent">
+              {{ $t('spigraph.exportCSVSPIGraphTip') }}
+            </v-tooltip>
+          </v-btn> <!-- /export button-->
+
+          <!-- hierarchy "add another field" anchor (own full-width row) -->
+          <div
+            v-if="['pie', 'table', 'treemap', 'sankey'].includes(spiGraphType)"
+            id="spigraph-subfield-anchor"
+            class="spigraph-subfield-anchor d-flex flex-wrap align-center gap-1 mt-1" />
         </div>
-      </ArkimeCollapsible>
-    </template>
+      </div>
+    </teleport>
 
     <!-- main visualization (timeline/map): always inline, scrolls with content -->
     <div v-if="spiGraphType === 'default' && mapData && graphData && fieldObj && showToolBars">
@@ -255,19 +249,22 @@ SPDX-License-Identifier: Apache-2.0
         :view="query.view" /> <!-- /no results -->
     </div>
 
+    <!-- connections overlay anchor: rendered before the connections graph so its
+         deferred teleport resolves first, leaving #connections-overlay-anchor in
+         place for the child's own deferred teleport of its floating buttons -->
+    <teleport
+      v-if="spiGraphType === 'connections'"
+      defer
+      to="#explore-overlay-anchor">
+      <div id="connections-overlay-anchor" />
+    </teleport>
+
     <!-- connections network graph type (self-contained: owns its own
          /api/connections fetch, controls, and overlay buttons) -->
     <arkime-connections-graph
-      v-else
-      ref="connectionsGraph" /> <!-- /connections graph type -->
-
-    <!-- overlay anchor: connections floating buttons teleport here -->
-    <template
       v-if="spiGraphType === 'connections'"
-      #overlay>
-      <div id="connections-overlay-anchor" />
-    </template>
-  </page-layout>
+      ref="connectionsGraph" /> <!-- /connections graph type -->
+  </div>
 </template>
 
 <script>
@@ -277,13 +274,10 @@ import FieldService from '../search/FieldService';
 import ConfigService from '../utils/ConfigService';
 // import internal
 import ArkimeError from '../utils/Error.vue';
-import ArkimeSearch from '../search/Search.vue';
 import ArkimeLoading from '../utils/Loading.vue';
 import ArkimeNoResults from '../utils/NoResults.vue';
 import ArkimeFieldTypeahead from '../utils/FieldTypeahead.vue';
 import ArkimeVisualizations from '../visualizations/Visualizations.vue';
-import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
-import PageLayout from '../utils/PageLayout.vue';
 import ArkimePie from './Hierarchy.vue';
 import ArkimeConnectionsGraph from '../connections/ConnectionsGraph.vue';
 import { commaString } from '@common/vueFilters.js';
@@ -299,16 +293,14 @@ export default {
   name: 'Spigraph',
   components: {
     ArkimeError,
-    ArkimeSearch,
     ArkimeLoading,
     ArkimeNoResults,
     ArkimeFieldTypeahead,
     ArkimeVisualizations,
-    ArkimeCollapsible,
-    PageLayout,
     ArkimePie,
     ArkimeConnectionsGraph
   },
+  emits: ['search-meta'],
   data: function () {
     return {
       error: '',
@@ -337,6 +329,10 @@ export default {
     };
   },
   computed: {
+    /* props the shared (host-owned) search bar needs while this tab is active */
+    searchBarProps: function () {
+      return { numMatchingSessions: this.filtered };
+    },
     user: function () {
       return this.$store.state.user;
     },
@@ -378,6 +374,11 @@ export default {
     }
   },
   watch: {
+    // feed the host-owned search bar this tab's props
+    searchBarProps: {
+      handler: function (val) { this.$emit('search-meta', val); },
+      immediate: true
+    },
     '$route.query' (newVal, oldVal) {
       if (newVal.size !== this.query.size) {
         this.query.size = newVal.size || 20;
@@ -674,15 +675,14 @@ export default {
    dropdown) sized to the 32px subnav band */
 .spigraph-page .spigraph-type-toggle {
   height: 32px;
+  min-height: 32px; /* override Vuetify's comfortable-density min-height so the
+                       toggle matches the 32px input rows and stays centered */
 }
 .spigraph-page .spigraph-type-toggle :deep(.v-btn) {
   height: 32px;
+  min-height: 32px;
   text-transform: none;
   letter-spacing: normal;
-}
-/* symmetric band padding: even spacing for single-row vs multi-row subnavs */
-.spigraph-page .page-subnav {
-  padding-block: 6px;
 }
 /* "add another field" on its own row: full-width forces a flex-wrap break */
 .spigraph-page .spigraph-subfield-anchor {

--- a/viewer/vueapp/src/components/spiview/Spiview.vue
+++ b/viewer/vueapp/src/components/spiview/Spiview.vue
@@ -3,190 +3,182 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <page-layout class="spiview-page">
-    <template #chrome>
-      <ArkimeCollapsible>
-        <div class="page-toolbar">
-          <!-- search navbar -->
-          <arkime-search
-            @change-search="changeSearch"
-            :num-matching-sessions="filtered" /> <!-- /search navbar -->
-
-          <!-- info navbar -->
-          <div class="d-flex align-center info-nav mx-1 gap-2 page-subnav">
-            <div v-if="!dataLoading">
-              <!-- field config save button -->
-              <v-menu
-                :close-on-content-click="false"
-                location="bottom start">
-                <template #activator="{ props: activatorProps }">
+  <div class="spiview-page">
+    <!-- info navbar + stale-data warning teleport into the host toolbar -->
+    <teleport
+      defer
+      to="#tab-subnav-anchor">
+      <!-- info navbar -->
+      <div class="d-flex align-center info-nav mx-1 gap-2 page-subnav">
+        <div v-if="!dataLoading">
+          <!-- field config save button -->
+          <v-menu
+            :close-on-content-click="false"
+            location="bottom start">
+            <template #activator="{ props: activatorProps }">
+              <v-btn
+                v-bind="activatorProps"
+                variant="flat"
+                size="large"
+                color="secondary"
+                class="field-config-trigger">
+                <v-icon icon="mdi-view-column" />
+                <v-tooltip
+                  activator="parent"
+                  location="right">
+                  {{ $t('spiview.spiViewFieldConfigTip') }}
+                </v-tooltip>
+              </v-btn>
+            </template>
+            <v-list
+              density="compact"
+              class="field-config-list">
+              <div class="px-2 py-1">
+                <div class="arkime-input-group">
+                  <input
+                    autofocus
+                    @click.stop
+                    maxlength="30"
+                    type="text"
+                    class="arkime-input-control"
+                    @input="debounceNewFieldConfigName"
+                    v-model.lazy="newFieldConfigName"
+                    :placeholder="$t('spiview.newConfigPlaceholder')"
+                    @keydown.enter.stop.prevent="saveFieldConfiguration">
                   <v-btn
-                    v-bind="activatorProps"
+                    :aria-label="$t('common.save')"
                     variant="flat"
-                    size="large"
-                    color="secondary"
-                    class="field-config-trigger">
-                    <v-icon icon="mdi-view-column" />
+                    size="small"
+                    density="comfortable"
+                    icon
+                    class="arkime-input-append-btn"
+                    :style="secondaryBtnStyle"
+                    :disabled="!newFieldConfigName"
+                    @click.stop.prevent="saveFieldConfiguration">
+                    <v-icon icon="mdi-content-save" />
                     <v-tooltip
                       activator="parent"
                       location="right">
-                      {{ $t('spiview.spiViewFieldConfigTip') }}
+                      {{ $t('spiview.spiViewFieldConfigSaveTip') }}
                     </v-tooltip>
                   </v-btn>
-                </template>
-                <v-list
-                  density="compact"
-                  class="field-config-list">
-                  <div class="px-2 py-1">
-                    <div class="arkime-input-group">
-                      <input
-                        autofocus
-                        @click.stop
-                        maxlength="30"
-                        type="text"
-                        class="arkime-input-control"
-                        @input="debounceNewFieldConfigName"
-                        v-model.lazy="newFieldConfigName"
-                        :placeholder="$t('spiview.newConfigPlaceholder')"
-                        @keydown.enter.stop.prevent="saveFieldConfiguration">
-                      <v-btn
-                        :aria-label="$t('common.save')"
-                        variant="flat"
-                        size="small"
-                        density="comfortable"
-                        icon
-                        class="arkime-input-append-btn"
-                        :style="secondaryBtnStyle"
-                        :disabled="!newFieldConfigName"
-                        @click.stop.prevent="saveFieldConfiguration">
-                        <v-icon icon="mdi-content-save" />
-                        <v-tooltip
-                          activator="parent"
-                          location="right">
-                          {{ $t('spiview.spiViewFieldConfigSaveTip') }}
-                        </v-tooltip>
-                      </v-btn>
-                    </div>
-                  </div>
-                  <v-divider />
-                  <v-list-item
-                    key="config-default"
-                    @click.stop.prevent="loadFieldConfiguration(-1)">
-                    {{ $t('spiview.arkimeDefault') }}
+                </div>
+              </div>
+              <v-divider />
+              <v-list-item
+                key="config-default"
+                @click.stop.prevent="loadFieldConfiguration(-1)">
+                {{ $t('spiview.arkimeDefault') }}
+                <v-tooltip
+                  activator="parent"
+                  location="end">
+                  {{ $t('spiview.spiViewConfigDefaultTip') }}
+                </v-tooltip>
+              </v-list-item>
+              <v-list-item
+                v-for="(config, key) in fieldConfigs"
+                :key="config.name"
+                @click.self.stop.prevent="loadFieldConfiguration(key)">
+                <div
+                  class="d-flex align-center w-100"
+                  @click.self="loadFieldConfiguration(key)">
+                  <span
+                    class="flex-grow-1"
+                    @click="loadFieldConfiguration(key)">
+                    {{ config.name }}
+                  </span>
+                  <v-btn
+                    :id="`updateFieldConfig${key}`"
+                    color="warning"
+                    variant="flat"
+                    size="small"
+                    density="comfortable"
+                    icon
+                    class="ms-1"
+                    :aria-label="$t('common.save')"
+                    @click.stop.prevent="updateFieldConfiguration(config.name, key)">
+                    <v-icon icon="mdi-content-save" />
                     <v-tooltip
-                      activator="parent"
+                      :activator="`[id='updateFieldConfig${key}']`"
                       location="end">
-                      {{ $t('spiview.spiViewConfigDefaultTip') }}
+                      Update this field configuration with the currently visible fields
                     </v-tooltip>
-                  </v-list-item>
-                  <v-list-item
-                    v-for="(config, key) in fieldConfigs"
-                    :key="config.name"
-                    @click.self.stop.prevent="loadFieldConfiguration(key)">
-                    <div
-                      class="d-flex align-center w-100"
-                      @click.self="loadFieldConfiguration(key)">
-                      <span
-                        class="flex-grow-1"
-                        @click="loadFieldConfiguration(key)">
-                        {{ config.name }}
-                      </span>
-                      <v-btn
-                        :id="`updateFieldConfig${key}`"
-                        color="warning"
-                        variant="flat"
-                        size="small"
-                        density="comfortable"
-                        icon
-                        class="ms-1"
-                        :aria-label="$t('common.save')"
-                        @click.stop.prevent="updateFieldConfiguration(config.name, key)">
-                        <v-icon icon="mdi-content-save" />
-                        <v-tooltip
-                          :activator="`[id='updateFieldConfig${key}']`"
-                          location="end">
-                          Update this field configuration with the currently visible fields
-                        </v-tooltip>
-                      </v-btn>
-                      <v-btn
-                        color="error"
-                        variant="flat"
-                        size="small"
-                        density="comfortable"
-                        icon
-                        class="ms-1"
-                        :aria-label="$t('common.delete')"
-                        @click.stop.prevent="deleteFieldConfiguration(config.name, key)">
-                        <v-icon icon="mdi-trash-can-outline" />
-                      </v-btn>
-                    </div>
-                  </v-list-item>
-                </v-list>
-                <v-alert
-                  v-if="fieldConfigError"
-                  density="compact"
-                  variant="tonal"
-                  type="error"
-                  class="ma-1">
-                  {{ fieldConfigError }}
-                </v-alert>
-                <v-alert
-                  v-if="fieldConfigSuccess"
-                  density="compact"
-                  variant="tonal"
-                  type="success"
-                  class="ma-1">
-                  {{ fieldConfigSuccess }}
-                </v-alert>
-              </v-menu> <!-- /field config save button -->
-            </div>
-            <div class="info-nav-count">
-              <strong
-                class="text-theme-accent"
-                v-if="!dataLoading && !error && filtered !== undefined">
-                {{ $t('common.showingAllTip', { count: commaString(filtered), total: commaString(total) }) }}
-              </strong>
-            </div>
-            <div
-              v-if="dataLoading"
-              class="info-nav-loading">
-              <v-icon
-                icon="mdi-loading"
-                size="small"
-                class="mdi-spin" />&nbsp;
-              <em>
-                {{ $t('common.loading') }}
-              </em>
-              <v-btn
-                :class="{'disabled-aggregations':disabledAggregations}"
-                color="warning"
-                variant="flat"
-                size="large"
-                class="ms-2"
-                @click="cancelLoading">
-                <v-icon
-                  icon="mdi-cancel"
-                  class="me-1" />
-                {{ $t('common.cancel') }}
-              </v-btn>
-            </div>
-          </div> <!-- /info navbar -->
+                  </v-btn>
+                  <v-btn
+                    color="error"
+                    variant="flat"
+                    size="small"
+                    density="comfortable"
+                    icon
+                    class="ms-1"
+                    :aria-label="$t('common.delete')"
+                    @click.stop.prevent="deleteFieldConfiguration(config.name, key)">
+                    <v-icon icon="mdi-trash-can-outline" />
+                  </v-btn>
+                </div>
+              </v-list-item>
+            </v-list>
+            <v-alert
+              v-if="fieldConfigError"
+              density="compact"
+              variant="tonal"
+              type="error"
+              class="ma-1">
+              {{ fieldConfigError }}
+            </v-alert>
+            <v-alert
+              v-if="fieldConfigSuccess"
+              density="compact"
+              variant="tonal"
+              type="success"
+              class="ma-1">
+              {{ fieldConfigSuccess }}
+            </v-alert>
+          </v-menu> <!-- /field config save button -->
         </div>
-
-        <!-- warning navbar -->
+        <div class="info-nav-count">
+          <strong
+            class="text-theme-accent"
+            v-if="!dataLoading && !error && filtered !== undefined">
+            {{ $t('common.showingAllTip', { count: commaString(filtered), total: commaString(total) }) }}
+          </strong>
+        </div>
         <div
-          class="text-theme-accent"
-          v-if="staleData && !dataLoading">
-          <v-icon icon="mdi-alert" />&nbsp;<span v-html="$t('spiview.cancelWarningHtml')" />
+          v-if="dataLoading"
+          class="info-nav-loading">
           <v-icon
-            icon="mdi-close"
-            class="cursor-pointer"
-            @click="staleData = false" />
-        </div> <!-- /warning navbar -->
-      </ArkimeCollapsible>
-      <!-- pinned visualizations land here (teleported from below) -->
-      <div id="viz-pin-anchor" />
-    </template>
+            icon="mdi-loading"
+            size="small"
+            class="mdi-spin" />&nbsp;
+          <em>
+            {{ $t('common.loading') }}
+          </em>
+          <v-btn
+            :class="{'disabled-aggregations':disabledAggregations}"
+            color="warning"
+            variant="flat"
+            size="large"
+            class="ms-2"
+            @click="cancelLoading">
+            <v-icon
+              icon="mdi-cancel"
+              class="me-1" />
+            {{ $t('common.cancel') }}
+          </v-btn>
+        </div>
+      </div> <!-- /info navbar -->
+
+      <!-- warning navbar -->
+      <div
+        class="text-theme-accent"
+        v-if="staleData && !dataLoading">
+        <v-icon icon="mdi-alert" />&nbsp;<span v-html="$t('spiview.cancelWarningHtml')" />
+        <v-icon
+          icon="mdi-close"
+          class="cursor-pointer"
+          @click="staleData = false" />
+      </div> <!-- /warning navbar -->
+    </teleport>
 
     <!-- visualizations: pinned = chrome row above the scroll container,
          unpinned = scrolls away with the content -->
@@ -472,7 +464,7 @@ SPDX-License-Identifier: Apache-2.0
         </div>
       </div> <!-- /spiview panels -->
     </div>
-  </page-layout>
+  </div>
 </template>
 
 <script>
@@ -484,10 +476,7 @@ import UserService from '../users/UserService';
 import SpiviewService from './SpiviewService';
 // internal components
 import ArkimeError from '../utils/Error.vue';
-import ArkimeSearch from '../search/Search.vue';
 import ArkimeVisualizations from '../visualizations/Visualizations.vue';
-import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
-import PageLayout from '../utils/PageLayout.vue';
 import FieldActions from '../sessions/FieldActions.vue';
 import { commaString, searchFields, buildExpression } from '@common/vueFilters.js';
 import { resolveMessage } from '@common/resolveI18nMessage';
@@ -512,12 +501,10 @@ export default {
   name: 'Spiview',
   components: {
     ArkimeError,
-    ArkimeSearch,
     ArkimeVisualizations,
-    ArkimeCollapsible,
-    PageLayout,
     FieldActions
   },
+  emits: ['search-meta'],
   data: function () {
     return {
       error: '',
@@ -551,6 +538,10 @@ export default {
     };
   },
   computed: {
+    /* props the shared (host-owned) search bar needs while this tab is active */
+    searchBarProps: function () {
+      return { numMatchingSessions: this.filtered };
+    },
     query: function () {
       return {
         facets: 1,
@@ -586,6 +577,11 @@ export default {
     }
   },
   watch: {
+    // feed the host-owned search bar this tab's props
+    searchBarProps: {
+      handler: function (val) { this.$emit('search-meta', val); },
+      immediate: true
+    },
     '$store.state.stickyViz': function () {
       // pin toggle teleports the viz between chrome and scroll content;
       // charts/map cache geometry, so nudge their resize handling
@@ -614,6 +610,10 @@ export default {
   },
   methods: {
     commaString,
+    // host delegates the shared search bar's change-search here
+    onSearch: function () {
+      this.changeSearch();
+    },
     /* exposed page functions ---------------------------------------------- */
     /**
      * Filters field buttons by the search filter

--- a/viewer/vueapp/src/components/utils/Navbar.vue
+++ b/viewer/vueapp/src/components/utils/Navbar.vue
@@ -102,7 +102,7 @@ export default {
     return {
       path: this.$constants.PATH,
       menuOrder: [
-        'arkime', 'sessions', 'spiview', 'spigraph', 'hunt',
+        'explore', 'hunt',
         'files', 'stats', 'history', 'upload', 'settings', 'users', 'roles'
       ],
       // active-pill colors -- use Arkime CSS vars so the pill flips
@@ -123,10 +123,9 @@ export default {
     },
     menu: function () {
       const menu = {
-        arkime: { title: this.$t('navigation.arkime'), link: 'arkime', hotkey: ['Arkime'], name: 'Arkime' },
-        sessions: { title: this.$t('navigation.sessions'), link: 'sessions', hotkey: ['Sessions'], name: 'Sessions' },
-        spiview: { title: this.$t('navigation.spiview'), link: 'spiview', hotkey: ['SPI ', 'View'], name: 'Spiview' },
-        spigraph: { title: this.$t('navigation.spigraph'), link: 'spigraph', hotkey: ['SPI ', 'Graph'], name: 'Spigraph' },
+        // Summary/Sessions/SPIView/SPIGraph folded into one tabbed Explore page;
+        // activePaths keeps the pill lit on any of the four tab routes
+        explore: { title: this.$t('navigation.explore'), link: 'arkime', name: 'Arkime', activePaths: ['/', '/arkime', '/sessions', '/spiview', '/spigraph'] },
         files: { title: this.$t('navigation.files'), link: 'files', permission: 'hideFiles', reverse: true, name: 'Files' },
         stats: { title: this.$t('navigation.stats'), link: 'stats', permission: 'hideStats', reverse: true, name: 'Stats' },
         upload: { title: this.$t('navigation.upload'), link: 'upload', permission: 'canUpload', name: 'Upload' },
@@ -170,7 +169,9 @@ export default {
           item.hasRole = !item.role || this.user.roles?.includes(item.role);
         }
 
-        item.isActive = this.$route.path === `/${item.link}`;
+        item.isActive = item.activePaths
+          ? item.activePaths.includes(this.$route.path)
+          : this.$route.path === `/${item.link}`;
       }
 
       return menu;
@@ -192,8 +193,10 @@ export default {
       let activeLink;
       const chosenPath = this.$route.path.split('/')[1];
       for (const page in this.menu) {
-        const link = this.menu[page].link;
-        if (link === chosenPath) {
+        const item = this.menu[page];
+        // grouped item (explore): resolve to the real path segment so the
+        // help anchor + toolbar chevron still work per tab
+        if (item.activePaths?.includes(`/${chosenPath}`) || item.link === chosenPath) {
           activeLink = chosenPath;
           break;
         }

--- a/viewer/vueapp/src/router.js
+++ b/viewer/vueapp/src/router.js
@@ -7,14 +7,11 @@ import Files from '@/components/files/Files.vue';
 import Users from '@/components/users/Users.vue';
 import Roles from '@/components/roles/Roles.vue';
 import ArkimeHistory from '@/components/history/History.vue';
-import Sessions from '@/components/sessions/Sessions.vue';
-import Spiview from '@/components/spiview/Spiview.vue';
-import Spigraph from '@/components/spigraph/Spigraph.vue';
+import Explore from '@/components/explore/Explore.vue';
 import Settings from '@/components/settings/Settings.vue';
 import Upload from '@/components/upload/Upload.vue';
 import Hunt from '@/components/hunt/Hunt.vue';
 import Arkime404 from '@/components/utils/404.vue';
-import Arkime from '@/components/arkime/Arkime.vue';
 
 const router = createRouter({
   // PATH is a global injected into index.ejs.html, by viewer.js
@@ -43,13 +40,15 @@ const router = createRouter({
     {
       path: '/arkime',
       name: 'Arkime',
-      component: Arkime
+      alias: '/',
+      component: Explore,
+      meta: { tab: 'arkime' }
     },
     {
       path: '/sessions',
       name: 'Sessions',
-      alias: '/',
-      component: Sessions
+      component: Explore,
+      meta: { tab: 'sessions' }
     },
     {
       path: '/help',
@@ -79,12 +78,14 @@ const router = createRouter({
     {
       path: '/spiview',
       name: 'Spiview',
-      component: Spiview
+      component: Explore,
+      meta: { tab: 'spiview' }
     },
     {
       path: '/spigraph',
       name: 'Spigraph',
-      component: Spigraph
+      component: Explore,
+      meta: { tab: 'spigraph' }
     },
     {
       // Connections folded into Spigraph as a graph type; keep old

--- a/viewer/vueapp/src/store.js
+++ b/viewer/vueapp/src/store.js
@@ -22,7 +22,7 @@ const store = createStore({
     fieldsAliasMap: {},
     fieldhistory: [],
     // eslint-disable-next-line no-undef
-    timeRange: DEFAULT_TIME_RANGE ?? 1,
+    timeRange: DEFAULT_TIME_RANGE ?? 0.25,
     expression: undefined,
     time: {
       startTime: undefined,


### PR DESCRIPTION
Combines the Summary, Sessions, SPIView, and SPIGraph pages into one tabbed **Explore** page that shares a single search bar, time range, and visualization (same pattern as #4039's Connections fold). The four navbar items collapse into one "Explore"; all four existing URLs still work and select their tab. Defaults to the Summary tab and a 15-minute query time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)