### PR TITLE
Speed up Connections and SPIView pages with 1000s of fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -102,6 +102,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4094 Fix raw packet search hunts matching bytes in pcap record headers when searching both directions
   - #4094 Fix multies GET _search crashing when one cluster returns an error
   - #4094 Fix map data still being computed when map=false is sent with facets
+  - #4096 Speed up the Connections and SPIView pages when there are 1000s of fields by lazily rendering field menus/categories and batching SPIView show/hide-all toggling
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors

--- a/viewer/vueapp/src/components/connections/Connections.vue
+++ b/viewer/vueapp/src/components/connections/Connections.vue
@@ -161,6 +161,7 @@ SPDX-License-Identifier: Apache-2.0
               v-if="!loading">
               <!-- node fields button -->
               <b-dropdown
+                lazy
                 size="sm"
                 no-flip
                 no-caret
@@ -178,11 +179,12 @@ SPDX-License-Identifier: Apache-2.0
                   </div>
                 </template>
                 <b-dropdown-header>
-                  <input
-                    type="text"
+                  <BFormInput
+                    size="sm"
+                    debounce="300"
                     v-model="fieldQuery"
-                    class="form-control form-control-sm dropdown-typeahead"
-                    :placeholder="$t('common.searchForFields')">
+                    class="dropdown-typeahead"
+                    :placeholder="$t('common.searchForFields')" />
                 </b-dropdown-header>
                 <b-dropdown-divider />
                 <b-dropdown-item
@@ -199,10 +201,10 @@ SPDX-License-Identifier: Apache-2.0
                     {{ key }}
                   </b-dropdown-header>
                   <template
-                    v-for="(field, k) in group"
-                    :key="key + k + 'itemnode'">
+                    v-for="field in group"
+                    :key="'node-' + field.exp">
                     <b-dropdown-item
-                      :id="key + k + 'itemnode'"
+                      :id="'node-' + field.exp"
                       :class="{'active':isFieldVisible(field.dbField, nodeFields) >= 0}"
                       @click.stop.prevent="toggleFieldVisibility(field.dbField, nodeFields)">
                       {{ field.friendlyName }}
@@ -211,7 +213,7 @@ SPDX-License-Identifier: Apache-2.0
                         v-if="field.help"
                         :delay="{show: 300, hide: 0}"
                         noninteractive
-                        :target="key + k + 'itemnode'">{{ field.help }}</BTooltip>
+                        :target="'node-' + field.exp">{{ field.help }}</BTooltip>
                     </b-dropdown-item>
                   </template>
                 </template>
@@ -219,6 +221,7 @@ SPDX-License-Identifier: Apache-2.0
 
               <!-- link fields button -->
               <b-dropdown
+                lazy
                 size="sm"
                 no-flip
                 no-caret
@@ -236,11 +239,12 @@ SPDX-License-Identifier: Apache-2.0
                   </div>
                 </template>
                 <b-dropdown-header>
-                  <input
-                    type="text"
+                  <BFormInput
+                    size="sm"
+                    debounce="300"
                     v-model="fieldQuery"
-                    class="form-control form-control-sm dropdown-typeahead"
-                    :placeholder="$t('common.searchForFields')">
+                    class="dropdown-typeahead"
+                    :placeholder="$t('common.searchForFields')" />
                 </b-dropdown-header>
                 <b-dropdown-divider />
                 <b-dropdown-item
@@ -257,10 +261,10 @@ SPDX-License-Identifier: Apache-2.0
                     {{ key }}
                   </b-dropdown-header>
                   <template
-                    v-for="(field, k) in group"
-                    :key="key + k + 'itemlink'">
+                    v-for="field in group"
+                    :key="'link-' + field.exp">
                     <b-dropdown-item
-                      :id="key + k + 'itemlink'"
+                      :id="'link-' + field.exp"
                       :class="{'active':isFieldVisible(field.dbField, linkFields) >= 0}"
                       @click.stop.prevent="toggleFieldVisibility(field.dbField, linkFields)">
                       {{ field.friendlyName }}
@@ -269,7 +273,7 @@ SPDX-License-Identifier: Apache-2.0
                         v-if="field.help"
                         :delay="{show: 300, hide: 0}"
                         noninteractive
-                        :target="key + k + 'itemlink'">{{ field.help }}</BTooltip>
+                        :target="'link-' + field.exp">{{ field.help }}</BTooltip>
                     </b-dropdown-item>
                   </template>
                 </template>

--- a/viewer/vueapp/src/components/spiview/Spiview.vue
+++ b/viewer/vueapp/src/components/spiview/Spiview.vue
@@ -238,6 +238,7 @@ SPDX-License-Identifier: Apache-2.0
             </span>
           </b-card-header>
           <b-collapse
