### PR TITLE
Fix medium-confidence viewer/cont3xt/parliament/wise/db bugs from Fable 5 scan

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,7 +105,7 @@ Arkime is a modular network analysis system with these components:
 - auth.js - Authentication (digest, basic, OIDC, header, form)
 - user.js - User management
 - vueapp/ - Shared Vue components (Search.vue, Users.vue, etc.)
-- vueapp/locales/ - i18n translations (11 languages: en, es, fr, de, ja, ko, zh, etc.)
+- vueapp/locales/ - i18n translations (9 languages + x-pl pseudo-locale: en, es, fr, de, ja, ko, zh, et, pt-BR)
 
 ## Frontend Architecture
 
@@ -137,7 +137,7 @@ viewer/vueapp/
 All services follow this pattern. Common components live in common/vueapp/.
 
 ### Development Workflow
-- Frontend: Vite dev server with hot reload (port configured in parentapp/vueapp/vite.config.js)
+- Frontend: Vite dev server with hot reload (port configured in parentapp/vueapp/vite.config.mjs)
 - Backend: nodemon auto-restarts on changes
 - Proxy: Vite proxies API requests to backend
 
@@ -227,7 +227,7 @@ Multiple auth modes via common/auth.js:
 
 ### Test Framework
 Custom Perl framework: tests/ArkimeTest.pm
-- 47 test files (*.t)
+- 52 test files (*.t)
 - Uses LWP::UserAgent for HTTP testing
 - Helper functions: viewerGet(), viewerPost(), esGet(), countTest()
 
@@ -238,7 +238,7 @@ tests/
 │   ├── api-sessions.t   # Session API tests
 │   ├── api-stats.t      # Stats API tests
 │   ├── dns.t            # Protocol parser tests
-│   └── [47 total]
+│   └── [52 total]
 ├── config.test.ini      # Viewer test config
 ├── config.test.json     # WISE test config
 └── cont3xt.ini          # Cont3xt test config

--- a/.claude/agents/cont3xt-integration-creator.md
+++ b/.claude/agents/cont3xt-integration-creator.md
@@ -24,7 +24,7 @@ You are an expert Cont3xt Integration Architect with deep knowledge of Arkime's 
 
 2. **Guide Integration Development**: Lead developers through the complete integration creation process:
    - Understanding the Integration class structure and required methods
-   - Implementing the doFetch() method for API calls
+   - Implementing the fetch methods referenced by the itypes map
    - Handling authentication (API keys, OAuth, etc.)
    - Parsing and formatting response data
    - Implementing rate limiting and error handling
@@ -72,7 +72,7 @@ You are an expert Cont3xt Integration Architect with deep knowledge of Arkime's 
 **Quality Standards:**
 
 - Integrations must extend the Integration base class
-- Must implement doFetch() method
+- Must declare an itypes map pointing at implemented fetch methods
 - Should handle errors gracefully
 - Must respect rate limits
 - Should cache results when appropriate

--- a/.claude/agents/synthetic-pcap-updater.md
+++ b/.claude/agents/synthetic-pcap-updater.md
@@ -32,7 +32,7 @@ If the user asks to rebuild entirely, generate a single script that creates all 
 
 ### Test with Arkime capture
 ```bash
-cd ~/arkime/capture
+cd capture
 ./capture --tests -o parsersDir=parsers -r ../tests/pcap/arkime_synthetic.pcap
 ```
 - Output is JSON to stdout with `{"sessions3": [...]}`
@@ -52,7 +52,7 @@ Must produce zero output.
 
 ### Verify specific fields
 ```bash
-cd ~/arkime/capture
+cd capture
 ./capture --tests -o parsersDir=parsers -r ../tests/pcap/arkime_synthetic.pcap 2>/dev/null | \
   grep -v "^[A-Z][a-z][a-z] " | python3 -c "
 import sys, json
@@ -152,7 +152,7 @@ grep -n "arkime_field_define" capture/parsers/PROTOCOL.c
 
 ### Check which fields are already exercised
 ```bash
-cd ~/arkime/capture
+cd capture
 ./capture --tests -o parsersDir=parsers -r ../tests/pcap/arkime_synthetic.pcap 2>/dev/null | \
   grep -v "^[A-Z][a-z][a-z] " | python3 -c "
 import sys, json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,7 +394,7 @@ jobs:
           echo "ARKIME_MAJOR_VERSION=$ARKIME_MAJOR_VERSION" >> $GITHUB_ENV
 
       - name: Build on FreeBSD
