### PR TITLE
Fix cont3xt bugs and typos found in code review

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,6 +39,10 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Breaking
   - #4072 WISE reversedns now saves resolved names that match none of the stripDomains entries in
           full (as documented) instead of silently dropping them
+  - #4073 The cont3xt Arkime integration searchDays setting now searches that many days instead of 7x that many.
+           Existing configs that relied on the wider window must increase searchDays to keep the previous range.
+  - #4073 The cont3xt redis integration now substitutes 'domain' (not 'domainip') for %type% in keyTemplate on domain lookups.
+          Deployments that stored domain data under the old 'domainip' key must re-key it as 'domain'.
 ## Release
   - #4066 Node 22.23.1
   - #4056 Add Fedora 44 builds
@@ -52,6 +56,11 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4068 Add some missing http methods to parser
 ## Capture/Viewer
   - #4054 Add mpacket link layer support
+## Cont3xt
+  - #4073 Fix search and single-integration refresh hanging when an integration errors or returns no data
+  - #4073 Fix integration cacheTimeout values specified in milliseconds being treated as seconds (1000x too long); short-TTL integrations like DNS now expire on time
+  - #4073 Fix csv/json integrations sometimes failing to load JSON feeds over http/elasticsearch/opensearch
+  - #4073 Fix ClickHouse integration being broken (wrong search method name and unawaited result parsing)
 ## Viewer
   - #4063 Fix CSV formula injection in the summary CSV export by neutralizing cells starting with = + - @
   - #4071 Fix negative numbers being rejected in expressions

