### PR TITLE
Fix viewer bugs, wise fixes, and doc typos from Fable 5 scan

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -79,17 +79,25 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4073 Fix integration cacheTimeout values specified in milliseconds being treated as seconds (1000x too long); short-TTL integrations like DNS now expire on time
   - #4073 Fix csv/json integrations sometimes failing to load JSON feeds over http/elasticsearch/opensearch
   - #4073 Fix ClickHouse integration being broken (wrong search method name and unawaited result parsing)
+## Multies
+  - #4092 Fix plaintext user:pass elasticsearchBasicAuth never working, and passwords containing a colon being truncated
 ## Viewer
   - #4063 Fix CSV formula injection in the summary CSV export by neutralizing cells starting with = + - @
   - #4071 Fix negative numbers being rejected in expressions
   - #4076 Fix raw packet search hunts hanging when a session's PCAP is missing or unreadable
   - #4079 Fix /api/upload storing the upload to disk before authorization
   - #4079 Fix /api/esindices/:index/shrink leaving the index read-only when shard relocation stalls
+  - #4092 Fix periodic queries silently processing at most 1000 sessions per run
+  - #4092 Fix hunts stalling instead of skipping the session when a failed session can't be fetched on retry
+  - #4092 Fix GRE packets with the routing bit set being misparsed in the viewer pcap decoder
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors
   - #4072 Fix databricks periodic mode never running the initial query and crashing on refresh
   - #4072 Fix caching md5/sha256 results without contentType, and crashes on repeated hashes params and on viewing an empty redisfile source
+  - #4092 Fix threatstream zip mode not working
+  - #4092 Fix virustotal v2 issues
+  - #4092 Fix opendns content category field being labeled Security instead of Content
 
 6.5.0 2026/06/15
 ## Breaking