-        uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f # v1.4.3
+        uses: vmactions/freebsd-vm@4441bea20b31bfa77329a5af583199362489567e # v1.4.9
         with:
           release: ${{ matrix.freebsdrelease }}
           arch: ${{ contains(matrix.version, 'aarch64') && 'aarch64' || 'x86_64' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
+          ref: "refs/tags/v${{ github.event.inputs.release_tag }}"
 
       - name: Build on FreeBSD
         uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f # v1.4.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
           ref: "refs/tags/v${{ github.event.inputs.release_tag }}"
 
       - name: Build on FreeBSD
-        uses: vmactions/freebsd-vm@4807432c7cab1c3f97688665332c0b932062d31f # v1.4.3
+        uses: vmactions/freebsd-vm@4441bea20b31bfa77329a5af583199362489567e # v1.4.9
         with:
           release: ${{ matrix.freebsdrelease }}
           arch: ${{ contains(matrix.version, 'aarch64') && 'aarch64' || 'x86_64' }}

--- a/.github/workflows/versions
+++ b/.github/workflows/versions
@@ -184,7 +184,7 @@ include:
 
   ############# FreeBSD #############
   - version: freebsd14.x86_64
-    freebsdrelease: "14.3"
+    freebsdrelease: "14.4"
     buildopt: "--kafka"
     fpmdeps: "-d glib -d yara -d libyaml -d libmaxminddb -d libuuid -d python312 -d libinotify -d pcre2 -d curl"
     ja4plus: true

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,6 +46,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Release
   - #4066 Node 22.23.1
   - #4056 Add Fedora 44 builds
+  - #4102 FreeBSD 14 builds now use 14.4
 ## All
   - #4065 Fix OIDC login not preserving the redirect URL's query parameters (thanks @yanover)
   - #4072 Fix header/OIDC auth requests hanging when a dynamic role update fails

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -46,7 +46,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Release
   - #4066 Node 22.23.1
   - #4056 Add Fedora 44 builds
-  - #4102 FreeBSD 14 builds now use 14.4
+  - #4102 FreeBSD 14 builds use 14.4
 ## All
   - #4065 Fix OIDC login not preserving the redirect URL's query parameters (thanks @yanover)
   - #4072 Fix header/OIDC auth requests hanging when a dynamic role update fails

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -54,6 +54,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4089 Consolidate header auth non-localhost host security warning across viewer/cont3xt/parliament/wiseService
   - #4093 Fix page load failing with a 500 in OIDC mode when the issuer has no end_session_endpoint
   - #4093 Fix user-role-mappings changes not taking effect until the next request; granted roles now apply and revoked roles stop working on the same request
+  - #4102 Fix concurrent requests during the first roles-cache population getting an undefined roles list
+  - #4102 Fix users CSV export header using comma-space separators while data rows use commas
 ## Capture
   - #4054 Fix GRE keepalive packets adding bogus 00:00:00:00:00:00 MACs
   - #4055 Fix DNS memory leak when parsing malformed answers
@@ -127,8 +129,18 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4093 Fix cont3xt crash with a malformed custom overview field, and custom overview join separators being rejected
   - #4093 Fix searches hanging when an invalid IP (e.g. 300.1.2.3) is the only indicator queried
   - #4093 Fix ipqs array fields not displaying comma-joined, the virustotal hash scans table never rendering, and the wise integration ignoring wiseURL
+  - #4102 Fix DNS integration decoding the CAA critical flag as decimal instead of hex
+  - #4102 Fix builtwith/greynoise/redis integrations silently swallowing errors (bad key, rate limit, outages) as no data; they now log
+  - #4102 Fix db errors without ES metadata throwing inside index-creation error handlers
+## db.pl
+  - #4102 Fix ARKIME__prefix/ARKIME_default__prefix env prefixes not being normalized like --prefix (missing trailing _)
+  - #4102 Fix info command counting old-prefix history indices but excluding their docs/bytes from Histories
 ## Multies
   - #4092 Fix plaintext user:pass elasticsearchBasicAuth never working, and passwords containing a colon being truncated
+## Parliament
+  - #4102 Fix parliament upgrade polluting the shared settings defaults, which broke restoring default settings until restart
+  - #4102 Fix issue cleanup sometimes removing an extra unrelated issue in the same pass
+  - #4102 Fix noPackets tracking not resetting when a node recovers, so a later dip alerted immediately instead of waiting noPacketsLength
 ## Viewer
   - #4063 Fix CSV formula injection in the summary CSV export by neutralizing cells starting with = + - @
   - #4071 Fix negative numbers being rejected in expressions
@@ -153,6 +165,11 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4098 Fix session detail Src/Dst payload preview not replacing unprintable characters
   - #4098 Fix PCAP retrieval with the writer-s3 plugin hanging queued readers forever when the S3 object is gone
   - #4101 Fix s3ExpireDays never expiring anything in the writer-s3 plugin
+  - #4102 Fix pcap scrub silently skipping packets larger than 5000 bytes (jumbo frames / large snaplen)
+  - #4102 Fix pcap scrub on short-header pcap files leaving the first 10 payload bytes unscrubbed
+  - #4102 Fix session packets requests with an unknown decode option hanging forever; they now return a 400
+  - #4102 Fix a session packets error when an SMTP MIME header continuation line lands on a packet chunk boundary
+  - #4102 Fix multiviewer sessions refresh dropping each cluster's index prefix, so prefixed clusters were never refreshed
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors
@@ -167,6 +184,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4093 Fix elasticsearch source registering anyway after logging that required settings are missing
   - #4094 Fix fieldactions/valueactions crashing wiseService when the watched file is deleted, and redis/elasticsearch content with a section header failing to load
   - #4094 Fix databricks and splunk sources loading anyway when required settings are missing
+  - #4102 Fix isepxgrid showing a duplicate cacheAgeMin field in the config UI
+  - #4102 Fix taggerUpload.pl corrupting keys from CRLF files and building invalid JSON when data contains quotes or backslashes
 
 6.5.0 2026/06/15
 ## Breaking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ Arkime supports internationalization to make the application accessible to users
 * 🇯🇵 Japanese (ja)
 * 🇰🇷 Korean (ko)
 * 🇨🇳 Chinese (zh)
+* 🇪🇪 Estonian (et)
+* 🇧🇷 Brazilian Portuguese (pt-BR)
 
 **Getting started with translations:**
 1. Read the comprehensive [Internationalization Guide](INTERNATIONALIZATION.md)

--- a/INTERNATIONALIZATION.md
+++ b/INTERNATIONALIZATION.md
@@ -9,7 +9,7 @@ This guide explains how to use and contribute to internationalization (i18n) in 
 Vue I18n is already configured and ready to use! The setup includes:
 
 - **Smart locale detection**: localStorage → browser language → fallback to English
-- **7 supported languages**: English, Spanish, French, German, Japanese, Korean, Chinese
+- **9 supported languages**: English, Spanish, French, German, Japanese, Korean, Chinese, Estonian, Brazilian Portuguese
 - **Composition API**: Modern Vue 3 approach with `useI18n()`
 - **Global injection**: Use `$t()` in templates
 - **Language persistence**: User preferences saved in localStorage
@@ -324,7 +324,10 @@ arkime/
 │   │   ├── de.json                     # German
 │   │   ├── ja.json                     # Japanese
 │   │   ├── ko.json                     # Korean
-│   │   └── zh.json                     # Chinese
+│   │   ├── zh.json                     # Chinese
+│   │   ├── et.json                     # Estonian
+│   │   ├── pt-BR.json                  # Brazilian Portuguese
+│   │   └── x-pl.json                   # Pseudo-locale (testing)
 │   ├── LanguageSwitcher.vue           # Shared language selector component
 │   └── I18nExample.vue                # Shared usage examples
 └── viewer/vueapp/src/

--- a/NOTICE
+++ b/NOTICE
@@ -194,136 +194,6 @@ Copyright 2011-2012, Kirill Lebedev
 Licensed under the MIT license.
 
 ================================================================================
-viewer/public/sprintf.js - MIT - https://github.com/kvz/phpjs
-
-/*
- * More info at: http://phpjs.org
- *
- * This is version: 3.26
- * php.js is copyright 2011 Kevin van Zonneveld.
- *
- * Portions copyright Brett Zamir (http://brett-zamir.me), Kevin van Zonneveld
- * (http://kevin.vanzonneveld.net), Onno Marsman, Theriault, Michael White
- * (http://getsprink.com), Waldo Malqui Silva, Paulo Freitas, Jack, Jonas
- * Raoni Soares Silva (http://www.jsfromhell.com), Philip Peterson, Legaev
- * Andrey, Ates Goral (http://magnetiq.com), Alex, Ratheous, Martijn Wieringa,
- * Rafa? Kukawski (http://blog.kukawski.pl), lmeyrick
- * (https://sourceforge.net/projects/bcmath-js/), Nate, Philippe Baumann,
- * Enrique Gonzalez, Webtoolkit.info (http://www.webtoolkit.info/), Carlos R.
- * L. Rodrigues (http://www.jsfromhell.com), Ash Searle
- * (http://hexmen.com/blog/), Jani Hartikainen, travc, Ole Vrijenhoek,
- * Erkekjetter, Michael Grier, Rafa? Kukawski (http://kukawski.pl), Johnny
- * Mast (http://www.phpvrouwen.nl), T.Wild, d3x,
- * http://stackoverflow.com/questions/57803/how-to-convert-decimal-to-hex-in-javascript,
- * Rafa? Kukawski (http://blog.kukawski.pl/), stag019, pilus, WebDevHobo
- * (http://webdevhobo.blogspot.com/), marrtins, GeekFG
- * (http://geekfg.blogspot.com), Andrea Giammarchi
- * (http://webreflection.blogspot.com), Arpad Ray (mailto:arpad@php.net),
- * gorthaur, Paul Smith, Tim de Koning (http://www.kingsquare.nl), Joris, Oleg
- * Eremeev, Steve Hilder, majak, gettimeofday, KELAN, Josh Fraser
- * (http://onlineaspect.com/2007/06/08/auto-detect-a-time-zone-with-javascript/),
- * Marc Palau, Kevin van Zonneveld (http://kevin.vanzonneveld.net/), Martin
- * (http://www.erlenwiese.de/), Breaking Par Consulting Inc
- * (http://www.breakingpar.com/bkp/home.nsf/0/87256B280015193F87256CFB006C45F7),
- * Chris, Mirek Slugen, saulius, Alfonso Jimenez
- * (http://www.alfonsojimenez.com), Diplom@t (http://difane.com/), felix,
- * Mailfaker (http://www.weedem.fr/), Tyler Akins (http://rumkin.com), Caio
- * Ariede (http://caioariede.com), Robin, Kankrelune
- * (http://www.webfaktory.info/), Karol Kowalski, Imgen Tata
- * (http://www.myipdf.com/), mdsjack (http://www.mdsjack.bo.it), Dreamer,
- * Felix Geisendoerfer (http://www.debuggable.com/felix), Lars Fischer, AJ,
- * David, Aman Gupta, Michael White, Public Domain
- * (http://www.json.org/json2.js), Steven Levithan
- * (http://blog.stevenlevithan.com), Sakimori, Pellentesque Malesuada,
- * Thunder.m, Dj (http://phpjs.org/functions/htmlentities:425#comment_134018),
- * Steve Clay, David James, Francois, class_exists, nobbler, T. Wild, Itsacon
- * (http://www.itsacon.net/), date, Ole Vrijenhoek (http://www.nervous.nl/),
- * Fox, Raphael (Ao RUDLER), Marco, noname, Mateusz "loonquawl" Zalega, Frank
- * Forte, Arno, ger, mktime, john (http://www.jd-tech.net), Nick Kolosov
- * (http://sammy.ru), marc andreu, Scott Cariss, Douglas Crockford
- * (http://javascript.crockford.com), madipta, Slawomir Kaniecki,
- * ReverseSyntax, Nathan, Alex Wilson, kenneth, Bayron Guevara, Adam Wallner
- * (http://web2.bitbaro.hu/), paulo kuong, jmweb, Lincoln Ramsay, djmix,
- * Pyerre, Jon Hohle, Thiago Mata (http://thiagomata.blog.com), lmeyrick
- * (https://sourceforge.net/projects/bcmath-js/this.), Linuxworld, duncan,
- * Gilbert, Sanjoy Roy, Shingo, sankai, Oskar Larsson H?gfeldt
- * (http://oskar-lh.name/), Denny Wardhana, 0m3r, Everlasto, Subhasis Deb,
- * josh, jd, Pier Paolo Ramon (http://www.mastersoup.com/), P, merabi, Soren
- * Hansen, Eugene Bulkin (http://doubleaw.com/), Der Simon
- * (http://innerdom.sourceforge.net/), echo is bad, Ozh, XoraX
- * (http://www.xorax.info), EdorFaus, JB, J A R, Marc Jansen, Francesco, LH,
- * Stoyan Kyosev (http://www.svest.org/), nord_ua, omid
- * (http://phpjs.org/functions/380:380#comment_137122), Brad Touesnard, MeEtc
- * (http://yass.meetcweb.com), Peter-Paul Koch
- * (http://www.quirksmode.org/js/beat.html), Olivier Louvignes
- * (http://mg-crea.com/), T0bsn, Tim Wiel, Bryan Elliott, Jalal Berrami,
- * Martin, JT, David Randall, Thomas Beaucourt (http://www.webapp.fr), taith,
- * vlado houba, Pierre-Luc Paour, Kristof Coomans (SCK-CEN Belgian Nucleair
- * Research Centre), Martin Pool, Kirk Strobeck, Rick Waldron, Brant Messenger
- * (http://www.brantmessenger.com/), Devan Penner-Woelk, Saulo Vallory, Wagner
- * B. Soares, Artur Tchernychev, Valentina De Rosa, Jason Wong
- * (http://carrot.org/), Christoph, Daniel Esteban, strftime, Mick@el, rezna,
- * Simon Willison (http://simonwillison.net), Anton Ongson, Gabriel Paderni,
- * Marco van Oort, penutbutterjelly, Philipp Lenssen, Bjorn Roesbeke
- * (http://www.bjornroesbeke.be/), Bug?, Eric Nagel, Tomasz Wesolowski,
- * Evertjan Garretsen, Bobby Drake, Blues (http://tech.bluesmoon.info/), Luke
- * Godfrey, Pul, uestla, Alan C, Ulrich, Rafal Kukawski, Yves Sucaet,
- * sowberry, Norman "zEh" Fuchs, hitwork, Zahlii, johnrembo, Nick Callen,
- * Steven Levithan (stevenlevithan.com), ejsanders, Scott Baker, Brian Tafoya
- * (http://www.premasolutions.com/), Philippe Jausions
- * (http://pear.php.net/user/jausions), Aidan Lister
- * (http://aidanlister.com/), Rob, e-mike, HKM, ChaosNo1, metjay, strcasecmp,
- * strcmp, Taras Bogach, jpfle, Alexander Ermolaev
- * (http://snippets.dzone.com/user/AlexanderErmolaev), DxGx, kilops, Orlando,
- * dptr1988, Le Torbi, James (http://www.james-bell.co.uk/), Pedro Tainha
- * (http://www.pedrotainha.com), James, Arnout Kazemier
- * (http://www.3rd-Eden.com), Chris McMacken, gabriel paderni, Yannoo,
- * FGFEmperor, baris ozdil, Tod Gentille, Greg Frazier, jakes, 3D-GRAF, Allan
- * Jensen (http://www.winternet.no), Howard Yeend, Benjamin Lupton, davook,
- * daniel airton wermann (http://wermann.com.br), Atli T¨®r, Maximusya, Ryan
- * W Tenney (http://ryan.10e.us), Alexander M Beedie, fearphage
- * (http://http/my.opera.com/fearphage/), Nathan Sepulveda, Victor, Matteo,
- * Billy, stensi, Cord, Manish, T.J. Leahy, Riddler
- * (http://www.frontierwebdev.com/), Rafa? Kukawski, FremyCompany, Matt
- * Bradley, Tim de Koning, Luis Salazar (http://www.freaky-media.com/), Diogo
- * Resende, Rival, Andrej Pavlovic, Garagoth, Le Torbi
- * (http://www.letorbi.de/), Dino, Josep Sanz (http://www.ws3.es/), rem,
- * Russell Walker (http://www.nbill.co.uk/), Jamie Beck
- * (http://www.terabit.ca/), setcookie, Michael, YUI Library:
- * http://developer.yahoo.com/yui/docs/YAHOO.util.DateLocale.html, Blues at
- * http://hacks.bluesmoon.info/strftime/strftime.js, Ben
- * (http://benblume.co.uk/), DtTvB
- * (http://dt.in.th/2008-09-16.string-length-in-bytes.html), Andreas, William,
- * meo, incidence, Cagri Ekin, Amirouche, Amir Habibi
- * (http://www.residence-mixte.com/), Luke Smith (http://lucassmith.name),
- * Kheang Hok Chin (http://www.distantia.ca/), Jay Klehr, Lorenzo Pisani,
- * Tony, Yen-Wei Liu, Greenseed, mk.keck, Leslie Hoare, dude, booeyOH, Ben
- * Bryan
- *
- * Dual licensed under the MIT (MIT-LICENSE.txt)
- * and GPL (GPL-LICENSE.txt) licenses.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including
- * without limitation the rights to use, copy, modify, merge, publish,
- * distribute, sublicense, and/or sell copies of the Software, and to
- * permit persons to whom the Software is furnished to do so, subject to
- * the following conditions:
- *
- * The above copyright notice and this permission notice shall be included
- * in all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL KEVIN VAN ZONNEVELD BE LIABLE FOR ANY CLAIM, DAMAGES
- * OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
-
-================================================================================
 mkpath in capture/db.c - BSD - https://github.com/phaag/nfdump
 
   The nfdump project is distributed under the BSD license:
@@ -355,7 +225,7 @@ mkpath in capture/db.c - BSD - https://github.com/phaag/nfdump
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
   POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
-viewer/public/cyberchef.htm.gz - Apache License 2.0 - https://gchq.github.io/CyberChef/
+viewer/public/cyberchef.html - Apache License 2.0 - https://gchq.github.io/CyberChef/
 <!--
     CyberChef - The Cyber Swiss Army Knife
 
@@ -376,11 +246,4 @@ viewer/public/cyberchef.htm.gz - Apache License 2.0 - https://gchq.github.io/Cyb
     See the License for the specific language governing permissions and
     limitations under the License.
 --->
-================================================================================
-viewer/public/colResizable.js - MIT - http://www.bacubacu.com/colresizable/
-
-v1.7 - jQuery plugin created by Alvaro Prieto Lauroba
-
-Licences: MIT & GPL
-Feel free to use or modify this plugin as far as my full name is kept
 ================================================================================

--- a/capture/plugins/taggerUpload.pl
+++ b/capture/plugins/taggerUpload.pl
@@ -64,13 +64,13 @@ open (FILE, $ARGV[2]);
 my $fields = "";
 while (<FILE>) {
     if (/^#field:/) {
-        chop;
+        s/[\r\n]+$//;
         $fields = '"fields":"' if ($fields eq "");
         $fields .= substr($_, 1) . ",";
         next;
     }
     next if (/^#/ || /^$/);
-    chop;
+    s/[\r\n]+$//;
     push(@ELEMENTS, $_);
 }
 
@@ -82,12 +82,19 @@ if ($fields ne "") {
 my $elements = join ',', @ELEMENTS;
 close (FILE);
 
+sub jsonEscape {
+    my ($str) = @_;
+    $str =~ s/\\/\\\\/g;
+    $str =~ s/"/\\"/g;
+    return $str;
+}
+
 my $md5hex = md5_hex($elements);
 
 my $tags = "";
-$tags = '"tags": "' . join(',', @ARGV[3 .. $#ARGV]) . '",' if (@ARGV >= 4);
+$tags = '"tags": "' . jsonEscape(join(',', @ARGV[3 .. $#ARGV])) . '",' if (@ARGV >= 4);
 
-my $content  = qq({${fields}${tags}"md5":"$md5hex", "type":"$ARGV[1]", "data":"$elements"}\n);
+my $content  = qq({${fields}${tags}"md5":"$md5hex", "type":"$ARGV[1]", "data":"@{[jsonEscape($elements)]}"}\n);
 $response = $userAgent->post("$host/tagger/_doc/$ARGV[2]", "Content-Type" => "application/json;charset=UTF-8", Content => $content);
 print $response->content, "\n";
 

--- a/common/user.js
+++ b/common/user.js
@@ -418,7 +418,7 @@ class User {
    * Return all available roles using cache
    */
   static async allRolesCache () {
-    if (User.#rolesCache._timeStamp > Date.now() - User.#userCacheTimeout) {
+    if (User.#rolesCache.roles && User.#rolesCache._timeStamp > Date.now() - User.#userCacheTimeout) {
       return User.#rolesCache.roles;
     }
 
@@ -645,7 +645,7 @@ class User {
     ]).then(([users, total]) => {
       if (users.error) { throw users.error; }
       const columns = 'userId,userName,enabled,webEnabled,headerAuthEnabled,roles,emailSearch,removeEnabled,packetSearch,hideStats,hideFiles,hidePcap,disablePcapDownload,expression,timeLimit'.split(',');
-      res.write(columns.join(', '));
+      res.write(columns.join(','));
       res.write('\r\n');
       users = users.users;
       for (let u = 0; u < users.length; u++) {

--- a/cont3xt/db.js
+++ b/cont3xt/db.js
@@ -229,7 +229,7 @@ class DbESImplementation {
       });
     } catch (err) {
       // If already exists ignore error
-      if (err.meta.body?.error?.type !== 'resource_already_exists_exception') {
+      if (err.meta?.body?.error?.type !== 'resource_already_exists_exception') {
         console.log('createLinksIndex', util.inspect(err, false, 10));
         process.exit(0);
       }
@@ -266,7 +266,7 @@ class DbESImplementation {
       });
     } catch (err) {
       // If already exists ignore error
-      if (err.meta.body?.error?.type !== 'resource_already_exists_exception') {
+      if (err.meta?.body?.error?.type !== 'resource_already_exists_exception') {
         console.log('createViewsIndex', util.inspect(err, false, 10));
         process.exit(0);
       }
@@ -300,7 +300,7 @@ class DbESImplementation {
       });
     } catch (err) {
       // If already exists ignore error
-      if (err.meta.body?.error?.type !== 'resource_already_exists_exception') {
+      if (err.meta?.body?.error?.type !== 'resource_already_exists_exception') {
         console.log('createHistoryIndex', util.inspect(err, false, 10));
         process.exit(0);
       }
@@ -347,7 +347,7 @@ class DbESImplementation {
       });
     } catch (err) {
       // If already exists ignore error
-      if (err.meta.body?.error?.type !== 'resource_already_exists_exception') {
+      if (err.meta?.body?.error?.type !== 'resource_already_exists_exception') {
         console.log('createOverviewIndex', util.inspect(err, false, 10));
         process.exit(0);
       }

--- a/cont3xt/integrations/README.md
+++ b/cont3xt/integrations/README.md
@@ -490,8 +490,8 @@ class SecondIntegration extends Integration {
 Set debug level to see detailed logs:
 
 ```bash
-# Start with debug logging
-DEBUG=2 npm start
+# Start with debug logging (repeat --debug for more detail)
+node cont3xt.js -c cont3xt.ini --debug --debug
 ```
 
 ### Common Issues

--- a/cont3xt/integrations/builtwith/index.js
+++ b/cont3xt/integrations/builtwith/index.js
@@ -88,6 +88,7 @@ class BuiltWithIntegration extends Integration {
       return result.data;
     } catch (err) {
       if (Integration.debug <= 1 && err?.response?.status === 404) { return null; }
+      console.log(this.name, query, err);
       return null;
     }
   }

--- a/cont3xt/integrations/dns/index.js
+++ b/cont3xt/integrations/dns/index.js
@@ -122,7 +122,7 @@ class DNSIntegration extends Integration {
         result.CAA.Answer.forEach(item => {
           const data = item.data.replace(/ /g, '');
           const len = parseInt(`0x${data.slice(6, 8)}`);
-          item.data = `${parseInt(data.slice(4, 6))} ${Buffer.from(data.slice(8, 8 + len * 2), 'hex').toString()} ${Buffer.from(data.slice(8 + len * 2), 'hex').toString()}`;
+          item.data = `${parseInt(`0x${data.slice(4, 6)}`)} ${Buffer.from(data.slice(8, 8 + len * 2), 'hex').toString()} ${Buffer.from(data.slice(8 + len * 2), 'hex').toString()}`;
         });
       }
 

--- a/cont3xt/integrations/greynoise/index.js
+++ b/cont3xt/integrations/greynoise/index.js
@@ -116,6 +116,7 @@ class GreyNoiseIntegration extends Integration {
         return Integration.NoResult; // IP not found in riot dataset or noise
       }
 
+      console.log(this.name, ip, err);
       return undefined;
     }
   }

--- a/cont3xt/integrations/ipqs/index.js
+++ b/cont3xt/integrations/ipqs/index.js
@@ -350,7 +350,7 @@ class IPQSEmailLeakIntegration extends Integration {
 class IPQSUrlIntegration extends Integration {
   name = 'IPQS URL Reputation';
   icon = 'integrations/ipqs/icon.png';
-  order = 605;
+  order = 608;
   configName = 'IPQualityScore';
 
   itypes = {

--- a/cont3xt/integrations/redis/index.js
+++ b/cont3xt/integrations/redis/index.js
@@ -76,6 +76,7 @@ class RedisIntegration extends Integration {
         }
       };
     } catch (e) {
+      console.log(this.name, item, e);
       return Integration.NoResult;
     }
   }

--- a/contrib/moloch_query
+++ b/contrib/moloch_query
@@ -117,6 +117,8 @@ def get_query(req):
 def print_progress(cur, tot):
     if tot == 0:
         tot = 1
+    if cur == 0:
+        cur = 1
     pct = int(cur / tot * 100)
     now = datetime.now()
     elap = now - start_time

--- a/contrib/netflow2arkime.pl
+++ b/contrib/netflow2arkime.pl
@@ -677,10 +677,13 @@ sub combine_or_queue {
         }
     }
     
-    # Queue this flow and wait for reverse
+    # Queue this flow and wait for reverse. If a same-direction flow with
+    # this key is already queued (same 5-tuple exported twice in the combine
+    # window), return the old one so it still gets sent instead of dropped.
+    my $old = $pending_flows{$key};
     $pending_flows{$key} = $flow;
     $pending_times{$key} = time();
-    return undef;
+    return $old;
 }
 
 sub flush_expired_pending {
@@ -1191,7 +1194,9 @@ if ($LISTEN_PORT) {
 }
 
 # Flush any remaining pending flows
+my $pending_unmatched = 0;
 if ($COMBINE_BIDIR) {
+    $pending_unmatched = scalar(keys %pending_flows);
     for my $flow (flush_all_pending()) {
         queue_flow($flow);
     }
@@ -1208,6 +1213,6 @@ print STDERR "\nSummary:\n";
 print STDERR "  Total flows read: $total_flows\n";
 print STDERR "  Sessions sent to ES: $total_sent\n";
 print STDERR "  Flows skipped (dedup): $total_skipped\n" if $DEDUP && $total_skipped;
-print STDERR "  Pending unmatched: " . scalar(keys %pending_flows) . "\n" if $COMBINE_BIDIR && %pending_flows;
+print STDERR "  Pending unmatched: $pending_unmatched\n" if $COMBINE_BIDIR && $pending_unmatched;
 
 exit(0);

--- a/db/db.pl
+++ b/db/db.pl
@@ -100,6 +100,11 @@ my $VERSION = 86;
 my $verbose = 0;
 my $PREFIX = $ENV{ARKIME_default__prefix} || $ENV{ARKIME__prefix};
 my $OLDPREFIX = "";
+# Normalize an env-provided prefix the same way --prefix is normalized below
+if (defined $PREFIX && $PREFIX ne "") {
+    $PREFIX .= "_" if ($PREFIX !~ /_$/);
+    $OLDPREFIX = $PREFIX;
+}
 my $SECURE = 1;
 my $CLIENTCERT = "";
 my $CLIENTKEY = "";
@@ -8401,7 +8406,6 @@ if ($ARGV[1] =~ /^(users-?import|import)$/) {
     my $historysBytes = 0;
     my @historys = grep /^(${PREFIX}history_v1-|${OLDPREFIX}history_v1-)/, keys %{$status->{indices}};
     foreach my $index (@historys) {
-        next if ($index !~ /^${PREFIX}history_v1-/);
         $historys += $status->{indices}->{$index}->{primaries}->{docs}->{count};
         $historysBytes += $status->{indices}->{$index}->{primaries}->{store}->{size_in_bytes};
     }

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1257,11 +1257,10 @@ function cleanUpIssues () {
       if (issue.provisional && timeSinceLastNoticed >= 10000) {
         issuesRemoved = true;
         issues.splice(len, 1);
-      }
 
       // remove all issues that have not been seen again for the removeIssuesAfter time, and
       // remove all acknowledged issues that have not been seen again for the removeAcknowledgedAfter time
-      if ((!issue.acknowledged && timeSinceLastNoticed > removeIssuesAfter) ||
+      } else if ((!issue.acknowledged && timeSinceLastNoticed > removeIssuesAfter) ||
           (issue.acknowledged && timeSinceLastNoticed > removeAcknowledgedAfter)) {
         issuesRemoved = true;
         issues.splice(len, 1);
@@ -1482,6 +1481,10 @@ async function getStats (cluster) {
             // if this issue has not been encountered yet, make a record of it
             noPacketsMap.set(id, Date.now());
           }
+        } else {
+          // the node is seeing packets again, clear the record so a future
+          // dip has to persist for noPacketsLength again
+          noPacketsMap.delete(cluster.title + ':' + stat.nodeName);
         }
 
         if (stat.deltaESDroppedPerSec > 0) {

--- a/parliament/upgrade.js
+++ b/parliament/upgrade.js
@@ -198,11 +198,12 @@ exports.upgrade = async function (parliament, issues, Parliament) {
   }
 
   // Fill in missing settings with defaults BEFORE saving to ES
+  // (copies so the shared static defaults object isn't mutated below)
   if (!parliament.settings) {
-    parliament.settings = Parliament.settingsDefault;
+    parliament.settings = structuredClone(Parliament.settingsDefault);
   }
   if (!parliament.settings.general) {
-    parliament.settings.general = Parliament.settingsDefault.general;
+    parliament.settings.general = structuredClone(Parliament.settingsDefault.general);
   }
 
   const defaults = Parliament.settingsDefault.general;

--- a/release/arkime_config_interfaces.sh
+++ b/release/arkime_config_interfaces.sh
@@ -69,7 +69,7 @@ for interface in $interfaces ; do
             /sbin/ethtool -K "$interface" "$i" off || true
         done
     else
-        echo "\nATTENTION :\nNIC : $interface seems to be absent/incorrect, can not update interface settings."
-        echo "Please check your configuration file : $file\n"
+        printf "\nATTENTION :\nNIC : %s seems to be absent/incorrect, can not update interface settings.\n" "$interface"
+        printf "Please check your configuration file : %s\n\n" "$file"
     fi
 done

--- a/release/config.ini.sample
+++ b/release/config.ini.sample
@@ -212,7 +212,7 @@ pluginsDir=ARKIME_INSTALL_DIR/plugins
 # plugins=tagger.so; netflow.so
 
 # Plugins to load as root, usually just readers
-#rootPlugins=reader-pfring; reader-daq.so
+#rootPlugins=reader-pfring.so; reader-daq.so
 
 # Semicolon ';' separated list of viewer plugins to load and the order to load in
 # viewerPlugins=wise.js

--- a/release/cont3xt.ini.sample
+++ b/release/cont3xt.ini.sample
@@ -15,14 +15,14 @@ elasticsearch=ARKIME_ELASTICSEARCH
 # If using SSO change to the http header with the username in it
 userNameHeader=digest
 
-# Password Hash Secret - Must be in default section. Since OpenSearch/Elasticsearch
+# Password Hash Secret - Must be in the [cont3xt] section. Since OpenSearch/Elasticsearch
 # is wide open by default, we encrypt the stored password hashes with this
 # so a malicious person can't insert a working new account.
 # Changing the value will make all previously stored passwords no longer work.
 # Make this RANDOM, you never need to type in
 passwordSecret=ARKIME_PASSWORD
 
-# HTTP Digest Realm - Must be in default section. Changing the value
+# HTTP Digest Realm - Must be in the [cont3xt] section. Changing the value
 # will make all previously stored passwords no longer work
 # This must be the same setting as Arkime uses, specified in config.ini
 httpRealm=Moloch

--- a/release/parliament.ini.sample
+++ b/release/parliament.ini.sample
@@ -1,6 +1,6 @@
 [parliament]
 # Where to store issues
-file=../etc/parliament.dev.json
+file=../etc/parliament.json
 
 # Port to listen on
 #port=8008

--- a/tests/api-hunt.t
+++ b/tests/api-hunt.t
@@ -9,7 +9,7 @@ use strict;
 
 my $token = getTokenCookie();
 my $otherToken = getTokenCookie('user2');
-my $nonadminToken = getTokenCookie2('user3');
+my $nonadminToken = getTokenCookie('user3');
 my $json;
 
 

--- a/tests/api-sessionDetail.t
+++ b/tests/api-sessionDetail.t
@@ -1,4 +1,4 @@
-use Test::More tests => 42;
+use Test::More tests => 44;
 
 use Cwd;
 use URI::Escape;
@@ -28,7 +28,7 @@ my $pwd = "*/pcap";
     while ($sd =~ /ts-value/g) {
         $count++;
     }
-    is (12, $count);
+    is ($count, 12);
 
     $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?line=false&ts=false&base=natural")->content;
     ok(bin2hex($sd) =~ /636f6c3a2038303a71756963.*08000000000002/, "encoding:natural");
@@ -224,3 +224,13 @@ ok($sd =~ m{Query A - &#123;constructor}s, "dns queryHost { escaped to &#123; in
 ok($sd !~ m{[^"]\{constructor}s, "dns queryHost has no raw { in /detail");
 
 esDelete("/$noPcapIndex/_doc/$xssDocId?refresh=true");
+
+# decode parameter validation
+    $sdId = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("file=$pwd/smtp-zip.pcap"));
+    $id = $sdId->{data}->[0]->{id};
+
+    my $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?decode=" . uri_escape('{"BODY-UNBASE64":{}}'));
+    is ($response->code, 200, "packets with valid decode key works");
+
+    $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$id/packets?decode=" . uri_escape('{"FOO":{}}'));
+    is ($response->code, 400, "packets with unknown decode key returns 400 instead of hanging");

--- a/tests/api-shareables.t
+++ b/tests/api-shareables.t
@@ -154,7 +154,7 @@ $info = viewerGet("/api/shareables?type=test2&arkimeRegressionUser=sac-test2");
 is($info->{recordsTotal}, 0, "viewOnly=true (default) excludes editRoles access");
 
 # list with viewOnly=false shows editRoles access
-$info = viewerGet("/api/shareables?type=test2&viewOnly=false&arkimeRegressionUser=sac-test1");
+$info = viewerGet("/api/shareables?type=test2&viewOnly=false&arkimeRegressionUser=sac-test2");
 is($info->{recordsTotal}, 1, "viewOnly=false includes editRoles access");
 
 # admin can always delete

--- a/tests/api-stats.t
+++ b/tests/api-stats.t
@@ -288,17 +288,17 @@ my $test1Token = getTokenCookie("test1");
 
     # Verify the endpoint correctly identifies primary vs replica by checking shard data structure
     my $foundPrimary = 0;
-    my $foundReplica = 0;
+    my $badPrirep = 0;
     foreach my $index (@{$shardsData->{indices}}) {
         foreach my $node (keys %{$index->{nodes}}) {
             foreach my $shard (@{$index->{nodes}->{$node}}) {
                 $foundPrimary = 1 if defined $shard->{prirep} && $shard->{prirep} eq 'p';
-                $foundReplica = 1 if defined $shard->{prirep} && $shard->{prirep} eq 'r';
+                $badPrirep = 1 if defined $shard->{prirep} && $shard->{prirep} !~ /^[pr]$/;
             }
         }
     }
     ok($foundPrimary, "esshard: shard data includes primary shard information");
-    ok($foundReplica || 1, "esshard: shard data includes replica information (or no replicas configured)");
+    ok(!$badPrirep, "esshard: prirep values are all p or r");
 
     # Test edge case: shard number 0 (valid shard number)
     $result = viewerPostToken("/api/esshards/nonexistentindex/0/delete", "", $token);

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -30,7 +30,7 @@ my $json;
 # csv
     my $csv = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/users.csv", Content => "")->content;
     $csv =~ s/\r//g;
-    eq_or_diff ($csv, 'userId, userName, enabled, webEnabled, headerAuthEnabled, roles, emailSearch, removeEnabled, packetSearch, hideStats, hideFiles, hidePcap, disablePcapDownload, expression, timeLimit
+    eq_or_diff ($csv, 'userId,userName,enabled,webEnabled,headerAuthEnabled,roles,emailSearch,removeEnabled,packetSearch,hideStats,hideFiles,hidePcap,disablePcapDownload,expression,timeLimit
 anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
 ', "CSV Users");
 
@@ -617,7 +617,7 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
 # csv
     my $csv = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/users.csv", Content => "")->content;
     $csv =~ s/\r//g;
-    eq_or_diff ($csv, 'userId, userName, enabled, webEnabled, headerAuthEnabled, roles, emailSearch, removeEnabled, packetSearch, hideStats, hideFiles, hidePcap, disablePcapDownload, expression, timeLimit
+    eq_or_diff ($csv, 'userId,userName,enabled,webEnabled,headerAuthEnabled,roles,emailSearch,removeEnabled,packetSearch,hideStats,hideFiles,hidePcap,disablePcapDownload,expression,timeLimit
 anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
 notadmin,,true,true,false,"arkimeUser, cont3xtUser, parliamentUser, wiseUser",true,true,true,,,,,,
 role:sac-test1,UserName,true,false,false,"",,,,,,,,,

--- a/tests/email.t
+++ b/tests/email.t
@@ -76,7 +76,7 @@ countTest(6, "date=-1&expression=" . uri_escape("$files&&protocols==smtp"));
 
 # email.mime-version
     countTest(1, "date=-1&expression=" . uri_escape("$files&&email.mime-version==\"1.0 (Apple Message framework v1283)\""));
-    countTest(1, "date=-1&expression=" . uri_escape("$files&&email.mime-version==\"1.0 (Apple Message framework v1283)\""));
+    countTest(0, "date=-1&expression=" . uri_escape("$files&&email.mime-version==\"1.0 (apple message framework v1283)\""));
     countTest(5, "date=-1&expression=" . uri_escape("$files&&email.mime-version.cnt==1"));
 
 # email.src
@@ -92,5 +92,5 @@ countTest(6, "date=-1&expression=" . uri_escape("$files&&protocols==smtp"));
 
 # host.email
     countTest(1, "date=-1&expression=" . uri_escape("$files&&host.email==\"xxxxxxxxxxxxxxxxxxxx.xxxxxxxxx.net\""));
-    countTest(1, "date=-1&expression=" . uri_escape("$files&&host.email==\"xxxxxxxxxxxxxxxxxxxx.xxxxxxxxx.net\""));
+    countTest(1, "date=-1&expression=" . uri_escape("$files&&host.email==\"Xxxxxxxxxxxxxxxxxxxx.xxxxxxxxx.net\""));
     countTest(2, "date=-1&expression=" . uri_escape("$files&&host.email.cnt==2"));

--- a/tests/email.tagger2.json
+++ b/tests/email.tagger2.json
@@ -3,7 +3,7 @@
 #field:tags;shortcut:2
 #view:if (session.tagger.str)
 #view:  div.sessionDetailMeta.bold Tagger
-#view:  dl.sessionDetailMeta.bold Tagger
+#view:  dl.sessionDetailMeta
 #view:    +arrayList(session.tagger, 'str', 'Str', 'tagger.str')
 12345678@aol.com;email.dst=added1;2=srcmatch;0=house;tagger.str=boat;dontSaveSPI=0
 xxxxx-xxxx@xxxx.xxx.xx.jp;email.src=added2;tags=dstmatch;1=1;tagger.int=3

--- a/tests/fakedatas.pl
+++ b/tests/fakedatas.pl
@@ -519,7 +519,7 @@ sub generateHTTP()
 
 ################################################################################
 my $HTTP = 100;
-for (my $pos;$pos <= $#ARGV; $pos++) {
+for (my $pos = 0;$pos <= $#ARGV; $pos++) {
     if ($ARGV[$pos] eq "--debug") {
         $DEBUG = 1;
     } elsif ($ARGV[$pos] eq "--http") {

--- a/tests/gen/gen_ntlm_synthetic.py
+++ b/tests/gen/gen_ntlm_synthetic.py
@@ -368,7 +368,7 @@ def smb1_setup_andx_secblob(blob):
     #   AndXCommand(1) AndXReserved(1) AndXOffset(2) MaxBufferSize(2)
     #   MaxMpxCount(2) VcNumber(2) SessionKey(4) SecurityBlobLength(2)
     #   Reserved(4) Capabilities(4)
-    words = struct.pack('<BBHHHHIHIA' if False else '<BBHHHHIHII',
+    words = struct.pack('<BBHHHHIHII',
                         0xff, 0, 0, 4356, 50, 1, 0,
                         len(blob), 0, 0x800000d4)
     # Data: SecurityBlob then native OS/LanMan/Domain (unicode, NUL-terminated).

--- a/tests/general.t
+++ b/tests/general.t
@@ -225,7 +225,7 @@ my $pwd = "*/pcap";
     countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/bt-udp.pcap&&packets.dst==1"));
     countTest(3, "date=-1&expression=" . uri_escape("file=$pwd/bt-udp.pcap&&packets.dst==0"));
     countTest(3, "date=-1&expression=" . uri_escape("file=$pwd/bt-udp.pcap&&packets.dst!=1"));
-    countTest(3, "date=-1&expression=" . uri_escape("file=$pwd/bt-udp.pcap&&packets.dst!=1"));
+    countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/bt-udp.pcap&&packets.src!=1"));
     countTest(3, "date=-1&expression=" . uri_escape("file=$pwd/socks-https-example.pcap&&packets>0"));
     countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/socks-https-example.pcap&&packets>30"));
     countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/socks-https-example.pcap&&packets.src>17"));

--- a/tests/http.t
+++ b/tests/http.t
@@ -65,7 +65,7 @@ my $pwd = "*/pcap";
     countTest(0, "date=-1&expression=" . uri_escape("(file=$pwd/http-content-zip.pcap||file=$pwd/http-500-head.pcap)&&http.uri==config.dat"));
     countTest(0, "date=-1&expression=" . uri_escape("(file=$pwd/http-content-zip.pcap||file=$pwd/http-500-head.pcap)&&http.uri==a.zip"));
     countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/http-content-zip.pcap||file=$pwd/http-500-head.pcap)&&http.uri==/.*a.zip/"));
-    countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/http-content-zip.pcap||file=$pwd/http-500-head.pcap)&&http.uri==/.*a.zip/"));
+    countTest(0, "date=-1&expression=" . uri_escape("(file=$pwd/http-content-zip.pcap||file=$pwd/http-500-head.pcap)&&http.uri==/.*A.zip/"));
 # http.uri.tokens tests
     countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/http-content-zip.pcap||file=$pwd/http-500-head.pcap)&&http.uri.tokens==http://samples.example.com/UpdataConfig.dat"));
     countTest(1, "date=-1&expression=" . uri_escape("(file=$pwd/http-content-zip.pcap||file=$pwd/http-500-head.pcap)&&http.uri.tokens==samples.example.com/UpdataConfig.dat"));

--- a/tests/postgresql.t
+++ b/tests/postgresql.t
@@ -19,4 +19,4 @@ countTest(3, "date=-1&expression=" . uri_escape("$files&&protocols==postgresql")
 
 # postgresql.app
     countTest(1, "date=-1&expression=" . uri_escape("$files&&postgresql.app==psql"));
-    countTest(1, "date=-1&expression=" . uri_escape("$files&&postgresql.app==psql"));
+    countTest(0, "date=-1&expression=" . uri_escape("$files&&postgresql.app==Psql"));

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -263,7 +263,7 @@ my ($json) = @_;
         }
 
         if (exists $body->{dns}) {
-            for (my $i; $i < @{$body->{dns}}; $i++) {
+            for (my $i = 0; $i < @{$body->{dns}}; $i++) {
                 if (exists $body->{dns}[$i]->{ip}) {
                     for (my $j = 0; $j < @{$body->{dns}[$i]->{ip}}; $j++) {
                         if ($body->{dns}[$i]->{ip}[$j] =~ /:/) {

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -416,6 +416,9 @@ class SessionAPIs {
     }
     for (const key in decodeOptions) {
       if (ArkimeUtil.isPP(key)) { continue; }
+      if (!decode.isRegistered(key)) {
+        return res.serverError(400, 'Invalid decode parameter', 'api.sessions.invalidDecodeParam');
+      }
       if (key.match(/^ITEM/)) {
         options.order.push(key);
       } else {
@@ -1110,11 +1113,12 @@ class SessionAPIs {
   static #scrubbingBuffers;
   static async #pcapScrub (req, res, sid, whatToRemove) {
     if (SessionAPIs.#scrubbingBuffers === undefined) {
-      SessionAPIs.#scrubbingBuffers = [Buffer.alloc(5000), Buffer.alloc(5000), Buffer.alloc(5000)];
+      // Sized to the max packet incl_len readPacket allows (65535)
+      SessionAPIs.#scrubbingBuffers = [Buffer.alloc(65535), Buffer.alloc(65535), Buffer.alloc(65535)];
       SessionAPIs.#scrubbingBuffers[0].fill(0);
       SessionAPIs.#scrubbingBuffers[1].fill(1);
       const str = 'Scrubbed! Hoot! ';
-      for (let i = 0; i < 5000;) {
+      for (let i = 0; i < 65535 - str.length;) {
         i += SessionAPIs.#scrubbingBuffers[2].write(str, i);
       }
     }

--- a/viewer/decode.js
+++ b/viewer/decode.js
@@ -399,12 +399,12 @@ class ItemSMTPStream extends ItemTransform {
 
         this.buffers.push(lines[l]);
 
+        if (!mime) {
+          mime = { line: '', base64: 0, doit: 0 };
+        }
         if (lines[l][0] === ' ' || lines[l][0] === '\t') {
           mime.line += lines[l];
           continue;
-        }
-        if (!mime) {
-          mime = { line: '', base64: 0, doit: 0 };
         }
 
         if (mime.line.substr(0, 13).toLowerCase() === 'content-type:') {
@@ -844,6 +844,9 @@ exports.register = function (regName, ClassOrCreate, settings) {
 };
 exports.settings = function () {
   return internals.settings;
+};
+exports.isRegistered = function (regName) {
+  return internals.registry[regName] !== undefined;
 };
 
 exports.register('BODY-UNXORBRUTEGZ', createUnxorBruteGzip, { name: 'UnXOR Brute GZip Header' });

--- a/viewer/multies.js
+++ b/viewer/multies.js
@@ -474,7 +474,9 @@ app.delete('/:index', simpleGather1Cluster);
 app.delete('/MULTIPREFIX_hunts/_doc/:id', simpleGather1Cluster);
 
 app.get('/MULTIPREFIX_sessions*/_refresh', (req, res) => {
-  req.url = '/sessions*/_refresh';
+  // Keep the MULTIPREFIX_ placeholder so each node's real prefix is
+  // substituted in simpleGather; collapse the index list to one pattern
+  req.url = '/MULTIPREFIX_sessions*/_refresh';
   return simpleGatherFirst(req, res);
 });
 

--- a/viewer/pcap.js
+++ b/viewer/pcap.js
@@ -479,26 +479,29 @@ class Pcap {
       pos += headerLen; // Don't delete pcap header
       len -= headerLen;
     } else {
+      let skip;
       switch (packet.ip.p) {
       case 1:
-        pos += (packet.icmp._pos + 8);
-        len -= (packet.icmp._pos + 8);
+        skip = packet.icmp._pos + 8;
         break;
       case 6:
-        pos += (packet.tcp._pos + 4 * packet.tcp.off);
-        len -= (packet.tcp._pos + 4 * packet.tcp.off);
+        skip = packet.tcp._pos + 4 * packet.tcp.off;
         break;
       case 17:
-        pos += (packet.udp._pos + 8);
-        len -= (packet.udp._pos + 8);
+        skip = packet.udp._pos + 8;
         break;
       case 132:
-        pos += (packet.sctp._pos + 8);
-        len -= (packet.sctp._pos + 8);
+        skip = packet.sctp._pos + 8;
         break;
       default:
         throw new Error("Unknown packet type, can't scrub");
       }
+      // decode() runs on the buffer readPacket rebuilds with a standard
+      // 16 byte header, so _pos values are 16-based even when the on-disk
+      // record header is 6 bytes
+      skip -= (16 - headerLen);
+      pos += skip;
+      len -= skip;
     }
 
     fs.writeSync(this.fd, buf, 0, len, pos);

--- a/wiseService/molochwise.bro
+++ b/wiseService/molochwise.bro
@@ -83,7 +83,6 @@ function requestWise()
 	}
 	local data = "";
 	for (key in wise_next_lookups[wtype]) {
-	    delete(wise_next_lookups[wtype][key]);
 	    add(wise_lookingup[key]);
 	    if (data == "") {
 		data += key;
@@ -91,6 +90,8 @@ function requestWise()
 		data += "," + key;
 	    }
 	}
+	# Clear after iterating; deleting while iterating a set is unsafe
+	wise_next_lookups[wtype] = set();
 
 	local url = fmt("%s/bro/%s?items=%s", base_url, wtype, data);
 	local req: ActiveHTTP::Request = ActiveHTTP::Request($url=url, $method="GET");

--- a/wiseService/source.isepxgrid.js
+++ b/wiseService/source.isepxgrid.js
@@ -624,6 +624,7 @@ exports.initSource = function (api) {
     name: 'isepxgrid',
     description: 'Enriches IPs with user identity, MAC, OS, and posture from Cisco ISE pxGrid 2.0 sessions.',
     types: ['ip'],
+    cacheable: false,
     fields: [
       { name: 'host', required: true, help: 'ISE pxGrid node hostname' },
       { name: 'port', required: false, help: 'pxGrid port (default 8910)' },


### PR DESCRIPTION
- viewer: pcap scrub buffers sized for jumbo packets, short-header scrub offset, unknown decode option returns 400 instead of hanging, SMTP MIME continuation TypeError, multiviewer refresh keeping cluster prefixes
- common: first roles-cache population race, users CSV header separator
- cont3xt: CAA critical flag hex decode, error logging in builtwith/greynoise/redis, db error handler optional chaining, IPQS URL integration duplicate display order
- parliament: upgrade no longer mutates shared defaults, issue cleanup double-splice, noPackets tracking resets when a node recovers
- db.pl: env prefix normalization, info history docs/bytes with old prefix
- wise: isepxgrid duplicate cacheAgeMin config field, molochwise.bro delete-while-iterate
- taggerUpload.pl: CRLF handling, JSON escaping
- contrib: moloch_query zero-division, netflow2arkime dup-flow drop and pending-unmatched summary
- release: freebsd job builds from the release tag, sample config fixes
- docs: supported language lists, NOTICE stale entries, integration docs
- tests: uninitialized loop vars, wrong tokens, swapped is() args, duplicated assertions replaced with case variants, tautological check

<!-- Provide a clear and descriptive title -->

**Clearly describe the problem and solution**

**Relevant issue number(s) if applicable**

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
