### PR TITLE
Fix capture bugs and docs found in code review

### DIFF
--- a/capture/DESIGN.md
+++ b/capture/DESIGN.md
@@ -8,7 +8,7 @@ When those data structures need to be updated we create a new one and replace th
 
 ## capture
 The main thread, all http requests are on the main thread.  
-Since sessions aren't locked, any sessions actions need to be added to the packet threads.
+Since sessions aren't locked, any session actions need to be added to the packet threads.
 
 ## arkime-stats
 Simple thread that just calculates all the stats occasionally and sends to ES.
@@ -16,7 +16,7 @@ Simple thread that just calculates all the stats occasionally and sends to ES.
 ## arkime-pkt##
 The packet threads controlled by packetThreads.
 These threads are responsible for processing packets that are passed to it in batches.
-Sessions are hashed across packet threads and all packets are processed by where the session is.
+Sessions are hashed across packet threads and all packets for a session are processed by the thread the session is assigned to.
 Any operations to a session has to happen in the packet thread since sessions don't have locks.
 Use arkime_session_add_cmd to schedule a session task from a different thread.
 
@@ -40,12 +40,12 @@ In reality there isn't much difference between parsers and plugins, other than w
 
 ## Parsers
 Anything in the parsers directories (parsersDir) are auto loaded and the arkime_parser_init function is called when loaded.
-If files have the same in multiple directories, capture will load the first one found.
+If files have the same name in multiple directories, capture will load the first one found.
 
 ## Plugins
 Which plugins to use have to be explicitly listed in rootPlugins and plugins variables.
 They are loaded from the plugins directories (pluginsDir) and the arkime_plugin_init function is called when loaded.
-If files have the same in multiple directories, capture will load the first one found.
+If files have the same name in multiple directories, capture will load the first one found.
 The rootPlugins are loaded first, before capture has dropped privileges.
 The normal plugins are loaded after the parsers.
 
@@ -62,7 +62,7 @@ This phase is responsible for
 * setting the `mProtocol` field with the arkime protocol
 * setting the `hash` field with the hash of the session id
 
-You only need to create a new enqueue callback for special ethernet and ip protocols, which can be set with the arkime_packet_set_ethernet_cb and arkime_packet_set_ip_cb..
+You only need to create a new enqueue callback for special ethernet and ip protocols, which can be set with the arkime_packet_set_ethernet_cb and arkime_packet_set_ip_cb.
 Normal TCP/UDP traffic should NOT set an enqueue callback.
 
 ## Ethernet/IP Process phase
