### PR TITLE
Fix s3ExpireDays never expiring anything (fixes #4099)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -152,6 +152,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4098 Fix IP field Add Exists menu items building queries with the database field name instead of the expression
   - #4098 Fix session detail Src/Dst payload preview not replacing unprintable characters
   - #4098 Fix PCAP retrieval with the writer-s3 plugin hanging queued readers forever when the S3 object is gone
+  - #4101 Fix s3ExpireDays never expiring anything in the writer-s3 plugin
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors

--- a/capture/plugins/writer-s3/index.js
+++ b/capture/plugins/writer-s3/index.js
@@ -344,7 +344,7 @@ async function processSessionIdS3 (session, headerCb, packetCb, endCb, limit) {
   }
 }
 /// ///////////////////////////////////////////////////////////////////////////////
-async function s3Expire () {
+async function s3Expire (expireDays) {
   const query = {
     _source: ['num', 'name', 'first', 'size', 'node'],
     from: '0',
@@ -352,7 +352,7 @@ async function s3Expire () {
     query: {
       bool: {
         must: [
-          { range: { first: { lte: Math.floor(Date.now() / 1000 - (+Config.get('s3ExpireDays')) * 60 * 60 * 24) } } },
+          { range: { first: { lte: Math.floor(Date.now() / 1000 - expireDays * 60 * 60 * 24) } } },
           { prefix: { name: 's3://' } }
         ],
         must_not: { term: { locked: 1 } }
@@ -362,7 +362,7 @@ async function s3Expire () {
   };
 
   try {
-    const { body: data } = await Db.search('files', query);
+    const data = await Db.search('files', query);
     if (!data.hits || !data.hits.hits) {
       return;
     }
@@ -403,9 +403,24 @@ exports.init = function (config, emitter, api) {
   Pcap = api.getPcap();
 
   if (Config.get('s3ExpireDays') !== undefined) {
-    s3Expire().catch(err => console.log('ERROR - s3Expire initial run failed:', err));
+    s3Expire(+Config.get('s3ExpireDays')).catch(err => console.log('ERROR - s3Expire initial run failed:', err));
     setInterval(() => {
-      s3Expire().catch(err => console.log('ERROR - s3Expire interval run failed:', err));
+      s3Expire(+Config.get('s3ExpireDays')).catch(err => console.log('ERROR - s3Expire interval run failed:', err));
     }, 600 * 1000);
+  }
+
+  if (Config.regressionTests) {
+    api.getPrePluginRouter().post('/regressionTests/s3Expire', async (req, res) => {
+      const days = parseFloat(req.query.days);
+      if (isNaN(days)) {
+        return res.status(400).send(JSON.stringify({ success: false, text: 'Missing days' }));
+      }
+      try {
+        await s3Expire(days);
+        res.send('{}');
+      } catch (err) {
+        res.status(500).send(JSON.stringify({ success: false, text: err.toString() }));
+      }
+    });
   }
 };

--- a/tests/api-s3.t
+++ b/tests/api-s3.t
@@ -1,4 +1,4 @@
-use Test::More tests => 23;
+use Test::More tests => 27;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -40,6 +40,7 @@ my ($tag, $compression, $extension, $gap, $input) = @_;
     unlink("/tmp/arkime.file.$compression.$gap");
     unlink("/tmp/arkime.file.$compression.$gap$extension");
     system("AWS_ACCESS_KEY_ID='foo'  AWS_SECRET_ACCESS_KEY='foo' aws --endpoint-url http://localhost:4566 s3 cp $s3url /tmp/arkime.file.$compression.$gap$extension");
+    return $s3url;
 }
 
 my $value = int(rand()*1000000);
@@ -48,7 +49,7 @@ my $files = "-r pcap/socks-http-pass.pcap -r pcap/wireshark-retrans.pcap";
 
 run("none-$value", "none", "",     "true",  $files);
 run("gzip-$value", "gzip", ".gz",  "true",  $files);
-run("zstd-$value", "zstd", ".zst", "false", $files);
+my $s3url = run("zstd-$value", "zstd", ".zst", "false", $files);
 
 system("gzip -d /tmp/arkime.file.gzip.true.gz > /dev/null 2>&1");
 system("zstd -d /tmp/arkime.file.zstd.false.zst > /dev/null 2>&1");
@@ -80,5 +81,29 @@ system("AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=foo aws --endpoint-url http:
 system("../capture/capture -o disablePython=true -c config.test.ini -n sqs-test --tag $sqstag -r sqshttp://127.0.0.1:4566/000000000000/sqsqueue > /tmp/arkime.capture.sqs.log 2>&1");
 
 countTest2($expected, "date=-1&expression=" . uri_escape("tags=$sqstag"));
+
+# --- s3Expire (issue #4099): force expire via regressionTests endpoint ---
+my $filesQuery = '{"query":{"bool":{"must":[{"prefix":{"name":"s3://"}}],"must_not":{"term":{"locked":1}}}}}';
+
+esGet("/tests2_files/_refresh");
+my $esjson = esPost("/tests2_files/_search?rest_total_hits_as_int=true", $filesQuery);
+my $before = $esjson->{hits}->{total};
+cmp_ok($before, '>', 0, "s3 files exist before expire");
+
+# A huge expireDays shouldn't expire anything
+viewerPost2("/plugin/regressionTests/s3Expire?days=36500", "");
+esGet("/tests2_files/_refresh");
+$esjson = esPost("/tests2_files/_search?rest_total_hits_as_int=true", $filesQuery);
+is($esjson->{hits}->{total}, $before, "no s3 files expired with large expire days");
+
+# Test pcaps have old packet times for first, so everything should expire
+viewerPost2("/plugin/regressionTests/s3Expire?days=1", "");
+esGet("/tests2_files/_refresh");
+$esjson = esPost("/tests2_files/_search?rest_total_hits_as_int=true", $filesQuery);
+is($esjson->{hits}->{total}, 0, "all s3 files expired");
+
+# The S3 object itself should be gone
+isnt(system("AWS_ACCESS_KEY_ID='foo' AWS_SECRET_ACCESS_KEY='foo' aws --endpoint-url http://localhost:4566 s3 cp $s3url /tmp/arkime.file.expired > /dev/null 2>&1"), 0, "s3 object deleted");
+unlink("/tmp/arkime.file.expired");
 
 esPost("/tests2_sessions*/_delete_by_query?conflicts=proceed&refresh", $nodeFilter);

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -31,6 +31,10 @@ class Config {
     return ArkimeConfig.debug;
   }
 
+  static get regressionTests () {
+    return ArkimeConfig.regressionTests;
+  }
+
   static esProfile = false;
 
   static keyFileData;


### PR DESCRIPTION
- Db.search already returns the body, so the double destructure made s3Expire a no-op
- Add /plugin/regressionTests/s3Expire endpoint to force expires in tests
- Add api-s3.t tests covering expire and S3 object deletion

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
