### PR TITLE
Fix medium-severity bugs from Fable 5 scan across common, cont3xt, viewer, wise

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -52,6 +52,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4074 Harden user-auto-create/user-role-mappings expressions to run in strict mode
   - #4079 Fix relative time +1M (month) and @M snapping being silently ignored; lowercase m still means minutes
   - #4089 Consolidate header auth non-localhost host security warning across viewer/cont3xt/parliament/wiseService
+  - #4093 Fix page load failing with a 500 in OIDC mode when the issuer has no end_session_endpoint
+  - #4093 Fix user-role-mappings changes not taking effect until the next request; granted roles now apply and revoked roles stop working on the same request
 ## Capture
   - #4054 Fix GRE keepalive packets adding bogus 00:00:00:00:00:00 MACs
   - #4055 Fix DNS memory leak when parsing malformed answers
@@ -72,6 +74,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4091 Fix MQTT parser PUBLISH issues
   - #4091 Fix s3:// directory listing silently dropping pages after the first when the bucket needs continuation requests
   - #4091 Rename misspelled protocol classifier stream-ihscp to steam-ihscp (Steam In-Home Streaming Control Protocol)
+  - #4092 Fix tagger and zeekintel plugins potentially cross-matching IPv4 and IPv6 entries whose leading bits coincide; IPv4 entries are now stored v4-mapped in the shared tree
 ## Capture/Viewer
   - #4054 Add mpacket link layer support
 ## Cont3xt
@@ -79,6 +82,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4073 Fix integration cacheTimeout values specified in milliseconds being treated as seconds (1000x too long); short-TTL integrations like DNS now expire on time
   - #4073 Fix csv/json integrations sometimes failing to load JSON feeds over http/elasticsearch/opensearch
   - #4073 Fix ClickHouse integration being broken (wrong search method name and unawaited result parsing)
+  - #4093 Fix cont3xt crash with a malformed custom overview field, and custom overview join separators being rejected
+  - #4093 Fix searches hanging when an invalid IP (e.g. 300.1.2.3) is the only indicator queried
+  - #4093 Fix ipqs array fields not displaying comma-joined, the virustotal hash scans table never rendering, and the wise integration ignoring wiseURL
 ## Multies
   - #4092 Fix plaintext user:pass elasticsearchBasicAuth never working, and passwords containing a colon being truncated
 ## Viewer
@@ -90,6 +96,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4092 Fix periodic queries silently processing at most 1000 sessions per run
   - #4092 Fix hunts stalling instead of skipping the session when a failed session can't be fetched on retry
   - #4092 Fix GRE packets with the routing bit set being misparsed in the viewer pcap decoder
+  - #4093 Fix SPI Graph fileand rows showing node-level data instead of per-file data
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors
@@ -98,6 +105,10 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4092 Fix threatstream zip mode not working
   - #4092 Fix virustotal v2 issues
   - #4092 Fix opendns content category field being labeled Security instead of Content
+  - #4093 Fix opendns, passivetotal, and virustotal queries hanging forever when an upstream request fails
+  - #4093 Fix wiseService crashing when a watched file source file is deleted
+  - #4093 Fix isepxgrid serving stale identities for up to cacheAgeMin and disconnects deleting a reassigned IP's newer session
+  - #4093 Fix elasticsearch source registering anyway after logging that required settings are missing
 
 6.5.0 2026/06/15
 ## Breaking

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -74,7 +74,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4091 Fix MQTT parser PUBLISH issues
   - #4091 Fix s3:// directory listing silently dropping pages after the first when the bucket needs continuation requests
   - #4091 Rename misspelled protocol classifier stream-ihscp to steam-ihscp (Steam In-Home Streaming Control Protocol)
-  - #4092 Fix tagger and zeekintel plugins potentially cross-matching IPv4 and IPv6 entries whose leading bits coincide; IPv4 entries are now stored v4-mapped in the shared tree
+  - #4093 Fix tagger and zeekintel plugins potentially cross-matching IPv4 and IPv6 entries whose leading bits coincide; IPv4 entries are now stored v4-mapped in the shared tree
 ## Capture/Viewer
   - #4054 Add mpacket link layer support
 ## Cont3xt

--- a/capture/plugins/tagger.c
+++ b/capture/plugins/tagger.c
@@ -109,6 +109,32 @@ LOCAL void tagger_process_match(ArkimeSession_t *session, GPtrArray *infos, int 
 }
 /******************************************************************************/
 /*
+ * Insert an ip[/mask] entry into the tree.  IPv4 entries are stored v4-mapped
+ * (::ffff:a.b.c.d, a /n mask becomes /(96+n)) so both families live in the
+ * one 128 bit tree without cross-family bit collisions - patricia compares
+ * raw bits and ignores prefix->family, and session addresses are already
+ * v4-mapped in6_addrs.
+ */
+LOCAL patricia_node_t *tagger_make_and_lookup(patricia_tree_t *tree, const char *ip)
+{
+    char mapped[80];
+
+    if (!strchr(ip, ':')) {
+        const char *slash = strchr(ip, '/');
+        if (slash) {
+            int bits = atoi(slash + 1);
+            if (bits < 0 || bits > 32 || slash - ip >= 40)
+                return NULL;
+            snprintf(mapped, sizeof(mapped), "::ffff:%.*s/%d", (int)(slash - ip), ip, 96 + bits);
+        } else {
+            snprintf(mapped, sizeof(mapped), "::ffff:%s", ip);
+        }
+        ip = mapped;
+    }
+    return make_and_lookup(tree, (char *)ip);
+}
+/******************************************************************************/
+/*
  * Called by arkime when a session is about to be saved
  */
 LOCAL void tagger_plugin_save(ArkimeSession_t *session, int UNUSED(final))
