### PR TITLE
Fix payload8 UTF8/Hex field mixup in sessions UI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -175,6 +175,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4103 Time picker displays YYYY/MM/DD HH:mm:ss again instead of the browser locale format, allows typing/pasting dates, and adds a date picker button
   - #4104 Fix PCAP retrieval with the writer-s3 plugin hanging queued readers forever when block decompression fails
   - #4104 Fix writer-s3 PCAP retrieval of multi-file sessions with pre-compression file records computing bogus byte ranges
+  - #4106 Fix payload8 UTF8/Hex fields: the sessions column and info field showed the UTF8 label with the hex value, and clicking the value built a broken payload8.*.utf8 expression
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors

--- a/tests/api-fresh.t
+++ b/tests/api-fresh.t
@@ -1,5 +1,5 @@
 # Tests on a fresh install
-use Test::More tests => 42;
+use Test::More tests => 46;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -83,3 +83,10 @@ my $json;
 
     $json = multiGet("/api/clusters");
     eq_or_diff($json, from_json('{"inactive": [], "active": ["test", "test2"]}'));
+
+# payload8 hex and utf8 field definitions are all served to the UI (issue #3201)
+    $json = viewerGet2("/api/fields");
+    eq_or_diff($json->{"payload8.src.hex"}, from_json('{"friendlyName":"Payload Src Hex","type":"lotermfield","exp":"payload8.src.hex","help":"First 8 bytes of source payload in hex","dbField":"srcPayload8","group":"general","dbField2":"srcPayload8","aliases":["payload.src"]}'), "payload8.src.hex field");
+    eq_or_diff($json->{"payload8.src.utf8"}, from_json('{"friendlyName":"Payload Src UTF8","type":"termfield","exp":"payload8.src.utf8","help":"First 8 bytes of source payload in utf8","dbField":"srcPayload8","group":"general","dbField2":"srcPayload8","transform":"utf8ToHex","noFacet":"true"}'), "payload8.src.utf8 field");
+    eq_or_diff($json->{"payload8.dst.hex"}, from_json('{"friendlyName":"Payload Dst Hex","type":"lotermfield","exp":"payload8.dst.hex","help":"First 8 bytes of destination payload in hex","dbField":"dstPayload8","group":"general","dbField2":"dstPayload8","aliases":["payload.dst"]}'), "payload8.dst.hex field");
+    eq_or_diff($json->{"payload8.dst.utf8"}, from_json('{"friendlyName":"Payload Dst UTF8","type":"termfield","exp":"payload8.dst.utf8","help":"First 8 bytes of destination payload in utf8","dbField":"dstPayload8","group":"general","dbField2":"dstPayload8","transform":"utf8ToHex","noFacet":"true"}'), "payload8.dst.utf8 field");

--- a/tests/general.t
+++ b/tests/general.t
@@ -1,4 +1,4 @@
-use Test::More tests => 723;
+use Test::More tests => 737;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -329,6 +329,16 @@ my $pwd = "*/pcap";
     countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.utf8=HTTP*"));
     countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.utf8=/.*TP.*/"));
     countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.utf8=/.*NOT.*/"));
+
+    countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.dst.utf8=\"HTTP/1.1\""));
+    countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.dst.utf8=HTTP*"));
+    countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.dst.utf8=/HTTP.*/"));
+    countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.dst.utf8=/.*NOT.*/"));
+    countTest(0, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.dst.utf8=\"GET / HT\""));
+
+# payload8 hex and utf8 expressions match the same session (issue #3201)
+    countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.src.hex==474554202f204854&&payload8.src.utf8=\"GET / HT\""));
+    countTest(1, "date=-1&expression=" . uri_escape("file=$pwd/http-301-get.pcap&&payload8.dst.hex==485454502f312e31&&payload8.dst.utf8=\"HTTP/1.1\""));
 
 if (0) {
 # session.segments tests

--- a/viewer/vueapp/src/store.js
+++ b/viewer/vueapp/src/store.js
@@ -224,16 +224,20 @@ const store = createStore({
 
       // fieldsMap has keys for these fields: dbField, dbField2, fieldECS, and exp (id/key)
       // fieldsAliasMap has keys for field aliases
+      // noFacet fields (search-only variants like payload8.src.utf8) must not
+      // claim the db field keys over the field that matches the stored data
+      const setDbKey = (key, field) => {
+        if (key === undefined) { return; }
+        if (!state.fieldsMap[key] || !field.noFacet) {
+          state.fieldsMap[key] = field;
+        }
+      };
       for (const key in value.fieldsMap) {
         const field = value.fieldsMap[key];
         state.fieldsMap[field.exp] = field;
-        state.fieldsMap[field.dbField] = field;
-        if (field.dbField2 !== undefined) {
-          state.fieldsMap[field.dbField2] = field;
-        }
-        if (field.fieldECS !== undefined) {
-          state.fieldsMap[field.fieldECS] = field;
-        }
+        setDbKey(field.dbField, field);
+        setDbKey(field.dbField2, field);
+        setDbKey(field.fieldECS, field);
         (field.aliases || []).forEach((alias) => {
           state.fieldsAliasMap[alias] = field;
         });


### PR DESCRIPTION
- store.js: noFacet search-only fields (payload8.*.utf8) no longer claim the dbField/dbField2 keys over the field matching the stored data, so columns show the Hex label/expression for the hex value
- tests: add payload8.dst.utf8 expression tests, combined hex+utf8 expression tests, and /api/fields definition checks

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
