### PR TITLE
Fix low-severity bugs from Fable 5 scan across viewer, cont3xt, wise

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -97,6 +97,11 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4092 Fix hunts stalling instead of skipping the session when a failed session can't be fetched on retry
   - #4092 Fix GRE packets with the routing bit set being misparsed in the viewer pcap decoder
   - #4093 Fix SPI Graph fileand rows showing node-level data instead of per-file data
+  - #4094 Fix history not recording the view name and expression used for a search since views moved to their own index
+  - #4094 Fix viewer pcap decoder issues: radiotap headers >= 256 bytes, NFLOG reading garbage offsets when no payload found, and SLL2 always decoding as IPv4
+  - #4094 Fix raw packet search hunts matching bytes in pcap record headers when searching both directions
+  - #4094 Fix multies GET _search crashing when one cluster returns an error
+  - #4094 Fix map data still being computed when map=false is sent with facets
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors
@@ -109,6 +114,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4093 Fix wiseService crashing when a watched file source file is deleted
   - #4093 Fix isepxgrid serving stale identities for up to cacheAgeMin and disconnects deleting a reassigned IP's newer session
   - #4093 Fix elasticsearch source registering anyway after logging that required settings are missing
+  - #4094 Fix fieldactions/valueactions crashing wiseService when the watched file is deleted, and redis/elasticsearch content with a section header failing to load
+  - #4094 Fix databricks and splunk sources loading anyway when required settings are missing
 
 6.5.0 2026/06/15
 ## Breaking

--- a/common/user.js
+++ b/common/user.js
@@ -1133,8 +1133,8 @@ class User {
       return res.serverError(403, 'New password needs to be at least 3 characters');
     }
 