@@ -121,33 +147,18 @@ LOCAL void tagger_plugin_save(ArkimeSession_t *session, int UNUSED(final))
 
     int i;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-    if (IN6_IS_ADDR_V4MAPPED(&session->addr1)) {
-        prefix.family = AF_INET;
-        prefix.bitlen = 32;
-        prefix.add.sin.s_addr = ARKIME_V6_TO_V4(session->addr1);
-    } else {
-        prefix.family = AF_INET6;
-        prefix.bitlen = 128;
-        memcpy(&prefix.add.sin6.s6_addr, &session->addr1, 16);
-    }
+    // Session/XFF addresses are v4-mapped in6_addrs, matching how v4 entries
+    // are stored, so everything is searched as a single 128 bit family.
+    prefix.family = AF_INET6;
+    prefix.bitlen = 128;
 
+    memcpy(&prefix.add.sin6.s6_addr, &session->addr1, 16);
     cnt = patricia_search_all(allIps, &prefix, 1, nodes);
     for (i = 0; i < cnt; i++) {
         tagger_process_match(session, ((TaggerIP_t *)(nodes[i]->data))->infos, srcIpField);
     }
 
-    if (IN6_IS_ADDR_V4MAPPED(&session->addr2)) {
-        prefix.family = AF_INET;
-        prefix.bitlen = 32;
-        prefix.add.sin.s_addr = ARKIME_V6_TO_V4(session->addr2);
-    } else {
-        prefix.family = AF_INET6;
-        prefix.bitlen = 128;
-        memcpy(&prefix.add.sin6.s6_addr, &session->addr2, 16);
-    }
-
+    memcpy(&prefix.add.sin6.s6_addr, &session->addr2, 16);
     cnt = patricia_search_all(allIps, &prefix, 1, nodes);
     for (i = 0; i < cnt; i++) {
         tagger_process_match(session, ((TaggerIP_t *)(nodes[i]->data))->infos, dstIpField);
@@ -161,23 +172,13 @@ LOCAL void tagger_plugin_save(ArkimeSession_t *session, int UNUSED(final))
         ghash = session->fields[httpXffField]->ghash;
         g_hash_table_iter_init (&iter, ghash);
         while (g_hash_table_iter_next (&iter, &ikey, NULL)) {
-            if (IN6_IS_ADDR_V4MAPPED((struct in6_addr *)ikey)) {
-                prefix.family = AF_INET;
-                prefix.bitlen = 32;
-                prefix.add.sin.s_addr = ARKIME_V6_TO_V4(*(struct in6_addr *)ikey);
-            } else {
-                prefix.family = AF_INET6;
-                prefix.bitlen = 128;
-                memcpy(&prefix.add.sin6.s6_addr, ikey, 16);
-            }
-
+            memcpy(&prefix.add.sin6.s6_addr, ikey, 16);
             cnt = patricia_search_all(allIps, &prefix, 1, nodes);
             for (i = 0; i < cnt; i++) {
                 tagger_process_match(session, ((TaggerIP_t *)(nodes[i]->data))->infos, httpXffField);
             }
         }
     }
