### PR TITLE
Time picker uses ISO year-first format with paste support and a date …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -171,6 +171,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4102 Fix session packets requests with an unknown decode option hanging forever; they now return a 400
   - #4102 Fix a session packets error when an SMTP MIME header continuation line lands on a packet chunk boundary
   - #4102 Fix multiviewer sessions refresh dropping each cluster's index prefix, so prefixed clusters were never refreshed
+  - #4103 Time picker displays YYYY/MM/DD HH:mm:ss again instead of the browser locale format, allows typing/pasting dates, and adds a date picker button
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -605,6 +605,7 @@
     "stopTime": "Ende",
     "startTimeTip": "Anfangszeit",
     "stopTimeTip": "Endzeit",
+    "openDatePickerTip": "Datumsauswahl öffnen",
     "prevStartTimeTip": "Anfang des aktuellen Tages / Vorheriger Tag",
     "nextStartTimeTip": "Anfang des nächsten Tages",
     "prevStopTimeTip": "Ende des vorherigen Tages",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -605,6 +605,7 @@
     "stopTime": "End",
     "startTimeTip": "Beginning time",
     "stopTimeTip": "Ending time",
+    "openDatePickerTip": "Open the date picker",
     "prevStartTimeTip": "Beginning of Current Day / Previous Day",
     "nextStartTimeTip": "Beginning of Next Day",
     "prevStopTimeTip": "Ending of Previous Day",

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -605,6 +605,7 @@
     "stopTime": "Fin",
     "startTimeTip": "Hora de inicio",
     "stopTimeTip": "Hora de finalización",
+    "openDatePickerTip": "Abrir el selector de fecha",
     "prevStartTimeTip": "Inicio del Día Actual / Día Anterior",
     "nextStartTimeTip": "Inicio del Día Siguiente",
     "prevStopTimeTip": "Finalización del Día Anterior",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -605,6 +605,7 @@
     "stopTime": "Lõpp",
     "startTimeTip": "Algusaeg",
     "stopTimeTip": "Lõpuaeg",
+    "openDatePickerTip": "Ava kuupäevavalija",
     "prevStartTimeTip": "Praeguse päeva algus / Eelmise päeva algus",
     "nextStartTimeTip": "Järgmise päeva algus",
     "prevStopTimeTip": "Eelmise päeva lõpp",

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -605,6 +605,7 @@
     "stopTime": "Fin",
     "startTimeTip": "Heure de début",
     "stopTimeTip": "Heure de fin",
+    "openDatePickerTip": "Ouvrir le sélecteur de date",
     "prevStartTimeTip": "Début du jour actuel / Jour précédent",
     "nextStartTimeTip": "Début du jour suivant",
     "prevStopTimeTip": "Fin du jour précédent",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -605,6 +605,7 @@
     "stopTime": "終了",
     "startTimeTip": "開始時刻",
     "stopTimeTip": "終了時刻",
+    "openDatePickerTip": "日付ピッカーを開く",
     "prevStartTimeTip": "当日/前日の開始",
     "nextStartTimeTip": "翌日の開始",
     "prevStopTimeTip": "前日の終了",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -605,6 +605,7 @@
     "stopTime": "종료",
     "startTimeTip": "시작 시간",
     "stopTimeTip": "종료 시간",
+    "openDatePickerTip": "날짜 선택기 열기",
     "prevStartTimeTip": "현재 날짜의 시작 / 이전 날짜",
     "nextStartTimeTip": "다음 날짜의 시작",
     "prevStopTimeTip": "이전 날짜의 종료",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -605,6 +605,7 @@
     "stopTime": "Fim",
     "startTimeTip": "Hora de início",
     "stopTimeTip": "Hora de término",
+    "openDatePickerTip": "Abrir o seletor de data",
     "prevStartTimeTip": "Início do Dia Atual / Dia Anterior",
     "nextStartTimeTip": "Início do Próximo Dia",
     "prevStopTimeTip": "Fim do Dia Anterior",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -606,6 +606,7 @@
     "stopTime": "Endway",
     "startTimeTip": "Eginningbay imetay",
     "stopTimeTip": "Endingway imetay",
+    "openDatePickerTip": "Openway ethay ateday ickerpay",
     "prevStartTimeTip": "Eginningbay ofway UrrentCay AyDay / EviousPray AyDay",
     "nextStartTimeTip": "Eginningbay ofway ExtNay AyDay",
     "prevStopTimeTip": "Endingway ofway EviousPray AyDay",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -605,6 +605,7 @@
     "stopTime": "结束",
     "startTimeTip": "起始时间",
     "stopTimeTip": "结束时间",
+    "openDatePickerTip": "打开日期选择器",
     "prevStartTimeTip": "当前日期的开始 / 前一天的开始",
     "nextStartTimeTip": "下一天的开始",
     "prevStopTimeTip": "前一天的结束",

--- a/viewer/vueapp/src/components/search/Time.vue
+++ b/viewer/vueapp/src/components/search/Time.vue
@@ -138,6 +138,20 @@ SPDX-License-Identifier: Apache-2.0
           @change="changeStartTime"
           @keyup.enter="changeStartTime"
           :value="localStartTime.format('YYYY/MM/DD HH:mm:ss')">