-    const storeHa1 = Auth.store2ha1(req.user.passStore);
-    const reqHa1 = Auth.store2ha1(Auth.pass2store(req.token.userId, req.body.currentPassword));
+    const storeHa1 = Auth.store2ha1(req.user.passStore, req.user.userId);
+    const reqHa1 = Auth.store2ha1(Auth.pass2store(req.token.userId, req.body.currentPassword), req.token.userId);
     if (!req.user.hasRole('usersAdmin') && (
       storeHa1.length !== reqHa1.length ||
       !cryptoLib.timingSafeEqual(Buffer.from(storeHa1), Buffer.from(reqHa1)) ||

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -290,15 +290,15 @@ function apiGetSettings (req, res, next) {
 
 // verify selectedOverviews, on error returns { msg: <errorMsg> }, on success returns { selectedOverviews }
 function verifySelectedOverviews (selectedOverviews) {
+  if (typeof selectedOverviews !== 'object' || selectedOverviews === null || Array.isArray(selectedOverviews)) {
+    return { msg: 'selectedOverviews must be an object' };
+  }
+
   selectedOverviews = (
     ({ // only allow these properties in selectedOverviews
       domain, ip, url, email, phone, hash, text
     }) => ({ domain, ip, url, email, phone, hash, text })
   )(selectedOverviews);
-
-  if (typeof selectedOverviews !== 'object') {
-    return { msg: 'selectedOverviews must be an object' };
-  }
 
   for (const selectedId of Object.values(selectedOverviews)) {
     if (!ArkimeUtil.isString(selectedId)) {

--- a/tests/api-history.t
+++ b/tests/api-history.t
@@ -1,4 +1,4 @@
-use Test::More tests => 56;
+use Test::More tests => 60;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -218,3 +218,21 @@ my ($url) = @_;
     ok (!exists $item->{body}->{password}, "Delete: should have no password item");
     ok (!exists $item->{body}->{newPassword}, "Delete: should have no newPassword item");
     ok (!exists $item->{body}->{currentPassword}, "Delete: should have no currentPassword item");
+
+# History records the view name + expression when a search uses a view
+    $json = viewerPostToken("/api/view", '{"name": "historyview", "expression": "tags == domainwise"}', $token);
+    is ($json->{success}, 1, "View: created");
+    my $viewId = $json->{view}->{id};
+
+    viewerGet("/sessions.json?date=-1&view=historyview&expression=" . uri_escape("file=$pwd/socks-https-example.pcap||file=$pwd/dns-mx.pcap"));
+    sleep(2);
+    esGet("/_flush");
+    esGet("/_refresh");
+
+    $json = viewerGet("/api/histories?userId=anonymous&api=sessions&sortField=timestamp&desc=true");
+    $item = $json->{data}->[0];
+    is ($item->{view}->{name}, "historyview", "View: history has view name");
+    is ($item->{view}->{expression}, "tags == domainwise", "View: history has view expression");
+
+    $json = viewerDeleteToken("/api/view/$viewId", $token);
+    is ($json->{success}, 1, "View: deleted");

--- a/tests/api-summary.t
+++ b/tests/api-summary.t
@@ -83,7 +83,7 @@ cmp_ok($summary->{lastPacket}, '>', 0, "lastPacket timestamp is positive");
 cmp_ok($summary->{lastPacket}, '>=', $summary->{firstPacket}, "lastPacket >= firstPacket");
 
 # Test downloadBytes calculation
-my $expectedDownloadBytes = 20 + $summary->{bytes} + 16 * $summary->{packets};
+my $expectedDownloadBytes = 24 + $summary->{bytes} + 16 * $summary->{packets};
 is($summary->{downloadBytes}, $expectedDownloadBytes, "downloadBytes calculated correctly");
 
 # Test field structure

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -102,7 +102,8 @@ class HuntAPIs {
       const packets = [];
       SessionAPIs.processSessionId(sessionId, true, null, (pcap, buffer, processSessionIdCb, i) => {
         if (options.src === options.dst) {
-          packets.push(buffer);
+          // strip the 16 byte pcap record header, only packet data should be searched
+          packets.push(buffer.slice(16));
         } else {
           const packet = {};
           pcap.decode(buffer, packet);

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2353,7 +2353,7 @@ class SessionAPIs {
     /* How should each item be processed. */
     let eachCb = writeCb;
 
-    if (req.query.field.match(/(ip.src:port.src|a1:p1|srcIp:srcPort|ip.src:srcPort|ip.dst:port.dst|a2:p2|dstIp:dstPort|ip.dst:dstPort|source.ip:source.port|ip.src:source.port|ip.dst:destination.port)/)) {
+    if (req.query.field.match(/(ip.src:port.src|a1:p1|srcIp:srcPort|ip.src:srcPort|ip.dst:port.dst|a2:p2|dstIp:dstPort|ip.dst:dstPort|source.ip:source.port|ip.src:source.port|destination.ip:destination.port|ip.dst:destination.port)/)) {
       eachCb = (item) => {
         const sep = (item.key.indexOf(':') === -1) ? ':' : '.';
         for (const item2 of item.field2.buckets) {
@@ -3013,7 +3013,7 @@ class SessionAPIs {
         map,
         graph
       };
-      response.downloadBytes = 20 + response.bytes + 16 * response.packets;
+      response.downloadBytes = 24 + response.bytes + 16 * response.packets; // pcap global header is 24 bytes
       await send(response, false);
 
       /****************************************/

--- a/viewer/apiShareables.js
+++ b/viewer/apiShareables.js
@@ -333,7 +333,7 @@ class ShareableAPIs {
       };
 
       const { data: items, total: recordsFiltered } = await Db.searchShareables(params);
-      const recordsTotal = await Db.numberOfShareables({ ...params, searchTerm: undefined });
+      const recordsTotal = await Db.numberOfShareables(params);
 
       const results = items.map(async (item) => {
         const shareable = item.source;

--- a/viewer/apiStats.js
+++ b/viewer/apiStats.js
@@ -1363,7 +1363,7 @@ class StatsAPIs {
       Db.shards(options.cluster ? { cluster: options.cluster } : undefined),
       Db.getClusterSettingsCache(options),
       Db.loadESId2Info(options.cluster)
-    ]).then(([{ body: shards, esid2info }, { body: settings }]) => {
+    ]).then(([{ body: shards }, { body: settings }]) => {
       if (!Array.isArray(shards)) {
         return res.serverError(500, 'No results', 'api.stats.noResults');
       }

--- a/viewer/apiUsers.js
+++ b/viewer/apiUsers.js
@@ -792,6 +792,11 @@ class UserAPIs {
           console.log(`${req.method} /api/user/%s/acknowledge (setUser)`, ArkimeUtil.sanitizeStr(req.params.userId), util.inspect(err, false, 50), user, info);
         }
 
+        if (err) {
+          console.log(`ERROR - ${req.method} /api/user/%s/acknowledge (setUser)`, ArkimeUtil.sanitizeStr(req.params.userId), util.inspect(err, false, 50));
+          return res.serverError(500, 'Error dismissing message');
+        }
+
         return res.json({
           success: true,
           text: `User, ${req.user.userId}, dismissed message ${user.welcomeMsgNum}`,

--- a/viewer/buildQuery.js
+++ b/viewer/buildQuery.js
@@ -381,7 +381,7 @@ class BuildQuery {
       query.aggregations = {};
 
       // only add map aggregations if requested
-      if (reqQuery.map === 'true' || reqQuery.map) {
+      if (reqQuery.map === 'true' || reqQuery.map === true) {
         query.aggregations = {
           mapG1: { terms: { field: 'source.geo.country_iso_code', size: 1000, min_doc_count: 1 } },
           mapG2: { terms: { field: 'destination.geo.country_iso_code', size: 1000, min_doc_count: 1 } },

--- a/viewer/decode.js
+++ b/viewer/decode.js
@@ -224,9 +224,6 @@ function createUnxorBruteGzip (options, context) {
           }
           if (j === gzip.length) {
             data = data.slice(d);
-            for (let i = 0; i < gzip.length + 4; i++) {
-              tmp[i] = data[d + i] ^ key[(i % key.length)];
-            }
             this.key = key;
             this.pos = 0;
             this.state = 1;
@@ -618,7 +615,7 @@ class ItemHTTPStream extends ItemTransform {
 
     case ItemHTTPStream.STATES.res:
       if (line.length === 0) {
-        if (this.code / 100 === 1 || this.code === 204 || this.code === 304) {
+        if (Math.floor(this.code / 100) === 1 || this.code === 204 || this.code === 304) {
           this.states[item.client] = ItemHTTPStream.STATES.start;
         } else if (this.method === undefined) {
           if (this.contentLength[item.client] > 0) {

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -626,8 +626,9 @@ app.get(['/:index/:type/_search', '/:index/_search'], (req, res) => {
   simpleGather(req, res, null, (err, results) => {
     const obj = results[0];
     for (let i = 1; i < results.length; i++) {
-      if (results[i].error) {
+      if (results[i].error || !results[i].hits) {
         console.log('ERROR - GET _search', req.query.index, req.query.type, results[i].error);
+        continue;
       }
       obj.hits.total += results[i].hits.total;
       obj.hits.hits = obj.hits.hits.concat(results[i].hits.hits);

--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -1010,7 +1010,8 @@ class Pcap {
 
   // --------------------------------------------------------------------------
   radiotap (buffer, obj, pos) {
-    const l = buffer[2] + 24 + 6;
+    // it_len is a little-endian uint16 at bytes 2-3
+    const l = (buffer[2] | (buffer[3] << 8)) + 24 + 6;
     const ethertype = buffer.readUInt16BE(l);
 
     if (this.ethertyperun(ethertype, buffer.slice(l + 2), obj, pos + l + 2)) { return; }
@@ -1033,13 +1034,7 @@ class Pcap {
         offset += advance;
       }
     }
-
-    const l = buffer[2] + 24;
-    if (buffer[l + 6] === 0x08 && buffer[l + 7] === 0x00) {
-      this.ip4(buffer.slice(l + 8), obj, pos + l + 8);
-    } else if (buffer[l + 6] === 0x86 && buffer[l + 7] === 0xdd) {
-      this.ip6(buffer.slice(l + 8), obj, pos + l + 8);
-    }
+    // no payload TLV (type 9) found, nothing to decode
   }
 
   // --------------------------------------------------------------------------
@@ -1113,9 +1108,12 @@ class Pcap {
     case 274: // IEEE 802.3br mPackets
       this.mpacket(buffer.slice(16, obj.pcap.incl_len + 16), obj, 16);
       break;
-    case 276: // SLL2
-      this.ip4(buffer.slice(36, obj.pcap.incl_len + 20), obj, 36);
+    case 276: { // SLL2
+      // dispatch on the SLL2 protocol field, payload starts 20 bytes into the SLL2 header
+      const sll2Ethertype = buffer.readUInt16BE(16);
+      this.ethertyperun(sll2Ethertype, buffer.slice(36, obj.pcap.incl_len + 16), obj, 36);
       break;
+    }
     default:
       console.log('Unsupported pcap file', this.filename, 'link type', this.linkType, 'Please open a new protocol issue with sample pcap - https://github.com/arkime/arkime/issues/new/choose');
       break;

--- a/viewer/schemes.js
+++ b/viewer/schemes.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const http = require('http');
+const https = require('https');
 const axios = require('axios');
 const { LRUCache } = require('lru-cache');
 // const fs = require('fs');
@@ -18,11 +19,12 @@ const blocklru = new LRUCache({ max: 100 });
 const S3s = new Map();
 
 const httpAgent = new http.Agent({ family: 4 });
+const httpsAgent = new https.Agent({ family: 4 });
 
 // --------------------------------------------------------------------------
 async function getBlockHTTP (info, pos) {
   async function getBlockHttpInternal () {
-    const result = await axios.get(info.name, { responseType: 'arraybuffer', httpAgent, headers: { range: `bytes=${blockStart}-${blockStart + blockSize - 1}` } });
+    const result = await axios.get(info.name, { responseType: 'arraybuffer', httpAgent, httpsAgent, headers: { range: `bytes=${blockStart}-${blockStart + blockSize - 1}` } });
     return result.data;
   }
 

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -636,14 +636,23 @@ function logAction (uiPage) {
       log.range = req.query.stopTime - req.query.startTime;
     }
 
-    if (req.query.view && req.user.views) {
-      const view = req.user.views[req.query.view];
-      if (view) {
-        log.view = {
-          name: req.query.view,
-          expression: view.expression
-        };
-      }
+    // Views live in their own index now; resolve async and let finish() await it
+    let viewPromise;
+    if (req.query.view) {
+      viewPromise = (async () => {
+        try {
+          const roles = [...await req.user.getRoles()];
+          const view = await Db.getViewByIdOrName(req.query.view, req.user.userId, roles);
+          if (view) {
+            log.view = {
+              name: view.name,
+              expression: view.expression
+            };
+          }
+        } catch (err) {
+          // Not finding the view is not a reason to skip logging
+        }
+      })();
     }
 
     // save the request body
@@ -667,13 +676,15 @@ function logAction (uiPage) {
 
     req._arkimeStartTime = new Date();
 
-    function finish () {
+    async function finish () {
       res.removeListener('finish', finish);
 
       log.queryTime = new Date() - req._arkimeStartTime;
 
       if (req._arkimeESQuery) { log.esQuery = req._arkimeESQuery; }
       if (req._arkimeESQueryIndices) { log.esQueryIndices = req._arkimeESQueryIndices; }
+
+      if (viewPromise) { await viewPromise; }
 
       try {
         Db.historyIt(log, req.body.cluster ?? req.query.cluster);

--- a/wiseService/source.alienvault.js
+++ b/wiseService/source.alienvault.js
@@ -87,7 +87,7 @@ class AlienVaultSource extends WISESource {
       // If statusCode isn't success or not changed then try again if not already
       if (statusCode !== 200 && statusCode !== 304) {
         if (!this.retry) {
-          this.retry = setTimeout(this.loadFile.bind(this), 5 * 60 * 1000);
+          this.retry = setTimeout(() => { delete this.retry; this.loadFile(); }, 5 * 60 * 1000);
         }
         return;
       }
@@ -109,7 +109,7 @@ class AlienVaultSource extends WISESource {
             delete this.retry;
           } else {
             if (!this.retry) {
-              this.retry = setTimeout(this.loadFile.bind(this), 5 * 60 * 1000); // Failed to load data file, try again in 5 minutes
+              this.retry = setTimeout(() => { delete this.retry; this.loadFile(); }, 5 * 60 * 1000); // Failed to load data file, try again in 5 minutes
             }
           }
         });

--- a/wiseService/source.databricks.js
+++ b/wiseService/source.databricks.js
@@ -22,13 +22,17 @@ class DatabricksSource extends WISESource {
     this.query = api.getConfig(section, 'query');
     this.periodic = api.getConfig(section, 'periodic');
     this.mergeQuery = api.getConfig(section, 'mergeQuery');
-    this.keyPath = api.getConfig(section, 'keyPath', api.getConfig(section, 'keyColumn', 0));
+    // no default so the required-check below can actually fire
+    this.keyPath = api.getConfig(section, 'keyPath', api.getConfig(section, 'keyColumn'));
 
+    let missing = false;
     ['host', 'path', 'token', 'query', 'keyPath'].forEach((item) => {
       if (this[item] === undefined) {
         console.log(this.section, `- ERROR not loading since no ${item} specified in config file`);
+        missing = true;
       }
     });
+    if (missing) { return; }
 
     if (this.periodic) {
       this.cacheTimeout = -1; // Don't cache

--- a/wiseService/source.elasticsearch.js
+++ b/wiseService/source.elasticsearch.js
@@ -19,7 +19,8 @@ class ElasticsearchSource extends WISESource {
     this.esIndex = api.getConfig(section, 'esIndex');
     this.esTimestampField = api.getConfig(section, 'esTimestampField');
     this.esQueryField = api.getConfig(section, 'esQueryField');
-    this.esResultField = api.getConfig(section, 'esResultField', 0);
+    // no default so the required-check below can actually fire
+    this.esResultField = api.getConfig(section, 'esResultField');
     this.esMaxTimeMS = api.getConfig(section, 'esMaxTimeMS', 60 * 60 * 1000);
     this.elasticsearch = api.getConfig(section, 'elasticsearch');
 

--- a/wiseService/source.elasticsearchfile.js
+++ b/wiseService/source.elasticsearchfile.js
@@ -41,7 +41,7 @@ class ElasticsearchFileSource extends SimpleSource {
     axios.get(info.url, { validateStatus: (code) => { return code < 500; }, auth: info.auth })
       .then((response) => {
         if (response.status === 404 || response?.data?._source === undefined) {
-          return cb(null, '{}', null, 2);
+          return cb(null, '{}');
         }
 
         return cb(null, JSON.stringify(response.data._source, null, 2));

--- a/wiseService/source.emergingthreats.js
+++ b/wiseService/source.emergingthreats.js
@@ -56,17 +56,21 @@ class EmergingThreatsSource extends WISESource {
         this.categories[data[i][0]] = data[i][1];
       }
     });
-    fs.createReadStream('/tmp/categories.txt').pipe(parser);
+    fs.createReadStream(fn).on('error', (err) => {
+      console.log(this.section, "- Couldn't read", fn, err);
+    }).pipe(parser);
   }
 
   // ----------------------------------------------------------------------------
-  parseRepData (fn, hash) {
+  parseRepData (fn, hashName) {
     const parser = csv.parse({ skip_empty_lines: true }, (err, data) => {
       if (err) {
         console.log(this.section, "- Couldn't parse", fn, 'csv', err);
         return;
       }
 
+      // Build a fresh map and swap on success so a failed load keeps prior data
+      const hash = new Map();
       for (let i = 1; i < data.length; i++) {
         if (data[i].length !== 3) {
           continue;
@@ -85,31 +89,35 @@ class EmergingThreatsSource extends WISESource {
 
         hash.set(data[i][0], encoded);
       }
+      this[hashName] = hash;
       console.log(this.section, '- Done Loading', fn);
     });
-    fs.createReadStream(fn).pipe(parser);
+    fs.createReadStream(fn).on('error', (err) => {
+      console.log(this.section, "- Couldn't read", fn, err);
+    }).pipe(parser);
   }
 
   // ----------------------------------------------------------------------------
   loadFiles () {
     console.log(this.section, '- Downloading Files');
     WISESource.request('https://rules.emergingthreatspro.com/' + this.key + '/reputation/categories.txt', '/tmp/categories.txt', (statusCode) => {
-      this.parseCategories('/tmp/categories.txt');
+      if (statusCode === 200 || !this.categoriesLoaded) {
+        this.categoriesLoaded = true;
+        this.parseCategories('/tmp/categories.txt');
+      }
     });
 
     WISESource.request('https://rules.emergingthreatspro.com/' + this.key + '/reputation/iprepdata.csv', '/tmp/iprepdata.csv', (statusCode) => {
       if (statusCode === 200 || !this.ipsLoaded) {
         this.ipsLoaded = true;
-        this.ips.clear();
-        this.parseRepData('/tmp/iprepdata.csv', this.ips);
+        this.parseRepData('/tmp/iprepdata.csv', 'ips');
       }
     });
 
     WISESource.request('https://rules.emergingthreatspro.com/' + this.key + '/reputation/domainrepdata.csv', '/tmp/domainrepdata.csv', (statusCode) => {
       if (statusCode === 200 || !this.domainsLoaded) {
         this.domainsLoaded = true;
-        this.domains.clear();
-        this.parseRepData('/tmp/domainrepdata.csv', this.domains);
+        this.parseRepData('/tmp/domainrepdata.csv', 'domains');
       }
     });
   }

--- a/wiseService/source.fieldactions.js
+++ b/wiseService/source.fieldactions.js
@@ -78,8 +78,10 @@ class FieldActionsSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   process (data) {
+    // content may optionally be wrapped in a [fieldactions] section header
+    data = data.fieldactions || data;
     const keys = Object.keys(data);
-    if (!keys) { return; }
+    if (keys.length === 0) { return; }
 
     keys.forEach((key) => {
       const obj = {};
@@ -126,10 +128,16 @@ class FieldActionsSource extends WISESource {
       clearTimeout(this.watchTimeout);
       if (e === 'rename') {
         this.watch.close();
-        setTimeout(() => {
+        // File may be briefly missing (atomic replace/delete); retry until it's back
+        const rearm = () => {
+          if (!fs.existsSync(this.url)) {
+            setTimeout(rearm, 500);
+            return;
+          }
           this.load();
           this.watch = fs.watch(this.url, watchCb);
-        }, 500);
+        };
+        setTimeout(rearm, 500);
       } else {
         this.watchTimeout = setTimeout(() => {
           this.watchTimeout = null;
@@ -148,9 +156,8 @@ class FieldActionsSource extends WISESource {
     }
 
     const config = ArkimeUtil.parseIniSync(this.url);
-    const data = config.fieldactions || config;
 
-    this.process(data);
+    this.process(config);
   }
 
   // ----------------------------------------------------------------------------

--- a/wiseService/source.isepxgrid.js
+++ b/wiseService/source.isepxgrid.js
@@ -159,7 +159,8 @@ class ISEPxGridSource extends WISESource {
     this.keyFile = api.getConfig(section, 'keyFile', '');
     this.caFile = api.getConfig(section, 'caFile', '');
     this.nodeName = api.getConfig(section, 'nodeName', '');
-    this.logEvents = api.getConfig(section, 'logEvents', false);
+    const logEventsVal = api.getConfig(section, 'logEvents', false);
+    this.logEvents = logEventsVal === true || logEventsVal === 'true'; // ini values are strings
     this.cacheAgeMin = +api.getConfig(section, 'cacheAgeMin', 1440); // 24h default
 
     if (!this.host) {
@@ -373,8 +374,10 @@ class ISEPxGridSource extends WISESource {
 
         // Bulk-load all active sessions so the Map is immediately complete.
         // Subscribe first (above) so no events are missed during the load.
-        this._loadAllSessions().catch(err =>
-          console.log(this.section, '- WARN: initial session load failed:', err.message));
+        this._loadAllSessions().catch(err => {
+          console.log(this.section, '- WARN: initial session load failed:', err.message);
+          this._scheduleRefresh(); // retry on the refresh interval
+        });
       } catch (err) {
         console.log(this.section, '- STOMP connect error:', err.message);
         ws.close();
@@ -456,12 +459,18 @@ class ISEPxGridSource extends WISESource {
   async _refreshCache () {
     this._refreshTimer = null;
     console.log(this.section, `- Cache age reached ${this.cacheAgeMin}min, refreshing from ISE…`);
-    this.sessionMap.clear();
-    this.sidMap.clear();
+    // Swap in fresh maps only after a successful load so a failed refresh
+    // keeps serving the existing data instead of destroying it
+    const oldSessionMap = this.sessionMap;
+    const oldSidMap = this.sidMap;
+    this.sessionMap = new Map();
+    this.sidMap = new Map();
     try {
       await this._loadAllSessions();
     } catch (err) {
-      console.log(this.section, '- WARN: cache refresh failed:', err.message);
+      console.log(this.section, '- WARN: cache refresh failed, keeping previous data:', err.message);
+      this.sessionMap = oldSessionMap;
+      this.sidMap = oldSidMap;
       this._scheduleRefresh(); // retry on next interval
     }
   }

--- a/wiseService/source.opendns.js
+++ b/wiseService/source.opendns.js
@@ -21,7 +21,8 @@ class OpenDNSSource extends WISESource {
     }
 
     this.waiting = [];
-    this.processing = {};
+    this.processing = new Map();
+    this.categories = {}; // filled async by getCategories
     this.statuses = { '-1': 'malicious', 0: 'unknown', 1: 'benign' };
 
     this.api.addSource('opendns', this, ['domain']);
@@ -65,7 +66,11 @@ class OpenDNSSource extends WISESource {
         response += chunk;
       });
       res.on('end', () => {
-        this.categories = JSON.parse(response);
+        try {
+          this.categories = JSON.parse(response);
+        } catch (e) {
+          console.log(this.section, '- ERROR parsing categories', e);
+        }
       });
     });
     request.on('error', (err) => {
@@ -95,9 +100,9 @@ class OpenDNSSource extends WISESource {
     // don't hang in processing forever
     const failBatch = (err) => {
       for (const domain of sent) {
-        const cbs = this.processing[domain];
+        const cbs = this.processing.get(domain);
         if (!cbs) { continue; }
-        delete this.processing[domain];
+        this.processing.delete(domain);
         let cb;
         while ((cb = cbs.shift())) {
           cb(err);
@@ -113,7 +118,7 @@ class OpenDNSSource extends WISESource {
       headers: {
         Authorization: 'Bearer ' + this.key,
         'Content-Type': 'application/x-www-form-urlencoded',
-        'Content-Length': postData.length
+        'Content-Length': Buffer.byteLength(postData)
       }
     };
 
@@ -133,13 +138,13 @@ class OpenDNSSource extends WISESource {
         }
 
         for (let result in results) {
-          const cbs = this.processing[result];
+          const cbs = this.processing.get(result);
           if (!cbs) {
             continue;
           }
-          delete this.processing[result];
+          this.processing.delete(result);
 
-          const args = [this.statusField, this.statuses[results[result].status]];
+          const args = [this.statusField, this.statuses[results[result].status] || ('' + results[result].status)];
 
           if (results[result].security_categories) {
             results[result].security_categories.forEach((value) => {
@@ -182,12 +187,12 @@ class OpenDNSSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   getDomain (domain, cb) {
-    if (domain in this.processing) {
-      this.processing[domain].push(cb);
+    if (this.processing.has(domain)) {
+      this.processing.get(domain).push(cb);
       return;
     }
 
-    this.processing[domain] = [cb];
+    this.processing.set(domain, [cb]);
     this.waiting.push(domain);
     if (this.waiting.length > 1000) {
       this.performQuery();

--- a/wiseService/source.passivetotal.js
+++ b/wiseService/source.passivetotal.js
@@ -28,7 +28,7 @@ class PassiveTotalSource extends WISESource {
     }
 
     this.waiting = [];
-    this.processing = {};
+    this.processing = new Map();
 
     this.api.addSource('passivetotal', this, ['domain', 'ip']);
 
@@ -76,11 +76,11 @@ class PassiveTotalSource extends WISESource {
         const results = response.data;
         for (const resultname in results.results) {
           const result = results.results[resultname];
-          const cbs = this.processing[resultname];
+          const cbs = this.processing.get(resultname);
           if (!cbs) {
             continue;
           }
-          delete this.processing[resultname];
+          this.processing.delete(resultname);
 
           let wiseResult;
           if (result.tags === undefined || result.tags.length === 0) {
@@ -106,9 +106,9 @@ class PassiveTotalSource extends WISESource {
         // Invoke and remove all callbacks for this batch so queries don't
         // hang in processing forever
         for (const key of sent) {
-          const cbs = this.processing[key];
+          const cbs = this.processing.get(key);
           if (!cbs) { continue; }
-          delete this.processing[key];
+          this.processing.delete(key);
           let cb;
           while ((cb = cbs.shift())) {
             cb(err);
@@ -119,12 +119,12 @@ class PassiveTotalSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   fetch (key, cb) {
-    if (key in this.processing) {
-      this.processing[key].push(cb);
+    if (this.processing.has(key)) {
+      this.processing.get(key).push(cb);
       return;
     }
 
-    this.processing[key] = [cb];
+    this.processing.set(key, [cb]);
     this.waiting.push(key);
     if (this.waiting.length >= 25) {
       this.performQuery();

--- a/wiseService/source.redisfile.js
+++ b/wiseService/source.redisfile.js
@@ -22,7 +22,6 @@ class RedisFileSource extends SimpleSource {
 
     if (this.key === undefined) {
       console.log(this.section, '- ERROR not loading since no key specified in config file');
-      delete this.client;
       return;
     }
 

--- a/wiseService/source.splunk.js
+++ b/wiseService/source.splunk.js
@@ -43,13 +43,17 @@ class SplunkSource extends WISESource {
     this.query = api.getConfig(section, 'query');
     this.mergeQuery = api.getConfig(section, 'mergeQuery');
     // this.arrayPath = api.getConfig(section, 'arrayPath');
-    this.keyPath = api.getConfig(section, 'keyPath', api.getConfig(section, 'keyColumn', 0));
+    // no default so the required-check below can actually fire
+    this.keyPath = api.getConfig(section, 'keyPath', api.getConfig(section, 'keyColumn'));
 
+    let missing = false;
     ['host', 'username', 'password', 'query', 'keyPath'].forEach((item) => {
       if (this[item] === undefined) {
         console.log(this.section, `- ERROR not loading since no ${item} specified in config file`);
+        missing = true;
       }
     });
+    if (missing) { return; }
 
     if (this.periodic) {
       this.cacheTimeout = -1; // Don't cache

--- a/wiseService/source.threatq.js
+++ b/wiseService/source.threatq.js
@@ -61,20 +61,36 @@ class ThreatQSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   parseFile () {
-    this.ips.clear();
-    this.domains.clear();
-    this.emails.clear();
-    this.md5s.clear();
+    // Build into fresh maps and swap at the end so a failed load keeps prior data
+    const ips = new Map();
+    const domains = new Map();
+    const emails = new Map();
+    const md5s = new Map();
 
     let count = 0;
+    let bad = false;
     fs.createReadStream('/tmp/threatquotient.zip')
+      .on('error', (err) => {
+        console.log(this.section, "- Couldn't read /tmp/threatquotient.zip", err);
+      })
       .pipe(unzipper.Parse())
+      .on('error', (err) => {
+        bad = true;
+        console.log(this.section, '- Error unzipping', err);
+      })
       .on('entry', (entry) => {
         const bufs = [];
         entry.on('data', (buf) => {
           bufs.push(buf);
         }).on('end', () => {
-          const json = JSON.parse(Buffer.concat(bufs));
+          let json;
+          try {
+            json = JSON.parse(Buffer.concat(bufs));
+          } catch (err) {
+            bad = true;
+            console.log(this.section, '- Error parsing', err);
+            return;
+          }
           json.forEach((item) => {
             const args = [this.idField, '' + item.id, this.typeField, item.type];
 
@@ -94,18 +110,26 @@ class ThreatQSource extends WISESource {
 
             count++;
             if (item.type === 'IP Address') {
-              this.ips.set(item.indicator, encoded);
+              ips.set(item.indicator, encoded);
             } else if (item.type === 'FQDN') {
-              this.domains.set(item.indicator, encoded);
+              domains.set(item.indicator, encoded);
             } else if (item.type === 'Email Address') {
-              this.emails.set(item.indicator, encoded);
+              emails.set(item.indicator, encoded);
             } else if (item.type === 'MD5') {
-              this.md5s.set(item.indicator, encoded);
+              md5s.set(item.indicator, encoded);
             }
           });
         });
       })
       .on('close', () => {
+        if (bad) {
+          console.log(this.section, '- Load failed, keeping previous data');
+          return;
+        }
+        this.ips = ips;
+        this.domains = domains;
+        this.emails = emails;
+        this.md5s = md5s;
         console.log(this.section, '- Done Loading', count, 'elements');
       });
   }

--- a/wiseService/source.threatstream.js
+++ b/wiseService/source.threatstream.js
@@ -118,22 +118,59 @@ class ThreatStreamSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   parseFile () {
-    this.ips.clear();
-    this.domains.clear();
-    this.emails.clear();
-    this.md5s.clear();
-    this.urls.clear();
+    // Build into fresh maps and swap at the end so a failed load keeps prior data
+    const ips = new Map();
+    const domains = new Map();
+    const emails = new Map();
+    const md5s = new Map();
+    const urls = new Map();
 
+    let bad = false;
     fs.createReadStream('/tmp/threatstream.zip')
+      .on('error', (err) => {
+        console.log(this.section, "- Couldn't read /tmp/threatstream.zip", err);
+      })
       .pipe(unzipper.Parse())
+      .on('error', (err) => {
+        bad = true;
+        console.log(this.section, '- Error unzipping', err);
+      })
       .on('entry', (entry) => {
         const bufs = [];
         entry.on('data', (buf) => {
           bufs.push(buf);
         }).on('end', () => {
-          const json = JSON.parse(Buffer.concat(bufs));
+          let json;
+          try {
+            json = JSON.parse(Buffer.concat(bufs));
+          } catch (e) {
+            bad = true;
+            console.log(this.section, 'ERROR - parsing', entry.path, e);
+            return;
+          }
           json.objects.forEach((item) => {
             if (item.state !== 'active') {
+              return;
+            }
+
+            // Figure out where the item goes and its indicator value first
+            let hash, indicator;
+            if (item.itype.match(/(_ip|anon_proxy|anon_vpn)/)) {
+              hash = ips; indicator = item.srcip;
+            } else if (item.itype.match(/_domain|_dns/)) {
+              hash = domains; indicator = item.domain;
+            } else if (item.itype.match(/_email/)) {
+              hash = emails; indicator = item.email;
+            } else if (item.itype.match(/_md5/)) {
+              hash = md5s; indicator = item.md5;
+            } else if (item.itype.match(/_url/)) {
+              hash = urls; indicator = item.url;
+              if (indicator.startsWith('http://')) {
+                indicator = indicator.substring(7);
+              } else if (indicator.startsWith('https://')) {
+                indicator = indicator.substring(8);
+              }
+            } else {
               return;
             }
 
@@ -141,6 +178,7 @@ class ThreatStreamSource extends WISESource {
             try {
               if (item.maltype && item.maltype !== 'null') {
                 encoded = WISESource.encodeResult(
+                  this.indicatorField, '' + indicator,
                   this.severityField, item.severity.toLowerCase(),
                   this.confidenceField, '' + item.confidence,
                   this.idField, '' + item.id,
@@ -150,6 +188,7 @@ class ThreatStreamSource extends WISESource {
                 );
               } else {
                 encoded = WISESource.encodeResult(
+                  this.indicatorField, '' + indicator,
                   this.severityField, item.severity.toLowerCase(),
                   this.confidenceField, '' + item.confidence,
                   this.idField, '' + item.id,
@@ -162,27 +201,21 @@ class ThreatStreamSource extends WISESource {
               return;
             }
 
-            if (item.itype.match(/(_ip|anon_proxy|anon_vpn)/)) {
-              this.ips.set(item.srcip, encoded);
-            } else if (item.itype.match(/_domain|_dns/)) {
-              this.domains.set(item.domain, encoded);
-            } else if (item.itype.match(/_email/)) {
-              this.emails.set(item.email, encoded);
-            } else if (item.itype.match(/_md5/)) {
-              this.md5s.set(item.md5, encoded);
-            } else if (item.itype.match(/_url/)) {
-              if (item.url.startsWith('http://')) {
-                item.url = item.url.substring(7);
-              } else if (item.url.startsWith('https://')) {
-                item.url = item.url.substring(8);
-              }
-              this.urls.set(item.url, encoded);
-            }
+            hash.set(indicator, encoded);
           });
           // console.log(this.section, "- Done", entry.path);
         });
       })
       .on('close', () => {
+        if (bad) {
+          console.log(this.section, '- Load failed, keeping previous data');
+          return;
+        }
+        this.ips = ips;
+        this.domains = domains;
+        this.emails = emails;
+        this.md5s = md5s;
+        this.urls = urls;
         console.log(this.section, '- Done Loading');
       });
   }
@@ -228,14 +261,17 @@ class ThreatStreamSource extends WISESource {
   // ----------------------------------------------------------------------------
   dumpZip (res) {
     res.write('{');
-    ['ips', 'domains', 'emails', 'md5s', 'urls'].forEach((ckey) => {
-      res.write(`${ckey}: [\n`);
+    ['ips', 'domains', 'emails', 'md5s', 'urls'].forEach((ckey, cindex) => {
+      if (cindex > 0) { res.write(',\n'); }
+      res.write(`"${ckey}": [\n`);
+      let first = true;
       this[ckey].forEach((value, key) => {
-        const str = `{"key": ${JSON.stringify(key)}, "ops":\n` +
-          WISESource.result2JSON(value) + '},\n';
+        const str = (first ? '' : ',\n') + `{"key": ${JSON.stringify(key)}, "ops":\n` +
+          WISESource.result2JSON(value) + '}';
+        first = false;
         res.write(str);
       });
-      res.write('],\n');
+      res.write(']');
     });
     res.write('}');
     res.end();
@@ -271,7 +307,7 @@ class ThreatStreamSource extends WISESource {
             this.sourceField, item.source
           );
 
-          if (item.maltype !== undefined && item.maltype !== 'null') {
+          if (item.maltype != null && item.maltype !== 'null') {
             args.push(this.maltypeField, item.maltype.toLowerCase());
           }
           if (item.severity !== undefined) {

--- a/wiseService/source.urlapi.js
+++ b/wiseService/source.urlapi.js
@@ -38,12 +38,6 @@ class URLApiSource extends WISESource {
     this[this.api.funcName(this.type)] = this.sendResult;
     api.addSource(section, this, [this.type]);
 
-    this.sourceFields = [this.resultField];
-    for (const k in this.shortcuts) {
-      if (this.sourceFields.indexOf(k) === -1) {
-        this.sourceFields.push(k);
-      }
-    }
   }
 
   // ----------------------------------------------------------------------------

--- a/wiseService/source.valueactions.js
+++ b/wiseService/source.valueactions.js
@@ -78,8 +78,10 @@ class ValueActionsSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   process (data) {
+    // content may optionally be wrapped in a [valueactions] section header
+    data = data.valueactions || data;
     const keys = Object.keys(data);
-    if (!keys) { return; }
+    if (keys.length === 0) { return; }
 
     keys.forEach((key) => {
       const obj = {};
@@ -126,10 +128,16 @@ class ValueActionsSource extends WISESource {
       clearTimeout(this.watchTimeout);
       if (e === 'rename') {
         this.watch.close();
-        setTimeout(() => {
+        // File may be briefly missing (atomic replace/delete); retry until it's back
+        const rearm = () => {
+          if (!fs.existsSync(this.url)) {
+            setTimeout(rearm, 500);
+            return;
+          }
           this.load();
           this.watch = fs.watch(this.url, watchCb);
-        }, 500);
+        };
+        setTimeout(rearm, 500);
       } else {
         this.watchTimeout = setTimeout(() => {
           this.watchTimeout = null;
@@ -148,9 +156,8 @@ class ValueActionsSource extends WISESource {
     }
 
     const config = ArkimeUtil.parseIniSync(this.url);
-    const data = config.valueactions || config;
 
-    this.process(data);
+    this.process(config);
   }
 
   // ----------------------------------------------------------------------------

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -344,7 +344,7 @@ class WISESourceAPI {
     const pos = internals.fields.length;
     newFieldsTS();
     internals.fields.push(field);
-    internals.fieldsSize += field.length + 10;
+    internals.fieldsSize += Buffer.byteLength(field) + 10; // UTF-8 bytes, not UTF-16 code units
 
     let offset;
     // Create version 0 of fields buf
@@ -948,7 +948,8 @@ async function processQuery (req, query, cb) {
       delete cacheResult[src.section];
 
       // If already in progress then add to the list and return, cb called later;
-      if (src.srcInProgress[query.typeName] && src.srcInProgress[query.typeName].has(valueKey)) {
+      src.srcInProgress[query.typeName] ??= new Map();
+      if (src.srcInProgress[query.typeName].has(valueKey)) {
         src.srcInProgress[query.typeName].get(valueKey).push(mapCb);
         return;
       }
@@ -1627,7 +1628,8 @@ if (internals.webconfig) {
     }
 
     // Make sure updateTime has increased in case of clock skew
-    config.wiseService.updateTime = Math.max(Date.now(), internals.updateTime + 1);
+    // updateTime may be a string from the config file, force numeric so + 1 doesn't concatenate
+    config.wiseService.updateTime = Math.max(Date.now(), +internals.updateTime + 1);
 
     ArkimeConfig.replace(config);
     ArkimeConfig.save((err) => {

--- a/wiseService/wiseSource.js
+++ b/wiseService/wiseSource.js
@@ -256,7 +256,8 @@ class WISESource {
    */
   parseJSONArray (json, setCb, endCb) {
     try {
-      if (this.keyPath === undefined) {
+      // keyPath often defaults to 0 via keyColumn, treat any non-string as unset
+      if (this.keyPath === undefined || this.keyPath === 0 || this.keyPath === '') {
         return endCb('No keyPath set');
       }
 
@@ -492,6 +493,11 @@ class WISESource {
       if (l > 250) {
         val = val.substring(0, 240);
         l = Buffer.byteLength(val);
+        // multibyte characters can still exceed the 1-byte length field, shrink until it fits
+        while (l > 250) {
+          val = val.substring(0, val.length - 10);
+          l = Buffer.byteLength(val);
+        }
       }
       vals.push(val);
       lens.push(l);


### PR DESCRIPTION
Viewer:
- viewer.js: history records the view name/expression again (views moved to their own index; now resolved async and awaited before historyIt); regression test in api-history.t
- apiSessions.js: Export Unique destination.ip:destination.port returns ip:port; downloadBytes uses the 24-byte pcap header size
- pcap.js: radiotap it_len read as 16-bit LE, NFLOG garbage-offset fallback removed, SLL2 dispatches on its protocol field (all matching capture/packet.c)
- apiHunts.js: raw hunts searching both directions no longer match bytes in pcap record headers
- multies.js: GET _search skips cluster error results instead of crashing
- buildQuery.js: map aggregations only added when map is actually true
- apiUsers.js: acknowledge message reports save errors instead of silent success
- decode.js: removed dead double-offset loop in unxor-brute-gzip; 1xx status match uses integer division
- apiStats.js/apiShareables.js: dead destructure and vestigial searchTerm spread removed
- schemes.js: https PCAP sources now use the force-IPv4 agent too

Cont3xt/Common:
- cont3xt.js: selectedOverviews non-object input gets the right error message
- user.js: store2ha1 failure logs name the affected user

WISE:
- fieldactions/valueactions: deleted watched file no longer crashes wiseService; section-headered content loads from redis/ES/raw-file paths; dead keys check
- emergingthreats/threatq/threatstream: loads build fresh maps and swap on success so failed downloads/parses keep prior data; stream/unzip/JSON error handlers
- threatstream: zip mode sets the Indicator field; api mode handles JSON null maltype; /dump/threatstream emits valid JSON
- databricks/splunk: abort loading when required settings are missing (keyPath default removed so the check fires)
- elasticsearch/elasticsearchfile: esResultField required-check fires; stray args removed
- alienvault: retry timers self-clear so retries continue after repeated failures
- isepxgrid: logEvents string coerced, initial-load failure arms the refresh retry, refresh keeps old data on failure
- opendns: categories parse guarded, Content-Length in bytes, status fallback; opendns/passivetotal processing converted to Maps (prototype-key hazard)
- redisfile: dead delete removed
- wiseService.js: srcInProgress lazily initialized, updateTime string concat fixed, fields buffer sized in bytes
- wiseSource.js: encodeResult truncates multibyte values by bytes; parseJSONArray rejects keyPath 0/''

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
