### PR TITLE
Fix capture and common bugs found in code review

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,11 +49,14 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## All
   - #4065 Fix OIDC login not preserving the redirect URL's query parameters (thanks @yanover)
   - #4072 Fix header/OIDC auth requests hanging when a dynamic role update fails
+  - #4074 Harden user-auto-create/user-role-mappings expressions to run in strict mode
 ## Capture
   - #4054 Fix GRE keepalive packets adding bogus 00:00:00:00:00:00 MACs
   - #4055 Fix DNS memory leak when parsing malformed answers
   - #4063 Fix pcapNG reader bugs: out-of-bounds read on blocks claiming >2GB, Simple Packet Block length including 32-bit padding, and Section Header Block lost when split across reads
   - #4068 Add some missing http methods to parser
+  - #4074 Fix Geneve packets with protocol type 0 adding bogus 00:00:00:00:00:00 MACs
+  - #4074 Fix pcap-over-IP client reader not connecting to IPv6 endpoints
 ## Capture/Viewer
   - #4054 Add mpacket link layer support
 ## Cont3xt

--- a/capture/parsers/geneve.c
+++ b/capture/parsers/geneve.c
@@ -40,6 +40,10 @@ LOCAL ArkimePacketRC geneve_packet_enqueue(ArkimePacketBatch_t *batch, ArkimePac
         return ARKIME_PACKET_UNKNOWN_IP;
     }
 
+    // protocol 0 isn't a valid EtherType; avoid ether handler (type 0) mis-dispatch / bogus MACs
+    if (protocol == 0)
+        return ARKIME_PACKET_UNKNOWN_IP;
+
     packet->tunnel |= ARKIME_PACKET_TUNNEL_GENEVE;
 
     return arkime_packet_run_ethernet_cb(batch, packet, BSB_WORK_PTR(bsb), BSB_REMAINING(bsb), protocol, "geneve");

--- a/capture/plugins/kafka/kafka.c
+++ b/capture/plugins/kafka/kafka.c
@@ -154,18 +154,22 @@ void arkime_plugin_init()
                           NULL);
 
     conf = rd_kafka_conf_new();
-    brokers = *arkime_config_str_list(NULL, "kafkaBootstrapServers", "");
+    gchar **brokersList = arkime_config_str_list(NULL, "kafkaBootstrapServers", "");
+    brokers = brokersList && brokersList[0] ? brokersList[0] : "";
     topic = arkime_config_str(NULL, "kafkaTopic", "arkime-json");
 
     // See more config on https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 
     if (rd_kafka_conf_set(conf, "metadata.broker.list", brokers,
                           errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
+        g_strfreev(brokersList);
         LOGEXIT("Error configuring kafka:metadata.broker.list, error = %s", errstr);
     }
 
     if (config.debug)
         LOG("kafka broker %s", brokers);
+
+    g_strfreev(brokersList);
 
     kafkaSSL = arkime_config_boolean(NULL, "kafkaSSL", FALSE);
     if (kafkaSSL) {

--- a/capture/reader-pcapoverip.c
+++ b/capture/reader-pcapoverip.c
@@ -199,27 +199,24 @@ LOCAL void pcapoverip_client_connect(int interface)
 
     GSocket *conn = NULL;
     while (!conn && (sockaddr = g_socket_address_enumerator_next (enumerator, NULL, &error))) {
-        conn = g_socket_new(G_SOCKET_FAMILY_IPV4, G_SOCKET_TYPE_STREAM, G_SOCKET_PROTOCOL_TCP, &error);
+        GSocketFamily family = g_socket_address_get_family(sockaddr);
+        conn = g_socket_new(family, G_SOCKET_TYPE_STREAM, G_SOCKET_PROTOCOL_TCP, &error);
 
         if (!error) {
-            g_socket_set_blocking (conn, TRUE);
+            g_socket_set_blocking(conn, TRUE);
             g_socket_connect(conn, sockaddr, NULL, &error);
         }
 
         if (error && error->code != G_IO_ERROR_PENDING) {
             g_clear_error(&error);
-            g_object_unref (conn);
+            g_object_unref(conn);
             conn = NULL;
         } else {
-            g_socket_set_blocking (conn, FALSE);
-            struct sockaddr_in localAddress, remoteAddress;
-            socklen_t addressLength = sizeof(localAddress);
-            getsockname(g_socket_get_fd(conn), (struct sockaddr *)&localAddress, &addressLength);
-            g_socket_address_to_native(sockaddr, &remoteAddress, addressLength, NULL);
+            g_socket_set_blocking(conn, FALSE);
             if (config.debug > 0)
                 LOG("connected %s:%d", config.interface[interface], port);
         }
-        g_object_unref (sockaddr);
+        g_object_unref(sockaddr);
     }
     g_object_unref (enumerator);
 

--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -971,7 +971,8 @@ class ArkimeUtil {
 
     // If we get here, expression is safe - compile it
 
-    return new Function(argName, `return ${expr};`);
+    // Strict mode so a bare `this` is undefined, not globalThis (avoids this.process.env leak).
+    return new Function(argName, `'use strict';\nreturn ${expr};`);
   }
 
   // ----------------------------------------------------------------------------


### PR DESCRIPTION
- Geneve: drop protocol type 0 instead of mis-parsing the payload as Ethernet (bogus 00:00:00:00:00:00 MACs)
- pcap-over-IP: connect using the resolved address family so IPv6 endpoints work
- kafka: handle empty kafkaBootstrapServers and free the broker list
- safeExpression: compile in strict mode so user-auto-create/user-role-mappings expressions can't reach globals like process.env

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
