### PR TITLE
Add find-in-content to session detail

### DIFF
--- a/common/vueapp/ContentFind.vue
+++ b/common/vueapp/ContentFind.vue
@@ -1,0 +1,162 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+-->
+<template>
+  <div class="tb-group content-find">
+    <v-text-field
+      :model-value="query"
+      :placeholder="placeholder"
+      prepend-inner-icon="mdi-magnify"
+      clearable
+      density="compact"
+      variant="outlined"
+      hide-details
+      :error="!!error"
+      :title="error || ''"
+      class="tshark-filter-input content-find-input"
+      @update:model-value="onInput"
+      @keydown.enter.prevent="onEnter" />
+
+    <!-- text mode: case-insensitive substring with an optional regex toggle -->
+    <v-btn
+      v-if="mode === 'text'"
+      :active="isRegex"
+      variant="text"
+      :title="$t('sessions.detail.findRegex')"
+      @click="toggleRegex">
+      <v-icon icon="mdi-regex" />
+    </v-btn>
+
+    <v-menu
+      v-else
+      location="bottom start">
+      <template #activator="{ props: activatorProps }">
+        <v-btn
+          v-bind="activatorProps"
+          variant="text"
+          :title="$t('sessions.detail.findTypeHint')"
+          class="packet-options-select-btn">
+          {{ $t('sessions.detail.findType.' + searchType) }}
+          <v-icon
+            icon="mdi-menu-down"
+            class="ms-1" />
+        </v-btn>
+      </template>
+      <v-list density="compact">
+        <v-list-item
+          v-for="st in searchTypes"
+          :key="st"
+          :active="st === searchType"
+          @click="setSearchType(st)">
+          {{ $t('sessions.detail.findType.' + st) }}
+        </v-list-item>
+      </v-list>
+    </v-menu>
+
+    <span
+      class="content-find-count"
+      :class="{ 'text-disabled': !matchCount }">
+      {{ countLabel }}
+    </span>
+    <v-btn
+      icon="mdi-chevron-up"
+      variant="text"
+      size="small"
+      :disabled="!matchCount"
+      :title="$t('sessions.detail.findPrev')"
+      @click="$emit('prev')" />
+    <v-btn
+      icon="mdi-chevron-down"
+      variant="text"
+      size="small"
+      :disabled="!matchCount"
+      :title="$t('sessions.detail.findNext')"
+      @click="$emit('next')" />
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue';
+
+const props = defineProps({
+  mode: { type: String, default: 'text' }, // 'text' (client) | 'bytes' (server)
+  matchCount: { type: Number, default: 0 },
+  currentIndex: { type: Number, default: -1 },
+  capped: { type: Boolean, default: false },
+  error: { type: String, default: '' },
+  placeholder: { type: String, default: '' },
+  initialQuery: { type: String, default: '' } // restore the box text when re-mounted (tab switch)
+});
+
+const emit = defineEmits(['search', 'next', 'prev']);
+
+const query = ref('');
+const isRegex = ref(false);
+const searchTypes = ['ascii', 'asciicase', 'hex', 'regex', 'hexregex'];
+const searchType = ref('ascii');
+
+let debounceTimeout = null;
+
+const payload = () => props.mode === 'bytes'
+  ? { query: query.value, searchType: searchType.value }
+  : { query: query.value, regex: isRegex.value };
+
+const emitSearch = () => {
+  debounceTimeout = null;
+  emit('search', payload());
+};
+
+const onInput = (val) => {
+  query.value = val ?? '';
+  if (debounceTimeout) { clearTimeout(debounceTimeout); }
+  if (!query.value) { emitSearch(); return; } // clear right away, don't wait out the debounce
+  debounceTimeout = setTimeout(emitSearch, 500);
+};
+
+// Enter commits a pending edit; with nothing pending it steps through hits (Shift = back).
+const onEnter = (e) => {
+  if (debounceTimeout) { clearTimeout(debounceTimeout); emitSearch(); return; }
+  e.shiftKey ? emit('prev') : emit('next');
+};
+
+const toggleRegex = () => {
+  isRegex.value = !isRegex.value;
+  if (query.value) { emitSearch(); }
+};
+
+const setSearchType = (st) => {
+  searchType.value = st;
+  if (query.value) { emitSearch(); }
+};
+
+const countLabel = computed(() => {
+  if (!query.value || props.error) { return ''; }
+  if (!props.matchCount) { return '0'; }
+  const total = props.capped ? `${props.matchCount}+` : props.matchCount;
+  if (props.currentIndex < 0) { return `${total}`; } // highlighted, not yet navigated
+  return `${props.currentIndex + 1}/${total}`;
+});
+
+// Let a parent drive the box (e.g. tshark histogram chips).
+const setQuery = (text, options = {}) => {
+  query.value = text ?? '';
+  if (options.regex !== undefined) { isRegex.value = options.regex; }
+  if (debounceTimeout) { clearTimeout(debounceTimeout); }
+  emitSearch();
+};
+
+defineExpose({ setQuery });
+
+onMounted(() => { if (props.initialQuery) { query.value = props.initialQuery; } });
+onUnmounted(() => { if (debounceTimeout) { clearTimeout(debounceTimeout); } });
+</script>
+
+<style scoped>
+.content-find-count {
+  font-size: 12px;
+  min-width: 2.5rem;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+</style>

--- a/common/vueapp/composables/useContentFind.js
+++ b/common/vueapp/composables/useContentFind.js
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+import { ref } from 'vue';
+
+const MARK_CLASS = 'find-hit';
+const START_CLASS = 'find-hit-start'; // one per match — used for counting/navigation
+const CURRENT_CLASS = 'find-hit--current';
+
+function escapeRegExp (s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// offsetParent catches a display:none ancestor; visibility inherits, so one
+// computed-style read catches a hidden (visibility:hidden/height:0) column.
+function hitVisible (el) {
+  return el.offsetParent !== null && window.getComputedStyle(el).visibility !== 'hidden';
+}
+
+// Find-in-content engine for a DOM subtree: marks matches and steps through them.
+// navigateOnly = don't mark, just collect server-rendered .find-hit spans (packets).
+export function useContentFind (getRoot, opts = {}) {
+  const { skipSelector = '', maxHits = 5000, navigateOnly = false, skipHidden = false, onBeforeNav } = opts;
+
+  const query = ref('');
+  const isRegex = ref(false);
+  const matchCount = ref(0);
+  const currentIndex = ref(-1);
+  const capped = ref(false);
+  const error = ref('');
+
+  let hits = [];
+
+  function reset () {
+    hits = [];
+    matchCount.value = 0;
+    currentIndex.value = -1;
+    capped.value = false;
+  }
+
+  function unmark (root) {
+    if (!root) { return; }
+    root.querySelectorAll('mark.' + MARK_CLASS).forEach((m) => {
+      const markParent = m.parentNode;
+      if (!markParent) { return; }
+      while (m.firstChild) { markParent.insertBefore(m.firstChild, m); }
+      markParent.removeChild(m);
+      markParent.normalize(); // re-merge split text nodes so repeated searches don't fragment
+    });
+  }
+
+  function buildMatcher () {
+    const q = (query.value || '').trim();
+    if (!q) { return null; }
+    error.value = '';
+    try {
+      return new RegExp(isRegex.value ? q : escapeRegExp(q), 'gi');
+    } catch (e) {
+      error.value = e.message || 'Invalid regex';
+      return null;
+    }
+  }
+
+  function skip (textNode) {
+    let el = textNode.parentElement;
+    while (el) {
+      const tag = el.tagName;
+      if (tag === 'SCRIPT' || tag === 'STYLE') { return true; }
+      if (el.classList && el.classList.contains(MARK_CLASS)) { return true; }
+      el = el.parentElement;
+    }
+    if (skipSelector && textNode.parentElement && textNode.parentElement.closest(skipSelector)) { return true; }
+    return false;
+  }
+
+  function setCurrent (idx, doScroll) {
+    hits.forEach((h, i) => h.classList.toggle(CURRENT_CLASS, i === idx));
+    currentIndex.value = idx;
+    if (doScroll && hits[idx]) {
+      if (onBeforeNav) { onBeforeNav(hits[idx]); }
+      hits[idx].scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }
+
+  // Collect server-rendered match anchors (navigateOnly mode). Highlights only —
+  // no current hit until the user navigates with next/prev.
+  function collectExisting (root) {
+    let found = Array.from(root.querySelectorAll('.' + START_CLASS));
+    if (found.length > maxHits) { found = found.slice(0, maxHits); capped.value = true; }
+    if (skipHidden) { found = found.filter(hitVisible); }
+    hits = found;
+    matchCount.value = hits.length;
+  }
+
+  function runHighlight () {
+    const root = getRoot();
+    if (!root) { reset(); return; }
+
+    if (navigateOnly) { reset(); collectExisting(root); return; }
+
+    unmark(root);
+    reset();
+
+    const re = buildMatcher();
+    if (!re) { return; }
+
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode (node) {
+        if (!node.nodeValue) { return NodeFilter.FILTER_REJECT; }
+        return skip(node) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    const textNodes = [];
+    let n;
+    while ((n = walker.nextNode())) { textNodes.push(n); }
+
+    let count = 0;
+    for (const textNode of textNodes) {
+      if (count >= maxHits) { capped.value = true; break; }
+      const text = textNode.nodeValue;
+      re.lastIndex = 0;
+      const ranges = [];
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[0].length === 0) { re.lastIndex++; continue; } // guard zero-width matches
+        ranges.push([m.index, m.index + m[0].length]);
+        if (count + ranges.length >= maxHits) { capped.value = true; break; }
+      }
+      // wrap back-to-front so earlier offsets stay valid as the node splits
+      for (let i = ranges.length - 1; i >= 0; i--) {
+        const range = document.createRange();
+        range.setStart(textNode, ranges[i][0]);
+        range.setEnd(textNode, ranges[i][1]);
+        const mark = document.createElement('mark');
+        mark.className = MARK_CLASS + ' ' + START_CLASS;
+        try { range.surroundContents(mark); count++; } catch (e) { /* skip un-wrappable range */ }
+      }
+    }
+
+    hits = Array.from(root.querySelectorAll('mark.' + START_CLASS)); // re-query for document order
+    matchCount.value = hits.length;
+  }
+
+  function search (q, options = {}) {
+    if (q !== undefined) { query.value = q; }
+    if (options.regex !== undefined) { isRegex.value = options.regex; }
+    runHighlight();
+  }
+
+  const reapply = runHighlight;
+
+  // first nav after a search jumps to the first (next) / last (prev) hit
+  function next () {
+    if (!hits.length) { return; }
+    const idx = currentIndex.value < 0 ? 0 : (currentIndex.value + 1) % hits.length;
+    setCurrent(idx, true);
+  }
+
+  function prev () {
+    if (!hits.length) { return; }
+    const idx = currentIndex.value < 0 ? hits.length - 1 : (currentIndex.value - 1 + hits.length) % hits.length;
+    setCurrent(idx, true);
+  }
+
+  return { matchCount, currentIndex, capped, error, search, reapply, next, prev };
+}

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "Sitzungspakete werden geladen",
       "renderingSessionPackets": "Sitzungspakete werden gerendert",
-      "loadingErr": "Fehler beim Laden der Sitzungsdetails"
+      "loadingErr": "Fehler beim Laden der Sitzungsdetails",
+      "findPlaceholderDetails": "In Details suchen…",
+      "findPlaceholderPackets": "Paketinhalt durchsuchen…",
+      "findPlaceholderTshark": "Pakete filtern…",
+      "findRegex": "Regulärer Ausdruck",
+      "findPrev": "Vorheriger Treffer",
+      "findNext": "Nächster Treffer",
+      "findTypeHint": "Übereinstimmungstyp",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII (Groß-/Kleinschreibung)",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Hex-Regex"
+      }
     },
     "field": {
       "cantLocate": "Wir können dieses Feld nicht finden",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "Loading session packets",
       "renderingSessionPackets": "Rendering session packets",
-      "loadingErr": "Error loading session detail"
+      "loadingErr": "Error loading session detail",
+      "findPlaceholderDetails": "Find in details…",
+      "findPlaceholderPackets": "Search packet content…",
+      "findPlaceholderTshark": "Filter packets…",
+      "findRegex": "Regular expression",
+      "findPrev": "Previous match",
+      "findNext": "Next match",
+      "findTypeHint": "Match type",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII (case)",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Hex regex"
+      }
     },
     "field": {
       "cantLocate": "We cannot locate this field",

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "Cargando paquetes de sesión",
       "renderingSessionPackets": "Renderizando paquetes de sesión",
-      "loadingErr": "Error al cargar el detalle de la sesión"
+      "loadingErr": "Error al cargar el detalle de la sesión",
+      "findPlaceholderDetails": "Buscar en los detalles…",
+      "findPlaceholderPackets": "Buscar contenido de paquetes…",
+      "findPlaceholderTshark": "Filtrar paquetes…",
+      "findRegex": "Expresión regular",
+      "findPrev": "Coincidencia anterior",
+      "findNext": "Coincidencia siguiente",
+      "findTypeHint": "Tipo de coincidencia",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII (distingue mayúsculas)",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Regex hex"
+      }
     },
     "field": {
       "cantLocate": "No podemos localizar este campo",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "Seansi pakettide laadimine",
       "renderingSessionPackets": "Seansi pakettide renderdamine",
-      "loadingErr": "Viga seansi detailide laadimisel"
+      "loadingErr": "Viga seansi detailide laadimisel",
+      "findPlaceholderDetails": "Otsi detailidest…",
+      "findPlaceholderPackets": "Otsi pakettide sisust…",
+      "findPlaceholderTshark": "Filtreeri pakette…",
+      "findRegex": "Regulaaravaldis",
+      "findPrev": "Eelmine vaste",
+      "findNext": "Järgmine vaste",
+      "findTypeHint": "Vaste tüüp",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII (tõstutundlik)",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Hex-regex"
+      }
     },
     "field": {
       "cantLocate": "Me ei leia seda välja",

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "Chargement des paquets de session",
       "renderingSessionPackets": "Rendu des paquets de session",
-      "loadingErr": "Erreur lors du chargement du détail de la session"
+      "loadingErr": "Erreur lors du chargement du détail de la session",
+      "findPlaceholderDetails": "Rechercher dans les détails…",
+      "findPlaceholderPackets": "Rechercher dans le contenu des paquets…",
+      "findPlaceholderTshark": "Filtrer les paquets…",
+      "findRegex": "Expression régulière",
+      "findPrev": "Correspondance précédente",
+      "findNext": "Correspondance suivante",
+      "findTypeHint": "Type de correspondance",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII (sensible à la casse)",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Regex hex"
+      }
     },
     "field": {
       "cantLocate": "Nous ne pouvons pas localiser ce champ",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "セッションパケットを読み込み中",
       "renderingSessionPackets": "セッションパケットを描画中",
-      "loadingErr": "セッション詳細の読み込みエラー"
+      "loadingErr": "セッション詳細の読み込みエラー",
+      "findPlaceholderDetails": "詳細内を検索…",
+      "findPlaceholderPackets": "パケット内容を検索…",
+      "findPlaceholderTshark": "パケットを絞り込み…",
+      "findRegex": "正規表現",
+      "findPrev": "前の一致",
+      "findNext": "次の一致",
+      "findTypeHint": "一致タイプ",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII（大文字小文字区別）",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Hex 正規表現"
+      }
     },
     "field": {
       "cantLocate": "このフィールドを特定できません",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "세션 패킷 로딩 중",
       "renderingSessionPackets": "세션 패킷 렌더링 중",
-      "loadingErr": "세션 상세 정보 로드 오류"
+      "loadingErr": "세션 상세 정보 로드 오류",
+      "findPlaceholderDetails": "상세 정보에서 찾기…",
+      "findPlaceholderPackets": "패킷 내용 검색…",
+      "findPlaceholderTshark": "패킷 필터링…",
+      "findRegex": "정규 표현식",
+      "findPrev": "이전 일치",
+      "findNext": "다음 일치",
+      "findTypeHint": "일치 유형",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII (대소문자 구분)",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Hex 정규식"
+      }
     },
     "field": {
       "cantLocate": "이 필드를 찾을 수 없습니다",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "Carregando pacotes da sessão",
       "renderingSessionPackets": "Renderizando pacotes da sessão",
-      "loadingErr": "Erro ao carregar detalhes da sessão"
+      "loadingErr": "Erro ao carregar detalhes da sessão",
+      "findPlaceholderDetails": "Buscar nos detalhes…",
+      "findPlaceholderPackets": "Buscar conteúdo dos pacotes…",
+      "findPlaceholderTshark": "Filtrar pacotes…",
+      "findRegex": "Expressão regular",
+      "findPrev": "Correspondência anterior",
+      "findNext": "Próxima correspondência",
+      "findTypeHint": "Tipo de correspondência",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII (diferencia maiúsculas)",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Regex hex"
+      }
     },
     "field": {
       "cantLocate": "Não conseguimos localizar este campo",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -498,7 +498,21 @@
     "detail": {
       "loadingSessionPackets": "Oadinglay essionsay acketspay",
       "renderingSessionPackets": "Enderinngray essionsay acketspay",
-      "loadingErr": "Errorway oadinglay essionsay etailday"
+      "loadingErr": "Errorway oadinglay essionsay etailday",
+      "findPlaceholderDetails": "Indfay inway etailsday…",
+      "findPlaceholderPackets": "Earchsay acketpay ontentcay…",
+      "findPlaceholderTshark": "Ilterfay acketspay…",
+      "findRegex": "Egularray expressionway",
+      "findPrev": "Eviouspray atchmay",
+      "findNext": "Extnay atchmay",
+      "findTypeHint": "Atchmay ypetay",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII (asecay)",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Exhay egexray"
+      }
     },
     "field": {
       "cantLocate": "Eway annotcay ocatelay isthay ieldfay",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -497,7 +497,21 @@
     "detail": {
       "loadingSessionPackets": "正在加载会话数据包",
       "renderingSessionPackets": "正在渲染会话数据包",
-      "loadingErr": "加载会话详情时出错"
+      "loadingErr": "加载会话详情时出错",
+      "findPlaceholderDetails": "在详情中查找…",
+      "findPlaceholderPackets": "搜索数据包内容…",
+      "findPlaceholderTshark": "筛选数据包…",
+      "findRegex": "正则表达式",
+      "findPrev": "上一个匹配",
+      "findNext": "下一个匹配",
+      "findTypeHint": "匹配类型",
+      "findType": {
+        "ascii": "ASCII",
+        "asciicase": "ASCII（区分大小写）",
+        "hex": "Hex",
+        "regex": "Regex",
+        "hexregex": "Hex 正则"
+      }
     },
     "field": {
       "cantLocate": "我们找不到此字段",

--- a/tests/api-sessionDetail.t
+++ b/tests/api-sessionDetail.t
@@ -1,4 +1,4 @@
-use Test::More tests => 48;
+use Test::More tests => 53;
 
 use Cwd;
 use URI::Escape;
@@ -61,6 +61,27 @@ my $pwd = "*/pcap";
 
     $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?line=true&ts=false&base=hex")->content;
     ok($sd =~ /00000272:.*636f 6c3a 2038 303a 7175 6963 0d0a 0d0a.*col:.80:quic.*00000000:.*0800 0000 0000 02ff/s, "encoding:hex line:true");
+
+# find-in-packets (byte-level content search)
+    # ascii search is case-insensitive and wraps the matched bytes in a find-hit span
+    $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?line=false&ts=false&base=natural&search=QUIC&searchType=ascii")->content;
+    ok($sd =~ m{class="find-hit find-hit-start">quic</span>}s, "find natural ascii (case-insensitive)");
+
+    # the same match highlights the anchor byte (q = 0x71) in hex mode
+    $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?line=false&ts=false&base=hex&search=quic&searchType=ascii")->content;
+    ok($sd =~ m{class="find-hit find-hit-start">71</span>}s, "find hex via ascii search");
+
+    # hex search type matches against the hex byte string
+    $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?line=false&ts=false&base=hex&search=717569&searchType=hex")->content;
+    ok($sd =~ m{class="find-hit find-hit-start">71</span>}s, "find hex via hex search");
+
+    # a term that isn't present produces no highlights
+    $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?line=false&ts=false&base=natural&search=zzznotpresentzzz&searchType=ascii")->content;
+    ok($sd !~ m{find-hit}s, "find no match -> no highlights");
+
+    # no search param -> highlighting is off by default
+    $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?line=false&ts=false&base=natural")->content;
+    ok($sd !~ m{find-hit}s, "find off by default");
 
 # http gzip:true
     $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?line=false&ts=false&base=natural&gzip=true")->content;

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -32,6 +32,7 @@ const ViewerUtils = require('./viewerUtils');
 const ipaddr = require('ipaddr.js');
 const { LRUCache } = require('lru-cache');
 const sanitizeHtml = require('sanitize-html');
+const RE2 = require('re2');
 const BuildQuery = require('./buildQuery');
 
 // Replace pug's escape with the same algorithm plus {. Detail HTML must be
@@ -377,6 +378,22 @@ class SessionAPIs {
   }
 
   // --------------------------------------------------------------------------
+  // searchType matches hunt's vocabulary; regex types pre-compile with RE2.
+  static #buildFindOptions (search, searchType) {
+    if (!search) { return undefined; }
+    searchType = searchType || 'ascii';
+    const findOpts = { search, searchType };
+    if (searchType === 'regex' || searchType === 'hexregex') {
+      try {
+        findOpts.regex = new RE2(search, searchType === 'regex' ? 'gi' : 'g');
+      } catch (e) {
+        return undefined; // invalid regex -> no highlighting
+      }
+    }
+    return findOpts;
+  }
+
+  // --------------------------------------------------------------------------
   static #localSessionDetailReturn (req, res, session, incoming) {
     // console.log("ALW", JSON.stringify(incoming));
     const numPackets = req.query.packets || 200;
@@ -401,6 +418,9 @@ class SessionAPIs {
       'ITEM-CB': {
       }
     };
+
+    const findOpts = SessionAPIs.#buildFindOptions(req.query.search, req.query.searchType);
+    if (findOpts) { options.find = findOpts; }
 
     if (req.query.needgzip) {
       options['ITEM-HTTP'].order.push('BODY-UNCOMPRESS');

--- a/viewer/decode.js
+++ b/viewer/decode.js
@@ -765,6 +765,7 @@ class ItemHexFormatterStream extends Transform {
     super({ objectMode: true });
     mkname(this, 'ItemHexFormaterStream');
     this.showOffsets = options['ITEM-HEX'] ? options['ITEM-HEX'].showOffsets || false : false;
+    this.find = options.find;
   }
 
   _transform (item, encoding, callback) {
@@ -772,10 +773,26 @@ class ItemHexFormatterStream extends Transform {
       return callback(null, item);
     }
 
-    let out = '<pre>';
     let i, ilen;
 
     const input = item.data;
+
+    // find-in-packets: per-byte hit mask + per-match start byte (for anchoring)
+    let hit = null;
+    let starts = null;
+    if (this.find) {
+      const ranges = findMatchRanges(input, this.find);
+      if (ranges.length) {
+        hit = new Uint8Array(input.length);
+        starts = new Uint8Array(input.length);
+        for (const [s, e] of ranges) {
+          if (s < input.length) { starts[s] = 1; }
+          for (let b = s; b < e && b < input.length; b++) { hit[b] = 1; }
+        }
+      }
+    }
+
+    let out = '<pre>';
     for (let pos = 0, poslen = input.length; pos < poslen; pos += 16) {
       const line = input.slice(pos, Math.min(pos + 16, input.length));
       if (this.showOffsets) {
@@ -788,8 +805,13 @@ class ItemHexFormatterStream extends Transform {
           out += ' ';
         }
         if (i < line.length) {
+          const b = pos + i;
           const paddedLine = line[i].toString(16).padStart(2, '0');
-          out += paddedLine;
+          if (hit && hit[b]) {
+            out += '<span class="find-hit' + (starts[b] ? ' find-hit-start' : '') + '">' + paddedLine + '</span>';
+          } else {
+            out += paddedLine;
+          }
         } else {
           out += '  ';
         }
@@ -798,10 +820,11 @@ class ItemHexFormatterStream extends Transform {
       out += ' ';
 
       for (i = 0, ilen = line.length; i < ilen; i++) {
-        if (line[i] <= 32 || line[i] > 128) {
-          out += '.';
+        const ch = (line[i] <= 32 || line[i] > 128) ? '.' : ArkimeUtil.safeStr(line.toString('ascii', i, i + 1));
+        if (hit && hit[pos + i]) {
+          out += '<span class="find-hit">' + ch + '</span>';
         } else {
-          out += ArkimeUtil.safeStr(line.toString('ascii', i, i + 1));
+          out += ch;
         }
       }
       out += '\n';
@@ -835,6 +858,96 @@ function createItemSorterStream (options) {
   stream.items = [];
   return stream;
 }
+/// /////////////////////////////////////////////////////////////////////////////
+// find-in-packets: match on the raw item bytes so a hit highlights in every render
+// mode. find = { search, searchType, regex }.
+
+// Merge sorted [start,end) ranges, collapsing overlaps/adjacency.
+function mergeRanges (ranges) {
+  if (ranges.length < 2) { return ranges; }
+  ranges.sort((a, b) => a[0] - b[0]);
+  const out = [ranges[0]];
+  for (let i = 1; i < ranges.length; i++) {
+    const last = out[out.length - 1];
+    if (ranges[i][0] <= last[1]) {
+      last[1] = Math.max(last[1], ranges[i][1]);
+    } else {
+      out.push(ranges[i]);
+    }
+  }
+  return out;
+}
+
+function findMatchRanges (buf, spec) {
+  if (!spec || !spec.search) { return []; }
+  const ranges = [];
+  try {
+    switch (spec.searchType) {
+    case 'asciicase':
+    case 'ascii': {
+      const ci = spec.searchType === 'ascii';
+      const hay = ci ? buf.toString('latin1').toLowerCase() : buf.toString('latin1');
+      const needle = ci ? spec.search.toLowerCase() : spec.search;
+      if (!needle) { break; }
+      let i = 0;
+      while ((i = hay.indexOf(needle, i)) !== -1) {
+        ranges.push([i, i + needle.length]);
+        i += needle.length;
+      }
+      break;
+    }
+    case 'hex': {
+      const hay = buf.toString('hex');
+      const needle = spec.search.toLowerCase().replace(/[^0-9a-f]/g, '');
+      if (!needle) { break; }
+      let i = 0;
+      while ((i = hay.indexOf(needle, i)) !== -1) {
+        if (i % 2 === 0) { ranges.push([i / 2, Math.ceil((i + needle.length) / 2)]); } // byte-aligned only
+        i += 1;
+      }
+      break;
+    }
+    case 'regex':
+    case 'hexregex': {
+      if (!spec.regex) { break; }
+      const hex = spec.searchType === 'hexregex';
+      const hay = hex ? buf.toString('hex') : buf.toString('latin1');
+      spec.regex.lastIndex = 0;
+      let m;
+      while ((m = spec.regex.exec(hay)) !== null) {
+        if (m[0].length === 0) { spec.regex.lastIndex++; continue; }
+        if (hex) {
+          ranges.push([Math.floor(m.index / 2), Math.ceil((m.index + m[0].length) / 2)]);
+        } else {
+          ranges.push([m.index, m.index + m[0].length]);
+        }
+      }
+      break;
+    }
+    }
+  } catch (e) { /* bad search -> no highlights */ }
+  return mergeRanges(ranges);
+}
+
+// Escaped text with find matches wrapped in find-hit spans (ascii/utf8/natural).
+function findWrapDecoded (buf, spec, encoding, naturalBr) {
+  const ranges = findMatchRanges(buf, spec);
+  const esc = (a, b) => {
+    const s = ArkimeUtil.safeStr(buf.toString(encoding, a, b));
+    return naturalBr ? s.replace(/\r?\n/g, '<br>') : s;
+  };
+  if (!ranges.length) { return esc(0, buf.length); }
+  let out = '';
+  let pos = 0;
+  for (const [s, e] of ranges) {
+    if (s > pos) { out += esc(pos, s); }
+    out += '<span class="find-hit find-hit-start">' + esc(s, e) + '</span>';
+    pos = e;
+  }
+  out += esc(pos, buf.length);
+  return out;
+}
+
 /// /////////////////////////////////////////////////////////////////////////////
 
 module.exports = exports = {};
@@ -875,19 +988,19 @@ exports.register('ITEM-PRINTER', through.ctor({ objectMode: true }, function (it
 exports.register('ITEM-HEX', ItemHexFormatterStream);
 exports.register('ITEM-UTF8', through.ctor({ objectMode: true }, function (item, encoding, callback) {
   if (item.html === undefined) {
-    item.html = '<pre>' + ArkimeUtil.safeStr(item.data.toString('utf8')) + '</pre>';
+    item.html = '<pre>' + findWrapDecoded(item.data, this.options?.find, 'utf8', false) + '</pre>';
   }
   callback(null, item);
 }));
 exports.register('ITEM-ASCII', through.ctor({ objectMode: true }, function (item, encoding, callback) {
   if (item.html === undefined) {
-    item.html = '<pre>' + ArkimeUtil.safeStr(item.data.toString('binary')) + '</pre>';
+    item.html = '<pre>' + findWrapDecoded(item.data, this.options?.find, 'latin1', false) + '</pre>';
   }
   callback(null, item);
 }));
 exports.register('ITEM-NATURAL', through.ctor({ objectMode: true }, function (item, encoding, callback) {
   if (item.html === undefined) {
-    item.html = ArkimeUtil.safeStr(item.data.toString()).replace(/\r?\n/g, '<br>');
+    item.html = findWrapDecoded(item.data, this.options?.find, 'utf8', true);
   }
   callback(null, item);
 }));

--- a/viewer/vueapp/src/components/sessions/SessionActions.vue
+++ b/viewer/vueapp/src/components/sessions/SessionActions.vue
@@ -116,6 +116,10 @@ SPDX-License-Identifier: Apache-2.0
     </v-btn>
   </template>
 
+  <!-- slot sits between the left action buttons and the right-justified
+       Columns/Actions menus (e.g. the detail find box) -->
+  <slot />
+
   <template v-if="showMenus">
     <v-menu>
       <template #activator="{ props: activatorProps }">

--- a/viewer/vueapp/src/components/sessions/SessionDetail.vue
+++ b/viewer/vueapp/src/components/sessions/SessionDetail.vue
@@ -78,7 +78,21 @@
         v-if="actions"
         :actions="actions"
         :show-menus="activeTab === 'details'"
-        @open-form="openForm" />
+        @open-form="openForm">
+        <content-find
+          v-if="activeTab === 'details'"
+          class="find-centered"
+          mode="text"
+          :initial-query="detailFindQuery"
+          :placeholder="$t('sessions.detail.findPlaceholderDetails')"
+          :match-count="detailFind.matchCount.value"
+          :current-index="detailFind.currentIndex.value"
+          :capped="detailFind.capped.value"
+          :error="detailFind.error.value"
+          @search="onDetailFind"
+          @next="detailFind.next"
+          @prev="detailFind.prev" />
+      </session-actions>
 
       <!-- push each tab's own controls to the right (Details' Columns/Actions
            already right-justify via ms-auto inside SessionActions) -->
@@ -87,6 +101,19 @@
         class="tb-spacer" />
 
       <!-- packets controls -->
+      <content-find
+        v-if="activeTab === 'packets'"
+        mode="bytes"
+        :initial-query="packetFindQuery"
+        :placeholder="$t('sessions.detail.findPlaceholderPackets')"
+        :match-count="packetFind.matchCount.value"
+        :current-index="packetFind.currentIndex.value"
+        :capped="packetFind.capped.value"
+        :error="packetFindError"
+        @search="onPacketFind"
+        @next="packetFind.next"
+        @prev="packetFind.prev" />
+
       <fieldset
         v-if="activeTab === 'packets'"
         class="toolbar-fieldset"
@@ -141,19 +168,19 @@
           </v-btn>
         </div>
 
-        <div
+        <content-find
           v-if="tsharkPackets.length"
-          class="tb-group">
-          <v-text-field
-            v-model="tsharkFilter"
-            placeholder="filter packets…"
-            prepend-inner-icon="mdi-magnify"
-            clearable
-            density="compact"
-            variant="outlined"
-            hide-details
-            class="tshark-filter-input" />
-        </div>
+          ref="tsharkFindRef"
+          mode="text"
+          :initial-query="tsharkFilter"
+          :placeholder="$t('sessions.detail.findPlaceholderTshark')"
+          :match-count="tsharkFind.matchCount.value"
+          :current-index="tsharkFind.currentIndex.value"
+          :capped="tsharkFind.capped.value"
+          :error="tsharkFind.error.value"
+          @search="onTsharkFind"
+          @next="tsharkFind.next"
+          @prev="tsharkFind.prev" />
 
         <div
           v-if="tsharkPackets.length"
@@ -221,7 +248,9 @@
     </div>
 
     <!-- details tab content -->
-    <div v-show="activeTab === 'details'">
+    <div
+      v-show="activeTab === 'details'"
+      ref="detailContainerRef">
       <SessionDetailDataComponent
         :key="componentKey"
         @add-tags="openForm({ type: 'add:tags' })"
@@ -323,7 +352,7 @@
             variant="flat"
             label
             :style="packetProtoStyle(proto)"
-            @click="tsharkFilter = (tsharkFilter === proto) ? '' : proto">
+            @click="tsharkFindRef?.setQuery((tsharkFilter === proto) ? '' : proto)">
             {{ proto.toUpperCase() }}&nbsp;×{{ count }}
           </v-chip>
         </div>
@@ -425,6 +454,8 @@ import ArkimeRemoveData from './Remove.vue';
 import ArkimeSendSessions from './Send.vue';
 import ArkimeExportPcap from './ExportPcap.vue';
 import ArkimeToast from '../utils/Toast.vue';
+import ContentFind from '@common/ContentFind.vue';
+import { useContentFind } from '@common/composables/useContentFind.js';
 // asynchronous component defined above with html injected by createDetailDataComponent
 let SessionDetailDataComponent = null;
 
@@ -479,6 +510,46 @@ const tsharkFilter = ref('');
 const tsharkSelectedIdx = ref(0);
 const tsharkExpandSignal = ref(0);
 const tsharkSplitWidth = ref(280);
+
+// find-in-content: one engine per tab. details/tshark mark client-side over the
+// rendered DOM; packets navigate spans the server renders (byte-level search).
+const detailContainerRef = ref(null);
+const tsharkFindRef = ref(null);
+const detailFindQuery = ref('');
+const packetFindQuery = ref('');
+const packetFindError = ref('');
+const packetSearchType = ref('ascii');
+const tsharkRegex = ref(false);
+const detailFind = useContentFind(() => detailContainerRef.value, { skipSelector: '.session-card-title' });
+const packetFind = useContentFind(() => packetContainerRef.value, { navigateOnly: true, skipHidden: true });
+const tsharkFind = useContentFind(() => tsharkOutputRef.value, {
+  onBeforeNav (el) { // open the collapsed tree nodes above the hit so it can scroll into view
+    let d = el.closest('details');
+    while (d) { d.open = true; d = d.parentElement?.closest('details'); }
+  }
+});
+
+const onDetailFind = ({ query, regex }) => {
+  detailFindQuery.value = query || '';
+  detailFind.search(query, { regex });
+};
+const onPacketFind = ({ query, searchType }) => {
+  // the server compiles regex with RE2; pre-validate here so a bad pattern surfaces
+  // an error instead of silently rendering zero highlights
+  if (query && (searchType === 'regex' || searchType === 'hexregex')) {
+    try { new RegExp(query); } catch (e) { packetFindError.value = e.message; return; }
+  }
+  packetFindError.value = '';
+  packetFindQuery.value = query || '';
+  packetSearchType.value = searchType;
+  getPackets(); // a full re-fetch + decode — pricier than the client-side detail/tshark paths
+};
+const onTsharkFind = ({ query, regex }) => {
+  tsharkFilter.value = query || '';
+  tsharkRegex.value = !!regex;
+  nextTick(() => tsharkFind.search(query, { regex }));
+};
+
 const params = ref({
   base: 'natural',
   line: false,
@@ -769,7 +840,11 @@ const getPackets = async () => {
       props.session.id,
       props.session.node,
       props.session.cluster,
-      params.value
+      {
+        ...params.value,
+        search: packetFindQuery.value || undefined,
+        searchType: packetSearchType.value
+      }
     );
     packetPromise.value = { controller };
 
@@ -837,6 +912,8 @@ const getPackets = async () => {
       dstBytes[0].addEventListener('mouseenter', showDstBytesImg);
     }
 
+    packetFind.reapply();
+
     renderingPackets.value = false;
   } catch (err) {
     loadingPackets.value = false;
@@ -891,16 +968,34 @@ const cancelTshark = () => {
   }
 };
 
-// Filter packets by text against summary/protocol/layer names.
+// Filter packets by text against summary/protocol and any field name/label/value.
 const filteredTsharkPackets = computed(() => {
   const list = tsharkPackets.value.map((p, i) => ({ pkt: p, origIdx: i }));
   // v-text-field clearable sets the model to null, so coerce before trim().
-  const f = (tsharkFilter.value || '').trim().toLowerCase();
-  if (!f) { return list; }
+  const raw = (tsharkFilter.value || '').trim();
+  if (!raw) { return list; }
+
+  let test;
+  if (tsharkRegex.value) {
+    let re;
+    try { re = new RegExp(raw, 'i'); } catch (e) { return list; } // invalid regex: don't filter
+    test = (s) => re.test(s || '');
+  } else {
+    const f = raw.toLowerCase();
+    test = (s) => (s || '').toLowerCase().includes(f);
+  }
+
+  const nodeMatches = (node) => {
+    if (!node) { return false; }
+    if (test(node.name) || test(node.label)) { return true; }
+    if (node.show !== undefined && test(String(node.show))) { return true; }
+    if (node.value !== undefined && test(String(node.value))) { return true; }
+    return (node.fields || []).some(nodeMatches);
+  };
+
   return list.filter(({ pkt }) => {
-    if (packetTopProto(pkt).toLowerCase().includes(f)) { return true; }
-    if (packetSummary(pkt).toLowerCase().includes(f)) { return true; }
-    return (pkt.layers || []).some(l => (l.name || '').toLowerCase().includes(f));
+    if (test(packetTopProto(pkt)) || test(packetSummary(pkt))) { return true; }
+    return (pkt.layers || []).some(nodeMatches);
   });
 });
 
@@ -1019,6 +1114,12 @@ watch(activeTab, (newTab) => {
   }
 });
 
+// reload swaps the detail subtree → re-mark
+watch(componentKey, () => { nextTick(() => detailFind.reapply()); });
+
+// selecting a packet re-renders the tree → re-mark
+watch(tsharkSelectedIdx, () => { nextTick(() => tsharkFind.reapply()); });
+
 // mounted
 onMounted(async () => {
   setUserParams();
@@ -1106,6 +1207,11 @@ onUnmounted(() => {
   flex: 1 1 auto;
   min-width: 0;
 }
+/* center the detail find box between the left action buttons and the
+   right-justified Columns/Actions menus (beats .tb-group's margin:0) */
+.arkime-pcap-toolbar .content-find.find-centered {
+  margin-inline-start: auto !important;
+}
 /* PacketOptions wrapping row sits right-justified after the spacer in the
    shared bar (don't grow, so the spacer keeps it on the right). */
 .arkime-pcap-toolbar .packet-options-row {
@@ -1160,6 +1266,19 @@ onUnmounted(() => {
   cursor: pointer;
   font-weight: 600;
   letter-spacing: 0.03em;
+}
+
+/* find-in-content match highlights — client-injected <mark> (details/tshark)
+   and server-rendered <span> (packets byte search) share these classes. */
+.find-hit {
+  background-color: rgba(var(--v-theme-warning), 0.4);
+  color: inherit;
+  border-radius: 2px;
+}
+.find-hit--current {
+  background-color: rgb(var(--v-theme-warning));
+  color: #000;
+  box-shadow: 0 0 0 1px rgb(var(--v-theme-warning));
 }
 
 /* split view: packet list (resizable) + grab handle + flexible tree pane */


### PR DESCRIPTION
Unified find bar on details/packets/tshark; client-side mark for details/tshark, server-side byte search (decode.js) for packets.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
