### PR TITLE
Validate full s2s auth token on the sessions receive route

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -183,6 +183,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4104 Fix writer-s3 PCAP retrieval of multi-file sessions with pre-compression file records computing bogus byte ranges
   - #4105 Fix time picker inputs showing local wall clock time in UTC mode; typed/pasted times are now interpreted in the displayed timezone and may include a timezone suffix (UTC, EDT, America/Chicago, +02:00)
   - #4106 Fix payload8 UTF8/Hex fields: the sessions column and info field showed the UTF8 label with the hex value, and clicking the value built a broken payload8.*.utf8 expression
+  - #4108 Fix receive endoint S2S auth bypass via browser session - fully validate auth token (path/user/date/method)
 ## WISE
   - #4072 Fix /get stalling the entire query batch until a timeout when a single source errors
   - #4072 Fix urlapi source failing every lookup (double JSON parse) and reporting 404 misses as errors

--- a/common/auth.js
+++ b/common/auth.js
@@ -764,40 +764,9 @@ class Auth {
         return done('S2S auth header corrupt');
       }
 
-      if (!ArkimeUtil.isString(obj.path)) {
-        return done('S2S bad path');
-      }
-
-      if (!ArkimeUtil.isString(obj.user)) {
-        return done('S2S bad user');
-      }
-
-      if (typeof (obj.date) !== 'number') {
-        return done('S2S bad date');
-      }
-
-      if (obj.user.startsWith('role:')) {
-        return done('Cannot authenticate with role');
-      }
-
-      let objPath = obj.path;
-      if (Auth.#basePath.length > 1 && obj.path.startsWith(Auth.#basePath)) {
-        objPath = obj.path.substring(Auth.#basePath.length);
-      }
-      if (obj.path !== req.url && objPath !== req.url) {
-        console.log('ERROR - mismatch url object:', obj.path, 'request:', ArkimeUtil.sanitizeStr(req.url));
-        return done('Unauthorized based on bad url');
-      }
-
-      // Backwards compatible: only enforce method when the signed token includes it
-      if (obj.method !== undefined && obj.method !== req.method.toUpperCase()) {
-        console.log('ERROR - mismatch method object:', obj.method, 'request:', ArkimeUtil.sanitizeStr(req.method));
-        return done('Unauthorized based on bad method');
-      }
-
-      if (Math.abs(Date.now() - obj.date) > 120000) { // Request has to be +- 2 minutes
-        console.log('ERROR - Denying server to server based on timestamp, are clocks out of sync?', Date.now(), obj.date);
-        return done('Unauthorized based on timestamp - check that all Arkime viewer machines have accurate clocks');
+      const s2sError = Auth.validateS2SObj(obj, req);
+      if (s2sError) {
+        return done(s2sError);
       }
 
       // Don't look up user for receiveSession
@@ -1241,6 +1210,56 @@ class Auth {
       console.log(error);
       throw new Error('Incorrect auth supplied');
     }
+  }
+
+  // ----------------------------------------------------------------------------
+  // Validate a decoded x-arkime-auth object as a genuine s2s token for this
+  // request: bound to this path/method, from a real (non-role) user, with a
+  // recent timestamp. auth2obj()/JSON.parse only proves the token decrypts/parses
+  // with the serverSecret, which on its own is not sufficient. Returns an error
+  // string when invalid, or undefined when the token is a valid s2s token.
+  static validateS2SObj (obj, req) {
+    if (obj === null || typeof obj !== 'object') {
+      return 'S2S auth header corrupt';
+    }
+
+    if (!ArkimeUtil.isString(obj.path)) {
+      return 'S2S bad path';
+    }
+
+    if (!ArkimeUtil.isString(obj.user)) {
+      return 'S2S bad user';
+    }
+
+    if (typeof (obj.date) !== 'number') {
+      return 'S2S bad date';
+    }
+
+    if (obj.user.startsWith('role:')) {
+      return 'Cannot authenticate with role';
+    }
+
+    let objPath = obj.path;
+    if (Auth.#basePath.length > 1 && obj.path.startsWith(Auth.#basePath)) {
+      objPath = obj.path.substring(Auth.#basePath.length);
+    }
+    if (obj.path !== req.url && objPath !== req.url) {
+      console.log('ERROR - mismatch url object:', obj.path, 'request:', ArkimeUtil.sanitizeStr(req.url));
+      return 'Unauthorized based on bad url';
+    }
+
+    // Backwards compatible: only enforce method when the signed token includes it
+    if (obj.method !== undefined && obj.method !== req.method.toUpperCase()) {
+      console.log('ERROR - mismatch method object:', obj.method, 'request:', ArkimeUtil.sanitizeStr(req.method));
+      return 'Unauthorized based on bad method';
+    }
+
+    if (Math.abs(Date.now() - obj.date) > 120000) { // Request has to be +- 2 minutes
+      console.log('ERROR - Denying server to server based on timestamp, are clocks out of sync?', Date.now(), obj.date);
+      return 'Unauthorized based on timestamp - check that all Arkime viewer machines have accurate clocks';
+    }
+
+    return undefined;
   }
 
   // ----------------------------------------------------------------------------

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -303,10 +303,17 @@ app.use(async (req, res, next) => {
       return res.status(401).send('receive session only allowed s2s');
     }
     try {
+      let s2sObj;
       if (Config.get('s2sRegressionTests')) {
-        JSON.parse(req.headers['x-arkime-auth']);
+        s2sObj = JSON.parse(req.headers['x-arkime-auth']);
       } else {
-        Auth.auth2obj(req.headers['x-arkime-auth']);
+        s2sObj = Auth.auth2obj(req.headers['x-arkime-auth']);
+      }
+      // A decryptable token is not enough: when a request is session-authenticated
+      // the s2s passport strategy is bypassed, so this gate is the only s2s check.
+      // Fully validate the token here too, not just that it decrypts/parses.
+      if (Auth.validateS2SObj(s2sObj, req)) {
+        return res.status(401).send('receive session only allowed s2s');
       }
       return next();
     } catch (e) {


### PR DESCRIPTION
Hardens the `/api/sessions/receive` gate to fully validate the s2s auth token (path/user/date/method) instead of only checking that it decrypts. The validation is shared with the s2s passport strategy via a new `Auth.validateS2SObj`.