+        <BInputGroupText
+          v-if="timezone !== 'local'"
+          :id="`startTimeTimezone`"
+          class="cursor-help">
+          {{ timezone === 'gmt' ? 'UTC' : getTimezoneShort() }}
+          <BTooltip
+            target="startTimeTimezone"
+            placement="bottom"
+            :delay="{show: 500, hide: 0}"
+            noninteractive>
+            {{ timezone === 'gmt' ? 'UTC' : Intl.DateTimeFormat().resolvedOptions().timeZone }}
+            {{ timezone === 'gmt' ? new Date().getTimezoneOffset() / -60 + ':00' : '' }}
+          </BTooltip>
+        </BInputGroupText>
         <BButton
           variant="outline-secondary"
           id="startTimePicker"
@@ -160,20 +174,6 @@ SPDX-License-Identifier: Apache-2.0
             {{ $t('search.openDatePickerTip') }}
           </BTooltip>
         </BButton>
-        <BInputGroupText
-          v-if="timezone !== 'local'"
-          :id="`startTimeTimezone`"
-          class="cursor-help">
-          {{ timezone === 'gmt' ? 'UTC' : getTimezoneShort() }}
-          <BTooltip
-            target="startTimeTimezone"
-            placement="bottom"
-            :delay="{show: 500, hide: 0}"
-            noninteractive>
-            {{ timezone === 'gmt' ? 'UTC' : Intl.DateTimeFormat().resolvedOptions().timeZone }}
-            {{ timezone === 'gmt' ? new Date().getTimezoneOffset() / -60 + ':00' : '' }}
-          </BTooltip>
-        </BInputGroupText>
         <BButton
           variant="outline-secondary"
           id="prevStartTime"
@@ -233,6 +233,20 @@ SPDX-License-Identifier: Apache-2.0
           @change="changeStopTime"
           @keyup.enter="changeStopTime"
           :value="localStopTime.format('YYYY/MM/DD HH:mm:ss')">
+        <BInputGroupText
+          v-if="timezone !== 'local'"
+          :id="`stopTimeTimezone`"
+          class="cursor-help">
+          {{ timezone === 'gmt' ? 'UTC' : getTimezoneShort() }}
+          <BTooltip
+            target="stopTimeTimezone"
+            placement="bottom"
+            :delay="{show: 500, hide: 0}"
+            noninteractive>
+            {{ timezone === 'gmt' ? 'UTC' : Intl.DateTimeFormat().resolvedOptions().timeZone }}
+            {{ timezone === 'gmt' ? new Date().getTimezoneOffset() / -60 + ':00' : '' }}
+          </BTooltip>
+        </BInputGroupText>
         <BButton
           variant="outline-secondary"
           id="stopTimePicker"
@@ -255,20 +269,6 @@ SPDX-License-Identifier: Apache-2.0
             {{ $t('search.openDatePickerTip') }}
           </BTooltip>
         </BButton>
-        <BInputGroupText
-          v-if="timezone !== 'local'"
-          :id="`stopTimeTimezone`"
-          class="cursor-help">
-          {{ timezone === 'gmt' ? 'UTC' : getTimezoneShort() }}
-          <BTooltip
-            target="stopTimeTimezone"
-            placement="bottom"
-            :delay="{show: 500, hide: 0}"
-            noninteractive>
-            {{ timezone === 'gmt' ? 'UTC' : Intl.DateTimeFormat().resolvedOptions().timeZone }}
-            {{ timezone === 'gmt' ? new Date().getTimezoneOffset() / -60 + ':00' : '' }}
-          </BTooltip>
-        </BInputGroupText>
         <BButton
           variant="outline-secondary"
           id="prevStopTime"

--- a/viewer/vueapp/src/components/search/Time.vue
+++ b/viewer/vueapp/src/components/search/Time.vue
@@ -126,14 +126,40 @@ SPDX-License-Identifier: Apache-2.0
           </BTooltip>
         </BInputGroupText>
         <input
-          type="datetime-local"
+          type="text"
           tabindex="4"
           id="startTime"
           ref="startTime"
           name="startTime"
-          class="form-control"
-          @input="changeStartTime"
-          :value="localStartTime.format('YYYY-MM-DDTHH:mm:ss')">
+          class="form-control time-input"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="YYYY/MM/DD HH:mm:ss"
+          @change="changeStartTime"
+          @keyup.enter="changeStartTime"
+          :value="localStartTime.format('YYYY/MM/DD HH:mm:ss')">
+        <BButton
+          variant="outline-secondary"
+          id="startTimePicker"
+          class="cursor-pointer date-picker-btn"
+          @click="openPicker('start')">
+          <span class="fa fa-calendar" />
+          <input
+            type="datetime-local"
+            step="1"
+            tabindex="-1"
+            ref="startTimePickerInput"
+            class="date-picker-input"
+            @input="changeStartTime"
+            :value="localStartTime.format('YYYY-MM-DDTHH:mm:ss')">
+          <BTooltip
+            target="startTimePicker"
+            placement="bottom"
+            :delay="{show: 500, hide: 0}"
+            noninteractive>
+            {{ $t('search.openDatePickerTip') }}
+          </BTooltip>
+        </BButton>
         <BInputGroupText
           v-if="timezone !== 'local'"
           :id="`startTimeTimezone`"
