### PR TITLE
Add matrix heatmap graph type to SPIGraph (#3956)

### DIFF
--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "Maximale Anzahl zurückgegebener Elemente (für das erste ausgewählte Feld)",
     "graphType": "Graphentyp",
     "graphType-default": "Zeitachse/Karte",
+    "graphType-heatmap": "Heatmap",
     "graphType-pie": "Donut",
     "graphType-table": "Tabelle",
     "graphType-treemap": "Baumkarte",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "Alphabetisch",
     "sortBy-graph": "Anzahl",
     "refreshEvery": "Alle aktualisieren",
+    "intensity": "Intensität",
+    "sessions": "Sitzungen",
     "exportCSV": "CSV exportieren",
     "exportCSVSPIGraphTip": "Diese Daten als CSV-Datei exportieren"
   },

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "Anzahl",
     "refreshEvery": "Alle aktualisieren",
     "intensity": "Intensität",
+    "showCount": "Anzahl anzeigen",
     "sessions": "Sitzungen",
     "exportCSV": "CSV exportieren",
     "exportCSVSPIGraphTip": "Diese Daten als CSV-Datei exportieren"

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -1404,7 +1404,7 @@
     "maxElements": "Max. Elemente",
     "maxElementsTip": "Maximale Anzahl zurückgegebener Elemente (für das erste ausgewählte Feld)",
     "graphType": "Graphentyp",
-    "graphType-default": "Zeitachse/Karte",
+    "graphType-default": "Zeitachse",
     "graphType-heatmap": "Heatmap",
     "graphType-pie": "Donut",
     "graphType-table": "Tabelle",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -1404,7 +1404,7 @@
     "maxElements": "Max Elements",
     "maxElementsTip": "Maximum number of elements returned (for the first field selected)",
     "graphType": "Graph Type",
-    "graphType-default": "Timeline/Map",
+    "graphType-default": "Timeline",
     "graphType-heatmap": "Heatmap",
     "graphType-pie": "Donut",
     "graphType-table": "Table",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "Count",
     "refreshEvery": "Refresh every",
     "intensity": "Intensity",
+    "showCount": "Show count",
     "sessions": "Sessions",
     "exportCSV": "Export CSV",
     "exportCSVSPIGraphTip": "Export this data as a CSV file"

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "Maximum number of elements returned (for the first field selected)",
     "graphType": "Graph Type",
     "graphType-default": "Timeline/Map",
+    "graphType-heatmap": "Heatmap",
     "graphType-pie": "Donut",
     "graphType-table": "Table",
     "graphType-treemap": "Treemap",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "Alphabetically",
     "sortBy-graph": "Count",
     "refreshEvery": "Refresh every",
+    "intensity": "Intensity",
+    "sessions": "Sessions",
     "exportCSV": "Export CSV",
     "exportCSVSPIGraphTip": "Export this data as a CSV file"
   },

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "Número máximo de elementos devueltos (para el primer campo seleccionado)",
     "graphType": "Tipo de gráfico",
     "graphType-default": "Línea de tiempo/mapa",
+    "graphType-heatmap": "Mapa de calor",
     "graphType-pie": "Dona",
     "graphType-table": "Tabla",
     "graphType-treemap": "Mapa de árbol",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "Alfabéticamente",
     "sortBy-graph": "Conteo",
     "refreshEvery": "Actualizar cada",
+    "intensity": "Intensidad",
+    "sessions": "Sesiones",
     "exportCSV": "Exportar CSV",
     "exportCSVSPIGraphTip": "Exportar estos datos como archivo CSV"
   },

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "Conteo",
     "refreshEvery": "Actualizar cada",
     "intensity": "Intensidad",
+    "showCount": "Mostrar recuento",
     "sessions": "Sesiones",
     "exportCSV": "Exportar CSV",
     "exportCSVSPIGraphTip": "Exportar estos datos como archivo CSV"

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -1404,7 +1404,7 @@
     "maxElements": "Elementos máximos",
     "maxElementsTip": "Número máximo de elementos devueltos (para el primer campo seleccionado)",
     "graphType": "Tipo de gráfico",
-    "graphType-default": "Línea de tiempo/mapa",
+    "graphType-default": "Línea de tiempo",
     "graphType-heatmap": "Mapa de calor",
     "graphType-pie": "Dona",
     "graphType-table": "Tabla",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -1404,7 +1404,7 @@
     "maxElements": "Maksimaalne elementide arv",
     "maxElementsTip": "Tagastatud elementide maksimaalne arv (esimese valitud välja jaoks)",
     "graphType": "Graafiku tüüp",
-    "graphType-default": "Ajajoon/kaart",
+    "graphType-default": "Ajajoon",
     "graphType-heatmap": "Soojuskaart",
     "graphType-pie": "Sõõrik",
     "graphType-table": "Tabel",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "Tagastatud elementide maksimaalne arv (esimese valitud välja jaoks)",
     "graphType": "Graafiku tüüp",
     "graphType-default": "Ajajoon/kaart",
+    "graphType-heatmap": "Soojuskaart",
     "graphType-pie": "Sõõrik",
     "graphType-table": "Tabel",
     "graphType-treemap": "Puukaart",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "Tähestikuliselt",
     "sortBy-graph": "Loendus",
     "refreshEvery": "Värskenda iga",
+    "intensity": "Intensiivsus",
+    "sessions": "Seansid",
     "exportCSV": "Ekspordi CSV",
     "exportCSVSPIGraphTip": "Ekspordi SPI graafiku andmed CSV kujul"
   },

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "Loendus",
     "refreshEvery": "Värskenda iga",
     "intensity": "Intensiivsus",
