### PR TITLE
Fix capture, cont3xt, and auth bugs found in code review

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,6 +51,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4072 Fix header/OIDC auth requests hanging when a dynamic role update fails
   - #4074 Harden user-auto-create/user-role-mappings expressions to run in strict mode
   - #4079 Fix relative time +1M (month) and @M snapping being silently ignored; lowercase m still means minutes
+  - #4089 Consolidate header auth non-localhost host security warning across viewer/cont3xt/parliament/wiseService
 ## Capture
   - #4054 Fix GRE keepalive packets adding bogus 00:00:00:00:00:00 MACs
   - #4055 Fix DNS memory leak when parsing malformed answers
@@ -62,6 +63,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4078 Fix Linux cooked (SLL) VLAN frames misdispatching non-IP payloads to IP and not recording the VLAN id
   - #4078 Classify Control4 SDDP as sddp instead of mislabeling it ssdp
   - #4079 Fix CAMEL recording the TCAP invokeID as a bogus operation code, and ENIP CIP class extraction failing on routed request paths with a port segment
+  - #4089 Fix netmap reader out-of-bounds ring index when netmapThreads doesn't evenly divide the interface's RX ring count
+  - #4089 Fix file reader silently stopping on EINTR instead of retrying
+  - #4089 Fix directory monitor leaking watch state when a watched directory is deleted
 ## Capture/Viewer
   - #4054 Add mpacket link layer support
 ## Cont3xt

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1714,6 +1714,7 @@ typedef void (*ArkimeSchemeExit)();
 void arkime_reader_scheme_register(char *name, ArkimeSchemeLoad load, ArkimeSchemeExit exit);
 int arkime_reader_scheme_process(const char *uri, uint8_t *data, int len, const char *extraInfo, ArkimeSchemeAction_t *actions);
 void arkime_reader_scheme_actions_ref(ArkimeSchemeAction_t *actions);
+void arkime_reader_scheme_actions_deref(ArkimeSchemeAction_t *actions);
 void arkime_reader_scheme_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions);
 
 /******************************************************************************/

