### PR TITLE
Fix capture bugs found in code review

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -57,6 +57,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4068 Add some missing http methods to parser
   - #4074 Fix Geneve packets with protocol type 0 adding bogus 00:00:00:00:00:00 MACs
   - #4074 Fix pcap-over-IP client reader not connecting to IPv6 endpoints
+  - #4078 Fix radiotap headers >= 256 bytes parsing at the wrong offset (it_len read as 8-bit instead of 16-bit)
+  - #4078 Fix Linux cooked (SLL) VLAN frames misdispatching non-IP payloads to IP and not recording the VLAN id
+  - #4078 Classify Control4 SDDP as sddp instead of mislabeling it ssdp
 ## Capture/Viewer
   - #4054 Add mpacket link layer support
 ## Cont3xt

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -1452,16 +1452,18 @@ LOCAL ArkimePacketRC arkime_packet_sll(ArkimePacketBatch_t *batch, ArkimePacket_
     int ethertype = data[14] << 8 | data[15];
     switch (ethertype) {
     case ETHERTYPE_VLAN:
-        if (len < 21) {
+        if (len < 20) {
 #ifdef DEBUG_PACKET
             LOG("BAD PACKET: Too short for VLAN %d", len);
 #endif
             return ARKIME_PACKET_CORRUPT;
         }
-        if ((data[20] & 0xf0) == 0x60)
-            return arkime_packet_ip6(batch, packet, data + 20, len - 20);
-        else
-            return arkime_packet_ip4(batch, packet, data + 20, len - 20);
+        if (!packet->vlan) {
+            packet->vlan = (data[16] << 8 | data[17]) & 0xfff;
+            packet->vlanCopy = 1;
+        }
+        // dispatch the VLAN payload by its encapsulated ethertype (bytes 18-19)
+        return arkime_packet_run_ethernet_cb(batch, packet, data + 20, len - 20, data[18] << 8 | data[19], "SLL");
     default:
         return arkime_packet_run_ethernet_cb(batch, packet, data + 16, len - 16, ethertype, "SLL");
     } // switch
@@ -1579,7 +1581,7 @@ LOCAL ArkimePacketRC arkime_packet_radiotap(ArkimePacketBatch_t *batch, ArkimePa
     if (data[0] != 0 || len < 36)
         return ARKIME_PACKET_UNKNOWN_ETHER;
 
-    int hl = data[2];
+    int hl = data[2] | (data[3] << 8); // it_len is a little-endian uint16 at bytes 2-3
     if (hl + 24 + 8 >= len)
         return ARKIME_PACKET_UNKNOWN_ETHER;
 

--- a/capture/parsers/dns.c
+++ b/capture/parsers/dns.c
@@ -325,7 +325,7 @@ LOCAL char *dns_name(ArkimeSession_t *session, const uint8_t *full, int fulllen,
 
         BSB_EXPORT_rewind(*curbsb, 1);
 
-        if (ch & 0xc0) {
+        if ((ch & 0xc0) == 0xc0) {
             if (didPointer > 10) {
                 arkime_session_add_tag(session, "dns:bad-pointer-loop");
                 return 0;
@@ -341,6 +341,11 @@ LOCAL char *dns_name(ArkimeSession_t *session, const uint8_t *full, int fulllen,
             BSB_INIT(tmpbsb, full + tpos, fulllen - tpos);
             curbsb = &tmpbsb;
             continue;
+        }
+
+        if (ch & 0xc0) {
+            // 0x40 and 0x80 are reserved label types (RFC 1035 4.1.4), not pointers
+            return 0;
         }
 
         if (BSB_LENGTH(nbsb)) {

--- a/capture/parsers/misc.c
+++ b/capture/parsers/misc.c
@@ -424,11 +424,12 @@ void arkime_parser_init()
 
     SIMPLE_CLASSIFY_UDP("ssdp", "M-SEARCH ");
     SIMPLE_CLASSIFY_UDP("ssdp", "NOTIFY * ");
-    SIMPLE_CLASSIFY_UDP("ssdp", "NOTIFY ALIVE SDDP/");
     arkime_parsers_classifier_register_udp("ssdp", NULL, 0, (uint8_t *)"HTTP/1.", 7, ssdp_response_classify);
 
     SIMPLE_CLASSIFY_UDP("bsdp", "SEARCH BSDP/");
     SIMPLE_CLASSIFY_UDP("bsdp", "NOTIFY BSDP/");
+
+    SIMPLE_CLASSIFY_UDP("sddp", "NOTIFY ALIVE SDDP/");
 
     SIMPLE_CLASSIFY_UDP("plex-gdm", "UPDATE * ");
     SIMPLE_CLASSIFY_UDP("plex-gdm", "VUPDATE * ");

--- a/capture/parsers/opcua.c
+++ b/capture/parsers/opcua.c
@@ -79,11 +79,11 @@ LOCAL void opcua_parse_hel(ArkimeSession_t *session, const uint8_t *p, uint32_t 
     BSB bsb;
     BSB_INIT(bsb, p + OPCUA_HEADER_LEN + OPCUA_HEL_PRELUDE, msgLen - OPCUA_HEADER_LEN - OPCUA_HEL_PRELUDE);
 
-    int32_t urlLen = 0;
+    uint32_t urlLen = 0;
     BSB_LIMPORT_u32(bsb, urlLen);
     if (BSB_IS_ERROR(bsb))
         return;
-    if (urlLen <= 0 || urlLen > OPCUA_MAX_URL || (uint32_t)urlLen > BSB_REMAINING(bsb))
+    if (urlLen == 0 || urlLen > OPCUA_MAX_URL || urlLen > BSB_REMAINING(bsb))
         return;
     arkime_field_string_add(endpointUrlField, session, (const char *)BSB_WORK_PTR(bsb), urlLen, TRUE);
 }
@@ -104,27 +104,27 @@ LOCAL void opcua_parse_opn(ArkimeSession_t *session, const uint8_t *p, uint32_t 
     BSB_INIT(bsb, p + OPCUA_HEADER_LEN, msgLen - OPCUA_HEADER_LEN);
     BSB_IMPORT_skip(bsb, 4);                    /* SecureChannelId */
 
-    int32_t sLen = 0;
+    uint32_t sLen = 0;
     BSB_LIMPORT_u32(bsb, sLen);
     if (BSB_IS_ERROR(bsb))
         return;
 
-    if (sLen > 0 && sLen <= OPCUA_MAX_URL && (uint32_t)sLen <= BSB_REMAINING(bsb)) {
+    if (sLen > 0 && sLen <= OPCUA_MAX_URL && sLen <= BSB_REMAINING(bsb)) {
         arkime_field_string_add(securityPolicyField, session,
                                 (const char *)BSB_WORK_PTR(bsb), sLen, TRUE);
         BSB_IMPORT_skip(bsb, sLen);
-    } else if (sLen > 0) {
-        /* length set but exceeds our cap or remaining bytes - stream is suspect */
+    } else if ((sLen & 0x80000000) == 0 && sLen != 0) {
+        /* positive length that exceeds our cap or remaining bytes - stream is suspect */
         return;
     }
-    /* sLen == 0 (empty) or sLen == -1 (null) both fall through to SenderCertificate */
+    /* sLen == 0 (empty) or high bit set (null) both fall through to SenderCertificate */
 
-    int32_t cLen = 0;
+    uint32_t cLen = 0;
     BSB_LIMPORT_u32(bsb, cLen);
     if (BSB_IS_ERROR(bsb))
         return;
 
-    if (cLen > 0 && cLen <= OPCUA_MAX_CERT && (uint32_t)cLen <= BSB_REMAINING(bsb)) {
+    if (cLen > 0 && cLen <= OPCUA_MAX_CERT && cLen <= BSB_REMAINING(bsb)) {
         arkime_parsers_call_named_func(tls_process_single_certificate_func,
                                        session, BSB_WORK_PTR(bsb), cLen, NULL);
     }

--- a/capture/parsers/stun.c
+++ b/capture/parsers/stun.c
@@ -491,6 +491,7 @@ void arkime_parser_init()
                                            "TURN XOR-PEER-ADDRESS port",
                                            ARKIME_FIELD_TYPE_INT_GHASH, ARKIME_FIELD_FLAG_CNT,
                                            "category", "port",
+                                           "aliases", "[\"stun.xor-peer-port\"]",
                                            (char *)NULL);
 
     attributesField = arkime_field_define("stun", "termfield",

--- a/tests/api-s3.t
+++ b/tests/api-s3.t
@@ -81,6 +81,4 @@ system("../capture/capture -o disablePython=true -c config.test.ini -n sqs-test 
 
 countTest2($expected, "date=-1&expression=" . uri_escape("tags=$sqstag"));
 
-system("curl -s http://localhost:4566/_shutdown > /dev/null 2>&1");
-
 esPost("/tests2_sessions*/_delete_by_query?conflicts=proceed&refresh", $nodeFilter);

--- a/tests/arkime.supp
+++ b/tests/arkime.supp
@@ -1,3 +1,4 @@
 leak:Py_NewInterpreterFromConfig
 leak:new_interpreter
 leak:pcre2_jit_compile_8
+leak:_tlv_get_addr


### PR DESCRIPTION
packet: parse radiotap it_len as the full 16-bit LE value so headers >= 256 bytes parse at the right offset
packet: dispatch Linux cooked (SLL) VLAN frames by the encapsulated ethertype and record the VLAN id, instead of forcing the payload to IP
dns: reject reserved DNS label types (0x40/0x80) instead of following them as compression pointers
misc: classify Control4 SDDP as its own sddp protocol instead of mislabeling it ssdp
stun: add stun.xor-peer-port alias for stun.xorPeerPort
tests: don't shut down the mini AWS mock in api-s3.t

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
