### PR TITLE
Fail digest auth closed on undecryptable passStore, test login open-redirect guard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,9 @@ jobs:
           (chown -R opensearch /opensearch-2.7.0; cd /opensearch-2.7.0 ; su opensearch -c "OPENSEARCH_JAVA_OPTS='-Xms1000m -Xmx1000m' bin/opensearch" > /tmp/os &)
           sleep 30
           cat /tmp/os
-          (cd tests ; G_SLICE=always-malloc ./tests.pl --viewer)
+          curl http://localhost:9200/_cat/health
+          free -h || true
+          (cd tests ; G_SLICE=always-malloc ./tests.pl --viewer --debug)
 
       - name: viewer test arkimedb
         if: ${{ matrix.viewertest == 'packetpocket' }}

--- a/common/auth.js
+++ b/common/auth.js
@@ -542,8 +542,14 @@ class Auth {
         if (!user) { console.log('AUTH: User', userId, "doesn't exist"); return done(null, false); }
         if (!user.enabled) { console.log('AUTH: User', userId, 'not enabled'); return done('Not enabled'); }
 
+        const ha1 = Auth.store2ha1(user.passStore, user.userId);
+        if (!ha1) {
+          console.log('AUTH: User', userId, 'passStore could not be decrypted, denying digest auth (check passwordSecret or reset the password)');
+          return done(null, false);
+        }
+
         user.setLastUsed();
-        return done(null, user, { ha1: Auth.store2ha1(user.passStore, user.userId) });
+        return done(null, user, { ha1 });
       });
     }, (poptions, done) => {
       return done(null, true);

--- a/tests/sessionAuth.t
+++ b/tests/sessionAuth.t
@@ -1,5 +1,5 @@
 # Session-authenticated s2s bypass regression tests (#4108)
-use Test::More tests => 14;
+use Test::More tests => 18;
 use ArkimeTest;
 use JSON;
 use strict;
@@ -49,3 +49,18 @@ $response = $ArkimeTest::userAgent->post("http://$host:$port/receiveSession", ':
 $rjson = from_json($response->content);
 is ($rjson->{success}, 0, "no-session s2s call reaches receiveSession handler");
 is ($response->code, 200, "no-session s2s call reaches receiveSession handler code");
+
+# Open redirect: a protocol-relative ogurl must not be honored on login (only same-origin paths).
+# Seed session.ogurl by hitting an unauthenticated protocol-relative path, then log in with that session.
+# Use a non-redirect-following agent so we capture the 302 + Set-Cookie instead of following to /auth.
+my $ua = LWP::UserAgent->new;
+$ua->max_redirect(0);
+my $seed = $ua->get("http://$host:$port//evil.example.com");
+my ($seedCookie) = ($seed->header('Set-Cookie') // '') =~ /^(ARKIME-SID=[^;]+)/;
+ok (defined $seedCookie, "unauthenticated request seeds a session");
+
+my $redir = $ua->post("http://$host:$port/api/login", { username => 'formtestuser', password => 'formtestuser' }, 'Cookie' => $seedCookie);
+is ($redir->code, 302, "login with seeded ogurl redirects");
+my $loc = $redir->header('Location') // '';
+isnt ($loc, '//evil.example.com', "login must not honor a protocol-relative (off-site) ogurl");
+is ($loc, '/', "login falls back to a safe same-origin path");


### PR DESCRIPTION
- Digest strategy now rejects when store2ha1 returns an empty ha1 (legacy or undecryptable passStore) instead of handing an empty ha1 to the verifier, which let anyone authenticate as that user by computing the response against ha1=''. Basic/form already failed closed; digest now matches.
- Add sessionAuth.t coverage that a protocol-relative ogurl is not honored on form login (no open redirect); safe same-origin paths still redirect.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