@@ -83,8 +83,8 @@ arkime_mprotocol_register (char *name, int ses, create_session_id, pre_process, 
 ## TCP/UDP parsing
 
 TCP/UDP parsing and classification is a two step process.
-* Classify - Look
-* Parsing - 
+* Classify - Look at the start of the session to determine the protocol, using classifiers registered with arkime_parsers_classifier_register_tcp, arkime_parsers_classifier_register_udp, or arkime_parsers_classifier_register_port.
+* Parsing - Once classified, parsers registered with arkime_parsers_register process the session data and extract the SPI fields.
 
 
 arkime_parsers_register2

--- a/capture/command.c
+++ b/capture/command.c
@@ -356,7 +356,9 @@ LOCAL void arkime_command_help(int argc, char **argv, gpointer cc)
 /******************************************************************************/
 LOCAL void arkime_command_exit(int UNUSED(argc), char UNUSED(**argv), gpointer cc)
 {
-    arkime_command_client_free(cc);
+    // commandList runs commands with no client connection (cc == NULL); nothing to close
+    if (cc)
+        arkime_command_client_free(cc);
 }
 /******************************************************************************/
 GSocketAddress *g_unix_socket_address_new (const gchar *path);

--- a/capture/db.c
+++ b/capture/db.c
@@ -1715,7 +1715,8 @@ LOCAL void arkime_db_update_stats(int n, gboolean sync)
 
     for (int i = 0; config.pcapDir[i]; i++) {
         struct statvfs vfs;
-        statvfs(config.pcapDir[i], &vfs);
+        if (statvfs(config.pcapDir[i], &vfs) != 0)
+            continue;
         freeSpaceM += (uint64_t)((vfs.f_frsize / 1000.0) * (vfs.f_bavail / 1000.0));
         totalSpaceM += (uint64_t)((vfs.f_frsize / 1000.0) * (vfs.f_blocks / 1000.0));
     }
@@ -2144,7 +2145,7 @@ char *arkime_db_create_file_full(const struct timeval *firstPacket, const char *
         name = g_regex_replace_literal(numHexRegex, name1, -1, 0, (char *)arkime_char_to_hexstr[num % 256], 0, NULL);
         g_free(name1);
 
-        BSB_EXPORT_sprintf(jbsb, "{\"num\":%d, \"name\":\"%s\", \"first\":%" PRIu64 ", \"node\":\"%s\", \"filesize\":%" PRIu64 ", \"locked\":%d", num, name, fp, config.nodeName, size, locked);
+        BSB_EXPORT_sprintf(jbsb, "{\"num\":%u, \"name\":\"%s\", \"first\":%" PRIu64 ", \"node\":\"%s\", \"filesize\":%" PRIu64 ", \"locked\":%d", num, name, fp, config.nodeName, size, locked);
         key_len = arkime_snprintf_len(key, sizeof(key), "/%sfiles/_doc/%s-%u?refresh=true", config.prefix, config.nodeName, num);
     } else {
 
@@ -2236,7 +2237,7 @@ char *arkime_db_create_file_full(const struct timeval *firstPacket, const char *
         snprintf(filename + flen, sizeof(filename) - flen, "/%s-%02d%02d%02d-%08u%s", config.nodeName, tmp.tm_year % 100, tmp.tm_mon + 1, tmp.tm_mday, num, name);
         name = 0;
 
-        BSB_EXPORT_sprintf(jbsb, "{\"num\":%d, \"name\":\"%s\", \"first\":%" PRIu64 ", \"node\":\"%s\", \"locked\":%d", num, filename, fp, config.nodeName, locked);
+        BSB_EXPORT_sprintf(jbsb, "{\"num\":%u, \"name\":\"%s\", \"first\":%" PRIu64 ", \"node\":\"%s\", \"locked\":%d", num, filename, fp, config.nodeName, locked);
         key_len = arkime_snprintf_len(key, sizeof(key), "/%sfiles/_doc/%s-%u?refresh=true", config.prefix, config.nodeName, num);
     }
 
@@ -3027,7 +3028,7 @@ void arkime_db_exit()
     g_regex_unref(numHexRegex);
 
     if (config.debug) {
-        LOG("totalPackets: %" PRId64 " totalSessions: %" PRId64 " writtenBytes: %" PRId64 " unwrittenBytes: %" PRId64 " pstats: %" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64,
+        LOG("totalPackets: %" PRIu64 " totalSessions: %" PRIu64 " writtenBytes: %" PRIu64 " unwrittenBytes: %" PRIu64 " pstats: %" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64,
             totalPackets, totalSessions, arkime_packet_written_bytes(), arkime_packet_unwritten_bytes(),
             packetStats[ARKIME_PACKET_DO_PROCESS],
             packetStats[ARKIME_PACKET_IP_DROPPED],

--- a/capture/http.c
+++ b/capture/http.c
@@ -845,7 +845,7 @@ gboolean arkime_http_schedule2(void *serverV, const char *method, const char *ke
         }
     }
 
-    request->priority = priority;
+    request->priority = MIN(priority, ARKIME_HTTP_PRIORITY_DROPABLE);
 
     if (priority == ARKIME_HTTP_PRIORITY_DROPABLE)
         request->retries = 0;

--- a/capture/plugins/daq/README.md
+++ b/capture/plugins/daq/README.md
@@ -5,6 +5,6 @@ To use:
 * install the daq package on the build hosts and all hosts that will run capture https://www.snort.org/downloads
 * build the plugin by using ```make``` in the ```capture/plugins/daq``` directory
 * load the daq plugin by changing configuration file so it has reader-daq.so as a rootPlugins ```rootPlugins=reader-daq.so```
-* tell capture to use daq as the reader method with ```pcapReadMethod=daq`` in your configuration file
+* tell capture to use daq as the reader method with ```pcapReadMethod=daq``` in your configuration file
 * optionally change ```interface``` to any special daq interface value
 

--- a/capture/plugins/kafka/README.md
+++ b/capture/plugins/kafka/README.md
@@ -13,7 +13,7 @@ Please note that communication to Elasticsearch is still needed, for the stats a
 
 # Configure
 
-The table below list all the possible configuration option of the kafka plugin.
+The table below lists all the possible configuration options of the kafka plugin.
 
 | Property | Details | Example |
 |----------|---------|---------|

--- a/capture/plugins/lua/README.md
+++ b/capture/plugins/lua/README.md
@@ -7,7 +7,7 @@ Simple lua integration, currently experimental.  It supports (with more coming a
 To use:
 * install the lua package for your OS, requires at least 5.3
 * build the plugin by using ```make``` in the ```capture/plugins/lua``` directory
-* load the lua plugin by change configuration file so it has lua.so as a plugins ```plugins=lua.so```
+* load the lua plugin by changing the configuration file so it has lua.so as a plugin ```plugins=lua.so```
 * set ```luaFiles``` to a list of lua files to load
 
 
@@ -19,7 +19,7 @@ How it works:
 ## Callbacks:
 
 ### classifyFunction(session, str, direction)
-Callback when the initial part of the data stream matches the details set by either arkime_parsers_classifier_register_tcp or arkime_parsers_classifier_register_udp.  It may be called multiple times for the same session if the first packets in each direction matches.  It is only called with the first packet of data, you want to see more call arkime_parseres_register
+Callback when the initial part of the data stream matches the details set by either arkime_parsers_classifier_register_tcp or arkime_parsers_classifier_register_udp.  It may be called multiple times for the same session if the first packets in each direction matches.  It is only called with the first packet of data, you want to see more call arkime_parsers_register
 * session = A ArkimeSession object
 * str = A lua string with the binary data from start of session
 * direction = traffic direction
@@ -32,7 +32,7 @@ Callback that receives the stream of data for session.  Will be called multiple 
 * returns = -1 to stop parsing
  
 ### httpResponseFunction(code, str)
-Callback to arkime_http_request.  It received the full data response.
+Callback to arkime_http_request.  It receives the full data response.
 * code = response code
 * str = A lua string with full response
 
@@ -75,9 +75,9 @@ Create a glob pattern to use for matching
 * returns = the new ArkimeData object
 
 ### data:memmem(str)
-Is str inside of data
+Find str inside of data
 * str = the lua string to check for
-* returns = true if present
+* returns = offset of str within data, or -1 if not present
 
 ### data:pattern_ismatch(compiledPattern)
 Perform a glob match
@@ -141,7 +141,7 @@ Register to receive a callback before saving.  This function can call the incr_o
 * preSaveFunctionName = the string name of the lua function to call.  Function should implement the saveCallbackFunction signature above.
 
 ### ArkimeSession.register_save(saveFunctionName)
-Register to receive a callback as saving.  This function can NOT call the incr_outstanding on the session to pause the save.
+Register to receive a callback when saving.  This function can NOT call the incr_outstanding on the session to pause the save.
 * saveFunctionName = the string name of the lua function to call.  Function should implement the saveCallbackFunction signature above.
 
 

--- a/capture/plugins/lua/samples/Readme.md
+++ b/capture/plugins/lua/samples/Readme.md
@@ -24,4 +24,4 @@ dcerpc.cmd=db:dcerpc.cmd;kind:termfield;friendly:DCERPC Command;count:true;help:
 You also need to add lua.so to plugins and the script files as listed below
 
 * plugins=lua.so
-* luaFiles=/opt/arkime/lua/dcerpc.lua;/opt/arkmie/lua/smb.lua;/opt/arkime/lua/entropy.lua
+* luaFiles=/opt/arkime/lua/dcerpc.lua;/opt/arkime/lua/smb.lua;/opt/arkime/lua/entropy.lua

--- a/capture/plugins/napatech/README.md
+++ b/capture/plugins/napatech/README.md
@@ -25,8 +25,8 @@ make
 sudo cp reader-napatech.so /opt/arkime/plugins/
 ```
 
-The `Makefile` detects libpcap headers via `pcap-config` or `pkg-config
-libpcap` automatically. To override the Napatech install path:
+The `Makefile` detects libpcap headers via `pcap-config` or `pkg-config libpcap`
+automatically. To override the Napatech install path:
 
 ```sh
 make NTDIR=/path/to/napatech3

--- a/capture/plugins/pfring/README.md
+++ b/capture/plugins/pfring/README.md
@@ -6,7 +6,7 @@ To use:
   http://packages.ntop.org/
 * build the plugin by using ```make``` in the ```capture/plugins/pfring``` directory
 * load the pfring plugin by changing configuration file so it has reader-pfring.so as a rootPlugins ```rootPlugins=reader-pfring.so```
-* tell capture to use pfring as the reader method with ```pcapReadMethod=pfring`` in your configuration file
+* tell capture to use pfring as the reader method with ```pcapReadMethod=pfring``` in your configuration file
 * optionally set ```pfringClusterId``` in configuration file 
 * optionally change ```interface``` to any special pfring interface value
 

--- a/capture/plugins/snf/README.md
+++ b/capture/plugins/snf/README.md
@@ -18,5 +18,5 @@ To use:
 * install the snf package on the build hosts and all hosts that will run capture
 * build the plugin by using ```make``` in the ```capture/plugins/snf``` directory
 * load the snf plugin by changing configuration file so it has reader-snf.so as a rootPlugins ```rootPlugins=reader-snf.so```
-* tell capture to use snf as the reader method with ```pcapReadMethod=snf`` in your configuration file
+* tell capture to use snf as the reader method with ```pcapReadMethod=snf``` in your configuration file
 * change ```interface``` to either the OS interface name or snf# where # is the portnum

--- a/capture/plugins/tagger.c
+++ b/capture/plugins/tagger.c
@@ -128,7 +128,7 @@ LOCAL void tagger_plugin_save(ArkimeSession_t *session, int UNUSED(final))
         prefix.bitlen = 32;
         prefix.add.sin.s_addr = ARKIME_V6_TO_V4(session->addr1);
     } else {
-        prefix.family = AF_INET;
+        prefix.family = AF_INET6;
         prefix.bitlen = 128;
         memcpy(&prefix.add.sin6.s6_addr, &session->addr1, 16);
     }
@@ -143,7 +143,7 @@ LOCAL void tagger_plugin_save(ArkimeSession_t *session, int UNUSED(final))
         prefix.bitlen = 32;
         prefix.add.sin.s_addr = ARKIME_V6_TO_V4(session->addr2);
     } else {
-        prefix.family = AF_INET;
+        prefix.family = AF_INET6;
         prefix.bitlen = 128;
         memcpy(&prefix.add.sin6.s6_addr, &session->addr2, 16);
     }

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -1069,8 +1069,8 @@ LOCAL void writer_s3_init(const char *UNUSED(name))
         }
     }
 
-    // Support up to 1000 S3 parts
-    config.maxFileSizeB = MIN(config.maxFileSizeB, config.pcapWriteSize * 1000LL);
+    // Support up to 10000 S3 parts
+    config.maxFileSizeB = MIN(config.maxFileSizeB, config.pcapWriteSize * 10000LL);
 
     // S3 has a 5TiB max size
     config.maxFileSizeB = MIN(config.maxFileSizeB, 0x50000000000LL);

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -419,8 +419,6 @@ LOCAL int reader_libpcapfile_stats(ArkimeReaderStats_t *stats)
 /******************************************************************************/
 LOCAL void reader_libpcapfile_pcap_cb(u_char *UNUSED(user), const struct pcap_pkthdr *h, const u_char *bytes)
 {
-    ArkimePacket_t *packet = arkime_packet_alloc();
-
     if (unlikely(h->caplen != h->len) && !config.readTruncatedPackets && !config.ignoreErrors) {
         LOGEXIT("ERROR - Arkime requires full packet captures caplen: %d pktlen: %d. "
                 "If using tcpdump use the \"-s0\" option, or set readTruncatedPackets in ini file",
@@ -430,6 +428,8 @@ LOCAL void reader_libpcapfile_pcap_cb(u_char *UNUSED(user), const struct pcap_pk
     if (unlikely(h->caplen > 0xffff)) {
         return;
     }
+
+    ArkimePacket_t *packet = arkime_packet_alloc();
 
     offlineInfo[readerPos].lastPackets++;
     offlineInfo[readerPos].lastPacketTime = h->ts;


### PR DESCRIPTION
- Fix crash when exit is used in the commandList config
- Clamp HTTP request priority before indexing outstandingPri
- Fix packet leak in libpcap-file reader when caplen > 0xffff
- Skip pcapDirs that can't be statvfs'd so disk stats aren't garbage
- Raise S3 writer max file size from 1000 to 10000 parts
- Use AF_INET6 family label for IPv6 prefixes in tagger
- Fix db.c stats log format specifiers for uint32/uint64 counters
- Fix typos and grammar in DESIGN.md and plugin READMEs

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