--- a/cont3xt/audit.js
+++ b/cont3xt/audit.js
@@ -91,7 +91,7 @@ class Audit {
     if (typeof (audit.userId) !== 'string') { return 'must have field userId of type string'; }
     if (typeof (audit.issuedAt) !== 'number') { return 'must have field issuedAt of type number (milliseconds)'; }
     if (typeof (audit.took) !== 'number') { return 'must have field took of type number (milliseconds)'; }
-    if (typeof (audit.resultCount) !== 'number') { return 'must have field resultCount of type number (milliseconds)'; }
+    if (typeof (audit.resultCount) !== 'number') { return 'must have field resultCount of type number'; }
     if (typeof (audit.iType) !== 'string') { return 'must have field iType of type string'; }
     if (typeof (audit.indicator) !== 'string') { return 'must have field indicator of type string'; }
     if (!Array.isArray(audit.tags)) { return 'must have field tags of type Array'; }

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -57,7 +57,7 @@ app.use((req, res, next) => {
   next();
 });
 
-// define csp headers - no-op in NODE_END=development, since csp will disable vite's HMR (hot module reloading)
+// define csp headers - no-op in NODE_ENV=development, since csp will disable vite's HMR (hot module reloading)
 const cspHeader = (process.env.NODE_ENV === 'development')
   ? (_req, _res, next) => { next(); }
   : helmet.contentSecurityPolicy({
@@ -164,12 +164,12 @@ const integrationsStatic = express.static(
   { maxAge: dayMs, fallthrough: false }
 );
 app.use('/integrations', (req, res, next) => {
-  if (req.path.endsWith('.png')) {
+  if (req.path.endsWith('.png') || req.path.endsWith('.jpg') || req.path.endsWith('.jpeg')) {
     return integrationsStatic(req, res, (err) => {
       ArkimeUtil.missingResource(err, req, res);
     });
   }
-  return ArkimeUtil.missingResource('Not png', req, res);
+  return ArkimeUtil.missingResource('Not png or jpg', req, res);
 });
 
 app.use(favicon(path.join(__dirname, '/favicon.ico')));
@@ -350,6 +350,10 @@ function apiPutSettings (req, res, next) {
     }
 
     user.save((err) => {
+      if (err) {
+        console.log('ERROR - saving cont3xt settings', err);
+        return res.send({ success: false, text: 'Save failed' });
+      }
       res.send({ success: true, text: 'Saved' });
     });
   });

--- a/cont3xt/db.js
+++ b/cont3xt/db.js
@@ -634,8 +634,8 @@ class DbESImplementation {
   async getMatchingAudits (userId, roles, reqQuery) {
     const { startMs, stopMs, searchTerm, page, itemsPerPage, sortBy, sortOrder } = reqQuery;
     const filter = [];
-    const allowedSortBy = { issuedAt: 1, indicator: 1, iType: 1 };
-    const safeSortBy = allowedSortBy[sortBy] ? sortBy : 'issuedAt';
+    const allowedSortBy = ['issuedAt', 'indicator', 'iType'];
+    const safeSortBy = allowedSortBy.includes(sortBy) ? sortBy : 'issuedAt';
     const safeSortOrder = sortOrder === 'asc' ? 'asc' : 'desc';
     const query = {
       size: itemsPerPage || 1000,
@@ -689,7 +689,7 @@ class DbESImplementation {
       };
     } catch (err) {
       console.log('ERROR - fetching audit log history', util.inspect(err, false, 10));
-      return [];
+      return { audits: [], total: 0 };
     }
   }
 
@@ -913,7 +913,7 @@ class DbLMDBImplementation {
   async getMatchingAudits (userId, roles, reqQuery) {
     const { startMs, stopMs, searchTerm, page, itemsPerPage, sortBy, sortOrder } = reqQuery;
     let audits = [...this.auditStore.getRange({})
-      .filter(({ _, value }) => {
+      .filter(({ value }) => {
         // remove entries outside the dateRange, if there is one
         if ((startMs != null && stopMs != null) && (value.issuedAt < startMs || value.issuedAt > stopMs)) {
           return false;

--- a/cont3xt/descriptions.txt
+++ b/cont3xt/descriptions.txt
@@ -6,7 +6,7 @@ Terminology
 User Settings Description - an object with each sub object a setting.
   * sub objects can have
     * help - some help text
-    * password - if true then its a password
+    * password - if true then it's a password
     * uiSetting - true if value is needed in the UI (do not set true for secure values like passwords)
 
 

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -77,7 +77,7 @@ class Integration {
    * Register an integration implementation
    * @param {string} integration.name The name of the integration
    * @param {object} integration.itypes An object of itypes to functions to call
-   * @param {boolean} integration.cacheable=true Should results be cache
+   * @param {boolean} integration.cacheable=true Should results be cached
    * @param {boolean} integration.noStats=false Should we not save stats
    * @param {number} integration.order=10000 What order should this integration be shown
    */
@@ -92,7 +92,7 @@ class Integration {
       return;
     }
 
-    // Can disable a integration globally
+    // Can disable an integration globally
     const disabled = integration.getConfig('disabled', false);
     if (disabled === true || disabled === 'true') {
       console.log(integration.name, 'disabled');
@@ -318,7 +318,7 @@ class Integration {
    * @typedef Integration
    * @type {object}
    * @param {string} cachePolicy - Who can access the cached results of this integration's data ("shared")
-   * @param {number} cacheTimeout - How long results will be cached, -1 not cached
+   * @param {number|string} cacheTimeout - How long results will be cached, as a time string (e.g. '1h', '1w') or a number of seconds, -1 not cached
    * @param {boolean} doable - Whether the user has access to execute this integration
    * @param {string} icon - The relative url to the integrations icon
    * @param {number} order - The order in which this integration displays in the UI
@@ -331,7 +331,7 @@ class Integration {
    *
    * List out all the integrations. Integrations without any itypes are skipped.
    * @name /integration
-   * @returns {Integrations[]} integrations - A map of integrations that the logged in user has configured
+   * @returns {Object.<string, Integration>} integrations - A map of integrations that the logged in user has configured
    * @returns {boolean} success - True if the request was successful, false otherwise
    */
   static async apiList (req, res, next) {
@@ -474,7 +474,7 @@ class Integration {
     }
 
     for (const integration of integrations) {
-      // Can disable a integration per user
+      // Can disable an integration per user
       const disabled = keys?.[integration.name]?.disabled;
       if (disabled === true || disabled === 'true') {
         shared.total--;
@@ -563,15 +563,16 @@ class Integration {
         })
         .catch(err => {
           if (ArkimeConfig.debug > 0) {
-            console.log('failure in %s - itype: %s query: %s error:', integration.section, itype, query, err);
+            console.log('failure in %s - itype: %s query: %s error:', integration.name ?? integration.section, itype, query, err);
           } else {
-            console.log('failure in %s - itype: %s error:', integration.section, itype, err.message ?? err);
+            console.log('failure in %s - itype: %s error:', integration.name ?? integration.section, itype, err.message ?? err);
           }
           shared.sent++;
           stats.directError++;
           istats.directError++;
           shared.res.write(JSON.stringify({ purpose: 'fail', sent: shared.sent, total: shared.total, name: integration.name, indicator }));
           shared.res.write(',\n');
+          checkWriteDone();
         });
     }
   }
@@ -594,7 +595,7 @@ class Integration {
   /**
    * Integration Data Chunk object
    *
-   * An chunk of data returned from searching integrations
+   * A chunk of data returned from searching integrations
    * @typedef IntegrationChunk
    * @type {object}
    * @param {DataChunkPurpose} purpose - String discriminator to indicate the use of this data chunk
@@ -751,6 +752,19 @@ class Integration {
 
     const indicator = { itype, query };
 
+    let normalizedQuery = query;
+    if (itype === 'ip') {
+      try {
+        normalizedQuery = ipaddr.parse(query).toNormalizedString();
+      } catch (e) {
+        return res.send({ purpose: 'error', text: `query does not match itype ${itype}` });
+      }
+      // match the bulk-search zero-padding so the cache key lines up
+      if (normalizedQuery.includes(':')) {
+        normalizedQuery = normalizedQuery.split(':').map(x => x.padStart(4, '0')).join(':');
+      }
+    }
+
     const integration = Integration.#integrationsByName[req.params.integration];
 
     if (integration === undefined || integration.itypes[itype] === undefined) {
@@ -778,7 +792,7 @@ class Integration {
     stats.directLookup++;
     istats.directLookup++;
     const dStartTime = Date.now();
-    integration[integration.itypes[itype]](req.user, query)
+    integration[integration.itypes[itype]](req.user, normalizedQuery)
       .then(response => {
         updateTime(stats, istats, Date.now() - dStartTime, 'direct');
         stats.directFound++;
@@ -792,9 +806,11 @@ class Integration {
           response._cont3xt.createTime = Date.now();
           res.send({ purpose: 'data', indicator, name: integration.name, data: response });
           if (Integration.#cache && integration.cacheable) {
-            const cacheKey = `${integration.sharedCache ? 'shared' : req.user.userId}-${integration.name}-${itype}-${query}`;
+            const cacheKey = `${integration.sharedCache ? 'shared' : req.user.userId}-${integration.name}-${itype}-${normalizedQuery}`;
             Integration.#cache.set(cacheKey, response);
           }
+        } else {
+          res.send({ purpose: 'data', indicator, name: integration.name, data: { _cont3xt: { createTime: Date.now() } } });
         }
       })
       .catch(err => {

--- a/cont3xt/integrations/alienvaultotx/index.js
+++ b/cont3xt/integrations/alienvaultotx/index.js
@@ -15,7 +15,7 @@ class AlienVaultOTXIntegration extends Integration {
     ip: 'fetchIp',
     domain: 'fetchDomain',
     hash: 'fetchHash',
-    url: 'fetchHash'
+    url: 'fetchUrl'
   };
 
   homePage = 'https://otx.alienvault.com/';
@@ -25,7 +25,7 @@ class AlienVaultOTXIntegration extends Integration {
       type: 'boolean'
     },
     key: {
-      help: 'Your Alien Vault OTX Key',
+      help: 'Your AlienVault OTX Key',
       password: true,
       required: true
     }
@@ -150,7 +150,7 @@ class AlienVaultOTXIntegration extends Integration {
         return undefined;
       }
 
-      const base = `https://otx.alienvault.com/api/v1/indicators/${type}/${query}`;
+      const base = `https://otx.alienvault.com/api/v1/indicators/${type}/${encodeURIComponent(query)}`;
 
       const result = {};
 

--- a/cont3xt/integrations/arkime/index.js
+++ b/cont3xt/integrations/arkime/index.js
@@ -217,7 +217,7 @@ class ArkimeIntegration extends Integration {
       query: {
         bool: {
           must: [
-            { range: { lastPacket: { gte: new Date() - (this.#searchDays * 7 * 24 * 60 * 60 * 1000) } } },
+            { range: { lastPacket: { gte: new Date() - (this.#searchDays * 24 * 60 * 60 * 1000) } } },
             { bool: { should: fields.map(field => { return { term: { [field]: item } }; }) } }
           ]
         }

--- a/cont3xt/integrations/clickhouse/index.js
+++ b/cont3xt/integrations/clickhouse/index.js
@@ -67,14 +67,14 @@ class ClickHouseIntegration extends Integration {
     Integration.register(this);
   }
 
-  async searchMethod (user, item) {
+  async search (user, item) {
     const resultSet = await this.#client.query({
       query: this.#statement,
       format: 'JSONEachRow',
       query_params: { value: item }
     });
 
-    const hits = resultSet.json();
+    const hits = await resultSet.json();
     const data = {
       hits,
       _cont3xt: {

--- a/cont3xt/integrations/crtsh/index.js
+++ b/cont3xt/integrations/crtsh/index.js
@@ -82,7 +82,7 @@ class CrtShIntegration extends Integration {
 
   // Cache for 1 week due to crt.sh being a flaky service that frequently returns
   // 503 errors with database recovery conflicts and timeouts
-  cacheTimeout = 7 * 24 * 60 * 60 * 1000;
+  cacheTimeout = '1w';
 
   constructor () {
     super();

--- a/cont3xt/integrations/csvjson/index.js
+++ b/cont3xt/integrations/csvjson/index.js
@@ -93,7 +93,7 @@ class CsvJsonIntegration extends Integration {
 
     if (this.#url[0] === '/' || this.#url.startsWith('./') || this.#url.startsWith('../')) {
       if (!fs.existsSync(this.#url)) {
-        console.log(this.section, '- ERROR not loading', this.section, 'since', this.#url, "doesn't exist");
+        console.log(this.section, '- ERROR not loading since', this.#url, "doesn't exist");
         return;
       }
       this.#load = this.#loadFile;
@@ -120,7 +120,7 @@ class CsvJsonIntegration extends Integration {
       this.#redisKey = redisParts.pop();
       this.#redisClient = ArkimeUtil.createRedisClient(redisParts.join('/'), section);
     } else {
-      console.log(this.section, '- ERROR not loading', this.section, `don't know how to open`, this.#url);
+      console.log(this.section, "- ERROR not loading, don't know how to open", this.#url);
       return;
     }
 
@@ -130,6 +130,7 @@ class CsvJsonIntegration extends Integration {
 
   // ----------------------------------------------------------------------------
   async getIp (user, item) {
+    if (!this.#ipCache) { return Integration.NoResult; }
     const result = this.#ipCache.find(item);
     if (!result) {
       return Integration.NoResult;
@@ -145,6 +146,7 @@ class CsvJsonIntegration extends Integration {
 
   // ----------------------------------------------------------------------------
   async getOther (user, item) {
+    if (!this.#otherCache) { return Integration.NoResult; }
     const result = this.#otherCache.get(item);
 
     if (!result) {
@@ -175,7 +177,7 @@ class CsvJsonIntegration extends Integration {
 
   // ----------------------------------------------------------------------------
   #parseJSON (data, setCb, endCb) {
-    let json = JSON.parse(data);
+    let json = typeof data === 'string' ? JSON.parse(data) : data;
     if (this.#arrayPath !== undefined) {
       const arrayPath = this.#arrayPath.split('.');
       for (let i = 0; i < arrayPath.length; i++) {
@@ -274,14 +276,14 @@ class CsvJsonIntegration extends Integration {
   // ----------------------------------------------------------------------------
   #loadFile () {
     if (!fs.existsSync(this.#url)) {
-      console.log(this.section, '- ERROR not loading', this.section, 'since', this.#url, "doesn't exist");
+      console.log(this.section, '- ERROR not loading since', this.#url, "doesn't exist");
       return;
     }
 
     // Process the file
     this.#process(fs.readFileSync(this.#url));
 
-    // Watch for file changes, debounce over 500ms
+    // Watch for file changes, debounce over 1000ms
     if (!this.#watch) {
       // Need to as variable because of 'this'
       const watchCb = () => {

--- a/cont3xt/integrations/databricks/index.js
+++ b/cont3xt/integrations/databricks/index.js
@@ -72,6 +72,7 @@ class DatabricksIntegration extends Integration {
   }
 
   async search (user, item) {
+    if (!this.#session) { return Integration.NoResult; }
     const queryOperation = await this.#session.executeStatement(this.#statement, { namedParameters: { SEARCHTERM: item } });
     const resultSet = await queryOperation.fetchAll();
     await queryOperation.close();

--- a/cont3xt/integrations/dns/index.js
+++ b/cont3xt/integrations/dns/index.js
@@ -15,7 +15,7 @@ class DNSIntegration extends Integration {
   };
 
   // Default cacheTimeout 10 minutes
-  cacheTimeout = 10 * 60 * 1000;
+  cacheTimeout = '10m';
 
   card = {
     title: 'DNS for %{query}',

--- a/cont3xt/integrations/domaintools/index.js
+++ b/cont3xt/integrations/domaintools/index.js
@@ -131,7 +131,7 @@ class DomainToolsWhoisIntegration extends Integration {
     ]
   };
 
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();

--- a/cont3xt/integrations/elasticsearch/index.js
+++ b/cont3xt/integrations/elasticsearch/index.js
@@ -168,7 +168,7 @@ class ElasticsearchIntegration extends Integration {
     const results = await this.#client.get({
       index: this.#index,
       id: item
-    });
+    }, { ignore: [404] });
 
     if (results.statusCode !== 200 || !results?.body?._source) {
       return Integration.NoResult;

--- a/cont3xt/integrations/ipqs/index.js
+++ b/cont3xt/integrations/ipqs/index.js
@@ -35,7 +35,7 @@ class IPQSIntegration extends Integration {
     }
   };
 
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();
@@ -75,7 +75,7 @@ class IPQSIPIntegration extends Integration {
     ]
   };
 
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
   constructor () {
     super();
     Integration.register(this);
@@ -160,7 +160,7 @@ class IPQSEmailIntegration extends Integration {
     }
   };
 
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   card = {
     title: 'IPQS Email Reputation for %{query}',
@@ -266,7 +266,7 @@ class IPQSEmailLeakIntegration extends Integration {
     }
   };
 
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   card = {
     title: 'IPQS Email Leak Records for %{query}',
@@ -308,10 +308,10 @@ class IPQSEmailLeakIntegration extends Integration {
           console.error(`${this.name}: Email Leak API request failed for ${email}. Status: ${axiosError.response.status}, Data: ${JSON.stringify(axiosError.response.data)}`);
         } else if (axiosError.request) {
           errorMsg = 'No response received from the Email Leak API.';
-          console.error(`${this.name}: No response received from Darkweb API for ${email}. Request: ${JSON.stringify(axiosError.request)}`);
+          console.error(`${this.name}: No response received from Email Leak API for ${email}. Request: ${JSON.stringify(axiosError.request)}`);
         } else {
           errorMsg = `Request setup failed. Message: ${axiosError.message}`;
-          console.error(`${this.name}: Error setting up Darkweb API request for ${email}. Message: ${axiosError.message}`);
+          console.error(`${this.name}: Error setting up Email Leak API request for ${email}. Message: ${axiosError.message}`);
         }
 
         return {
@@ -328,7 +328,7 @@ class IPQSEmailLeakIntegration extends Integration {
         };
       }
       if (response.data?.success === false) {
-        console.error(`${this.name}: Darkweb API reported failure for ${email}. Message: ${response.data.message || 'No specific message.'}`);
+        console.error(`${this.name}: Email Leak API reported failure for ${email}. Message: ${response.data.message || 'No specific message.'}`);
         return {
           _cont3xt: { count: 0 },
           error: response.data.message || 'Invalid input'
@@ -338,7 +338,7 @@ class IPQSEmailLeakIntegration extends Integration {
       response.data._cont3xt = { count: 1 };
       return response.data;
     } catch (err) {
-      console.error(`${this.name}: An unexpected error occurred while fetching darkweb data for ${email}:`, err);
+      console.error(`${this.name}: An unexpected error occurred while fetching Email Leak data for ${email}:`, err);
       return {
         _cont3xt: { count: 0 },
         error: `Unexpected error occurred while fetching data for ${email}.`
@@ -386,7 +386,7 @@ class IPQSUrlIntegration extends Integration {
     ]
   };
 
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();
@@ -490,7 +490,7 @@ class IPQSPhoneIntegration extends Integration {
     ]
   };
 
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();

--- a/cont3xt/integrations/passivetotal/index.js
+++ b/cont3xt/integrations/passivetotal/index.js
@@ -27,7 +27,7 @@ class PassiveTotalIntegration extends Integration {
   };
 
   // Default cacheTimeout 24 hours
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();
@@ -116,7 +116,7 @@ class PassiveTotalWhoisIntegration extends Integration {
   };
 
   // Default cacheTimeout 24 hours
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();
@@ -189,7 +189,7 @@ class PassiveTotalSubdomainsIntegration extends Integration {
   };
 
   // Default cacheTimeout 24 hours
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();
@@ -298,7 +298,7 @@ class PassiveTotalDNSIntegration extends Integration {
   };
 
   // Default cacheTimeout 24 hours
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();

--- a/cont3xt/integrations/quad9/index.js
+++ b/cont3xt/integrations/quad9/index.js
@@ -13,7 +13,7 @@ class Quad9 extends Integration {
     domain: 'fetch'
   };
 
-  homePage = 'https://dns.quad9.net/dns-query';
+  homePage = 'https://quad9.net/';
   settings = {
     disabled: {
       help: 'Disable integration for all queries',

--- a/cont3xt/integrations/redis/index.js
+++ b/cont3xt/integrations/redis/index.js
@@ -35,7 +35,7 @@ class RedisIntegration extends Integration {
   #redisMethod;
   #keyTemplate;
 
-  constructor (section, isCSV) {
+  constructor (section) {
     super();
 
     this.section = section;
@@ -82,7 +82,7 @@ class RedisIntegration extends Integration {
 
   // ----------------------------------------------------------------------------
   async ipFetch (user, item) { return this.#fetch(user, item, 'ip'); }
-  async domainFetch (user, item) { return this.#fetch(user, item, 'domainip'); }
+  async domainFetch (user, item) { return this.#fetch(user, item, 'domain'); }
   async phoneFetch (user, item) { return this.#fetch(user, item, 'phone'); }
   async emailFetch (user, item) { return this.#fetch(user, item, 'email'); }
   async hashFetch (user, item) { return this.#fetch(user, item, 'hash'); }
@@ -93,5 +93,5 @@ class RedisIntegration extends Integration {
 const sections = ArkimeConfig.getSections().filter((e) => { return e.match(/^redis:/); });
 sections.forEach((section) => {
 
-  new RedisIntegration(section, true);
+  new RedisIntegration(section);
 });

--- a/cont3xt/integrations/urlscan/index.js
+++ b/cont3xt/integrations/urlscan/index.js
@@ -139,7 +139,7 @@ class URLScanIntegration extends Integration {
 
       const result = await axios.get('https://urlscan.io/api/v1/search/', {
         params: {
-          q: encodeURIComponent(query)
+          q: query
         },
         headers: {
           'API-Key': key,

--- a/cont3xt/integrations/virustotal/index.js
+++ b/cont3xt/integrations/virustotal/index.js
@@ -22,7 +22,7 @@ class VirusTotalIntegration extends Integration {
   };
 
   // Default cacheTimeout 24 hours
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();
@@ -148,7 +148,7 @@ class VirusTotalDomainIntegration extends Integration {
   };
 
   // Default cacheTimeout 24 hours
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();
@@ -280,7 +280,7 @@ class VirusTotalIPIntegration extends Integration {
   };
 
   // Default cacheTimeout 24 hours
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();
@@ -379,7 +379,7 @@ class VirusTotalHashIntegration extends Integration {
   };
 
   // Default cacheTimeout 24 hours
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();

--- a/cont3xt/integrations/zetalytics/index.js
+++ b/cont3xt/integrations/zetalytics/index.js
@@ -80,7 +80,7 @@ class ZetalyticsIntegration extends Integration {
     ]
   };
 
-  cacheTimeout = 24 * 60 * 60 * 1000;
+  cacheTimeout = '24h';
 
   constructor () {
     super();

--- a/cont3xt/linkGroup.js
+++ b/cont3xt/linkGroup.js
@@ -39,7 +39,7 @@ class LinkGroup {
    * @param {string} _id - The id of the link group
    * @param {string} name - The name of the link group
    * @param {string} creator - The creator of the link group
-   * @param {Links[]} links - The array of links in this link group
+   * @param {Link[]} links - The array of links in this link group
    * @param {array} editRoles - The Arkime roles that can edit this link group
    * @param {array} viewRoles - The Arkime roles that can view this link group
    * @param {boolean} _editable - Whether the logged in user is allowed to edit this link group
@@ -116,20 +116,13 @@ class LinkGroup {
       return { msg: 'editRoles must be an array of strings' };
     }
 
-    if (lg.editRoles !== undefined) {
-      if (!Array.isArray(lg.editRoles)) {
-        return { msg: 'editRoles must be array' };
-      }
-
-      for (const editRole of lg.editRoles) {
-        if (!ArkimeUtil.isString(editRole)) {
-          return { msg: 'editRoles must contain strings' };
-        }
-      }
-    }
-
     for (let i = 0; i < lg.links.length; i++) {
       const link = lg.links[i];
+
+      if (typeof link !== 'object' || link === null) {
+        return { msg: 'Link must be object' };
+      }
+
       lg.links[i] = (
         ({ // only allow these properties in links
           // eslint-disable-next-line no-shadow
@@ -137,9 +130,6 @@ class LinkGroup {
         }) => ({ name, url, itypes, color, infoField, externalDocName, externalDocUrl })
       )(link);
 
-      if (typeof link !== 'object') {
-        return { msg: 'Link must be object' };
-      }
       if (!ArkimeUtil.isString(link.name)) {
         return { msg: 'Link missing name' };
       }

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -1,5 +1,5 @@
 # Test cont3xt.js
-use Test::More tests => 218;
+use Test::More tests => 219;
 use Test::Differences;
 use Data::Dumper;
 use ArkimeTest;
@@ -89,6 +89,15 @@ $json = cont3xtPutToken("/api/linkGroup", to_json({
   viewRoles => ["cont3xtUser"],
   editRoles => ["superAdmin"],
   links => [1]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Link must be object"}'));
+
+# a null link must be rejected, not throw (typeof null === 'object')
+$json = cont3xtPutToken("/api/linkGroup", to_json({
+  name => "Links1",
+  viewRoles => ["cont3xtUser"],
+  editRoles => ["superAdmin"],
+  links => [undef]
 }), $token);
 eq_or_diff($json, from_json('{"success": false, "text": "Link must be object"}'));
 


### PR DESCRIPTION
integration: call checkWriteDone on the search fetch-error path so the response isn't left hanging; respond on single-search falsy results; normalize the single-search IP query/cache key like bulk; log integration.name instead of undefined section linkGroup: reject null links before the property-pick destructuring; drop dead editRoles re-validation db: return {audits,total} shape on audit fetch error; harden audit sortBy against prototype keys cont3xt: report save failures in PUT settings instead of always "Saved" integrations: fix ClickHouse (method name + unawaited json), csvjson (JSON.parse on parsed objects + unguarded cache), databricks/elasticsearch session/404 guards, urlscan double-encoding, redis domain type, alienvaultotx url endpoint + encoding, arkime searchDays weeks->days integrations: cacheTimeout ms literals were 1000x too long, use time strings Numerous comment, JSDoc, log, and help-text fixes; add linkGroup null-link test

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