--- a/capture/dedup.c
+++ b/capture/dedup.c
@@ -75,7 +75,8 @@ LOCAL DedupSeconds_t *seconds;
 /******************************************************************************/
 int arkime_dedup_should_drop (const ArkimePacket_t *packet, int headerLen)
 {
-    // Cap headerLen to prevent large stack VLA on attacker-controlled IPv6 ext headers
+    // Cap headerLen so the headerLen-derived copies below can't overflow the
+    // fixed-size md[]/buf[] stack buffers
     if (headerLen <= 0 || headerLen > 256) {
         return 0;
     }

--- a/capture/field.c
+++ b/capture/field.c
@@ -669,7 +669,7 @@ const char *arkime_field_string_add(int pos, ArkimeSession_t *session, const cha
             hstring->len = len;
             hstring->utf8 = 0;
             hstring->uw = 0;
-            HASH_ADD(s_, *hash, hstring->str, hstring);
+            HASH_ADD_HASH(s_, *hash, arkime_string_hash_len(hstring->str, hstring->len), hstring->str, hstring);
             goto added;
         case ARKIME_FIELD_TYPE_STR_GHASH:
             field->ghash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
@@ -861,7 +861,7 @@ const char *arkime_field_string_uw_add(int pos, ArkimeSession_t *session, const 
             hstring->len = len;
             hstring->utf8 = 0;
             hstring->uw = uw;
-            HASH_ADD(s_, *hash, hstring->str, hstring);
+            HASH_ADD_HASH(s_, *hash, arkime_string_hash_len(hstring->str, hstring->len), hstring->str, hstring);
             if (info->ruleEnabled)
                 arkime_rules_run_field_set(session, pos, (const gpointer) string);
             return string;

--- a/capture/parsers/adb.c
+++ b/capture/parsers/adb.c
@@ -147,8 +147,11 @@ LOCAL void adb_parse_sync_payload(ArkimeSession_t *session, const uint8_t *data,
         }
 
         /* For SEND/RECV/STAT/LIST, the arg is the path length, followed by path */
-        if ((id == SYNC_SEND || id == SYNC_RECV || id == SYNC_STAT || id == SYNC_LIST) && arg > 0 && arg < 4096) {
-            if (BSB_REMAINING(bsb) >= arg) {
+        if ((id == SYNC_SEND || id == SYNC_RECV || id == SYNC_STAT || id == SYNC_LIST) && arg > 0) {
+            if (BSB_REMAINING(bsb) < arg) {
+                break;
+            }
+            if (arg < 4096) {
                 const uint8_t *path = BSB_WORK_PTR(bsb);
                 int path_len = MIN(arg, 1023);
                 char path_str[1024];
@@ -162,10 +165,10 @@ LOCAL void adb_parse_sync_payload(ArkimeSession_t *session, const uint8_t *data,
                 }
 
                 arkime_field_string_add(syncPathField, session, path_str, -1, TRUE);
-                BSB_IMPORT_skip(bsb, arg);
-            } else {
-                break;
             }
+            /* Always skip the full path payload, even when arg is too large to
+             * record, so parsing of subsequent sync messages doesn't desync. */
+            BSB_IMPORT_skip(bsb, arg);
         } else if (id == SYNC_DATA && arg > 0) {
             /* DATA packet - skip the data payload */
             if (BSB_REMAINING(bsb) >= arg) {

--- a/capture/parsers/enip.c
+++ b/capture/parsers/enip.c
@@ -613,6 +613,10 @@ LOCAL int enip_tcp_parser(ArkimeSession_t *session, void *uw, const uint8_t *dat
         }
 
         uint32_t total = (uint32_t)ENIP_HEADER_LEN + length;
+        if (total > (uint32_t)enip->bufMax) {
+            arkime_session_add_tag(session, "enip:message-too-long");
+            return ARKIME_PARSER_UNREGISTER;
+        }
         if (total > (uint32_t)enip->len[which]) {
             return 0;  // need more data
         }

--- a/capture/parsers/smb.c
+++ b/capture/parsers/smb.c
@@ -467,6 +467,13 @@ LOCAL int smb2_parse(ArkimeSession_t *session, const SMBInfo_t *UNUSED(smb), BSB
         if (BSB_REMAINING(*bsb) < 64) {
             return 1;
         }
+        if (*remlen < 64) {
+            // Message declared less data (via the NETBIOS length) than a full SMB2 header
+            // needs - malformed/too short. Skip it rather than reading past remlen and
+            // underflowing *remlen below.
+            *state = SMB_SKIP;
+            break;
+        }
         BSB_IMPORT_skip(*bsb, 12);
         BSB_LIMPORT_u16(*bsb, cmd);
         BSB_IMPORT_skip(*bsb, 2);

--- a/capture/reader-netmap.c
+++ b/capture/reader-netmap.c
@@ -181,28 +181,41 @@ void reader_netmap_init(char *UNUSED(name))
             LOG("Netmap opened on interface %s with %d RX rings", config.interface[i], nmd->nifp->ni_rx_rings);
         }
 
-        uint16_t ringsPerThread = nmd->nifp->ni_rx_rings / threadsPerInterface;
-        if (ringsPerThread == 0) {
-            ringsPerThread = 1;
+        if (nmd->nifp->ni_rx_rings == 0) {
+            CONFIGEXIT("Interface %s reports 0 RX rings", config.interface[i]);
         }
 
+        // Don't create more threads than there are rings - any extra threads
+        // would have no rings to read from
+        int numThreads = threadsPerInterface;
+        if (numThreads > nmd->nifp->ni_rx_rings) {
+            LOG("WARNING - netmapThreads (%d) is more than the %d RX rings available on %s, using %d threads instead",
+                numThreads, nmd->nifp->ni_rx_rings, config.interface[i], nmd->nifp->ni_rx_rings);
+            numThreads = nmd->nifp->ni_rx_rings;
+        }
+
+        // Evenly distribute rings across threads - the first `extraRings` threads
+        // get one extra ring each so no single thread is overloaded and every
+        // ring index handed out is guaranteed to be < ni_rx_rings
+        const uint16_t ringsPerThread = nmd->nifp->ni_rx_rings / numThreads;
+        const uint16_t extraRings = nmd->nifp->ni_rx_rings % numThreads;
+
         // Create reader threads with assigned rings
-        for (int t = 0; t < threadsPerInterface; t++) {
+        uint16_t nextRing = 0;
+        for (int t = 0; t < numThreads; t++) {
             if (numReaders >= MAX_NETMAP_READERS) {
                 CONFIGEXIT("Too many reader threads, max is %d", MAX_NETMAP_READERS);
             }
+
+            const uint16_t thisThreadRings = ringsPerThread + (t < extraRings ? 1 : 0);
 
             ArkimeNetmap_t *reader = &readers[numReaders];
             reader->nmd = nmd;
             reader->interfacePos = i;
             reader->threadNum = t;
-            reader->ringStart = t * ringsPerThread;
-            reader->ringEnd = (t + 1) * ringsPerThread - 1;
-
-            // Last thread gets any remaining rings
-            if (t == threadsPerInterface - 1) {
-                reader->ringEnd = nmd->nifp->ni_rx_rings - 1;
-            }
+            reader->ringStart = nextRing;
+            reader->ringEnd = nextRing + thisThreadRings - 1;
+            nextRing += thisThreadRings;
 
             if (config.debug) {
                 LOG("Thread %d for interface %s assigned rings %u-%u", t, config.interface[i], reader->ringStart, reader->ringEnd);

--- a/capture/reader-pcapoverip.c
+++ b/capture/reader-pcapoverip.c
@@ -269,7 +269,16 @@ LOCAL gboolean pcapoverip_server_read_cb(gint UNUSED(fd), GIOCondition UNUSED(co
 
     GSocket *client = g_socket_accept((GSocket *)data, NULL, &error);
     if (!client || error) {
-        LOGEXIT("ERROR - Error accepting pcap-over-ip: %s", error ? error->message : "unknown error");
+        if (error) {
+            LOG("ERROR - Error accepting pcap-over-ip: %s", error->message);
+            g_error_free(error);
+        } else {
+            LOG("ERROR - Error accepting pcap-over-ip");
+        }
+        // Transient accept errors (e.g. ECONNABORTED, EMFILE/ENFILE) shouldn't take down
+        // the whole capture process - keep the listening socket watch alive so future
+        // connections can still be accepted.
+        return TRUE;
     }
 
     POIClient_t *poic = ARKIME_TYPE_ALLOC0(POIClient_t);

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -25,9 +25,28 @@ typedef struct {
 
 LOCAL void scheme_file_monitor_dir(const char *dirname, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions);
 
+LOCAL void scheme_watch_free(gpointer data)
+{
+    SchemeWatch_t *sw = (SchemeWatch_t *)data;
+    g_free(sw->dirname);
+    arkime_reader_scheme_actions_deref(sw->actions);
+    ARKIME_TYPE_FREE(SchemeWatch_t, sw);
+}
+
 LOCAL void scheme_file_monitor_do(struct inotify_event *event)
 {
     SchemeWatch_t *sw = g_hash_table_lookup(wdHashTable, (void *)(long)event->wd);
+    if (!sw)
+        return;
+
+    // The watch is gone (directory deleted/unmounted, or explicitly removed).
+    // Drop our tracking entry now instead of waiting for the kernel to maybe
+    // reuse this wd number for an unrelated watch later.
+    if (event->mask & IN_IGNORED) {
+        g_hash_table_remove(wdHashTable, (void *)(long)event->wd);
+        return;
+    }
+
     gchar *fullfilename = g_build_filename (sw->dirname, event->name, NULL);
 
     if ((sw->flags & ARKIME_SCHEME_FLAG_RECURSIVE) &&
@@ -82,7 +101,7 @@ LOCAL void scheme_file_init_monitor()
     if (monitorFd < 0)
         LOGEXIT("ERROR - Couldn't init inotify %s", strerror(errno));
 
-    wdHashTable = g_hash_table_new (g_direct_hash, g_direct_equal);
+    wdHashTable = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, scheme_watch_free);
     arkime_watch_fd(monitorFd, ARKIME_GIO_READ_COND, scheme_file_monitor_read, NULL);
 }
 /******************************************************************************/
@@ -260,6 +279,11 @@ LOCAL int scheme_file_load(const char *uri, ArkimeSchemeFlags flags, ArkimeSchem
                 }
                 return 1;
             }
+        } else if (bytesRead < 0) {
+            if (errno == EINTR)
+                continue;
+            LOG("ERROR - pcap read failed - Couldn't read file: '%s' with %s (%d)", uri, strerror(errno), errno);
+            break;
         } else {
             break;
         }

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -102,7 +102,7 @@ void arkime_reader_scheme_actions_ref(ArkimeSchemeAction_t *actions)
     actions->refs++;
 }
 /******************************************************************************/
-LOCAL void reader_scheme_actions_deref(ArkimeSchemeAction_t *actions)
+void arkime_reader_scheme_actions_deref(ArkimeSchemeAction_t *actions)
 {
     if (!actions)
         return;
@@ -298,7 +298,7 @@ LOCAL int reader_scheme_header_common(const char *uri, int dlt, int snaplen, con
     offlineInfo[readerState.readerPos].extra = g_strdup(extraInfo);
 
     if (schemeActions[readerState.readerPos])
-        reader_scheme_actions_deref(schemeActions[readerState.readerPos]);
+        arkime_reader_scheme_actions_deref(schemeActions[readerState.readerPos]);
 
     schemeActions[readerState.readerPos] = actions;
     arkime_reader_scheme_actions_ref(actions);
@@ -464,7 +464,7 @@ LOCAL void *reader_scheme_thread(void *UNUSED(arg))
         currentProcessingUri = NULL;
         ARKIME_UNLOCK(laterLock);
         g_free(item->uri);
-        reader_scheme_actions_deref(item->actions);
+        arkime_reader_scheme_actions_deref(item->actions);
         ARKIME_TYPE_FREE(ArkimeSchemeLater_t, item);
     }
 

--- a/capture/writer-simple.c
+++ b/capture/writer-simple.c
@@ -238,6 +238,7 @@ LOCAL ArkimeSimple_t *writer_simple_process_buf(int thread, int closing)
             info->file->zstd_completedBlockStart += writeSize;
             ninfo->file->zstd_out.dst = ninfo->buf;
             ninfo->file->zstd_out.pos = ninfo->bufpos;
+            break;
 #endif
         default:
             break;
@@ -391,6 +392,10 @@ LOCAL char *writer_simple_get_kekId ()
             continue;
         }
         i++;
+        if (kek[i] == 0) {
+            // Trailing unescaped '%' at end of string - stop, nothing more to parse
+            break;
+        }
         switch (kek[i]) {
         case 'y':
             okek[j] = '0' + (tmp.tm_year % 100) / 10;

--- a/common/auth.js
+++ b/common/auth.js
@@ -82,6 +82,9 @@ class Auth {
    * @param {boolean} options.s2s Support s2s auth also
    * @param {object} options.authConfig options specific to each auth mode
    * @param {object} options.caTrustFile Optional path to CA certificate file to use for external authentication
+   * @param {string} options.hostVar The name of this service's *Host config variable (e.g. 'viewHost') -
+   *                                 used only to print a security warning when header auth is enabled and
+   *                                 the service isn't restricted to loopback
    */
   static async initialize (options) {
     // Make sure all options we need below are set
@@ -205,6 +208,16 @@ class Auth {
     } else if (Auth.mode.startsWith('header')) {
       Auth.#userAuthIps.add('::ffff:127.0.0.0', 96 + 8, 1);
       Auth.#userAuthIps.add('::1', 128, 1);
+
+      // No explicit userAuthIps set, so we're relying on the loopback-only default above.
+      // If this service is also listening on a non-loopback host, warn - a reverse proxy or
+      // trustProxy misconfiguration could let a remote client's header be trusted.
+      if (options.hostVar) {
+        const hostVal = ArkimeConfig.get(options.hostVar);
+        if (hostVal !== undefined && hostVal !== 'localhost' && hostVal !== '127.0.0.1' && hostVal !== '::1') {
+          console.log(`SECURITY WARNING - When using any form of header auth, ${options.hostVar} (currently '${hostVal}') should be localhost OR make sure you have set authIps correctly.`);
+        }
+      }
     } else {
       Auth.#userAuthIps.add('::', 0, 1);
     }

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -486,7 +486,8 @@ async function setupAuth () {
   await Auth.initialize({
     appAdminRole: 'cont3xtAdmin',
     passwordSecretSection: 'cont3xt',
-    basePath: internals.webBasePath
+    basePath: internals.webBasePath,
+    hostVar: 'cont3xtHost'
   });
 
   User.initialize({
@@ -538,9 +539,6 @@ async function main () {
   setupHSTS();
 
   const cont3xtHost = ArkimeConfig.get('cont3xtHost');
-  if (Auth.mode === 'header' && cont3xtHost !== 'localhost' && cont3xtHost !== '127.0.0.1') {
-    console.log('SECURITY WARNING - When using header auth, cont3xtHost should be localhost or use iptables');
-  }
 
   ArkimeUtil.createHttpServer(app, cont3xtHost, ArkimeConfig.get('port', 3218));
 }

--- a/cont3xt/integrations/emailrep/index.js
+++ b/cont3xt/integrations/emailrep/index.js
@@ -96,7 +96,7 @@ class EmailReputationIntegration extends Integration {
     }
 
     try {
-      let result = await axios.get(`https://emailrep.io/${query}`, {
+      let result = await axios.get(`https://emailrep.io/${encodeURIComponent(query)}`, {
         headers: {
           'User-Agent': this.userAgent(),
           key

--- a/cont3xt/integrations/wise/index.js
+++ b/cont3xt/integrations/wise/index.js
@@ -59,7 +59,7 @@ class WiseIntegration extends Integration {
 
   // ----------------------------------------------------------------------------
   async doFetch (user, item, type) {
-    const response = await axios.get(`${this.#wiseUrl}/${type}/${item}`);
+    const response = await axios.get(`${this.#wiseUrl}/${type}/${encodeURIComponent(item)}`);
 
     const results = response.data.map(e => {
       return {

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -2124,7 +2124,8 @@ app.use((err, req, res, next) => {
 async function setupAuth () {
   await Auth.initialize({
     appAdminRole: 'parliamentAdmin',
-    passwordSecretSection: 'parliament'
+    passwordSecretSection: 'parliament',
+    hostVar: 'parliamentHost'
   });
 
   User.initialize({
@@ -2235,9 +2236,6 @@ async function main () {
   await setupAuth();
 
   const parliamentHost = ArkimeConfig.get('parliamentHost');
-  if (Auth.mode === 'header' && parliamentHost !== 'localhost' && parliamentHost !== '127.0.0.1') {
-    console.log('SECURITY WARNING - When using header auth, parliamentHost should be localhost or use iptables');
-  }
 
   ArkimeUtil.createHttpServer(app, parliamentHost, ArkimeConfig.get('port', 8008), async () => {
     if (ArkimeConfig.debug) {

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -309,6 +309,7 @@ class Config {
         appAdminRole: 'arkimeAdmin',
         basePath: Config.basePath(),
         passwordSecretSection: internals.nodeName === 'cont3xt' ? 'cont3xt' : 'default',
+        hostVar: 'viewHost',
         s2s: true,
         s2sRegressionTests: !!Config.get('s2sRegressionTests')
       });

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -2250,9 +2250,6 @@ async function main () {
   setInterval(() => createActions('field-actions', 'makeFieldActions', 'fieldActions'), 150 * 1000); // Check every 2.5 minutes
 
   const viewHost = Config.get('viewHost', undefined);
-  if (internals.userNameHeader !== undefined && viewHost !== 'localhost' && viewHost !== '127.0.0.1') {
-    console.log('SECURITY WARNING - when userNameHeader is set, viewHost should be localhost or use iptables');
-  }
 
   const server = ArkimeUtil.createHttpServer(app, viewHost, Config.get('viewPort', '8005'));
   server.setTimeout(20 * 60 * 1000);

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -199,7 +199,8 @@ async function setupAuth () {
   await Auth.initialize({
     appAdminRole: 'wiseAdmin',
     passwordSecretSection: 'wiseService',
-    basePath: internals.webBasePath
+    basePath: internals.webBasePath,
+    hostVar: 'wiseHost'
   });
 
   if (Auth.mode === 'anonymous') {


### PR DESCRIPTION
- capture/dedup.c: update stale comment referencing a removed VLA
- capture/reader-netmap.c: fix out-of-bounds ring index when netmapThreads doesn't evenly divide RX ring count
- capture/reader-scheme-file.c: retry on EINTR instead of treating it as EOF; fix inotify watch descriptor leak on directory deletion
- capture/reader-pcapoverip.c: don't LOGEXIT the whole process on a failed accept() in pcap-over-IP server mode
- capture/writer-simple.c: fix out-of-bounds heap read in writer_simple_get_kekId() on a trailing unescaped '%'; add missing break in ZSTD compression case
- capture/field.c: fix inconsistent string hash function between first and subsequent inserts into STR_HASH fields
- capture/parsers/enip.c: unregister parser instead of hanging forever when a message exceeds bufMax
- capture/parsers/smb.c: fix *remlen underflow on short SMB2 messages in SMB_SMBHEADER state
- capture/parsers/adb.c: fix parser desync when sync payload path length >= 4096
- cont3xt/integrations/wise, emailrep: encodeURIComponent() email value to prevent path-segment injection
- common/auth.js, viewer, cont3xt, parliament, wiseService: consolidate the header-auth non-localhost host security warning into Auth.initialize(), fixing an inconsistency where header-jwt mode and wiseService were not covered

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