+    "showCount": "Näita arvu",
     "sessions": "Seansid",
     "exportCSV": "Ekspordi CSV",
     "exportCSVSPIGraphTip": "Ekspordi SPI graafiku andmed CSV kujul"

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "Compte",
     "refreshEvery": "Actualiser toutes les",
     "intensity": "Intensité",
+    "showCount": "Afficher le nombre",
     "sessions": "Sessions",
     "exportCSV": "Exporter CSV",
     "exportCSVSPIGraphTip": "Exporter les données du graphique SPI au format CSV"

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "Nombre maximum d'éléments retournés (pour le premier champ sélectionné)",
     "graphType": "Type de graphique",
     "graphType-default": "Chronologie/carte",
+    "graphType-heatmap": "Carte thermique",
     "graphType-pie": "Beignet",
     "graphType-table": "Tableau",
     "graphType-treemap": "Treemap",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "Alphabétiquement",
     "sortBy-graph": "Compte",
     "refreshEvery": "Actualiser toutes les",
+    "intensity": "Intensité",
+    "sessions": "Sessions",
     "exportCSV": "Exporter CSV",
     "exportCSVSPIGraphTip": "Exporter les données du graphique SPI au format CSV"
   },

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -1404,7 +1404,7 @@
     "maxElements": "Max. éléments",
     "maxElementsTip": "Nombre maximum d'éléments retournés (pour le premier champ sélectionné)",
     "graphType": "Type de graphique",
-    "graphType-default": "Chronologie/carte",
+    "graphType-default": "Chronologie",
     "graphType-heatmap": "Carte thermique",
     "graphType-pie": "Beignet",
     "graphType-table": "Tableau",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "カウント順",
     "refreshEvery": "更新間隔",
     "intensity": "強度",
+    "showCount": "件数を表示",
     "sessions": "セッション",
     "exportCSV": "CSV をエクスポート",
     "exportCSVSPIGraphTip": "このデータを CSV ファイルとしてエクスポート"

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "返される最大要素数（最初に選択されたフィールドに適用）",
     "graphType": "グラフタイプ",
     "graphType-default": "タイムライン/マップ",
+    "graphType-heatmap": "ヒートマップ",
     "graphType-pie": "ドーナツ",
     "graphType-table": "テーブル",
     "graphType-treemap": "ツリーマップ",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "アルファベット順",
     "sortBy-graph": "カウント順",
     "refreshEvery": "更新間隔",
+    "intensity": "強度",
+    "sessions": "セッション",
     "exportCSV": "CSV をエクスポート",
     "exportCSVSPIGraphTip": "このデータを CSV ファイルとしてエクスポート"
   },

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -1404,7 +1404,7 @@
     "maxElements": "最大要素数",
     "maxElementsTip": "返される最大要素数（最初に選択されたフィールドに適用）",
     "graphType": "グラフタイプ",
-    "graphType-default": "タイムライン/マップ",
+    "graphType-default": "タイムライン",
     "graphType-heatmap": "ヒートマップ",
     "graphType-pie": "ドーナツ",
     "graphType-table": "テーブル",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "반환되는 최대 요소 수 (선택된 첫 번째 필드 기준)",
     "graphType": "그래프 유형",
     "graphType-default": "타임라인/지도",
+    "graphType-heatmap": "히트맵",
     "graphType-pie": "도넛형",
     "graphType-table": "테이블",
     "graphType-treemap": "트리맵",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "사전순",
     "sortBy-graph": "개수",
     "refreshEvery": "새로고침 주기",
+    "intensity": "강도",
+    "sessions": "세션",
     "exportCSV": "CSV 내보내기",
     "exportCSVSPIGraphTip": "이 데이터를 CSV 파일로 내보내기"
   },

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "개수",
     "refreshEvery": "새로고침 주기",
     "intensity": "강도",
+    "showCount": "개수 표시",
     "sessions": "세션",
     "exportCSV": "CSV 내보내기",
     "exportCSVSPIGraphTip": "이 데이터를 CSV 파일로 내보내기"

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -1404,7 +1404,7 @@
     "maxElements": "최대 요소 수",
     "maxElementsTip": "반환되는 최대 요소 수 (선택된 첫 번째 필드 기준)",
     "graphType": "그래프 유형",
-    "graphType-default": "타임라인/지도",
+    "graphType-default": "타임라인",
     "graphType-heatmap": "히트맵",
     "graphType-pie": "도넛형",
     "graphType-table": "테이블",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -1404,7 +1404,7 @@
     "maxElements": "Máx de Elementos",
     "maxElementsTip": "Número máximo de elementos retornados (para o primeiro campo selecionado)",
     "graphType": "Tipo de Gráfico",
-    "graphType-default": "Linha do tempo/mapa",
+    "graphType-default": "Linha do tempo",
     "graphType-heatmap": "Mapa de calor",
     "graphType-pie": "Rosca",
     "graphType-table": "Tabela",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "Número máximo de elementos retornados (para o primeiro campo selecionado)",
     "graphType": "Tipo de Gráfico",
     "graphType-default": "Linha do tempo/mapa",
+    "graphType-heatmap": "Mapa de calor",
     "graphType-pie": "Rosca",
     "graphType-table": "Tabela",
     "graphType-treemap": "Treemap",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "Alfabeticamente",
     "sortBy-graph": "Contagem",
     "refreshEvery": "Atualizar a cada",
+    "intensity": "Intensidade",
+    "sessions": "Sessões",
     "exportCSV": "Exportar CSV",
     "exportCSVSPIGraphTip": "Exportar estes dados como arquivo CSV"
   },

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "Contagem",
     "refreshEvery": "Atualizar a cada",
     "intensity": "Intensidade",