@@ -195,14 +221,40 @@ SPDX-License-Identifier: Apache-2.0
           </BTooltip>
         </BInputGroupText>
         <input
-          type="datetime-local"
+          type="text"
           tabindex="5"
           id="stopTime"
           ref="stopTime"
           name="stopTime"
-          class="form-control"
-          @input="changeStopTime"
-          :value="localStopTime.format('YYYY-MM-DDTHH:mm:ss')">
+          class="form-control time-input"
+          autocomplete="off"
+          spellcheck="false"
+          placeholder="YYYY/MM/DD HH:mm:ss"
+          @change="changeStopTime"
+          @keyup.enter="changeStopTime"
+          :value="localStopTime.format('YYYY/MM/DD HH:mm:ss')">
+        <BButton
+          variant="outline-secondary"
+          id="stopTimePicker"
+          class="cursor-pointer date-picker-btn"
+          @click="openPicker('stop')">
+          <span class="fa fa-calendar" />
+          <input
+            type="datetime-local"
+            step="1"
+            tabindex="-1"
+            ref="stopTimePickerInput"
+            class="date-picker-input"
+            @input="changeStopTime"
+            :value="localStopTime.format('YYYY-MM-DDTHH:mm:ss')">
+          <BTooltip
+            target="stopTimePicker"
+            placement="bottom"
+            :delay="{show: 500, hide: 0}"
+            noninteractive>
+            {{ $t('search.openDatePickerTip') }}
+          </BTooltip>
+        </BButton>
         <BInputGroupText
           v-if="timezone !== 'local'"
           :id="`stopTimeTimezone`"
@@ -565,7 +617,12 @@ export default {
     },
     /* Fired when start datetime is changed */
     changeStartTime: function (e) {
-      const msDate = moment(e.target.value).valueOf();
+      const parsed = this.parseTimeInput(e.target.value);
+      if (!parsed) { // invalid input - reset the display to the current value
+        e.target.value = this.localStartTime.format('YYYY/MM/DD HH:mm:ss');
+        return;
+      }
+      const msDate = parsed.valueOf();
       this.localStartTime = moment(msDate);
       this.time.startTime = Math.floor(msDate / 1000);
       this.timeRange = '0'; // custom time range
@@ -573,11 +630,43 @@ export default {
     },
     /* Fired when stop datetime is changed */
     changeStopTime: function (e) {
-      const msDate = moment(e.target.value).valueOf();
+      const parsed = this.parseTimeInput(e.target.value);
+      if (!parsed) { // invalid input - reset the display to the current value
+        e.target.value = this.localStopTime.format('YYYY/MM/DD HH:mm:ss');
+        return;
+      }
+      const msDate = parsed.valueOf();
       this.localStopTime = moment(msDate);
       this.time.stopTime = Math.floor(msDate / 1000);
       this.timeRange = '0'; // custom time range
       this.validateDate();
+    },
+    /**
+     * Parses typed or pasted datetime text in several common formats
+     * @param {string} value the input text
+     * @returns {object|undefined} a valid moment or undefined
+     */
+    parseTimeInput: function (value) {
+      const formats = [
+        'YYYY/MM/DD HH:mm:ss', 'YYYY/MM/DD HH:mm', 'YYYY/MM/DD',
+        'YYYY-MM-DD HH:mm:ss', 'YYYY-MM-DD HH:mm', 'YYYY-MM-DD',
+        moment.ISO_8601
+      ];
+      const parsed = moment(value, formats);
+      return parsed.isValid() ? parsed : undefined;
+    },
+    /**
+     * Opens the native date picker attached to the calendar button
+     * @param {string} which start or stop
+     */
+    openPicker: function (which) {
+      const input = which === 'start' ? this.$refs.startTimePickerInput : this.$refs.stopTimePickerInput;
+      if (!input) { return; }
+      try {
+        input.showPicker();
+      } catch (e) { // showPicker unsupported or blocked - focus instead
+        input.focus();
+      }
     },
     /**
      * Determines whether the supplied time is the start of a day
@@ -902,5 +991,27 @@ export default {
 <style scoped>
 .time-range-display {
   font-size: 0.85rem;
+}
+
+.time-input {
+  min-width: 168px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* keep the native picker input rendered (showPicker needs it) but invisible
+   inside the calendar button */
+.date-picker-btn {
+  position: relative;
+}
+.date-picker-input {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  border: none;
+  padding: 0;
+  opacity: 0;
+  pointer-events: none;
 }
 </style>


### PR DESCRIPTION
…picker button

- Start/End are text inputs displaying YYYY/MM/DD HH:mm:ss like Arkime 5
- Typed or pasted dates accepted in Y/M/D, Y-M-D, and ISO forms; invalid input resets to the current value
- Calendar button opens the native browser date picker
- New search.openDatePickerTip key added to all locales

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