--- a/common/vueapp/UserService.js
+++ b/common/vueapp/UserService.js
@@ -148,7 +148,7 @@ export default {
    * Determines whether a user has role to perform a specific task
    * @param {Object} user The user to check roles for
    * @param {String} role The role(s) in question (comma separated list)
-   * @returns {Boolean} true if all roles are included
+   * @returns {Boolean} true if the user has any of the roles
    */
   hasRole (user, role) {
     if (!user) { return false; }

--- a/cont3xt/db.js
+++ b/cont3xt/db.js
@@ -267,7 +267,7 @@ class DbESImplementation {
     } catch (err) {
       // If already exists ignore error
       if (err.meta.body?.error?.type !== 'resource_already_exists_exception') {
-        console.log('createViewIndex', util.inspect(err, false, 10));
+        console.log('createViewsIndex', util.inspect(err, false, 10));
         process.exit(0);
       }
     }
@@ -964,7 +964,7 @@ class DbLMDBImplementation {
 
   /* Overviews ---------------------------------------- */
   /**
-   * Get all the links that match the creator and set of roles
+   * Get all the overviews that match the creator and set of roles
    */
   async getMatchingOverviews (creator, roles, all) {
     const hits = [];

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -621,7 +621,7 @@ class Integration {
    * @param {boolean} skipChildren - Don't query integrations for sub-indicators
    * @param {string[]} tags - Tags applied at the time of search
    * @param {string | undefined} viewId - The ID of the view at the time of search (if any)
-   * @returns {IntegrationChunk[]} results - An array data chunks with the data
+   * @returns {IntegrationChunk[]} results - An array of data chunks with the data
    */
   static async apiSearch (req, res, next) {
     if (!ArkimeUtil.isString(req.body.query)) {

--- a/cont3xt/integrations/threatstream/index.js
+++ b/cont3xt/integrations/threatstream/index.js
@@ -114,7 +114,7 @@ class ThreatstreamIntegration extends Integration {
       uiSetting: true
     },
     host: {
-      help: 'The threatstream host to send queries. Only set if you have a on premise deployment.'
+      help: 'The threatstream host to send queries. Only set if you have an on-premise deployment.'
     },
     user: {
       help: 'Your threatstream api user',

--- a/cont3xt/vueapp/src/components/services/AuditService.js
+++ b/cont3xt/vueapp/src/components/services/AuditService.js
@@ -24,7 +24,7 @@ export default {
 
   /**
    * Deletes a history log
-   * @param {String} id - The id of the view to delete
+   * @param {String} id - The id of the audit/history entry to delete
    * @returns {Promise} - The promise that either resolves the request or rejects in error
    */
   deleteAudit (id) {

--- a/cont3xt/vueapp/src/components/services/UserService.js
+++ b/cont3xt/vueapp/src/components/services/UserService.js
@@ -5,7 +5,7 @@ import { parseRoles } from '@common/vueFilters.js';
 
 export default {
   /**
-   * Fetches the list of user roles.
+   * Fetches the currently logged in user.
    * @returns {Promise} - The promise that either resolves the request or rejects in error
    */
   getUser () {

--- a/viewer/addUser.js
+++ b/viewer/addUser.js
@@ -1,7 +1,7 @@
 /******************************************************************************/
 /* addUser.js -- Create a new user in the database
  *
- * addUser.js <user id> <user friendly name> <password> [-noweb] [-admin]
+ * addUser.js [<config options>] <user id> <user friendly name> <password|-> [<options>]
  *
  * Copyright 2012-2016 AOL Inc. All rights reserved.
  *
@@ -45,7 +45,7 @@ function help (msg) {
   console.log('  --remove                  Can remove data (scrub, delete tags)');
   console.log('  --no-remove               Cannot remove data (scrub, delete tags)');
   console.log('  --roles <roles>           Comma separated list of roles');
-  console.log('  --timeLimit               Max time limit for searches in hours');
+  console.log('  --timeLimit <hours>       Max time limit for searches in hours');
   console.log('  --webauth                 Can auth using the web auth header or password');
   console.log('  --webauthonly             Can auth using the web auth header only, password ignored');
   console.log();

--- a/viewer/apiConnections.js
+++ b/viewer/apiConnections.js
@@ -148,7 +148,7 @@ class ConnectionAPIs {
   } // buildConnectionQuery
 
   // --------------------------------------------------------------------------
-  // dbConnectionQuerySearch(connQueries, resultId, cb)
+  // dbConnectionQuerySearch(connQueries, cb)
   //
   // Executes the query/queries specified in the connQueries array (elements are
   // of the type returned by buildConnectionQuery) by calling Db.searchSessions

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -508,7 +508,8 @@ class CronAPIs {
           agent: client === http ? internals.httpAgent : internals.httpsAgent
         };
 
-        Auth.addS2SAuth(reqOptions, pOptions.user, node, sendPath);
+        // Sign the path exactly as the remote node will see it in req.url
+        Auth.addS2SAuth(reqOptions, pOptions.user, node, url.pathname + (url.search ?? ''));
         ViewerUtils.addCaTrust(reqOptions, node);
 
         await new Promise((resolve) => {
@@ -693,7 +694,7 @@ class CronAPIs {
 
           const query = {
             from: 0,
-            size: 1000,
+            size: 10000000, // >10000 forces searchSessionsIterator to scroll ALL hits in the window (2000/chunk)
             query: { bool: { filter: [{}] } },
             _source: ['_id', 'node']
           };

--- a/viewer/apiHistory.js
+++ b/viewer/apiHistory.js
@@ -55,7 +55,7 @@ class HistoryAPIs {
    * @param {string} userId - The ID of a user to request history results for. Admin can retrieve all users. Normal users can only retrieve their own.
    * @returns {History[]} data - The list of history results.
    * @returns {number} recordsTotal - The total number of history results stored.
-   * @returns {number} recordsFiltered - The number of history items returned in this result.
+   * @returns {number} recordsFiltered - The number of history items matching query.
    */
   static async getHistories (req, res) {
     try {

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -359,7 +359,8 @@ ${Config.arkimeWebURL()}hunt
     async.forEachLimit(failedSessions, 3, (sessionId, cb) => {
       Db.getSession(sessionId, { arkime_unflatten: true, _source: false, fields: 'node,huntName,huntId,lastPacket,fileId'.split(',') }, async (err, session) => {
         if (err) {
-          const result = await HuntAPIs.#continueHuntSkipSession(hunt, huntId, session, sessionId, searchedSessions);
+          // session is undefined on error, pass a stub so #updateHuntStats doesn't throw
+          const result = await HuntAPIs.#continueHuntSkipSession(hunt, huntId, {}, sessionId, searchedSessions);
           return cb(result);
         }
 
@@ -786,7 +787,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
    * @property {number} matchedSessions - How many sessions contain packets that match the search text.
    * @property {number} searchedSessions - How many sessions have had their packets searched.
    * @property {number} totalSessions - The number of sessions to search.
-   * @property {number} lastPacketTime - The date of the last packet of the last searched session. Used to query for the next chunk of sessions to search. Format is seconds since Unix EPOCH.
+   * @property {number} lastPacketTime - The date of the last packet of the last searched session. Used to query for the next chunk of sessions to search. Format is milliseconds since Unix EPOCH.
    * @property {number} created - The time that the hunt was created. Format is seconds since Unix EPOCH.
    * @property {number} lastUpdated - The time that the hunt was last updated in the DB. Used to only update every 2 seconds. Format is seconds since Unix EPOCH.
    * @property {number} started - The time that the hunt was started (put into running state). Format is seconds since Unix EPOCH.
@@ -821,7 +822,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
      hex - search for hex text.
      regex - search for text using <a href="https://github.com/google/re2/wiki/Syntax">safe regex</a>.
      hexregex - search for text using <a href="https://github.com/google/re2/wiki/Syntax">safe hex regex</a>.
-   * @param {string} notifier - A comma separated list of notifier IDs to alert when there is an error or when the hunt is complete.
+   * @param {string[]} notifier - An array of notifier IDs to alert when there is an error or when the hunt is complete.
    * @param {string} users - The comma separated list of users to be added to the hunt so they can view the results.
    * @returns {boolean} success - Whether the creation of the hunt was successful.
    * @returns {Hunt} hunt - The newly created hunt object.
@@ -1340,7 +1341,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
    * GET - /api/hunt/:nodeName/:huntId/remote/:sessionId
    *
    * Searches a session on a remote node.
-   * @name /:nodeName/hunt/:huntId/remote/:sessionId
+   * @name /hunt/:nodeName/:huntId/remote/:sessionId
    * @returns {boolean} matched - Whether searching the session packets resulted in a match with the search text.
    * @returns {string} error - If an error occurred, describes the error.
    */

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2248,7 +2248,7 @@ class SessionAPIs {
           }
         }
 
-        // There is 1 entry per row, the entry is determine by the leafs, with an array of parents.
+        // There is 1 entry per row, the entry is determined by the leaves, with an array of parents.
         // This uses a depth first search.
         const tableResults = [];
         function addDataToTable (parents, buckets) {

--- a/viewer/apiStats.js
+++ b/viewer/apiStats.js
@@ -232,7 +232,7 @@ class StatsAPIs {
    * @param {string} name - The name of the field to get the detailed stats for.
    * @param {number} start - The start time of data to return. Format is seconds since Unix EPOCH.
    * @param {number} stop  - The stop time of data to return. Format is seconds since Unix EPOCH.
-   * @param {number} step - The context step of the cubism graph in milliseconds.
+   * @param {number} step - The context step of the cubism graph in seconds.
    * @param {number} interval=60 - The time interval to search for.
    * @param {number} size=1440 - The size of the cubism graph. Defaults to 1440.
    * @returns {array} List of values to populate the cubism graph.

--- a/viewer/apiUsers.js
+++ b/viewer/apiUsers.js
@@ -628,7 +628,7 @@ class UserAPIs {
    * @name /user/layouts/:type
    * @returns {boolean} success - Whether the operation was successful.
    * @returns {string} text - The success/error message to (optionally) display to the user.
-   * @returns {object} layout - The new layout configuration.
+   * @returns {string} name - The name of the new layout.
    */
   static createUserLayout (req, res) {
     let result;

--- a/viewer/db.js
+++ b/viewer/db.js
@@ -1936,7 +1936,7 @@ Db.session2Sid = function (item) {
   } else if (item._id.length < 31) {
     // sessions2 didn't have new arkime_ prefix
     if (ver === '2@' && internals.prefix === 'arkime_') {
-      // tests_sessions2-191021 191021-abcd => 3@191021:191021-abcd
+      // sessions2-191021 191021-abcd => 2@191021:191021-abcd
       return ver + item._index.substring(10) + ':' + item._id;
     } else if (item._index.startsWith('partial-')) {
       // partial-tests_sessions3-191021 191021-abcd => 3@191021:191021-abcd

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -195,7 +195,7 @@ function node2ESBasicAuth (node) {
   for (let p = 1; p < parts.length; p++) {
     const kv = parts[p].split(':');
     if (kv[0] === 'elasticsearchBasicAuth') {
-      return kv[1];
+      return kv.slice(1).join(':'); // value may be user:pass, keep everything after the key
     }
   }
   return null;
@@ -1380,7 +1380,7 @@ async function premain () {
       if (!esBasicAuth.includes(':')) {
         esBasicAuth = Buffer.from(esBasicAuth, 'base64').toString();
       }
-      esBasicAuth = esBasicAuth.split(':');
+      esBasicAuth = ArkimeUtil.splitRemain(esBasicAuth, ':', 1);
       esClientOptions.auth = {
         username: esBasicAuth[0],
         password: esBasicAuth[1]

--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -695,8 +695,8 @@ class Pcap {
     if (obj.gre.flags_version & 0x4000) {
       while (true) {
         bpos += 3;
-        if (bpos + 2 > buffer.length) { break; }
-        const len = buffer.readUInt16BE(bpos);
+        if (bpos + 1 > buffer.length) { break; }
+        const len = buffer[bpos]; // SRE Length is 1 byte (RFC 1701)
         bpos++;
         if (len === 0) { break; }
         bpos += len;

--- a/wiseService/source.opendns.js
+++ b/wiseService/source.opendns.js
@@ -31,7 +31,7 @@ class OpenDNSSource extends WISESource {
 
     this.statusField = this.api.addField('field:opendns.domain.status;db:opendns.status;kind:lotermfield;friendly:Status;help:OpenDNS domain security status;count:true');
     this.scField = this.api.addField('field:opendns.domain.security;db:opendns.securityCategory;kind:termfield;friendly:Security;help:OpenDNS domain security category;count:true');
-    this.ccField = this.api.addField('field:opendns.domain.content;db:opendns.contentCategory;kind:termfield;friendly:Security;help:OpenDNS domain content category;count:true');
+    this.ccField = this.api.addField('field:opendns.domain.content;db:opendns.contentCategory;kind:termfield;friendly:Content;help:OpenDNS domain content category;count:true');
 
     this.api.addView('opendns',
       'if (session.opendns)\n' +

--- a/wiseService/source.threatstream.js
+++ b/wiseService/source.threatstream.js
@@ -115,15 +115,10 @@ class ThreatStreamSource extends WISESource {
   // ----------------------------------------------------------------------------
   parseFile () {
     this.ips.clear();
-    this.ips.reserve(2000000);
     this.domains.clear();
-    this.domains.reserve(200000);
     this.emails.clear();
-    this.emails.reserve(200000);
     this.md5s.clear();
-    this.md5s.reserve(200000);
     this.urls.clear();
-    this.urls.reserve(200000);
 
     fs.createReadStream('/tmp/threatstream.zip')
       .pipe(unzipper.Parse())
@@ -172,8 +167,10 @@ class ThreatStreamSource extends WISESource {
             } else if (item.itype.match(/_md5/)) {
               this.md5s.set(item.md5, encoded);
             } else if (item.itype.match(/_url/)) {
-              if (item.url.lastIndexOf('http://', 0) === 0) {
+              if (item.url.startsWith('http://')) {
                 item.url = item.url.substring(7);
+              } else if (item.url.startsWith('https://')) {
+                item.url = item.url.substring(8);
               }
               this.urls.set(item.url, encoded);
             }
@@ -221,7 +218,6 @@ class ThreatStreamSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   getURLZip (url, cb) {
-    url = `http://${url}`;
     cb(null, this.urls.get(url));
   }
 
@@ -452,7 +448,7 @@ class ThreatStreamSource extends WISESource {
             this.db = null;
           }
 
-          // 5) Remove old .moloch and rename .tmp to .moloch
+          // 5) Remove old .moloch and rename .temp to .moloch
           execFile('/bin/rm', ['-f', `${dbFile}.moloch`], (err, subStdout, subStderr) => {
             execFile('/bin/mv', ['-f', `${dbFile}.temp`, `${dbFile}.moloch`], (err, subSubStdout, subSubStderr) => {
               // 6) open new .moloch file

--- a/wiseService/source.virustotal.js
+++ b/wiseService/source.virustotal.js
@@ -149,9 +149,9 @@ class VirusTotalSource extends WISESource {
 
 // ----------------------------------------------------------------------------
 const reportApi = function (req, res) {
-  source.getMd5(req.query.resource, (err, result) => {
+  source.getMd5({ value: req.query.resource }, (err, result) => {
     // console.log(err, result);
-    if (result[0] === 0) {
+    if (err || result === undefined || result[0] === 0) {
       res.send({ response_code: 0, resource: req.query.resource, verbose_msg: 'The requested resource is not among the finished, queued or pending scans' });
     } else {
       const obj = { scans: {} };

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -127,7 +127,7 @@ function processArgs (argv) {
       console.log('  --debug                     Increase debug level, multiple are supported');
       console.log('  --webconfig                 Allow the config to be edited from web page');
       console.log('  --webcode <code>            Set the web config code instead of random');
-      console.log('  --workers <b>               Number of worker processes to create');
+      console.log('  --workers <num>             Number of worker processes to create');
       console.log('  --insecure                  Disable certificate verification for https calls');
 
       process.exit(0);
@@ -495,7 +495,7 @@ class WISESourceAPI {
    * This is used by the UI to generate what to display to the admin.
    * @typedef {Object} WISESourceAPI~SourceConfig
    * @property {string} name - The name of the source
-   * @property {boolean} singleton - Can there be multiple instances of this source
+   * @property {boolean} singleton - Only one instance of this source can be configured
    * @property {string} description - Friendly text about the source
    * @property {Array} types - List of WISE types the source supports
    * @property {boolean} [cacheable=true] - Can the source be cached by WISE
@@ -1022,7 +1022,7 @@ function processQueryResponse0 (req, res, queries, results) {
 // ----------------------------------------------------------------------------
 // pos len value
 // 0   4   flags
-// 4   2   2
+// 4   4   2
 // 8   32  md5 of fields
 // 40  2   count of fields if md5 unknown
 // 42  L   fields info

--- a/wiseService/wiseSource.js
+++ b/wiseService/wiseSource.js
@@ -24,7 +24,7 @@ class WISESource {
    * @param {string} section - the section name
    * @param {object} options - All the options
    * @param {boolean} [options.dontCache=false] - do not cache this source, the source handles itself
-   * @param {integer} [options.cacheTimeout=cacheAgeMin*60 or 60] - override the cacheAgeMin setting, -1 same as don't
+   * @param {integer} [options.cacheTimeout=cacheAgeMin*60 or 60] - override the cacheAgeMin setting, -1 same as dontCache
    * @param {boolean} [options.tagsSetting=false] - load the optional tags setting
    * @param {boolean} [options.typeSetting=false] - load the required type setting
    * @param {boolean} [options.formatSetting=false] - load the format setting with default the provided value if not false
@@ -250,7 +250,7 @@ class WISESource {
   // ----------------------------------------------------------------------------
   /**
    * Util function to parse JSON formatted data
-   * @param {string} body - the raw JSON data
+   * @param {array} json - the parsed JSON array
    * @param {function} setCb - the function to call for each row found
    * @param {function} endCb - all done parsing
    */
@@ -474,7 +474,7 @@ class WISESource {
   /**
    * Convert field ids and string values into the encoded form used in WISE.
    *
-   * This method tags a variable number of arguments, each in a pair of field id and string value.
+   * This method takes a variable number of arguments, each in a pair of field id and string value.
    * @returns {buffer} - the encoded results
    */
   static encodeResult () {


### PR DESCRIPTION
Viewer:
- apiCrons.js: periodic queries processed at most 1000 sessions per run (scroll regression from #3519)
- apiCrons.js: periodic query forward: from a remote node was always rejected (S2S path signed without leading /)
- multies.js: plaintext user:pass elasticsearchBasicAuth never worked; colon-in-password truncated in both forms
- apiHunts.js: hunts stalled instead of skipping when a failed session couldn't be fetched on retry
- pcap.js: GRE SRE length read as 16-bit instead of 8-bit, misparsing routing-bit GRE packets

WISE:
- source.opendns.js: content category field was labeled Security instead of Content
- source.threatstream.js: zip mode urls with https, remove url mangling, drop map reserve calls
- source.virustotal.js: report api passed a bare string to getMd5 and crashed on undefined results
- wiseService.js/wiseSource.js: help text and doc comment fixes

Docs/typos:
- viewer: JSDoc/comment corrections in apiSessions, apiConnections, apiHistory, apiStats, apiHunts, db.js, apiUsers, addUser
- cont3xt: JSDoc/log-label corrections in db.js, integration.js, threatstream help text, UserService/AuditService docs
- common: hasRole JSDoc said ALL-match, is ANY-match

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