+    "showCount": "Mostrar contagem",
     "sessions": "Sessões",
     "exportCSV": "Exportar CSV",
     "exportCSVSPIGraphTip": "Exportar estes dados como arquivo CSV"

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -1406,6 +1406,7 @@
     "maxElementsTip": "Aximummay umbernay ofway elementsway eturnedray (orfay ethay irtsfay ieldfay electedsay)",
     "graphType": "Raphgray Ypetay",
     "graphType-default": "Imelinetay/apmay",
+    "graphType-heatmap": "Eatmaphay",
     "graphType-pie": "Onutday",
     "graphType-table": "Abletay",
     "graphType-treemap": "Eemaptray",
@@ -1415,6 +1416,8 @@
     "sortBy-name": "Alphabeticallyway",
     "sortBy-graph": "Ountcay",
     "refreshEvery": "Efreshrway everyway",
+    "intensity": "Intensityway",
+    "sessions": "Essionssay",
     "exportCSV": "Exportway SVCAY",
     "exportCSVSPIGraphTip": "Exportway isthay ataday asway away SVCAY ilefay"
   },

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -1405,7 +1405,7 @@
     "maxElements": "Axmay Elementsway",
     "maxElementsTip": "Aximummay umbernay ofway elementsway eturnedray (orfay ethay irtsfay ieldfay electedsay)",
     "graphType": "Raphgray Ypetay",
-    "graphType-default": "Imelinetay/apmay",
+    "graphType-default": "Imelinetay",
     "graphType-heatmap": "Eatmaphay",
     "graphType-pie": "Onutday",
     "graphType-table": "Abletay",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -1417,6 +1417,7 @@
     "sortBy-graph": "Ountcay",
     "refreshEvery": "Efreshrway everyway",
     "intensity": "Intensityway",
+    "showCount": "Owshay ountcay",
     "sessions": "Essionssay",
     "exportCSV": "Exportway SVCAY",
     "exportCSVSPIGraphTip": "Exportway isthay ataday asway away SVCAY ilefay"

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -1404,7 +1404,7 @@
     "maxElements": "最大元素数",
     "maxElementsTip": "返回的最大元素数（针对第一个选定字段）",
     "graphType": "图表类型",
-    "graphType-default": "时间线/地图",
+    "graphType-default": "时间线",
     "graphType-heatmap": "热力图",
     "graphType-pie": "圆环图",
     "graphType-table": "表格",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -1405,6 +1405,7 @@
     "maxElementsTip": "返回的最大元素数（针对第一个选定字段）",
     "graphType": "图表类型",
     "graphType-default": "时间线/地图",
+    "graphType-heatmap": "热力图",
     "graphType-pie": "圆环图",
     "graphType-table": "表格",
     "graphType-treemap": "树状图",
@@ -1414,6 +1415,8 @@
     "sortBy-name": "按字母顺序",
     "sortBy-graph": "按计数",
     "refreshEvery": "每隔多久刷新一次",
+    "intensity": "强度",
+    "sessions": "会话",
     "exportCSV": "导出 CSV",
     "exportCSVSPIGraphTip": "以 CSV 格式导出 SPI 图表数据"
   },

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -1416,6 +1416,7 @@
     "sortBy-graph": "按计数",
     "refreshEvery": "每隔多久刷新一次",
     "intensity": "强度",
+    "showCount": "显示计数",
     "sessions": "会话",
     "exportCSV": "导出 CSV",
     "exportCSVSPIGraphTip": "以 CSV 格式导出 SPI 图表数据"

--- a/viewer/vueapp/src/components/spigraph/Heatmap.vue
+++ b/viewer/vueapp/src/components/spigraph/Heatmap.vue
@@ -15,13 +15,16 @@ SPDX-License-Identifier: Apache-2.0
       </div>
 
       <div class="heatmap-body">
-        <div class="heatmap-labels">
+        <div
+          class="heatmap-labels"
+          :style="{ flex: '0 0 ' + labelW + 'px', width: labelW + 'px' }">
           <div
             v-for="(row, r) in rows"
             :key="row.name"
             class="heatmap-row-label"
             :class="{ 'heatmap-row-alt': r % 2 }"
-            :style="{ height: rowH + 'px' }">
+            :style="{ height: rowH + 'px' }"
+            :title="row.name">
             <arkime-session-field
               :field="fieldObj"
               :value="row.name"
@@ -32,6 +35,10 @@ SPDX-License-Identifier: Apache-2.0
             <sup>({{ commaString(row.total) }})</sup>
           </div>
         </div>
+
+        <div
+          class="heatmap-divider"
+          @mousedown="startDrag" />
 
         <div
           ref="grid"
@@ -90,6 +97,7 @@ import { commaString, timezoneDateString, humanReadableBytes, humanReadableNumbe
 
 const ROW_H = 26;
 const AXIS_H = 18;
+const LABEL_W = 200; // value-label gutter width (px), draggable
 const MIN_COL_PX = 6; // rebucket columns once cells would be narrower than this
 
 export default {
@@ -107,6 +115,7 @@ export default {
       rowH: ROW_H,
       axisH: AXIS_H,
       gridWidth: 600,
+      labelW: LABEL_W,
       tooltip: null
     };
   },
@@ -232,6 +241,12 @@ export default {
       return out;
     }
   },