+            lazy
             :visible="categoryObjects[category].isopen"
             :id="category">
             <b-card-body>
@@ -276,6 +277,7 @@ SPDX-License-Identifier: Apache-2.0
                         :key="field.dbField">
                         <b-dropdown
                           split
+                          lazy
                           size="sm"
                           variant="default"
                           class="me-1 mb-1 field-dropdown"
@@ -298,8 +300,8 @@ SPDX-License-Identifier: Apache-2.0
                           <field-actions
                             :separator="true"
                             :expr="field.exp" />
-                          <BTooltip :target="`spiViewField-${field.dbField}`">{{ field.help }}</BTooltip>
                         </b-dropdown>
+                        <BTooltip :target="`spiViewField-${field.dbField}`">{{ field.help }}</BTooltip>
                       </span>
                     </template>
                   </transition-group>
@@ -326,6 +328,7 @@ SPDX-License-Identifier: Apache-2.0
                       class="spi-buckets pe-1 ps-1 pb-1">
                       <!-- spiview field label button -->
                       <b-dropdown
+                        lazy
                         size="sm"
                         variant="default"
                         class="field-dropdown me-2"
@@ -564,10 +567,12 @@ export default {
      * @param {object} field      The field to get spi data for
      * @param {bool} issueQuery   Whether to issue query for the data
      * @param {bool} saveFields   Whether to save the visible fields
+     * @param {bool} updateQuery  Whether to update the spi query parameter
+     *                            (false lets callers batch the update)
      * @returns {string} spiQuery The query string for the toggled on fields
      *                            e.g. 'lp:200,fp:100'
      */
-    toggleSpiData: function (field, issueQuery, saveFields) {
+    toggleSpiData: function (field, issueQuery, saveFields, updateQuery = true) {
       field.active = !field.active;
 
       let spiData;
@@ -591,11 +596,14 @@ export default {
 
       // update spi query parameter by adding or removing field id
       if (addToQuery) {
-        if (this.spiQuery && this.spiQuery !== '') {
-          this.spiQuery += ',';
+        spiQuery = `${field.dbField}:100`;
+        if (updateQuery) {
+          if (this.spiQuery && this.spiQuery !== '') {
+            this.spiQuery += ',';
+          }
+          this.spiQuery += spiQuery;
         }
-        this.spiQuery += spiQuery += `${field.dbField}:100`;
-      } else {
+      } else if (updateQuery) {
         const spiParamsArray = this.spiQuery.split(',');
         for (let i = 0, len = spiParamsArray.length; i < len; ++i) {
           if (spiParamsArray[i].includes(field.dbField)) {
@@ -716,6 +724,12 @@ export default {
       let query = '';
       const category = this.categoryObjects[categoryName];
 
+      // batch the spi query parameter update: updating it inside
+      // toggleSpiData is O(query length) per field, so doing it once per
+      // field made toggling a whole category O(n^2)
+      const toggledOn = [];
+      const toggledOff = new Set();
+
       for (let i = 0, len = category.fields.length; i < len; ++i) {
         const field = category.fields[i];
         if (category.spi && category.spi[field.dbField]) {
@@ -724,12 +738,28 @@ export default {
              (!spiData.active && load)) {
             // the spi data for this field is already visible and we don't want
             // it to be, or it's NOT visible and we want it to be
-            this.toggleSpiData(field);
+            const seg = this.toggleSpiData(field, false, false, false);
+            if (seg) { toggledOn.push(seg); } else { toggledOff.add(field.dbField); }
           }
         } else if (load) { // spi data doesn't exist in the category
-          if (query) { query += ','; }
-          query += this.toggleSpiData(field);
+          const seg = this.toggleSpiData(field, false, false, false);
+          if (seg) {
+            if (query) { query += ','; }
+            query += seg;
+            toggledOn.push(seg);
+          }
         }
+      }
+
+      // update the spi query parameter once for all the toggled fields
+      if (toggledOn.length) {
+        const additions = toggledOn.join(',');
+        this.spiQuery = (this.spiQuery && this.spiQuery !== '') ? `${this.spiQuery},${additions}` : additions;
+      }
+      if (toggledOff.size) {
+        this.spiQuery = this.spiQuery.split(',').filter((param) => {
+          return !toggledOff.has(param.split(':')[0]);
+        }).join(',');
       }
 
       if (load && query) { this.getSpiData(query); }


### PR DESCRIPTION
- Lazily render Connections node/link field menus (items + tooltips only mount on open)
- Debounce Connections field filter input and use stable field-based keys
- Lazily render SPIView category collapses and per-field dropdown menus
- Batch SPIView show/hide-all spiQuery updates (was O(n^2))

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