-#pragma GCC diagnostic pop
 
     ArkimeString_t *hstring;
     if (httpHostField != -1 && session->fields[httpHostField]) {
@@ -560,7 +561,7 @@ LOCAL void tagger_load_file_cb(int UNUSED(code), uint8_t *data, int data_len, gp
         TaggerStringHash_t *hash = 0;
         switch (file->type[0]) {
         case 'i':
-            node = make_and_lookup(allIps, parts[0]);
+            node = tagger_make_and_lookup(allIps, parts[0]);
             if (!node) {
                 LOG("Couldn't create node for %s", parts[0]);
                 tagger_info_free(info);

--- a/capture/plugins/zeekintel.c
+++ b/capture/plugins/zeekintel.c
@@ -245,8 +245,34 @@ LOCAL void zeekintel_hash_add(ZeekIntelStringHash_t *hash, const char *key, Zeek
     g_ptr_array_add(s->items, item);
 }
 /******************************************************************************/
+/*
+ * Insert an ADDR/SUBNET indicator.  IPv4 indicators are stored v4-mapped
+ * (::ffff:a.b.c.d, a /n subnet becomes /(96+n)) so both families live in the
+ * one 128 bit tree without cross-family bit collisions - patricia compares
+ * raw bits and ignores prefix->family, and session addresses are already
+ * v4-mapped in6_addrs.
+ */
 LOCAL void zeekintel_ip_add(patricia_tree_t *tree, const char *indicator, ZeekIntelItem_t *item)
 {
+    char mapped[80];
+
+    if (!strchr(indicator, ':')) {
+        const char *slash = strchr(indicator, '/');
+        if (slash) {
+            int bits = atoi(slash + 1);
+            if (bits < 0 || bits > 32 || slash - indicator >= 40) {
+                if (config.debug)
+                    LOG("Invalid IPv4 indicator %s", indicator);
+                zeekintel_item_free(item);
+                return;
+            }
+            snprintf(mapped, sizeof(mapped), "::ffff:%.*s/%d", (int)(slash - indicator), indicator, 96 + bits);
+        } else {
+            snprintf(mapped, sizeof(mapped), "::ffff:%s", indicator);
+        }
+        indicator = mapped;
+    }
+
     patricia_node_t *node = make_and_lookup(tree, (char *)indicator);
     if (!node) {
         if (config.debug)
@@ -665,18 +691,11 @@ LOCAL void zeekintel_match_ip(ArkimeSession_t *session, ZeekIntelDB_t *db, const
     patricia_node_t *nodes[PATRICIA_MAXBITS + 1];
     prefix_t         prefix;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-aliasing"
-    if (IN6_IS_ADDR_V4MAPPED(addr)) {
-        prefix.family = AF_INET;
-        prefix.bitlen = 32;
-        prefix.add.sin.s_addr = ARKIME_V6_TO_V4(*addr);
-    } else {
-        prefix.family = AF_INET6;
-        prefix.bitlen = 128;
-        memcpy(&prefix.add.sin6.s6_addr, addr, 16);
-    }
-#pragma GCC diagnostic pop
+    // Session addresses are v4-mapped in6_addrs, matching how v4 indicators
+    // are stored, so everything is searched as a single 128 bit family.
+    prefix.family = AF_INET6;
+    prefix.bitlen = 128;
+    memcpy(&prefix.add.sin6.s6_addr, addr, 16);
 
     int cnt = patricia_search_all(db->ips, &prefix, 1, nodes);
     for (int i = 0; i < cnt; i++) {

--- a/common/auth.js
+++ b/common/auth.js
@@ -396,7 +396,7 @@ class Auth {
   // ----------------------------------------------------------------------------
   static logoutUrl (req) {
     let logoutUrl = Auth.#logoutUrl;
-    if (req.session?.id_token !== undefined) {
+    if (logoutUrl && req.session?.id_token !== undefined) {
       logoutUrl = logoutUrl.replace('ARKIME_ID_TOKEN', req.session.id_token);
     }
     if (ArkimeConfig.debug > 0) {

--- a/common/user.js
+++ b/common/user.js
@@ -1776,6 +1776,12 @@ class User {
     }
 
     this.roles = newRoles;
+    // Clear memoized permission state so expandFromRoles recomputes from the
+    // new roles instead of early-returning on the startup expansion
+    this.#allRoles = undefined;
+    this.#allExpression = undefined;
+    this.#allTimeLimit = undefined;
+    this.#allSettings = {};
     await this.expandFromRoles();
     await new Promise((resolve, reject) => {
       this.save((err) => {

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -460,6 +460,8 @@ class Integration {
       } catch (e) {
         console.log('WARNING - "%s" is not really an ip', query);
         shared.total -= integrations.length;
+        // Finish the response if this was the last outstanding work
+        checkWriteDone();
         return;
       }
       // I'm sure there is some function to do this with ipv6 but I couldn't find it

--- a/cont3xt/integrations/ipqs/index.js
+++ b/cont3xt/integrations/ipqs/index.js
@@ -173,8 +173,8 @@ class IPQSEmailIntegration extends Integration {
       { label: 'Recent Abuse', field: 'recent_abuse' },
       makeSamples('domain_age'),
       makeSamples('first_seen'),
-      { label: 'A Records', field: 'a_records', type: 'array', separator: ', ' },
-      { label: 'MX Records', field: 'mx_records', type: 'array', separator: ', ' }
+      { label: 'A Records', field: 'a_records', type: 'array', join: ', ' },
+      { label: 'MX Records', field: 'mx_records', type: 'array', join: ', ' }
     ]
   };
 
@@ -272,7 +272,7 @@ class IPQSEmailLeakIntegration extends Integration {
     title: 'IPQS Email Leak Records for %{query}',
     fields: [
       { label: 'Exposed', field: 'exposed', type: 'boolean' },
-      { label: 'Source', field: 'source', type: 'array', separator: ', ' },
+      { label: 'Source', field: 'source', type: 'array', join: ', ' },
       { label: 'Plain Text Password', field: 'plain_text_password', type: 'boolean' },
       makeSamples('first_seen')
     ]
@@ -380,9 +380,9 @@ class IPQSUrlIntegration extends Integration {
       { label: 'Adult', field: 'adult', type: 'boolean' },
       { label: 'Country Code', field: 'country_code' },
       makeSamples('domain_age'),
-      { label: 'A Records', field: 'a_records', type: 'array', separator: ', ' },
-      { label: 'MX Records', field: 'mx_records', type: 'array', separator: ', ' },
-      { label: 'NS Records', field: 'ns_records', type: 'array', separator: ', ' }
+      { label: 'A Records', field: 'a_records', type: 'array', join: ', ' },
+      { label: 'MX Records', field: 'mx_records', type: 'array', join: ', ' },
+      { label: 'NS Records', field: 'ns_records', type: 'array', join: ', ' }
     ]
   };
 

--- a/cont3xt/integrations/virustotal/index.js
+++ b/cont3xt/integrations/virustotal/index.js
@@ -361,8 +361,11 @@ class VirusTotalHashIntegration extends Integration {
       'verbose_msg',
       {
         label: 'scans',
+        field: 'scans',
+        type: 'table',
+        postProcess: { keyedToArrayWith: 'engine' },
         fields: [
-          'scan type',
+          'engine',
           'detected',
           'result',
           'update',

--- a/cont3xt/integrations/wise/index.js
+++ b/cont3xt/integrations/wise/index.js
@@ -52,7 +52,9 @@ class WiseIntegration extends Integration {
     this.section = section;
     this.name = ArkimeConfig.getFull(section, 'name', section);
     this.icon = ArkimeConfig.getFull(section, 'icon', this.icon);
-    this.#wiseUrl = ArkimeConfig.getFull(section, 'arkimeUrl', 'http://localhost:8081');
+    // wiseURL is the standard key for pointing at a WISE server; arkimeUrl
+    // kept as a fallback since this integration historically misused it
+    this.#wiseUrl = ArkimeConfig.getFull(section, 'wiseURL') ?? ArkimeConfig.getFull(section, 'arkimeUrl', 'http://localhost:8081');
 
     Integration.register(this);
   }

--- a/cont3xt/overview.js
+++ b/cont3xt/overview.js
@@ -130,8 +130,8 @@ class Overview {
     if (custom.pivot != null && typeof custom.pivot !== 'boolean') {
       return { msg: 'Custom pivot must be a boolean when present' };
     }
-    if (custom.join != null && typeof custom.join !== 'boolean') {
-      return { msg: 'Custom join must be a boolean when present' };
+    if (custom.join != null && !ArkimeUtil.isString(custom.join)) {
+      return { msg: 'Custom join must be a string when present' };
     }
     if (custom.filterEmpty != null && typeof custom.filterEmpty !== 'boolean') {
       return { msg: 'Custom filterEmpty must be a boolean when present' };
@@ -144,6 +144,9 @@ class Overview {
     }
 
     if (custom.fields != null) {
+      if (!Array.isArray(custom.fields)) {
+        return { msg: 'Custom fields must be an array when present' };
+      }
       for (let i = 0; i < custom.fields.length; i++) {
         const { custom: customSubField, msg } = this.verifyOverviewCustomField(custom.fields[i], depth + 1);
         if (msg) { return { msg }; }

--- a/tests/addUser.t
+++ b/tests/addUser.t
@@ -1,5 +1,5 @@
 # Test addUser.js and general authentication
-use Test::More tests => 104;
+use Test::More tests => 108;
 use Test::Differences;
 use Data::Dumper;
 use ArkimeTest;
@@ -262,6 +262,23 @@ is ($response->code, 200, "combouser with wrong header auth success");
 $response = viewerGet("/regressionTests/getUser/combouser");
 ok(!grep(/^role:combinedRole$/, @{$response->{roles}}), "combouser loses role:combinedRole when expression is false");
 
+# Test dynamic roles take effect on the SAME request that grants/revokes them.
+# /api/user returns the in-memory expanded roles (#allRoles), so a stale
+# memoized expansion shows up here even though the saved user is correct.
+$response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8126/api/user", ':arkime_user' => 'samerequser', 'x-test-role' => 'special');
+is ($response->code, 200, "samerequser auth success");
+my $sameReq = from_json($response->content);
+ok(grep(/^role:headerRole$/, @{$sameReq->{roles}}), "samerequser has role:headerRole on the granting request");
+
+# Same user again WITHOUT the header - role must be gone on this same request
+$response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8126/api/user", ':arkime_user' => 'sameequser');
+$response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8126/api/user", ':arkime_user' => 'sameequser', 'x-test-role' => 'special');
+$sameReq = from_json($response->content);
+ok(grep(/^role:headerRole$/, @{$sameReq->{roles}}), "sameequser gains role:headerRole on the granting request");
+$response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8126/api/user", ':arkime_user' => 'sameequser');
+$sameReq = from_json($response->content);
+ok(!grep(/^role:headerRole$/, @{$sameReq->{roles}}), "sameequser loses role:headerRole on the revoking request");
+
 
 #### JWT Auth Header tests (test4 node on port 8127)
 
@@ -322,6 +339,8 @@ viewerDeleteToken("/api/user/normaluser", $token);
 viewerDeleteToken("/api/user/combouser", $token);
 viewerDeleteToken("/api/user/jwtuser1", $token);
 viewerDeleteToken("/api/user/jwtuser2", $token);
+viewerDeleteToken("/api/user/samerequser", $token);
+viewerDeleteToken("/api/user/sameequser", $token);
 
 $response = viewerGet("/api/user/__proto__");
 eq_or_diff($response, from_json('{"success": false, "text": "Bad path &#47;api&#47;user&#47;__proto__"}'));

--- a/tests/api-spigraph.t
+++ b/tests/api-spigraph.t
@@ -1,4 +1,4 @@
-use Test::More tests => 96;
+use Test::More tests => 99;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -143,6 +143,11 @@ cmp_ok ($json->{recordsFiltered}, '==', 6);
     is (scalar @{$json->{"items"}}, 3);
     is ($json->{"items"}->[0]->{name}, '/DIR/tests/pcap/socks-http-example.pcap');
     cmp_ok ($json->{recordsFiltered}, '==', 6);
+    # each item must show per-file session counts, not node-level totals
+    my %fileandCounts = map { $_->{name} => $_->{sessionsHisto} } @{$json->{"items"}};
+    is ($fileandCounts{'/DIR/tests/pcap/socks-http-example.pcap'}, 3, "fileand per-file sessions socks-http-example");
+    is ($fileandCounts{'/DIR/tests/pcap/bt-tcp.pcap'}, 2, "fileand per-file sessions bt-tcp");
+    is ($fileandCounts{'/DIR/tests/pcap/bigendian.pcap'}, 1, "fileand per-file sessions bigendian");
 
 # ip.dst:port works
     $json = get("/spigraph.json?date=-1&field=ip.dst:port&expression=" . uri_escape("file=$pwd/socks5-reverse.pcap|file=$pwd/socks-http-example.pcap|file=$pwd/bt-tcp.pcap"));

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -1,5 +1,5 @@
 # Test cont3xt.js
-use Test::More tests => 219;
+use Test::More tests => 223;
 use Test::Differences;
 use Data::Dumper;
 use ArkimeTest;
@@ -552,6 +552,68 @@ $json = cont3xtPutToken("/api/overview", to_json({
     }]
 }), $token);
 eq_or_diff($json, from_json('{"success": false, "text": "Custom field must not have alias"}'));
+
+# custom.fields must be an array - a string used to crash the process (iterated char-by-char then assigned to a string index)
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "Overview1",
+    title => "Overview of %{query}",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type   => "custom",
+        from => "Foo",
+        custom => {
+            label  => "foo name",
+            fields => "abc"
+        }
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Custom fields must be an array when present"}'));
+
+# custom.join is a string separator (like every integration card), not a boolean
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "Overview1",
+    title => "Overview of %{query}",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type   => "custom",
+        from => "Foo",
+        custom => {
+            label => "foo name",
+            field => "foo.bar",
+            type  => "array",
+            join  => JSON::true
+        }
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Custom join must be a string when present"}'));
+
+# custom.join with a string separator must be accepted
+$json = cont3xtPutToken("/api/overview", to_json({
+    name => "OverviewJoin",
+    title => "Overview of %{query}",
+    iType => "domain",
+    viewRoles => ["cont3xtUser"],
+    editRoles => ["superAdmin"],
+    fields => [{
+        type   => "custom",
+        from => "Foo",
+        custom => {
+            label => "foo name",
+            field => "foo.bar",
+            type  => "array",
+            join  => ", "
+        }
+    }]
+}), $token);
+eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
+$json = cont3xtGet('/api/overview');
+my $joinOverviewId = $json->{overviews}->[0]->{_id};
+$json = cont3xtDeleteToken("/api/overview/$joinOverviewId", "{}", $token);
+eq_or_diff($json, from_json('{"success": true, "text": "Success"}'));
 
 $json = cont3xtPutToken("/api/overview", to_json({
     name => "Overview1",

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -515,15 +515,15 @@ class CronAPIs {
         await new Promise((resolve) => {
           const preq = client.request(url, reqOptions, (pres) => {
             pres.on('data', (chunk) => {
-              CronAPIs.#qlworking[url.path] = 'data';
+              CronAPIs.#qlworking[url.pathname] = 'data';
             });
             pres.on('end', () => {
-              delete CronAPIs.#qlworking[url.path];
+              delete CronAPIs.#qlworking[url.pathname];
               resolve();
             });
           });
           preq.on('error', (e) => {
-            delete CronAPIs.#qlworking[url.path];
+            delete CronAPIs.#qlworking[url.pathname];
             console.log("ERROR - Couldn't proxy sendSession request=", url, '\nerror=', e);
             resolve();
           });
@@ -531,7 +531,7 @@ class CronAPIs {
           preq.write('ids=');
           preq.write(nodes[node].join(','));
           preq.end();
-          CronAPIs.#qlworking[url.path] = 'sent';
+          CronAPIs.#qlworking[url.pathname] = 'sent';
         });
       }
     });

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -1369,7 +1369,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
       }
 
       hunt = hunt._source;
-      session = session._source;
+      session = session.fields;
 
       const options = HuntAPIs.#buildHuntOptions(huntId, hunt);
 

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2007,7 +2007,7 @@ class SessionAPIs {
         const sfilter = { term: {} };
         query.query.bool.filter.push(filter);
 
-        if (field === 'ip.dst:port') {
+        if (field === 'ip.dst:port' || field === 'fileand') {
           query.query.bool.filter.push(sfilter);
         }
 
@@ -2120,7 +2120,7 @@ class SessionAPIs {
           } else if (field === 'fileand') {
             filter.term.node = item.key;
             for (const sitem of item.sub.buckets) {
-              sfilter.term.fileand = sitem.key;
+              sfilter.term.fileId = sitem.key;
               intermediateResults.push({ key: filter.term.node + ':' + sitem.key, doc_count: sitem.doc_count, query: JSON.stringify(query) });
             }
           } else {

--- a/wiseService/source.elasticsearch.js
+++ b/wiseService/source.elasticsearch.js
@@ -23,11 +23,14 @@ class ElasticsearchSource extends WISESource {
     this.esMaxTimeMS = api.getConfig(section, 'esMaxTimeMS', 60 * 60 * 1000);
     this.elasticsearch = api.getConfig(section, 'elasticsearch');
 
+    let missing = false;
     ['esIndex', 'esTimestampField', 'esQueryField', 'esResultField', 'elasticsearch'].forEach((item) => {
       if (this[item] === undefined) {
         console.log(this.section, `- ERROR not loading since no ${item} specified in config file`);
+        missing = true;
       }
     });
+    if (missing) { return; }
 
     this[this.api.funcName(this.type)] = this.sendResult;
 

--- a/wiseService/source.file.js
+++ b/wiseService/source.file.js
@@ -34,10 +34,16 @@ class FileSource extends SimpleSource {
       clearTimeout(this.watchTimeout);
       if (e === 'rename') {
         this.watch.close();
-        setTimeout(() => {
+        // File may be briefly missing (atomic replace/delete); retry until it's back
+        const rearm = () => {
+          if (!fs.existsSync(this.file)) {
+            setTimeout(rearm, 500);
+            return;
+          }
           this.load();
           this.watch = fs.watch(this.file, watchCb);
-        }, 500);
+        };
+        setTimeout(rearm, 500);
       } else {
         this.watchTimeout = setTimeout(() => {
           this.watchTimeout = null;

--- a/wiseService/source.isepxgrid.js
+++ b/wiseService/source.isepxgrid.js
@@ -148,7 +148,9 @@ class StompClient {
 class ISEPxGridSource extends WISESource {
   // -------------------------------------------------------------------------
   constructor (api, section) {
-    super(api, section, {});
+    // dontCache: results come from the live in-memory sessionMap (STOMP push);
+    // wiseService result caching would serve stale identities for up to cacheAgeMin
+    super(api, section, { dontCache: true });
 
     // ---- Config ------------------------------------------------------------
     this.host = api.getConfig(section, 'host');
@@ -505,11 +507,17 @@ class ISEPxGridSource extends WISESource {
       const user = s.adUserResolvedIdentities || s.userName || '';
 
       if (s.state === 'DISCONNECTED' || s.state === 'TERMINATED') {
-        // Use sidMap to purge ALL IPs ever associated with this session
+        // Use sidMap to purge ALL IPs ever associated with this session, but
+        // only delete entries still owned by this session - the IP may have
+        // been reassigned to a newer session already
         const knownIps = (sid && this.sidMap.has(sid))
           ? [...this.sidMap.get(sid)]
           : newIps;
-        for (const ip of knownIps) this.sessionMap.delete(ip);
+        for (const ip of knownIps) {
+          if ((this.sessionMap.get(ip)?.auditSessionId || '') === sid) {
+            this.sessionMap.delete(ip);
+          }
+        }
         if (sid) this.sidMap.delete(sid);
 
         if (this.logEvents) {
@@ -518,11 +526,12 @@ class ISEPxGridSource extends WISESource {
       } else {
         if (!newIps.length) continue;
 
-        // Remove any STALE IPs for this session that are no longer in the new set
+        // Remove any STALE IPs for this session that are no longer in the new
+        // set, unless the IP was already reassigned to a different session
         const stalePurged = [];
         if (sid && this.sidMap.has(sid)) {
           for (const ip of this.sidMap.get(sid)) {
-            if (!newIps.includes(ip)) {
+            if (!newIps.includes(ip) && (this.sessionMap.get(ip)?.auditSessionId || '') === sid) {
               this.sessionMap.delete(ip);
               stalePurged.push(ip);
             }

--- a/wiseService/source.opendns.js
+++ b/wiseService/source.opendns.js
@@ -88,7 +88,22 @@ class OpenDNSSource extends WISESource {
     // http://stackoverflow.com/questions/6158933/how-to-make-an-http-post-request-in-node-js/6158966
     // console.log("doing query:", waiting.length, "current cache", Object.keys(cache).length);
     const postData = JSON.stringify(this.waiting);
+    const sent = this.waiting.slice(); // for error cleanup
     this.waiting.length = 0;
+
+    // On failure invoke and remove all callbacks for this batch so queries
+    // don't hang in processing forever
+    const failBatch = (err) => {
+      for (const domain of sent) {
+        const cbs = this.processing[domain];
+        if (!cbs) { continue; }
+        delete this.processing[domain];
+        let cb;
+        while ((cb = cbs.shift())) {
+          cb(err);
+        }
+      }
+    };
 
     const postOptions = {
       host: 'sgraph.api.opendns.com',
@@ -113,13 +128,14 @@ class OpenDNSSource extends WISESource {
           results = JSON.parse(response);
         } catch (e) {
           console.log(this.section, 'Error parsing for request:\n', postData, '\nresponse:\n', response);
-          results = {};
+          failBatch('opendns parse error');
+          return;
         }
 
         for (let result in results) {
           const cbs = this.processing[result];
           if (!cbs) {
-            return;
+            continue;
           }
           delete this.processing[result];
 
@@ -156,6 +172,7 @@ class OpenDNSSource extends WISESource {
     });
     request.on('error', (err) => {
       console.log(this.section, err);
+      failBatch(err);
     });
 
     // post the data

--- a/wiseService/source.passivetotal.js
+++ b/wiseService/source.passivetotal.js
@@ -55,11 +55,14 @@ class PassiveTotalSource extends WISESource {
       console.log(this.section, '- Fetching', this.waiting.length);
     }
 
+    const sent = this.waiting.slice();
+    this.waiting.length = 0;
+
     const options = {
       url: 'https://api.passivetotal.org/v2/enrichment/bulk',
       data: {
         additional: ['osint', 'malware'],
-        query: this.waiting
+        query: sent
       },
       auth: {
         username: this.user,
@@ -100,9 +103,18 @@ class PassiveTotalSource extends WISESource {
         }
       }).catch((err) => {
         console.log(this.section, err);
+        // Invoke and remove all callbacks for this batch so queries don't
+        // hang in processing forever
+        for (const key of sent) {
+          const cbs = this.processing[key];
+          if (!cbs) { continue; }
+          delete this.processing[key];
+          let cb;
+          while ((cb = cbs.shift())) {
+            cb(err);
+          }
+        }
       });
-
-    this.waiting.length = 0;
   };
 
   // ----------------------------------------------------------------------------

--- a/wiseService/source.redis.js
+++ b/wiseService/source.redis.js
@@ -51,21 +51,25 @@ class RedisSource extends WISESource {
         return cb(null, undefined);
       }
 
-      let found = false;
+      let answered = false;
+      const rowResults = [];
       try {
         this.parse(reply, (ignorekey, result) => {
-          found = true;
-          const newresult = WISESource.combineResults([result, this.tagsResult]);
-          return cb(null, newresult);
+          // Collect every row; cb must only be invoked once per query
+          rowResults.push(result);
         }, (err) => {
           if (err) {
             console.log(`${this.section} -`, err);
+            answered = true;
             return cb(null, undefined);
           }
-          if (!found) {
+          if (rowResults.length === 0) {
             console.log(`${this.section} - The keyPath ${this.keyPath} wasn't found even though document was returned`, reply);
+            answered = true;
             return cb(null, undefined);
           }
+          answered = true;
+          return cb(null, WISESource.combineResults([...rowResults, this.tagsResult]));
         });
       } catch (err) {
         if (err) {
@@ -73,7 +77,7 @@ class RedisSource extends WISESource {
         }
         // parse threw before producing a result; complete the query so the
         // wiseService in-progress entry isn't left hanging until the timeout
-        if (!found) {
+        if (!answered) {
           return cb(null, undefined);
         }
       }

--- a/wiseService/source.splunk.js
+++ b/wiseService/source.splunk.js
@@ -81,7 +81,7 @@ class SplunkSource extends WISESource {
       }
 
       let cache;
-      if (merging) {
+      if (merging && this.cache !== undefined) {
         cache = this.cache;
       } else {
         if (this.type === 'ip') {

--- a/wiseService/source.threatstream.js
+++ b/wiseService/source.threatstream.js
@@ -83,7 +83,11 @@ class ThreatStreamSource extends WISESource {
       ThreatStreamSource.prototype.getURL = ThreatStreamSource.prototype.getURLSqlite3;
       this.loadTypes(true);
       api.app.get('/threatstream/_reload', (req, res) => {
-        this.openDb.bind(this)();
+        if (this.mode === 'sqlite3-copy') {
+          this.openDbCopy();
+        } else {
+          this.openDb();
+        }
         res.send('Ok');
       });
       break;
@@ -251,7 +255,6 @@ class ThreatStreamSource extends WISESource {
     this.inProgress++;
     axios(options)
       .then((response) => {
-        this.inProgress--;
         const body = response.data;
 
         if (body.objects.length === 0) {
@@ -280,6 +283,8 @@ class ThreatStreamSource extends WISESource {
       }).catch((err) => {
         console.log(this.section, 'problem fetching ', options, err);
         return cb(null, WISESource.emptyResult);
+      }).finally(() => {
+        this.inProgress--;
       });
   }
 
@@ -512,18 +517,20 @@ class ThreatStreamSource extends WISESource {
 
     this.checkMd5Index(this.db, dbFile);
 
-    setInterval(() => {
-      try {
-        const result = this.db.pragma('main.wal_checkpoint(TRUNCATE)');
-        console.log('Threatstream Truncate - ', result);
-        if (result.length > 0 && result[0].busy) {
-          const result2 = this.db.pragma('main.wal_checkpoint(PASSIVE)');
-          console.log('Threatstream Passive Truncate - ', result2);
+    if (this.checkpointInterval === undefined) { // only one checkpoint timer, openDb can be called repeatedly
+      this.checkpointInterval = setInterval(() => {
+        try {
+          const result = this.db.pragma('main.wal_checkpoint(TRUNCATE)');
+          console.log('Threatstream Truncate - ', result);
+          if (result.length > 0 && result[0].busy) {
+            const result2 = this.db.pragma('main.wal_checkpoint(PASSIVE)');
+            console.log('Threatstream Passive Truncate - ', result2);
+          }
+        } catch (err) {
+          console.log('Threatstream truncate error', err);
         }
-      } catch (err) {
-        console.log('Threatstream truncate error', err);
-      }
-    }, 5 * 60 * 1000);
+      }, 5 * 60 * 1000);
+    }
   }
 }
 

--- a/wiseService/source.virustotal.js
+++ b/wiseService/source.virustotal.js
@@ -102,11 +102,13 @@ class VirusTotalSource extends WISESource {
         }
 
         results.forEach((result) => {
-          const cb = this.processing.get(result.md5);
+          // not-found results only have resource, found ones also have md5
+          const key = result.resource || result.md5;
+          const cb = this.processing.get(key);
           if (!cb) {
             return;
           }
-          this.processing.delete(result.md5);
+          this.processing.delete(key);
 
           let wiseResult;
           if (result.response_code === 0) {
@@ -129,6 +131,15 @@ class VirusTotalSource extends WISESource {
         });
       }).catch((err) => {
         console.log(this.section, err);
+        // Invoke and remove this batch's callbacks so queries don't hang
+        sent.forEach((md5) => {
+          const cb = this.processing.get(md5);
+          if (!cb) {
+            return;
+          }
+          this.processing.delete(md5);
+          cb(undefined, undefined);
+        });
       });
   };
 
@@ -138,12 +149,22 @@ class VirusTotalSource extends WISESource {
       return cb(null, undefined);
     }
 
-    this.processing.set(query.value, cb);
-    if (this.waiting.length < this.maxOutstanding) {
-      this.waiting.push(query.value);
-    } else {
+    const existing = this.processing.get(query.value);
+    if (existing !== undefined) {
+      // Same md5 already in flight - chain the callbacks, don't queue it twice
+      this.processing.set(query.value, (err, result) => {
+        existing(err, result);
+        cb(err, result);
+      });
+      return;
+    }
+
+    if (this.waiting.length >= this.maxOutstanding) {
       return cb('dropped');
     }
+
+    this.processing.set(query.value, cb);
+    this.waiting.push(query.value);
   }
 }
 

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -485,7 +485,7 @@ class WISESourceAPI {
    * @property {boolean} [password=false] - Is it a password type field that should be hidden
    * @property {string} [multiline] - If set this should be split using the value and shown in the UI as a text area
    * @property {string} help - The help text to show the user about the field
-   * @property {string} [ifField] - Only show the field if the 'ifValue' field is set and is equal to 'ifValue'
+   * @property {string} [ifField] - Only show the field if the 'ifField' field is set and is equal to 'ifValue'
    * @property {string} [ifValue] - Only show the field if the 'ifValue' field is set and is equal to 'ifValue'
    * @property {string} [regex] - The value must match the regex to be considered valid
    */


### PR DESCRIPTION
Common:
- auth.js: 500 on every page in OIDC mode when issuer has no end_session_endpoint
- user.js: user-role-mappings changes now take effect on the same request (memoized role expansion was never recomputed); same-request regression test in addUser.t

Cont3xt:
- overview.js: malformed custom field with string fields crashed the process (any user); join is validated as a string separator; crash + accept/reject tests in cont3xt.t
- integration.js: invalid-IP-only searches no longer hang the chunked response
- ipqs: separator -> join so array fields display comma-joined
- virustotal: hash scans render as a table (keyedToArrayWith engine)
- wise: prefer wiseURL config key, arkimeUrl kept as fallback

Viewer:
- apiSessions.js: SPI Graph fileand rows show per-file data instead of node totals; regression test in api-spigraph.t
- apiHunts.js: remoteHunt read session._source which getSession deletes; use .fields
- apiCrons.js: qlworking keyed on url.pathname (url.path is always undefined)

WISE:
- opendns/passivetotal/virustotal: failed upstream requests no longer hang queries forever (error-path callback cleanup)
- virustotal: capacity checked before registering, concurrent same-hash callbacks chained, not-found results keyed on resource
- threatstream: api mode no longer leaks in-flight slots on failure; _reload honors sqlite3-copy mode; single wal-checkpoint interval
- file source: deleted watched file no longer crashes wiseService (existsSync retry on rearm)
- redis source: multi-row values answer the query once instead of crashing
- splunk: failed initial query no longer breaks every merge refresh
- isepxgrid: dontCache so live STOMP updates aren't masked; disconnect purges only delete entries still owned by the session
- elasticsearch source: missing required settings abort loading instead of registering broken
- wiseService.js: ifField JSDoc copy-paste

Capture:
- tagger.c/zeekintel.c: store IPv4 patricia entries v4-mapped so both families share the 128-bit tree without collisions

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