+  watch: {
+    // resizing the label gutter changes the grid width — remeasure after layout
+    labelW () {
+      this.$nextTick(() => this.measure());
+    }
+  },
   mounted () {
     this.measure();
     this._resize = () => this.measure();
@@ -251,6 +266,22 @@ export default {
     measure () {
       const w = this.$refs.grid?.clientWidth;
       if (w && w > 0) { this.gridWidth = w; }
+    },
+    startDrag (e) {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startW = this.labelW;
+      const bodyW = this.$refs.root?.clientWidth || 1000;
+      const onMove = (ev) => {
+        const next = startW + (ev.clientX - startX);
+        this.labelW = Math.max(80, Math.min(bodyW - 120, next));
+      };
+      const onUp = () => {
+        window.removeEventListener('mousemove', onMove);
+        window.removeEventListener('mouseup', onUp);
+      };
+      window.addEventListener('mousemove', onMove);
+      window.addEventListener('mouseup', onUp);
     },
     cellFill (v) {
       const norm = this.maxVal > 0 ? v / this.maxVal : 0;
@@ -309,11 +340,19 @@ export default {
   display: flex;
   align-items: flex-start;
 }
-/* divider marks where the timeline starts */
 .spigraph-heatmap .heatmap-labels {
   flex: 0 0 200px;
   width: 200px;
-  border-right: 2px solid rgba(var(--v-theme-foreground), 0.45);
+}
+/* draggable divider marks where the timeline starts */
+.spigraph-heatmap .heatmap-divider {
+  flex: 0 0 5px;
+  align-self: stretch;
+  cursor: col-resize;
+  border-left: 2px solid rgba(var(--v-theme-foreground), 0.45);
+}
+.spigraph-heatmap .heatmap-divider:hover {
+  border-left-color: rgb(var(--v-theme-foreground-accent));
 }
 .spigraph-heatmap .heatmap-row-label {
   display: flex;

--- a/viewer/vueapp/src/components/spigraph/Heatmap.vue
+++ b/viewer/vueapp/src/components/spigraph/Heatmap.vue
@@ -8,6 +8,12 @@ SPDX-License-Identifier: Apache-2.0
     class="spigraph-heatmap">
     <template v-if="rows.length && cols.length">
       <div class="heatmap-legend">
+        <v-checkbox-btn
+          v-model="showCount"
+          :label="$t('spigraph.showCount')"
+          density="compact"
+          hide-details
+          class="heatmap-count-toggle me-auto" />
         <span class="heatmap-legend-label">{{ metricLabel }}</span>
         <span class="heatmap-legend-min">0</span>
         <span class="heatmap-legend-bar" />
@@ -25,6 +31,9 @@ SPDX-License-Identifier: Apache-2.0
             :class="{ 'heatmap-row-alt': r % 2 }"
             :style="{ height: rowH + 'px' }"
             :title="row.name">
+            <span
+              v-if="showCount"
+              class="heatmap-row-count">{{ commaString(row.total) }}</span>
             <arkime-session-field
               :field="fieldObj"
               :value="row.name"
@@ -32,7 +41,6 @@ SPDX-License-Identifier: Apache-2.0
               :parse="true"
               :pull-left="true"
               :session-btn="true" />
-            <sup>({{ commaString(row.total) }})</sup>
           </div>
         </div>
 
@@ -97,7 +105,7 @@ import { commaString, timezoneDateString, humanReadableBytes, humanReadableNumbe
 
 const ROW_H = 26;
 const AXIS_H = 18;
-const LABEL_W = 200; // value-label gutter width (px), draggable
+const LABEL_W = 280; // value-label gutter width (px), draggable
 const MIN_COL_PX = 6; // rebucket columns once cells would be narrower than this
 
 export default {
@@ -116,6 +124,7 @@ export default {
       axisH: AXIS_H,
       gridWidth: 600,
       labelW: LABEL_W,
+      showCount: true,
       tooltip: null
     };
   },
@@ -315,7 +324,6 @@ export default {
 <style scoped>
 .spigraph-heatmap {
   position: relative;
-  padding: 10px;
 }
 .spigraph-heatmap .heatmap-legend {
   display: flex;
@@ -324,6 +332,17 @@ export default {
   gap: 4px;
   font-size: 0.75rem;
   padding-bottom: 8px;
+}
+.spigraph-heatmap .heatmap-count-toggle {
+  flex: 0 0 auto;
+}
+.spigraph-heatmap .heatmap-count-toggle :deep(.v-label) {
+  font-size: 0.75rem;
+  opacity: 1;
+}
+.spigraph-heatmap .heatmap-count-toggle :deep(.v-selection-control__wrapper) {
+  width: 28px;
+  height: 28px;
 }
 .spigraph-heatmap .heatmap-legend-bar {
   display: inline-block;
@@ -359,24 +378,31 @@ export default {
   align-items: center;
   white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
   font-size: 0.8rem;
   padding: 0 6px;
-  background-color: rgb(var(--v-theme-quaternary-lightest));
+  background-color: rgba(var(--v-theme-foreground), 0.04);
 }
 .spigraph-heatmap .heatmap-row-label.heatmap-row-alt {
   background-color: transparent;
 }
-.spigraph-heatmap .heatmap-row-label sup {
-  margin-left: 2px;
-  opacity: 0.7;
+/* fixed-width count column so the value labels all align */
+.spigraph-heatmap .heatmap-row-count {
+  flex: 0 0 64px;
+  box-sizing: border-box;
+  margin-right: 6px;
+  padding: 1px 6px;
+  border-radius: 9px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-align: center;
+  background-color: rgba(var(--v-theme-foreground), 0.1);
 }
 .spigraph-heatmap .heatmap-grid {
   flex: 1 1 auto;
   min-width: 0;
 }
 .spigraph-heatmap .heatmap-track {
-  fill: rgb(var(--v-theme-quaternary-lightest));
+  fill: rgba(var(--v-theme-foreground), 0.04);
 }
 .spigraph-heatmap .heatmap-track-alt {
   fill: transparent;

--- a/viewer/vueapp/src/components/spigraph/Heatmap.vue
+++ b/viewer/vueapp/src/components/spigraph/Heatmap.vue
@@ -1,0 +1,362 @@
+<!--
+Copyright Yahoo Inc.
+SPDX-License-Identifier: Apache-2.0
+-->
+<template>
+  <div
+    ref="root"
+    class="spigraph-heatmap">
+    <template v-if="rows.length && cols.length">
+      <div class="heatmap-legend">
+        <span class="heatmap-legend-label">{{ metricLabel }}</span>
+        <span class="heatmap-legend-min">0</span>
+        <span class="heatmap-legend-bar" />
+        <span class="heatmap-legend-max">{{ formatVal(maxVal) }}</span>
+      </div>
+
+      <div class="heatmap-body">
+        <div class="heatmap-labels">
+          <div
+            v-for="(row, r) in rows"
+            :key="row.name"
+            class="heatmap-row-label"
+            :class="{ 'heatmap-row-alt': r % 2 }"
+            :style="{ height: rowH + 'px' }">
+            <arkime-session-field
+              :field="fieldObj"
+              :value="row.name"
+              :expr="fieldObj.exp"
+              :parse="true"
+              :pull-left="true"
+              :session-btn="true" />
+            <sup>({{ commaString(row.total) }})</sup>
+          </div>
+        </div>
+
+        <div
+          ref="grid"
+          class="heatmap-grid">
+          <svg
+            :width="gridWidth"
+            :height="rows.length * rowH + axisH"
+            @mousemove="onMove"
+            @mouseleave="tooltip = null">
+            <rect
+              v-for="(row, r) in rows"
+              :key="'t' + r"
+              x="0"
+              :y="r * rowH"
+              :width="gridWidth"
+              :height="rowH"
+              :class="['heatmap-track', { 'heatmap-track-alt': r % 2 }]" />
+            <rect
+              v-for="cell in cells"
+              :key="cell.k"
+              :x="cell.x"
+              :y="cell.y"
+              :width="cell.w"
+              :height="rowH - 2"
+              :style="{ fill: cell.fill }" />
+            <g :transform="`translate(0, ${rows.length * rowH})`">
+              <text
+                v-for="tick in ticks"
+                :key="tick.x"
+                :x="tick.x"
+                y="14"
+                class="heatmap-tick"
+                :text-anchor="tick.anchor">
+                {{ tick.label }}
+              </text>
+            </g>
+          </svg>
+        </div>
+      </div>
+
+      <div
+        v-if="tooltip"
+        class="heatmap-tooltip"
+        :style="{ left: tooltip.x + 'px', top: tooltip.y + 'px' }">
+        <div><strong>{{ tooltip.name }}</strong></div>
+        <div>{{ tooltip.time }}</div>
+        <div>{{ metricLabel }}: {{ tooltip.value }}</div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+import { metricHistoKeys } from '../visualizations/metrics.js';
+import { commaString, timezoneDateString, humanReadableBytes, humanReadableNumber } from '@common/vueFilters.js';
+
+const ROW_H = 26;
+const AXIS_H = 18;
+const MIN_COL_PX = 6; // rebucket columns once cells would be narrower than this
+
+export default {
+  name: 'ArkimeHeatmap',
+  props: {
+    items: { type: Array, required: true }, // top-N values, each with item.graph
+    graph: { type: Object, required: true }, // aggregate graph (xmin/xmax/interval)
+    fieldObj: { type: Object, required: true },
+    metric: { type: String, default: 'sessionsHisto' },
+    timelineDataFilters: { type: Array, default: () => [] },
+    sortBy: { type: String, default: 'graph' } // 'name' | 'graph'
+  },
+  data () {
+    return {
+      rowH: ROW_H,
+      axisH: AXIS_H,
+      gridWidth: 600,
+      tooltip: null
+    };
+  },
+  computed: {
+    timezone () {
+      return this.$store.state.user.settings.timezone;
+    },
+    metricKeys () {
+      return metricHistoKeys(this.metric);
+    },
+    metricLabel () {
+      if (this.metric === 'sessionsHisto') { return this.$t('spigraph.sessions'); }
+      const filter = this.timelineDataFilters.find(f => f.dbField === this.metric.slice(0, -5));
+      return filter?.friendlyName || this.metric;
+    },
+    isBytes () {
+      return this.metric.toLowerCase().includes('bytes');
+    },
+    intervalMs () {
+      return (this.graph?.interval || 60) * 1000;
+    },
+    // backend xmin/xmax are null for relative ranges; fall back to the data
+    bounds () {
+      let xmin = this.graph?.xmin;
+      let xmax = this.graph?.xmax;
+      if (!xmin || !xmax) {
+        let lo = Infinity; let hi = -Infinity;
+        for (const item of this.items) {
+          for (const key of this.metricKeys) {
+            for (const [ts] of (item.graph?.[key] || [])) {
+              if (ts < lo) { lo = ts; }
+              if (ts > hi) { hi = ts; }
+            }
+          }
+        }
+        if (Number.isFinite(lo) && Number.isFinite(hi)) { xmin = lo; xmax = hi; }
+      }
+      return { xmin, xmax };
+    },
+    rawCols () {
+      const { xmin, xmax } = this.bounds;
+      if (!xmin || !xmax || !this.intervalMs) { return []; }
+      const out = [];
+      for (let t = xmin; t <= xmax; t += this.intervalMs) { out.push(t); }
+      return out;
+    },
+    factor () {
+      const maxCols = Math.max(1, Math.floor(this.gridWidth / MIN_COL_PX));
+      return this.rawCols.length > maxCols ? Math.ceil(this.rawCols.length / maxCols) : 1;
+    },
+    cols () {
+      const out = [];
+      for (let i = 0; i < this.rawCols.length; i += this.factor) { out.push(this.rawCols[i]); }
+      return out;
+    },
+    colSpanMs () {
+      return this.intervalMs * this.factor;
+    },
+    colW () {
+      return this.cols.length ? this.gridWidth / this.cols.length : 0;
+    },
+    rows () {
+      const { xmin } = this.bounds;
+      if (!xmin || !this.cols.length) { return []; }
+      const span = this.colSpanMs;
+      const rows = this.items.map((item) => {
+        const values = new Array(this.cols.length).fill(0);
+        for (const key of this.metricKeys) {
+          for (const [ts, val] of (item.graph?.[key] || [])) {
+            const idx = Math.floor((ts - xmin) / span);
+            if (idx >= 0 && idx < values.length) { values[idx] += val; }
+          }
+        }
+        const total = values.reduce((a, b) => a + b, 0);
+        return { name: item.name, values, total };
+      });
+      if (this.sortBy === 'name') {
+        rows.sort((a, b) => String(a.name).localeCompare(String(b.name)));
+      } else {
+        rows.sort((a, b) => b.total - a.total);
+      }
+      return rows;
+    },
+    maxVal () {
+      let max = 0;
+      for (const row of this.rows) {
+        for (const v of row.values) { if (v > max) { max = v; } }
+      }
+      return max;
+    },
+    cells () {
+      const out = [];
+      const w = Math.max(1, this.colW - 1);
+      for (let r = 0; r < this.rows.length; r++) {
+        const values = this.rows[r].values;
+        for (let c = 0; c < values.length; c++) {
+          const v = values[c];
+          if (v <= 0) { continue; }
+          out.push({
+            k: r + '-' + c,
+            x: c * this.colW + 0.5,
+            y: r * this.rowH + 1,
+            w,
+            fill: this.cellFill(v)
+          });
+        }
+      }
+      return out;
+    },
+    ticks () {
+      if (!this.cols.length) { return []; }
+      const count = Math.min(6, this.cols.length);
+      const out = [];
+      for (let i = 0; i < count; i++) {
+        const idx = Math.round((this.cols.length - 1) * (i / Math.max(1, count - 1)));
+        const x = idx * this.colW + this.colW / 2;
+        out.push({
+          x,
+          label: timezoneDateString(this.cols[idx], this.timezone),
+          anchor: i === 0 ? 'start' : (i === count - 1 ? 'end' : 'middle')
+        });
+      }
+      return out;
+    }
+  },
+  mounted () {
+    this.measure();
+    this._resize = () => this.measure();
+    window.addEventListener('resize', this._resize);
+    if (typeof ResizeObserver !== 'undefined' && this.$refs.root) {
+      // observe root (always present); the grid may mount later once data arrives
+      this._ro = new ResizeObserver(() => this.measure());
+      this._ro.observe(this.$refs.root);
+    }
+  },
+  beforeUnmount () {
+    window.removeEventListener('resize', this._resize);
+    if (this._ro) { this._ro.disconnect(); }
+  },
+  methods: {
+    commaString,
+    measure () {
+      const w = this.$refs.grid?.clientWidth;
+      if (w && w > 0) { this.gridWidth = w; }
+    },
+    cellFill (v) {
+      const norm = this.maxVal > 0 ? v / this.maxVal : 0;
+      const alpha = (0.12 + 0.88 * norm).toFixed(3);
+      return `rgba(var(--v-theme-foreground-accent), ${alpha})`;
+    },
+    formatVal (v) {
+      return this.isBytes ? humanReadableBytes(v) : humanReadableNumber(v);
+    },
+    onMove (e) {
+      const svgRect = e.currentTarget.getBoundingClientRect();
+      const c = Math.floor((e.clientX - svgRect.left) / this.colW);
+      const r = Math.floor((e.clientY - svgRect.top) / this.rowH);
+      if (r < 0 || r >= this.rows.length || c < 0 || c >= this.cols.length) {
+        this.tooltip = null;
+        return;
+      }
+      const rootRect = this.$refs.root.getBoundingClientRect();
+      this.tooltip = {
+        x: e.clientX - rootRect.left + 14,
+        y: e.clientY - rootRect.top + 8,
+        name: this.rows[r].name,
+        time: timezoneDateString(this.cols[c], this.timezone),
+        value: this.formatVal(this.rows[r].values[c])
+      };
+    }
+  }
+};
+</script>
+
+<style scoped>
+.spigraph-heatmap {
+  position: relative;
+  padding: 10px;
+}
+.spigraph-heatmap .heatmap-legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  font-size: 0.75rem;
+  padding-bottom: 8px;
+}
+.spigraph-heatmap .heatmap-legend-bar {
+  display: inline-block;
+  width: 90px;
+  height: 10px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to right,
+    rgba(var(--v-theme-foreground-accent), 0.12),
+    rgba(var(--v-theme-foreground-accent), 1)
+  );
+}
+.spigraph-heatmap .heatmap-body {
+  display: flex;
+  align-items: flex-start;
+}
+/* divider marks where the timeline starts */
+.spigraph-heatmap .heatmap-labels {
+  flex: 0 0 200px;
+  width: 200px;
+  border-right: 2px solid rgba(var(--v-theme-foreground), 0.45);
+}
+.spigraph-heatmap .heatmap-row-label {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.8rem;
+  padding: 0 6px;
+  background-color: rgb(var(--v-theme-quaternary-lightest));
+}
+.spigraph-heatmap .heatmap-row-label.heatmap-row-alt {
+  background-color: transparent;
+}
+.spigraph-heatmap .heatmap-row-label sup {
+  margin-left: 2px;
+  opacity: 0.7;
+}
+.spigraph-heatmap .heatmap-grid {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.spigraph-heatmap .heatmap-track {
+  fill: rgb(var(--v-theme-quaternary-lightest));
+}
+.spigraph-heatmap .heatmap-track-alt {
+  fill: transparent;
+}
+.spigraph-heatmap .heatmap-tick {
+  fill: rgb(var(--v-theme-foreground));
+  font-size: 10px;
+  opacity: 0.7;
+}
+.spigraph-heatmap .heatmap-tooltip {
+  position: absolute;
+  z-index: 10;
+  pointer-events: none;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  border-radius: 3px;
+  background-color: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-foreground));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+</style>

--- a/viewer/vueapp/src/components/spigraph/Spigraph.vue
+++ b/viewer/vueapp/src/components/spigraph/Spigraph.vue
@@ -82,10 +82,30 @@ SPDX-License-Identifier: Apache-2.0
                 id="connections-controls-anchor"
                 class="connections-controls-anchor d-flex flex-wrap align-center gap-1 mt-1 mb-1" />
 
+              <!-- intensity select (heatmap only) -->
+              <div
+                class="arkime-input-group"
+                v-if="spiGraphType === 'heatmap'">
+                <span class="arkime-input-label">
+                  {{ $t('spigraph.intensity') }}:
+                </span>
+                <select
+                  class="arkime-input-control"
+                  :value="intensity"
+                  @change="changeIntensity($event.target.value)">
+                  <option
+                    v-for="opt in intensityOptions"
+                    :key="opt.value"
+                    :value="opt.value">
+                    {{ opt.label }}
+                  </option>
+                </select>
+              </div> <!-- /intensity select -->
+
               <!-- sort select (not shown for the pie graph) -->
               <div
                 class="arkime-input-group"
-                v-if="spiGraphType === 'default'">
+                v-if="spiGraphType === 'default' || spiGraphType === 'heatmap'">
                 <span class="arkime-input-label">
                   {{ $t('spigraph.sortBy') }}:
                 </span>
@@ -105,7 +125,7 @@ SPDX-License-Identifier: Apache-2.0
               <!-- refresh input (not shown for pie) -->
               <div
                 class="arkime-input-group"
-                v-if="spiGraphType === 'default'">
+                v-if="spiGraphType === 'default' || spiGraphType === 'heatmap'">
                 <span class="arkime-input-label">
                   {{ $t('spigraph.refreshEvery') }}:
                 </span>
@@ -128,7 +148,7 @@ SPDX-License-Identifier: Apache-2.0
               <!-- page info -->
               <div
                 class="records-display align-self-center"
-                v-if="spiGraphType === 'default'">
+                v-if="spiGraphType === 'default' || spiGraphType === 'heatmap'">
                 <strong
                   class="text-theme-accent"
                   v-if="!error && recordsFiltered !== undefined">
@@ -177,8 +197,20 @@ SPDX-License-Identifier: Apache-2.0
     <div
       class="spigraph-content"
       v-if="spiGraphType !== 'connections'">
+      <!-- heatmap graph type -->
+      <div v-if="spiGraphType === 'heatmap'">
+        <arkime-heatmap
+          v-if="items && items.length && fieldObj && graphData"
+          :items="items"
+          :graph="graphData"
+          :field-obj="fieldObj"
+          :metric="intensity"
+          :timeline-data-filters="timelineDataFilters"
+          :sort-by="sortBy" />
+      </div> <!-- /heatmap graph type -->
+
       <!-- pie graph type -->
-      <div v-if="spiGraphType !== 'default'">
+      <div v-else-if="spiGraphType !== 'default'">
         <arkime-pie
           v-if="items && items.length"
           :base-field="baseField"
@@ -285,6 +317,7 @@ import ArkimeVisualizations from '../visualizations/Visualizations.vue';
 import ArkimeCollapsible from '../utils/CollapsibleWrapper.vue';
 import PageLayout from '../utils/PageLayout.vue';
 import ArkimePie from './Hierarchy.vue';
+import ArkimeHeatmap from './Heatmap.vue';
 import ArkimeConnectionsGraph from '../connections/ConnectionsGraph.vue';
 import { commaString } from '@common/vueFilters.js';
 import { resolveMessage } from '@common/resolveI18nMessage';
@@ -307,6 +340,7 @@ export default {
     ArkimeCollapsible,
     PageLayout,
     ArkimePie,
+    ArkimeHeatmap,
     ArkimeConnectionsGraph
   },
   data: function () {
@@ -333,7 +367,7 @@ export default {
       // <option> blocks into one.
       maxElementsOptions: [5, 10, 15, 20, 30, 50, 100, 200, 500],
       refreshOptions: [0, 5, 10, 15, 30, 45, 60],
-      graphTypeOptions: ['default', 'pie', 'table', 'treemap', 'sankey', 'connections']
+      graphTypeOptions: ['default', 'heatmap', 'pie', 'table', 'treemap', 'sankey', 'connections']
     };
   },
   computed: {
@@ -346,6 +380,21 @@ export default {
     },
     graphType: function () {
       return this.$store.state.graphType;
+    },
+    // heatmap intensity choices: sessions + each timeline metric
+    intensityOptions: function () {
+      const opts = [{ value: 'sessionsHisto', label: this.$t('spigraph.sessions') }];
+      for (const f of this.timelineDataFilters) {
+        opts.push({ value: f.dbField + 'Histo', label: f.friendlyName });
+      }
+      return opts;
+    },
+    intensity: function () {
+      // graphType may name a metric whose timeline filter was since removed
+      if (this.graphType && this.intensityOptions.some(o => o.value === this.graphType)) {
+        return this.graphType;
+      }
+      return 'sessionsHisto';
     },
     query: function () {
       let sort = 'name';
@@ -472,6 +521,11 @@ export default {
         }
       });
     },
+    changeIntensity: function (value) {
+      // recolors + re-sorts client-side (all metrics are already fetched); the
+      // backend top-N ranking only switches to this metric on the next fetch
+      this.$store.commit('updateGraphType', value);
+    },
     changeSortBy: function (sortBy) {
       this.sortBy = sortBy;
       if (this.sortBy === 'graph') {
@@ -511,6 +565,8 @@ export default {
         this.query.sort = this.graphType;
         this.refresh = 0;
         this.changeRefreshInterval(0);
+      } else if (this.spiGraphType === 'heatmap') {
+        if (!this.graphType) { this.$store.commit('updateGraphType', 'sessionsHisto'); }
       } else if (this.spiGraphType === 'connections') {
         // connections owns its data; stop spigraph refresh
         this.refresh = 0;

--- a/viewer/vueapp/src/components/visualizations/TimelineGraph.vue
+++ b/viewer/vueapp/src/components/visualizations/TimelineGraph.vue
@@ -21,6 +21,7 @@ import uPlot from 'uplot';
 import { themedColor } from '@common/themes/themedColor.js';
 import 'uplot/dist/uPlot.min.css';
 import { commaString, timezoneDateString, humanReadableBytes, humanReadableNumber } from '@common/vueFilters.js';
+import { COMPOSITE_METRICS } from './metrics.js';
 import moment from 'moment-timezone';
 
 const HOST_HEIGHT = 180;
@@ -89,27 +90,15 @@ export default {
       this.restartColor = this.foregroundColor;
     },
     seriesDefsFor (type) {
-      switch (type) {
-      case 'totPacketsHisto':
-      case 'network.packetsHisto':
-        return [
-          { label: 'Src packets', key: 'source.packetsHisto', color: this.srcColor },
-          { label: 'Dst packets', key: 'destination.packetsHisto', color: this.dstColor }
-        ];
-      case 'totBytesHisto':
-      case 'network.bytesHisto':
-        return [
-          { label: 'Src bytes', key: 'source.bytesHisto', color: this.srcColor },
-          { label: 'Dst bytes', key: 'destination.bytesHisto', color: this.dstColor }
-        ];
-      case 'totDataBytesHisto':
-        return [
-          { label: 'Client bytes', key: 'client.bytesHisto', color: this.srcColor },
-          { label: 'Server bytes', key: 'server.bytesHisto', color: this.dstColor }
-        ];
-      default:
-        return [{ label: this.friendlyTypeName(type), key: type, color: this.foregroundColor }];
+      const defs = COMPOSITE_METRICS[type];
+      if (defs) {
+        return defs.map(d => ({
+          label: d.label,
+          key: d.key,
+          color: d.role === 'src' ? this.srcColor : this.dstColor
+        }));
       }
+      return [{ label: this.friendlyTypeName(type), key: type, color: this.foregroundColor }];
     },
     friendlyTypeName (type) {
       if (type === 'sessionsHisto') return 'Sessions';

--- a/viewer/vueapp/src/components/visualizations/metrics.js
+++ b/viewer/vueapp/src/components/visualizations/metrics.js
@@ -1,0 +1,26 @@
+// Composite timeline metrics: the *Histo keys that sum into each selectable
+// metric, with the src/dst role used for series color. Single source of truth
+// shared by TimelineGraph (series defs) and Heatmap (intensity binning).
+export const COMPOSITE_METRICS = {
+  'network.packetsHisto': [
+    { key: 'source.packetsHisto', label: 'Src packets', role: 'src' },
+    { key: 'destination.packetsHisto', label: 'Dst packets', role: 'dst' }
+  ],
+  'network.bytesHisto': [
+    { key: 'source.bytesHisto', label: 'Src bytes', role: 'src' },
+    { key: 'destination.bytesHisto', label: 'Dst bytes', role: 'dst' }
+  ],
+  totDataBytesHisto: [
+    { key: 'client.bytesHisto', label: 'Client bytes', role: 'src' },
+    { key: 'server.bytesHisto', label: 'Server bytes', role: 'dst' }
+  ]
+};
+// legacy aliases
+COMPOSITE_METRICS.totPacketsHisto = COMPOSITE_METRICS['network.packetsHisto'];
+COMPOSITE_METRICS.totBytesHisto = COMPOSITE_METRICS['network.bytesHisto'];
+
+// histo keys that sum into a metric; a non-composite metric is its own key
+export function metricHistoKeys (metric) {
+  const defs = COMPOSITE_METRICS[metric];
+  return defs ? defs.map(d => d.key) : [metric];
+}


### PR DESCRIPTION
Implements the Matrix Heatmap visualization from #3956 as a new **SPIGraph graph type**.

- **Y axis** — top-N values of any field (existing field picker + Max Elements)
- **X axis** — time buckets
- **Intensity** — a selectable metric (sessions by default, plus the configured timeline metrics: bytes / packets / data bytes)
- Sort rows alphabetically or by total; changing intensity or sort recolors & re-sorts **client-side** (no refetch)

### Implementation
Frontend-only — reuses the existing `/api/spigraph` response (each top-N item already carries its per-metric timeline), so there are **no backend/API changes**.

- New `Heatmap.vue` renders an SVG matrix (alternating row bands, hover tooltip, time-axis ticks, value legend).
- `Spigraph.vue` registers the `heatmap` graph type and adds the Intensity selector.
- New shared `visualizations/metrics.js` (`COMPOSITE_METRICS` / `metricHistoKeys`) deduplicates the metric→histo-key mapping previously copied in `TimelineGraph.seriesDefsFor` (behavior preserved).
- i18n keys added across all 10 locales.

### Scope
Targets the **SPIGraph** surface only; the "Arkime tab" placement also mentioned in #3956 is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
