### PR TITLE
Fix viewer raw hunt hang and related callback bugs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -67,6 +67,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Viewer
   - #4063 Fix CSV formula injection in the summary CSV export by neutralizing cells starting with = + - @
   - #4071 Fix negative numbers being rejected in expressions
+  - #4076 Fix raw packet search hunts hanging when a session's PCAP is missing or unreadable
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "Benutzerfeld muss eine Zeichenkette sein",
       "created": "Abfrage erstellt!",
       "createFailed": "Erstellen der Abfrage fehlgeschlagen",
+      "retrieveFailed": "Fehler beim Abrufen der periodischen Abfragen",
       "badKey": "Ungültiger Abfrageschlüssel",
       "missingKey": "Abfrageschlüssel fehlt",
       "updated": "Periodische Abfrage aktualisiert!",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "Users field must be a string",
       "created": "Created query!",
       "createFailed": "Create query failed",
+      "retrieveFailed": "Error retrieving periodic queries",
       "badKey": "Bad query key",
       "missingKey": "Missing query key",
       "updated": "Updated periodic query!",

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "El campo de usuarios debe ser una cadena de texto",
       "created": "¡Consulta creada!",
       "createFailed": "Error al crear la consulta",
+      "retrieveFailed": "Error al recuperar las consultas periódicas",
       "badKey": "Clave de consulta inválida",
       "missingKey": "Falta la clave de consulta",
       "updated": "¡Consulta periódica actualizada!",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "Kasutajate väli peab olema sõne",
       "created": "Päring loodud!",
       "createFailed": "Päringu loomine ebaõnnestus",
+      "retrieveFailed": "Viga perioodiliste päringute toomisel",
       "badKey": "Vigane päringu võti",
       "missingKey": "Päringu võti puudub",
       "updated": "Perioodiline päring uuendatud!",

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "Le champ des utilisateurs doit être une chaîne",
       "created": "Requête créée !",
       "createFailed": "Échec de la création de la requête",
+      "retrieveFailed": "Erreur lors de la récupération des requêtes périodiques",
       "badKey": "Clé de requête invalide",
       "missingKey": "Clé de requête manquante",
       "updated": "Requête périodique mise à jour !",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "ユーザーフィールドは文字列である必要があります",
       "created": "クエリを作成しました！",
       "createFailed": "クエリの作成に失敗しました",
+      "retrieveFailed": "定期クエリの取得エラー",
       "badKey": "無効なクエリキー",
       "missingKey": "クエリキーが未入力です",
       "updated": "定期クエリを更新しました！",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "사용자 필드는 문자열이어야 합니다",
       "created": "쿼리가 생성되었습니다!",
       "createFailed": "쿼리 생성 실패",
+      "retrieveFailed": "주기적 쿼리 조회 오류",
       "badKey": "잘못된 쿼리 키",
       "missingKey": "쿼리 키가 없습니다",
       "updated": "주기적 쿼리가 업데이트되었습니다!",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "O campo de usuários deve ser uma string",
       "created": "Consulta criada!",
       "createFailed": "Falha ao criar consulta",
+      "retrieveFailed": "Erro ao recuperar consultas periódicas",
       "badKey": "Chave de consulta inválida",
       "missingKey": "Chave de consulta ausente",
       "updated": "Consulta periódica atualizada!",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -1668,6 +1668,7 @@
       "usersMustBeString": "Usersway ieldfay ustmay ebay away ingstray",
       "created": "Eatedcray eryquay!",
       "createFailed": "Eatecray eryquay ailedfay",
+      "retrieveFailed": "Errorway etrievingray eriodicpay eriesquay",
       "badKey": "Adbay eryquay eykay",
       "missingKey": "Issingmay eryquay eykay",
       "updated": "Updatedway eriodicpay eryquay!",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -1667,6 +1667,7 @@
       "usersMustBeString": "用户字段必须是字符串",
       "created": "查询已创建！",
       "createFailed": "创建查询失败",
+      "retrieveFailed": "检索周期性查询出错",
       "badKey": "无效的查询键",
       "missingKey": "缺少查询键",
       "updated": "定期查询已更新！",

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -185,6 +185,7 @@ class CronAPIs {
       res.send(queries);
     } catch (err) {
       console.log(`ERROR - ${req.method} /api/crons`, util.inspect(err, false, 50));
+      return res.serverError(500, 'Error retrieving periodic queries', 'api.crons.retrieveFailed');
     }
   }
 

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -112,7 +112,7 @@ class HuntAPIs {
         processSessionIdCb(null);
       }, (err, session) => {
         if (err) {
-          return; /* cb(null, false); */
+          return cb(null, false);
         }
 
         const len = packets.length;

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -1256,6 +1256,16 @@ class SessionAPIs {
   // EXPOSED HELPERS
   // --------------------------------------------------------------------------
   static async processSessionId (idOrSession, fullSession, headerCb, packetCb, endCb, maxPackets, limit) {
+    // endCb must fire exactly once: psid helpers can call it directly on an error
+    // path and again via their async.eachLimit completion callback
+    const origEndCb = endCb;
+    let endCbCalled = false;
+    endCb = (err, fields) => {
+      if (endCbCalled) { return undefined; }
+      endCbCalled = true;
+      return origEndCb(err, fields);
+    };
+
     let extra;
     let options;
     if (!fullSession) {


### PR DESCRIPTION
- apiSessions: make processSessionId endCb fire exactly once; psid helpers could call it both directly on an error path and again via their async.eachLimit completion callback
- apiHunts: restore cb(null, false) in raw packet search so a missing/unreadable PCAP is skipped instead of hanging the hunt (now safe given the endCb fix)
- apiCrons: return serverError when getCrons fails instead of leaving the request open
- add api.crons.retrieveFailed locale string across all languages
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
