### PR TITLE
Preserve redirect URL query parameters across OIDC login

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Release
   - #4048 Node 22.23.0
   - #4056 Add Fedora 44 builds
+## All
+  - #4065 Fix OIDC login not preserving the redirect URL's query parameters (thanks @yanover)
 ## Capture
   - #4054 Fix GRE keepalive packets adding bogus 00:00:00:00:00:00 MACs
   - #4055 Fix DNS memory leak when parsing malformed answers

--- a/common/auth.js
+++ b/common/auth.js
@@ -987,7 +987,11 @@ class Auth {
           if (ogurlEncoded) {
             try {
               const ogurl = Auth.auth2objNext(Buffer.from(ogurlEncoded, 'base64').toString());
-              return res.redirect(ogurl);
+              // Only redirect to a local same-origin path; reject absolute, protocol-relative
+              // ('//') and backslash ('/\') targets to prevent an open redirect.
+              if (typeof ogurl === 'string' && ogurl[0] === '/' && ogurl[1] !== '/' && ogurl[1] !== '\\') {
+                return res.redirect(ogurl);
+              }
             } catch (e) {
               console.log('Error', e);
               // Fall through to redirect below

--- a/common/auth.js
+++ b/common/auth.js
@@ -953,11 +953,13 @@ class Auth {
       req.url = req.url.replace('/', Auth.#basePath);
     }
 
-    if (req.url.toLowerCase() !== '/api/login' && req.originalUrl !== '/' && req.session) {
+    if (req.url.toLowerCase() !== '/api/login' && req.originalUrl !== '/' && req.session && req._parsedUrl.pathname !== '/auth/login/callback') {
       // save the original url so we can redirect after successful login
       // the ogurl is saved in the form login page and accessed using req.body.ogurl
       req.session.ogurl = Buffer.from(Auth.obj2authNext(req.originalUrl)).toString('base64');
     }
+
+    const savedOgurl = req.session?.ogurl;
 
     const passportAuthOptionsExtra = {};
     if (Auth.#strategies.includes('oidc') && (Auth.#authConfig.redirectURIs === undefined || Auth.#authConfig.redirectURIs.split(',').length > 1)) {
@@ -981,9 +983,10 @@ class Auth {
       } else {
         // Redirect to / if this is a login url
         if (req.route?.path === '/api/login' || req._parsedUrl.pathname === '/auth/login/callback') {
-          if (req.body?.ogurl) {
+          const ogurlEncoded = req.body?.ogurl || req.session?.ogurl || savedOgurl;
+          if (ogurlEncoded) {
             try {
-              const ogurl = Auth.auth2objNext(Buffer.from(req.body.ogurl, 'base64').toString());
+              const ogurl = Auth.auth2objNext(Buffer.from(ogurlEncoded, 'base64').toString());
               return res.redirect(ogurl);
             } catch (e) {
               console.log('Error', e);


### PR DESCRIPTION
**Clearly describe the problem and solution**

When using `authMode=oidc`, the first unauthenticated request to a URL with query parameters (e.g. `/sessions?expression=...&startTime=...&stopTime=...`) loses all parameters after the OIDC round-trip. The user is redirected to `/sessions` instead of the original URL. 

The second click works because the session already exists.

**Fix**
1. Exclude `/auth/login/callback` from overwriting ogurl

2. Capture ogurl in a local variable before `passport.authenticate` runs a local variable survives session regeneration, unlike `req.session.ogurl`.

3. Try multiple sources to find ogurl, instead of only checking `req.body.ogurl`, check three sources in order and use the first one that has a value:
   - `req.body.ogurl` : form auth submits it as a hidden POST field (unchanged behavior)
   - `req.session.ogurl` : still set if Passport didn't regenerate the session
   - `savedOgurl` : the local variable captured before `passport.authenticate`, survives session regeneration (fixes OIDC)

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**
yes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
