### PR TITLE
Fix viewer bugs and typos found in code review

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4054 Add mpacket link layer support
 ## Viewer
   - #4063 Fix CSV formula injection in the summary CSV export by neutralizing cells starting with = + - @
+  - #4071 Fix negative numbers being rejected in expressions
 
 6.5.0 2026/06/15
 ## Breaking

--- a/viewer/SHAREABLES.md
+++ b/viewer/SHAREABLES.md
@@ -163,7 +163,7 @@ DB Indices (Elasticsearch indices) tab column layout.
 
 ---
 
-### 5. `files-columns` — Files Tab Column Layout
+### `files-columns` (Alkeme TUI)
 
 Configures visible columns and sort order for the Files tab (PCAP file browser).
 

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -537,8 +537,8 @@ class CronAPIs {
 
   // --------------------------------------------------------------------------
   /* Process a single cron query.  At max it will process 24 hours worth of data
-   * to give other queries a chance to run.  Because its timestamp based and not
-   * lastPacket based since 1.0 it now search all indices each time.
+   * to give other queries a chance to run.  Because it's timestamp based and not
+   * lastPacket based since 1.0 it now searches all indices each time.
    */
   static async #processCronQuery (cq, options, query, endTime) {
     if (Config.debug > 2) {

--- a/viewer/apiHistory.js
+++ b/viewer/apiHistory.js
@@ -170,7 +170,7 @@ class HistoryAPIs {
         recordsFiltered: results.total
       });
     } catch (err) {
-      console.log(`ERROR - ${req.method} /api/history`, util.inspect(err, false, 50));
+      console.log(`ERROR - ${req.method} /api/histories`, util.inspect(err, false, 50));
       return res.serverError(500, 'Error retrieving history', 'api.history.retrieveFailed');
     }
   }

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -357,7 +357,7 @@ ${Config.arkimeWebURL()}hunt
     const failedSessions = JSON.parse(JSON.stringify(hunt.failedSessionIds));
     // we don't need to search the db for session, we just need to search each session in failedSessionIds
     async.forEachLimit(failedSessions, 3, (sessionId, cb) => {
-      Db.getSession(sessionId, { arkime_unflatten: true, _source: false, fields: 'node,huntName,huntId,lastPacket,field'.split(',') }, async (err, session) => {
+      Db.getSession(sessionId, { arkime_unflatten: true, _source: false, fields: 'node,huntName,huntId,lastPacket,fileId'.split(',') }, async (err, session) => {
         if (err) {
           const result = await HuntAPIs.#continueHuntSkipSession(hunt, huntId, session, sessionId, searchedSessions);
           return cb(result);
@@ -368,11 +368,11 @@ ${Config.arkimeWebURL()}hunt
         const huntRemotePath = `api/hunt/${session.node}/${huntId}/remote/${sessionId}`;
 
         if (Config.debug > 1) {
-          console.log('HUNT - remote', huntRemotePath);
+          console.log('HUNT - failed remote', huntRemotePath);
         }
         ViewerUtils.makeRequest(session.node, huntRemotePath, user, async (err, response) => {
           if (Config.debug > 1) {
-            console.log('HUNT - remote response', huntRemotePath, err, response);
+            console.log('HUNT - failed remote response', huntRemotePath, err, response);
           }
           if (err) {
             const updateResult = await HuntAPIs.#continueHuntSkipSession(hunt, huntId, session, sessionId, searchedSessions);
@@ -516,11 +516,11 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
             const huntRemotePath = `api/hunt/${node}/${huntId}/remote/${sessionId}`;
 
             if (Config.debug > 1) {
-              console.log('HUNT - failed remote', huntRemotePath);
+              console.log('HUNT - remote', huntRemotePath);
             }
             ViewerUtils.makeRequest(node, huntRemotePath, user, async (err, response) => {
               if (Config.debug > 1) {
-                console.log('HUNT - failed remote response', huntRemotePath, err, response);
+                console.log('HUNT - remote response', huntRemotePath, err, response);
               }
               if (err) {
                 const skipResult = await HuntAPIs.#continueHuntSkipSession(hunt, huntId, session, sessionId, searchedSessions);
@@ -786,7 +786,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
    * @property {number} matchedSessions - How many sessions contain packets that match the search text.
    * @property {number} searchedSessions - How many sessions have had their packets searched.
    * @property {number} totalSessions - The number of sessions to search.
-   * @property {number} lastPacketTime - The date of the first packet of the last searched session. Used to query for the next chunk of sessions to search. Format is seconds since Unix EPOCH.
+   * @property {number} lastPacketTime - The date of the last packet of the last searched session. Used to query for the next chunk of sessions to search. Format is seconds since Unix EPOCH.
    * @property {number} created - The time that the hunt was created. Format is seconds since Unix EPOCH.
    * @property {number} lastUpdated - The time that the hunt was last updated in the DB. Used to only update every 2 seconds. Format is seconds since Unix EPOCH.
    * @property {number} started - The time that the hunt was started (put into running state). Format is seconds since Unix EPOCH.
@@ -1235,7 +1235,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
         return res.serverError(500, 'Unable to update hunt', 'api.hunts.errorUpdating');
       }
     } catch (err) {
-      console.log(`ERROR - ${req.method} /api/hunt/%s/users (getHunt)`, ArkimeUtil.sanitizeStr(req.params.id), util.inspect(err, false, 50));
+      console.log(`ERROR - ${req.method} /api/hunt/%s (updateHunt)`, ArkimeUtil.sanitizeStr(req.params.id), util.inspect(err, false, 50));
       return res.serverError(500, 'Unable to update hunt', 'api.hunts.errorUpdating');
     }
   }

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -608,7 +608,7 @@ class SessionAPIs {
         return;
       }
 
-      // Get the pcap file for this node a filenum, if it isn't opened then do the filename lookup and open it
+      // Get the pcap file for this node and filenum, if it isn't opened then do the filename lookup and open it
       const opcap = Pcap.get(fields.node + ':' + fileNum);
       if (opcap.isCorrupt()) {
         throw new Error('Only have SPI data, PCAP file no longer available for ' + fields.node + '-' + fileNum);
@@ -1096,8 +1096,8 @@ class SessionAPIs {
       b.writeUInt32LE(0x80808080, 0); // Block Type
       b.writeUInt32LE(len, 4); // Block Len 1
       b.write('MOWL', 8); // Magic
-      b.writeUInt32LE(json.length, 12); // Block Len 1
-      b.write(json, 16); // Magic
+      b.writeUInt32LE(json.length, 12); // JSON Length
+      b.write(json, 16); // JSON Data
       b.fill(0, 16 + json.length, 16 + json.length + (4 - (json.length % 4)) % 4); // padding
       b.writeUInt32LE(len, len - 4); // Block Len 2
       res.write(b);
@@ -1161,7 +1161,7 @@ class SessionAPIs {
           return;
         }
 
-        // Get the pcap file for this node a filenum, if it isn't opened then do the filename lookup and open it
+        // Get the pcap file for this node and filenum, if it isn't opened then do the filename lookup and open it
         const opcap = Pcap.get(`write:${fields.node}:${fileNum}`);
         if (opcap.isCorrupt()) {
           throw new Error('Corrupt');
@@ -1881,7 +1881,7 @@ class SessionAPIs {
             response.recordsTotal = total.count;
             response.spi = sessions.aggregations;
             response.recordsFiltered = recordsFiltered;
-            res.logCounts(response.spi.count, response.recordsFiltered, response.total);
+            res.logCounts(response.spi.count, response.recordsFiltered, response.recordsTotal);
             return res.send(response);
           } catch (e) {
             console.trace('fetch spiview error', ArkimeUtil.sanitizeStr(e.stack));

--- a/viewer/apiShortcuts.js
+++ b/viewer/apiShortcuts.js
@@ -57,7 +57,7 @@ class ShortcutAPIs {
    * Also validates that the users added to the shortcut are valid within the system
    * NOTE: Mutates the shortcut directly
    * @param {Shortcut} shortcut - The shortcut to normalize
-   * @returns {Object} {type, values, invalidusers} - The shortcut type (ip, string, number),
+   * @returns {Object} {type, values, invalidUsers} - The shortcut type (ip, string, number),
    *                                                  array of values, and list of invalid users
    */
   static async #normalizeShortcut (shortcut) {

--- a/viewer/apiStats.js
+++ b/viewer/apiStats.js
@@ -414,7 +414,7 @@ class StatsAPIs {
 
         const writeInfo = node.thread_pool.bulk || node.thread_pool.write;
 
-        const oldnode = StatsAPIs.#previousNodesStats[0][nodeKeys[n]];
+        const oldnode = StatsAPIs.#previousNodesStats[0]?.[nodeKeys[n]];
         if (oldnode !== undefined && node.fs.io_stats !== undefined && oldnode.fs.io_stats !== undefined && 'total' in node.fs.io_stats) {
           const timediffsec = (node.timestamp - oldnode.timestamp) / 1000.0;
           read = Math.max(0, Math.ceil((node.fs.io_stats.total.read_kilobytes - oldnode.fs.io_stats.total.read_kilobytes) / timediffsec * 1024));
@@ -696,7 +696,7 @@ class StatsAPIs {
    * @name /esindices/:index/shrink
    * @param {string} target - The index name to shrink the index to.
    * @param {number} numShards - The number of shards to shrink the index to.
-   * @returns {boolean} success - Whether the close shrink operation was successful.
+   * @returns {boolean} success - Whether the shrink operation was successful.
    * @returns {string} text - The success/error message to (optionally) display to the user.
    */
   static async shrinkESIndex (req, res) {
@@ -850,7 +850,7 @@ class StatsAPIs {
         data: rtasks
       });
     } catch (err) {
-      console.log(`ERROR - ${req.method} /api/estask`, util.inspect(err, false, 50));
+      console.log(`ERROR - ${req.method} /api/estasks`, util.inspect(err, false, 50));
       return res.send({
         data: [],
         recordsTotal: 0,
@@ -1107,7 +1107,7 @@ class StatsAPIs {
       } else {
         const parts = req.body.value.split(',');
         if (parts.length !== 3) {
-          return res.serverError(500, 'Must be 3 piece of info', 'api.stats.mustBeThreePieces');
+          return res.serverError(500, 'Must be 3 pieces of info', 'api.stats.mustBeThreePieces');
         }
 
         query.body.persistent['cluster.routing.allocation.disk.watermark.low'] = parts[0];
@@ -1227,7 +1227,7 @@ class StatsAPIs {
       await Db.reroute(req.query.cluster);
       return res.json({ success: true, text: 'Reroute successful', i18n: 'api.stats.rerouteSuccessful' });
     } catch (err) {
-      return res.json({ success: true, text: 'Reroute failed', i18n: 'api.stats.rerouteFailed' });
+      return res.json({ success: false, text: 'Reroute failed', i18n: 'api.stats.rerouteFailed' });
     }
   }
 
@@ -1374,7 +1374,7 @@ class StatsAPIs {
       for (const shard of shards) {
         if (shard.node === null || shard.node === 'null') {
           if (shard.ud && shard.ud.startsWith('node_left [')) {
-            shard.oldNode = Db.getESId2Node(shard.ud.substring(11, shard.ud.length - 1), req.cluster);
+            shard.oldNode = Db.getESId2Node(shard.ud.substring(11, shard.ud.length - 1), options.cluster);
           }
           shard.node = 'Unassigned';
         }
@@ -1530,9 +1530,9 @@ class StatsAPIs {
   /**
    * POST - /api/esshards/:index/:shard/delete
    *
-   * Delete OpenSearch/Elasticsearch (admin only).
+   * Deletes an OpenSearch/Elasticsearch shard (admin only).
    * @name /esshards/:index/:shard/delete
-   * @returns {boolean} success - Whether include node operation was successful.
+   * @returns {boolean} success - Whether the delete shard operation was successful.
    * @returns {string} text - The success/error message to (optionally) display to the user.
    */
   static async deleteESShard (req, res) {

--- a/viewer/arkimeparser.jison
+++ b/viewer/arkimeparser.jison
@@ -168,7 +168,7 @@ function getRegexInfoList (yy, info) {
 function parseIpPort (yy, field, ipPortStr) {
   const dbField = getFieldInfo(yy, field).dbField;
 
-  // Have just a single Ip, create obj for it
+  // Have just a single ip, create obj for it
   function parseSingleIp (exp, singleDbField, singleIp, singlePort) {
     let singleObj;
 
@@ -296,7 +296,6 @@ function parseIpPort (yy, field, ipPortStr) {
     }
 
     if (slash[1] === undefined) {
-      console.log(colons2.length, colons2, colons2.length, 16*colons2.length);
       slash[1] = `${16*colons2.length}`;
     }
 
@@ -474,10 +473,7 @@ function formatShortcutsQuery (yy, field, op, value, shortcutParent) {
       if (field === 'ip') {
         const infos = getIpInfoList(yy, false);
         for (const ipInfo of infos) {
-          const newObj = formatShortcutsQuery(yy, ipInfo.exp, op, '$' + value, obj);
-          if (newObj) {
-            obj.bool[operation].concat(newObj);
-          }
+          formatShortcutsQuery(yy, ipInfo.exp, op, '$' + value, obj);
         }
       } else {
         terms[info.dbField] = {
@@ -698,7 +694,7 @@ function field2Raw (yy, field) {
   const dbField = info.dbField;
   if (info.rawField) { return info.rawField; }
 
-  if (dbField.indexOf('.snow', dbField.length - 5) === 0) { return dbField.substring(0, dbField.length - 5) + '.raw'; }
+  if (dbField.endsWith('.snow')) { return dbField.substring(0, dbField.length - 5) + '.raw'; }
 
   return dbField;
 }
@@ -967,7 +963,7 @@ function termOrTermsInt (dbField, str) {
       obj = { range: {} };
       obj.range[dbField] = { gte: parseInt(match[1]), lte: parseInt(match[2]) };
       return obj;
-    } else if (str.match(/[^\d]+/)) {
+    } else if (!str.match(/^-?\d+$/)) {
       throw str + ' is not a number';
     }
     obj = { term: {} };

--- a/viewer/arkimeparser.js
+++ b/viewer/arkimeparser.js
@@ -366,7 +366,7 @@ function getRegexInfoList (yy, info) {
 function parseIpPort (yy, field, ipPortStr) {
   const dbField = getFieldInfo(yy, field).dbField;
 
-  // Have just a single Ip, create obj for it
+  // Have just a single ip, create obj for it
   function parseSingleIp (exp, singleDbField, singleIp, singlePort) {
     let singleObj;
 
@@ -494,7 +494,6 @@ function parseIpPort (yy, field, ipPortStr) {
     }
 
     if (slash[1] === undefined) {
-      console.log(colons2.length, colons2, colons2.length, 16*colons2.length);
       slash[1] = `${16*colons2.length}`;
     }
 
@@ -672,10 +671,7 @@ function formatShortcutsQuery (yy, field, op, value, shortcutParent) {
       if (field === 'ip') {
         const infos = getIpInfoList(yy, false);
         for (const ipInfo of infos) {
-          const newObj = formatShortcutsQuery(yy, ipInfo.exp, op, '$' + value, obj);
-          if (newObj) {
-            obj.bool[operation].concat(newObj);
-          }
+          formatShortcutsQuery(yy, ipInfo.exp, op, '$' + value, obj);
         }
       } else {
         terms[info.dbField] = {
@@ -896,7 +892,7 @@ function field2Raw (yy, field) {
   const dbField = info.dbField;
   if (info.rawField) { return info.rawField; }
 
-  if (dbField.indexOf('.snow', dbField.length - 5) === 0) { return dbField.substring(0, dbField.length - 5) + '.raw'; }
+  if (dbField.endsWith('.snow')) { return dbField.substring(0, dbField.length - 5) + '.raw'; }
 
   return dbField;
 }
@@ -1165,7 +1161,7 @@ function termOrTermsInt (dbField, str) {
       obj = { range: {} };
       obj.range[dbField] = { gte: parseInt(match[1]), lte: parseInt(match[2]) };
       return obj;
-    } else if (str.match(/[^\d]+/)) {
+    } else if (!str.match(/^-?\d+$/)) {
       throw str + ' is not a number';
     }
     obj = { term: {} };

--- a/viewer/db.js
+++ b/viewer/db.js
@@ -438,7 +438,7 @@ async function fixPacketPos (fields) {
   try {
     const fileInfo = await Db.fileIdToFile(fields.node, -1 * fields.packetPos[0]);
     if (internals.debug > 2) {
-      console.log('GETSESSION - fixPackPos', fileInfo);
+      console.log('GETSESSION - fixPacketPos', fileInfo);
     }
 
     if (!fileInfo || !fileInfo.packetPosEncoding) {
@@ -686,7 +686,7 @@ Db.cancelByOpaqueId = async (cancelId, cluster) => {
 };
 
 Db.searchScroll = async (index, query, options, cb) => {
-  // external scrolling, or multiesES or (not regressionTests AND lesseq 10000), do a normal search which does its own Promise conversion
+  // external scrolling, or multiES or (not regressionTests AND lesseq 10000), do a normal search which does its own Promise conversion
   if (options?.scroll !== undefined || internals.multiES || (!internals.regressionTests && (query.size ?? 0) + (parseInt(query.from ?? 0, 10)) <= 10000)) {
     if (!cb) {
       return Db.search(index, query, options);
@@ -758,7 +758,7 @@ Db.searchScroll = async (index, query, options, cb) => {
 };
 
 Db.searchScrollIterator = async function* (index, query, options) {
-  // external scrolling, or multiesES or (not regressionTests AND lesseq 10000), do a normal search which does its own Promise conversion
+  // external scrolling, or multiES or (not regressionTests AND lesseq 10000), do a normal search which does its own Promise conversion
   if (options?.scroll !== undefined || internals.multiES || (!internals.regressionTests && (query.size ?? 0) + (parseInt(query.from ?? 0, 10)) <= 10000)) {
     const result = await Db.search(index, query, options);
     yield result;

--- a/viewer/decode.js
+++ b/viewer/decode.js
@@ -763,7 +763,7 @@ class ItemHTTPStream extends ItemTransform {
 class ItemHexFormatterStream extends Transform {
   constructor (options) {
     super({ objectMode: true });
-    mkname(this, 'ItemHexFormaterStream');
+    mkname(this, 'ItemHexFormatterStream');
     this.showOffsets = options['ITEM-HEX'] ? options['ITEM-HEX'].showOffsets || false : false;
   }
 
@@ -1039,7 +1039,7 @@ if (require.main === module) {
     async.whilst(
       function (cb) { return cb(null, pos < stat.size); },
       async function (callback) {
-        const packet = pcap.readPacket(pos);
+        const packet = await pcap.readPacket(pos);
         const obj = {};
         pcap.decode(packet, obj);
         packets.push(obj);

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -453,7 +453,7 @@ function validateBulk (req) {
         if (!isFieldsIndex(_index)) { throw new Error(`Bad index ${_index}`); }
       } else {
         console.log('Failed bulk', JSON.stringify(json, null, 2));
-        throw new Error('Missing create, update or index operation');
+        throw new Error('Missing create, update, delete or index operation');
       }
     } catch (err) {
       console.log('Bulk error', err, ArkimeUtil.sanitizeStr(lines[i]));

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -1,5 +1,5 @@
 /******************************************************************************/
-/* multies.js  -- Make multiple ES servers look like one but merging results
+/* multies.js  -- Make multiple ES servers look like one by merging results
  *
  * Copyright 2012-2016 AOL Inc. All rights reserved.
  *
@@ -1079,7 +1079,7 @@ app.post(['/MULTIPREFIX_fields/field/_search', '/MULTIPREFIX_fields/_search'], f
       const result = results[i];
 
       if (result.error) {
-        console.log('ERROR - GET /fields/field/_search', result.error);
+        console.log('ERROR - POST /fields/field/_search', result.error);
         return res.send(obj);
       }
 
@@ -1342,7 +1342,7 @@ async function premain () {
   for (let i = 0; i < nodes.length; i++) {
     const nodeName = node2Name(nodes[i]);
     if (!nodeName) {
-      console.log('ERROR - name is missing in multiESNodes for', nodes[i], 'Set node name as multiESNodes=http://example1:9200,name:<friendly-name-11>;http://example2:9200,name:<friendly-name-2>');
+      console.log('ERROR - name is missing in multiESNodes for', nodes[i], 'Set node name as multiESNodes=http://example1:9200,name:<friendly-name-1>;http://example2:9200,name:<friendly-name-2>');
       process.exit(1);
     }
     clusterList[i] = nodeName; // name

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1706,7 +1706,7 @@ app.post( // include OpenSearch/Elasticsearch shard endpoint
   StatsAPIs.includeESShard
 );
 
-app.post( // include OpenSearch/Elasticsearch shard endpoint
+app.post( // delete OpenSearch/Elasticsearch shard endpoint
   ['/api/esshards/:index/:shard/delete'],
   [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
   StatsAPIs.deleteESShard
@@ -2264,13 +2264,13 @@ async function main () {
 function processArgs (argv) {
   for (let i = 0, ilen = argv.length; i < ilen; i++) {
     if (argv[i] === '--help') {
-      console.log('node.js [<options>]');
+      console.log('viewer.js [<options>]');
       console.log('');
       console.log('Options:');
       console.log('  -c, --config <file|url>  Where to fetch the config file from');
       console.log('  -n <node name>           Node name section to use in config file, default first part of hostname');
       console.log('  --debug                  Increase debug level, multiple are supported');
-      console.log('  --esprofile              Turn on profiling to es search queries');
+      console.log('  --esprofile              Turn on profiling of es search queries');
       console.log('  --host <host name>       Host name to use, default os hostname');
       console.log('  --insecure               Disable certificate verification for https calls');
 


### PR DESCRIPTION
apiStats: return success:false on a failed reroute, guard /api/esstats when ES stats init failed, and use the request cluster for the unassigned-shard old-node lookup arkimeparser: allow negative single-integer expression values, fix .snow fields without a rawField targeting the wrong ES field, and drop debug logging and a dead concat apiSessions: pass recordsTotal (not undefined) to the spiview logCounts call decode: await pcap.readPacket in the standalone decode mode Fix typos, comments, and JSDoc in apiCrons, apiHistory, apiHunts, apiShortcuts, db, esProxy, multies, viewer, decode, and SHAREABLES

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
