### PR TITLE
Add mini-wise-source mock to test splunk and databricks wise sources

### DIFF
--- a/tests/config.wise.yaml
+++ b/tests/config.wise.yaml
@@ -68,6 +68,27 @@ file:url:
   tags: urlwise
   type: url
   format: tagger
+splunk:test:
+  type: splunktest
+  tags: splunkwise
+  host: localhost
+  port: 9998
+  username: admin
+  password: admin
+  keyPath: ip
+  query: search index=threats ip="%%SEARCHTERM%%" | fields ip, threat
+  fields: field:tags;shortcut:threat
+databricks:test:
+  type: databrickstest
+  tags: databrickswise
+  host: localhost
+  port: 9998
+  path: /sql
+  token: mock-token
+  keyPath: ip
+  periodic: 1000000
+  query: SELECT ip, threat FROM threats
+  fields: field:tags;shortcut:threat
 reversedns:
   ips: 0.0.0.0/32
   field: asset

--- a/tests/mini-wise-source.js
+++ b/tests/mini-wise-source.js
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Mini Splunk + Databricks server for testing the WISE source.splunk.js and
+ * source.databricks.js sources. Everything is in memory and all auth is
+ * ignored.
+ *
+ * Both SDKs insist on talking HTTPS to their host, so this server serves TLS
+ * with an embedded self-signed cert (CN=localhost). The splunk-sdk sets
+ * rejectUnauthorized:false itself; the databricks SDK does not, so the wise
+ * test process is launched with NODE_TLS_REJECT_UNAUTHORIZED=0 (see tests.pl).
+ *
+ * Splunk  - plain REST/JSON: /services/auth/login, /services/server/info,
+ *           and a oneshot search POST to .../search/jobs.
+ * Databricks - Thrift TBinaryProtocol over HTTP POST (Content-Type
+ *           application/x-thrift), the Hive TCLIService API. We reuse the
+ *           real thrift library + the generated TCLIService types shipped with
+ *           @databricks/sql so the wire encoding is always correct. Responses
+ *           use "direct results" so no separate fetch round-trip is needed.
+ *
+ * Usage: node mini-wise-source.js [--debug] <port>
+ *
+ * To add fake data, edit SPLUNK_ROWS / DATABRICKS_ROWS below. Each row is a
+ * plain object whose properties become columns; `ip` is the key column and the
+ * other properties are matched by the source's `fields`/`shortcut` config.
+ */
+'use strict';
+
+const https = require('https');
+const path = require('path');
+const thrift = require('thrift');
+
+// The databricks generated thrift types live outside the package `exports`
+// map, so resolve them relative to the installed package.
+const dbsqlDir = path.dirname(require.resolve('@databricks/sql'));
+const TCLIService = require(path.join(dbsqlDir, '..', 'thrift', 'TCLIService.js'));
+const ttypes = require(path.join(dbsqlDir, '..', 'thrift', 'TCLIService_types.js'));
+
+let debug = 0;
+if (process.argv[2] === '--debug') {
+  debug = 1;
+  process.argv.splice(2, 1);
+}
+const port = parseInt(process.argv[2], 10) || 9998;
+
+// ----------------------------------------------------------------------------
+// Fake data. Edit these to add/change what the sources return.
+// ----------------------------------------------------------------------------
+const SPLUNK_ROWS = [
+  { ip: '66.66.66.66', threat: 'splunk-malware' },
+  { ip: '66.66.66.67', threat: 'splunk-botnet' }
+];
+
+const DATABRICKS_ROWS = [
+  { ip: '77.77.77.77', threat: 'databricks-c2' },
+  { ip: '77.77.77.78', threat: 'databricks-phish' }
+];
+
+// ----------------------------------------------------------------------------
+// Embedded self-signed cert for localhost (valid ~100 years).
+// ----------------------------------------------------------------------------
+const KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDGW+gGgl2gI/mB
+Ng4vrriBuT6rf5jHZWm8M9mXHsrlR6pwIELNuaFl6xKCMEN3zMqmIEFUVKvWG7lJ
+PFDN4ljfNRLJRaFfbRFeYOmSWmaw6+pSfeUqJqsLZXjFQh10f0QESkS45r5LPIx1
+V6fCKPMnZ5DeIZJ+fhE9BcVJ3CHnmqjE4GJqXx8CXsbpgdwubZNwT/lFvv28miiS
+9LfjgCePRaPkinqUlqHU8guJXrFlCVhq+M90CJjtukwu++4dZ316Lx5f6nzBQzSz
+uyn202ENDZkI/b4p20og+XhEgUh/abVVskXiCkPv3wgDCa7KN6kab+LFFD7qWhU9
+A6n2/HGDAgMBAAECggEBAJBZ39+kzZe1tmQ2v1op73HQKnBJ2hf5kFn67bVRHlx+
+q+UPRS5Lkc4GpSCDGQY8zZjZzlEdkTOuV0eZkkBSIVTGXdaFSquURtiE9FWiXisQ
+dCT2I2hqXX1cqef7dk4KM6hfl+VrXj6IYLsgQCBHBrS9ZKqSifZtrgPXiDx461+M
+YDB7TBUOLgzLRAVSlICmazNM1SvyuA6xf59BT2fvdLCHYova2i6DejfkZX6svoVI
+ClWQpH+SPh7yJPwILcpa96hN2HAW4X58uSH0g76QMrl4YkuU79CseByGWWkGuRKx
+rjF/niQAlVJGRh+cm8rb/sXZPsMrnbNh9TY6b/frIlkCgYEA7QkMSbFDIjCMiBpC
+Jff+8IaoO/RhSTGhb0vQmYPzCBpZ3lB6DSV5SFAAkmaN2/eN9gsCsqkImxW/qX9a
+e/3P07CTDzM6z7zVNyCOPpNTKxT3r4gfRf5uTX6FocSULwBhdEak+jfMr78IYaJs
+J+TOB3w+iLfdCech7tKAIOaVivcCgYEA1jqwzRiewQji7dXPb/F8JciCfaMVfRkZ
+VgJ3sesUPV7shHpiFIcHiBTxkrZovM+5KwwN3pHiUL8IudoZRkRIHqf+nchy4ki1
+5dXgPngNzYmftOlE0sGkxi3+QRKaLIyXoAMGJdSTqIpUkVu18piG//HaZG+SGTKF
+YdcpnuBYPtUCgYBohbvgZwUmd2gQwBt5KLFHmOlofqvDndoE/NaAS1oIsa39RVl8
+oJCpnXWTGRvm6nO0EkjfRYBg+qcoc9sPn+1b+JnwcvO1FRykEXwIBej/r2BFC+5W
+bApxq5/7pHZ/f1h58IjhOWfN+5wTiY7NzKw5SsU8fm8+5afl6vbLC0LYIwKBgBzN
+OTXpyHY1ZqUJKOFo+wLtaTXQ9jOiaziYDlWaQFdb6rqI5aTS3p1aC3xpD73Kw59Y
++Ihi3qVyeY7bFqjOx09v0JiP+XoYwnPLBGIBrAFlLlaZQgp/xFJsnpFLGfVBVaVK
+osn1QYDYUDRWuyiJfyTr9CuqoF7I3wvfbJYSnWqdAoGAOa/UHk1QotM96TNsfM5j
+2rXzIEtF0JbuBqKHjFetnWV1AdQAvbepfHd5V5oN2FKLX+pam4BPNDkCDMFAUe5V
+rOgXIqepvAWHl/1QREsisltRgHZSheNSF1k3n+XB7IiK7c87Mlf++enmWWUVxw63
+qEBsMPdlCLQbx2l4nG47p1k=
+-----END PRIVATE KEY-----`;
+
+const CERT = `-----BEGIN CERTIFICATE-----
+MIICyzCCAbOgAwIBAgIJAP+sa1l20MjhMA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDAgFw0yNjA3MTAxNTQwNDJaGA8yMTI2MDYxNjE1NDA0Mlow
+FDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEAxlvoBoJdoCP5gTYOL664gbk+q3+Yx2VpvDPZlx7K5UeqcCBCzbmhZesS
+gjBDd8zKpiBBVFSr1hu5STxQzeJY3zUSyUWhX20RXmDpklpmsOvqUn3lKiarC2V4
+xUIddH9EBEpEuOa+SzyMdVenwijzJ2eQ3iGSfn4RPQXFSdwh55qoxOBial8fAl7G
+6YHcLm2TcE/5Rb79vJookvS344Anj0Wj5Ip6lJah1PILiV6xZQlYavjPdAiY7bpM
+LvvuHWd9ei8eX+p8wUM0s7sp9tNhDQ2ZCP2+KdtKIPl4RIFIf2m1VbJF4gpD798I
+AwmuyjepGm/ixRQ+6loVPQOp9vxxgwIDAQABox4wHDAaBgNVHREEEzARgglsb2Nh
+bGhvc3SHBH8AAAEwDQYJKoZIhvcNAQELBQADggEBAKHLvK7xVDmzzoaqAMwxPfyF
+BCzEXHcLWHTHhGXGgV45roMoBVvjCiuXVq0mNcfuKN69RlbaaoAmyaPMZFEsTBRG
+3JSmN6a0uHX+2yohQWj2avvzpPKzCl4DxpS02X/E4HiVl2ymAydkC3KHe7ZUnss8
+Rx3jRiE/TC3lj4NBqerjEoB9ddptmzaef30+yOXffmZborIKe60gsaCO+LrTvN1i
+7YlCLrkGF65NZal7Xn89JbIruxVauOlqeKcl/dmJM/0K4f6R4+Q9Mzlg/anCvn2g
+JAX0pBPenRVmpFPfupy4B7ezQBytmQf9JWpwzlREuKznN4ivMMDDxZ5sQSK+3gQ=
+-----END CERTIFICATE-----`;
+
+function log (...args) {
+  if (debug) { console.log(...args); }
+}
+
+// ----------------------------------------------------------------------------
+// Splunk REST emulation
+// ----------------------------------------------------------------------------
+function splunkResults (rows) {
+  // Shape matches what oneshotSearch({output_mode:'json'}) returns.
+  return JSON.stringify({
+    preview: false,
+    init_offset: 0,
+    fields: [{ name: 'ip' }, { name: 'threat' }],
+    results: rows
+  });
+}
+
+function handleSplunk (req, res, body) {
+  const url = req.url.split('?')[0];
+
+  if (url === '/services/auth/login') {
+    // The SDK reads response.data.sessionKey
+    return sendJSON(res, { sessionKey: 'mini-wise-session' });
+  }
+
+  if (url === '/services/server/info') {
+    // The SDK reads response.data.generator.version
+    return sendJSON(res, {
+      generator: { version: '9.0.0', instance_type: 'mini' },
+      entry: [{ name: 'mini', content: { version: '9.0.0' } }]
+    });
+  }
+
+  if (url.endsWith('/search/jobs')) {
+    // The source has already substituted %%SEARCHTERM%% into the search, so
+    // match any known key that appears in the query string.
+    const search = decodeURIComponent((body.match(/(?:^|&)search=([^&]*)/) || [])[1] || '');
+    const rows = SPLUNK_ROWS.filter((r) => search.includes(r.ip));
+    log(`SPLUNK oneshot search=${search} -> ${rows.length} row(s)`);
+    return send(res, 200, 'application/json', splunkResults(rows));
+  }
+
+  log(`SPLUNK 404 ${req.method} ${req.url}`);
+  return send(res, 404, 'application/json', '{}');
+}
+
+// ----------------------------------------------------------------------------
+// Databricks Thrift (TCLIService) emulation
+// ----------------------------------------------------------------------------
+// Must be a valid v4 UUID (byte 6 high nibble = 4, byte 8 high nibble = 8..b):
+// the SDK runs guid through uuid.stringify() which validates it.
+const GUID = Buffer.from([0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0x4c, 0xde, 0x8f, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd]);
+const SECRET = Buffer.from('fedcba9876543210', 'utf8');  // 16 bytes, opaque
+
+function okStatus () {
+  return new ttypes.TStatus({ statusCode: ttypes.TStatusCode.SUCCESS_STATUS });
+}
+
+function handleIdentifier () {
+  return new ttypes.THandleIdentifier({ guid: GUID, secret: SECRET });
+}
+
+// Build a COLUMN_BASED result set + metadata for the given rows.
+function buildResultSetMetadata () {
+  const columns = ['ip', 'threat'].map((colName, i) => new ttypes.TColumnDesc({
+    columnName: colName,
+    typeDesc: new ttypes.TTypeDesc({
+      types: [new ttypes.TTypeEntry({
+        primitiveEntry: new ttypes.TPrimitiveTypeEntry({ type: ttypes.TTypeId.STRING_TYPE })
+      })]
+    }),
+    position: i + 1
+  }));
+
+  return new ttypes.TGetResultSetMetadataResp({
+    status: okStatus(),
+    resultFormat: ttypes.TSparkRowSetType.COLUMN_BASED_SET,
+    schema: new ttypes.TTableSchema({ columns })
+  });
+}
+
+function stringColumn (values) {
+  return new ttypes.TColumn({
+    stringVal: new ttypes.TStringColumn({ values, nulls: Buffer.alloc(0) })
+  });
+}
+
+function buildRowSet (rows) {
+  return new ttypes.TRowSet({
+    startRowOffset: 0,
+    rows: [],
+    columns: [
+      stringColumn(rows.map((r) => r.ip)),
+      stringColumn(rows.map((r) => r.threat))
+    ]
+  });
+}
+
+const databricksHandler = {
+  OpenSession (req, cb) {
+    log('DATABRICKS OpenSession');
+    cb(null, new ttypes.TOpenSessionResp({
+      status: okStatus(),
+      // Advertise the newest protocol so the client will send named
+      // parameters (needs >= V8). Result format is still forced to
+      // COLUMN_BASED_SET below, so no Arrow/LZ4 handling is needed.
+      serverProtocolVersion: ttypes.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V9,
+      sessionHandle: new ttypes.TSessionHandle({ sessionId: handleIdentifier() })
+    }));
+  },
+
+  ExecuteStatement (req, cb) {
+    log(`DATABRICKS ExecuteStatement: ${req.statement}`);
+    // Non-periodic queries carry a SEARCHTERM named parameter; periodic
+    // queries carry none and want the whole table.
+    let rows = DATABRICKS_ROWS;
+    const term = searchTermParam(req);
+    if (term !== undefined) {
+      rows = DATABRICKS_ROWS.filter((r) => r.ip === term);
+    }
+
+    const operationHandle = new ttypes.TOperationHandle({
+      operationId: handleIdentifier(),
+      operationType: ttypes.TOperationType.EXECUTE_STATEMENT,
+      hasResultSet: true
+    });
+
+    cb(null, new ttypes.TExecuteStatementResp({
+      status: okStatus(),
+      operationHandle,
+      directResults: new ttypes.TSparkDirectResults({
+        operationStatus: new ttypes.TGetOperationStatusResp({
+          status: okStatus(),
+          operationState: ttypes.TOperationState.FINISHED_STATE
+        }),
+        resultSetMetadata: buildResultSetMetadata(),
+        resultSet: new ttypes.TFetchResultsResp({
+          status: okStatus(),
+          hasMoreRows: false,
+          results: buildRowSet(rows)
+        }),
+        closeOperation: new ttypes.TCloseOperationResp({ status: okStatus() })
+      })
+    }));
+  },
+
+  // Defensive fallbacks in case the client does not use direct results.
+  GetOperationStatus (req, cb) {
+    cb(null, new ttypes.TGetOperationStatusResp({
+      status: okStatus(),
+      operationState: ttypes.TOperationState.FINISHED_STATE
+    }));
+  },
+  GetResultSetMetadata (req, cb) {
+    cb(null, buildResultSetMetadata());
+  },
+  FetchResults (req, cb) {
+    cb(null, new ttypes.TFetchResultsResp({
+      status: okStatus(),
+      hasMoreRows: false,
+      results: buildRowSet(DATABRICKS_ROWS)
+    }));
+  },
+  CloseOperation (req, cb) {
+    cb(null, new ttypes.TCloseOperationResp({ status: okStatus() }));
+  },
+  CloseSession (req, cb) {
+    cb(null, new ttypes.TCloseSessionResp({ status: okStatus() }));
+  }
+};
+
+// Pull the SEARCHTERM named-parameter string value out of an ExecuteStatement
+// request, or undefined if there isn't one.
+function searchTermParam (req) {
+  if (!req.parameters) { return undefined; }
+  for (const p of req.parameters) {
+    if (p.name === 'SEARCHTERM' && p.value && p.value.stringValue !== undefined && p.value.stringValue !== null) {
+      return p.value.stringValue;
+    }
+  }
+  return undefined;
+}
+
+function handleThrift (req, res, bodyBuf) {
+  const processor = new TCLIService.Processor(databricksHandler);
+  const outChunks = [];
+  const outTransport = new thrift.TBufferedTransport(null, (buf) => outChunks.push(buf));
+  const outProtocol = new thrift.TBinaryProtocol(outTransport);
+
+  const receiver = thrift.TBufferedTransport.receiver((inTransport) => {
+    const inProtocol = new thrift.TBinaryProtocol(inTransport);
+    try {
+      processor.process(inProtocol, outProtocol);
+      // Our handlers reply synchronously, so the response is fully flushed now.
+      send(res, 200, 'application/x-thrift', Buffer.concat(outChunks));
+    } catch (err) {
+      log('DATABRICKS thrift error', err);
+      send(res, 500, 'text/plain', 'thrift error');
+    }
+  });
+  receiver(bodyBuf);
+}
+
+// ----------------------------------------------------------------------------
+// HTTP plumbing
+// ----------------------------------------------------------------------------
+function send (res, code, type, body) {
+  res.writeHead(code, { 'Content-Type': type, 'Content-Length': Buffer.byteLength(body) });
+  res.end(body);
+}
+
+function sendJSON (res, obj) {
+  send(res, 200, 'application/json', JSON.stringify(obj));
+}
+
+const server = https.createServer({ key: KEY, cert: CERT }, (req, res) => {
+  const chunks = [];
+  req.on('data', (c) => chunks.push(c));
+  req.on('end', () => {
+    const bodyBuf = Buffer.concat(chunks);
+
+    if (req.url.split('?')[0] === '/_shutdown') {
+      send(res, 200, 'text/plain', 'bye');
+      return server.close(() => process.exit(0));
+    }
+
+    if ((req.headers['content-type'] || '').includes('application/x-thrift')) {
+      return handleThrift(req, res, bodyBuf);
+    }
+
+    return handleSplunk(req, res, bodyBuf.toString('utf8'));
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  console.log(`mini-wise-source listening on port ${port}`);
+});
+
+process.on('SIGINT', () => process.exit(0));

--- a/tests/tests.pl
+++ b/tests/tests.pl
@@ -17,6 +17,8 @@ use ArkimeTest;
 use Socket6 qw(AF_INET6 inet_pton);
 
 $main::userAgent = LWP::UserAgent->new(timeout => 20, keep_alive => 10);
+# Allow the self-signed cert used by mini-wise-source.js (https shutdown, etc)
+$main::userAgent->ssl_opts(SSL_verify_mode => 0, verify_hostname => 0);
 
 my $ELASTICSEARCH = $ENV{ELASTICSEARCH} = "http://127.0.0.1:9200";
 my $USERSELASTICSEARCH = $ENV{USERSELASTICSEARCH} || $ELASTICSEARCH;
@@ -348,6 +350,7 @@ sub doShutdown {
     $main::userAgent->post("http://localhost:7200/regressionTests/shutdown");
     if (my $rs2 = IO::Socket::INET->new(PeerAddr => "127.0.0.1", PeerPort => 7379, Proto => "tcp")) { $rs2->autoflush(1); print $rs2 "*1\r\n\$8\r\nSHUTDOWN\r\n"; my $resp = <$rs2>; $rs2->close(); }
     eval { $main::userAgent->get("http://localhost:4566/_shutdown"); };
+    eval { $main::userAgent->get("https://localhost:9998/_shutdown"); };
 }
 
 sub doViewer {
@@ -384,16 +387,23 @@ my ($cmd) = @_;
         if ($main::debug) {
             system("perl mini-redis.pl --debug 7379 > /tmp/arkime.redis 2>&1 &");
             system("perl mini-aws.pl --debug 4566 > /tmp/arkime.aws 2>&1 &");
+            system("node mini-wise-source.js --debug 9998 > /tmp/arkime.wisesource 2>&1 &");
         } else {
             system("perl mini-redis.pl 7379 &");
             system("perl mini-aws.pl 4566 &");
+            system("node mini-wise-source.js 9998 > /dev/null &");
         }
+
+        # WISE connects to the mock Splunk/Databricks server at startup, so wait for it first
+        waitFor($ArkimeTest::host, 9998, 1);
+
+        # NODE_TLS_REJECT_UNAUTHORIZED=0 lets the databricks SDK accept the mock's self-signed cert
         my $wes = "-o 'wiseService.usersElasticsearch=$USERSELASTICSEARCH'";
         print ("Starting WISE\n");
         if ($main::debug) {
-            system("cd ../wiseService ; $node wiseService.js $wes $INSECURE --webcode thecode --webconfig --regressionTests -c ../tests/config.wise.yaml > /tmp/arkime.wise &");
+            system("cd ../wiseService ; NODE_TLS_REJECT_UNAUTHORIZED=0 $node wiseService.js $wes $INSECURE --webcode thecode --webconfig --regressionTests -c ../tests/config.wise.yaml > /tmp/arkime.wise &");
         } else {
-            system("cd ../wiseService ; $node wiseService.js $wes $INSECURE --webcode thecode --webconfig --regressionTests -c ../tests/config.wise.yaml > /dev/null &");
+            system("cd ../wiseService ; NODE_TLS_REJECT_UNAUTHORIZED=0 $node wiseService.js $wes $INSECURE --webcode thecode --webconfig --regressionTests -c ../tests/config.wise.yaml > /dev/null &");
         }
 
         waitFor($ArkimeTest::host, 8081, 1);

--- a/tests/wise.t
+++ b/tests/wise.t
@@ -1,5 +1,5 @@
 # WISE tests
-use Test::More tests => 160;
+use Test::More tests => 167;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
@@ -269,13 +269,48 @@ $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/file:mac/mac/
 eq_or_diff($wise, '[{"field":"tags","len":10,"value":"wisebymac1"},
 {"field":"tags","len":7,"value":"macwise"}]',"file:mac query");
 
+# Splunk source (non-periodic, per-key oneshot search against mini-wise-source.js)
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/splunktest/66.66.66.66")->content;
+$wise = [sort { $a->{value} cmp $b->{value}} @{from_json($wise)}];
+eq_or_diff($wise, from_json('[{"field":"tags","len":14,"value":"splunk-malware"},
+{"field":"tags","len":10,"value":"splunkwise"}]'), "splunk 66.66.66.66");
+
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/splunktest/66.66.66.67")->content;
+$wise = [sort { $a->{value} cmp $b->{value}} @{from_json($wise)}];
+eq_or_diff($wise, from_json('[{"field":"tags","len":13,"value":"splunk-botnet"},
+{"field":"tags","len":10,"value":"splunkwise"}]'), "splunk 66.66.66.67");
+
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/splunktest/1.2.3.4")->content;
+eq_or_diff($wise, '[]', "splunk miss");
+
+# Databricks source (periodic full-table query, cached at startup, against mini-wise-source.js)
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/databrickstest/77.77.77.77")->content;
+$wise = [sort { $a->{value} cmp $b->{value}} @{from_json($wise)}];
+eq_or_diff($wise, from_json('[{"field":"tags","len":13,"value":"databricks-c2"},
+{"field":"tags","len":14,"value":"databrickswise"}]'), "databricks 77.77.77.77");
+
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/databrickstest/77.77.77.78")->content;
+$wise = [sort { $a->{value} cmp $b->{value}} @{from_json($wise)}];
+eq_or_diff($wise, from_json('[{"field":"tags","len":16,"value":"databricks-phish"},
+{"field":"tags","len":14,"value":"databrickswise"}]'), "databricks 77.77.77.78");
+
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/databrickstest/9.9.9.9")->content;
+eq_or_diff($wise, '[]', "databricks miss");
+
+$wise = "[" . $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/dump/databricks:test")->content . "]";
+@wise = sort { $a->{key} cmp $b->{key}} @{from_json($wise, {relaxed=>1})};
+eq_or_diff(\@wise, from_json('[
+{"key":"77.77.77.77","ops":[{"field":"tags","len":14,"value":"databrickswise"},{"field":"tags","len":13,"value":"databricks-c2"}]},
+{"key":"77.77.77.78","ops":[{"field":"tags","len":14,"value":"databrickswise"},{"field":"tags","len":16,"value":"databricks-phish"}]}
+]', {relaxed=>1}), "databricks:test dump");
+
 # Sources
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/sources")->content;
-eq_or_diff($wise, '["fieldactions:test","file:domain","file:email","file:ip","file:ipcsv","file:ipjson","file:ipjsonl","file:ipjsonnested","file:ja3","file:mac","file:md5","file:sha256","file:url","reversedns","url:aws-ips","url:gcloud-ips4","url:gcloud-ips6","valueactions:test"]',"/sources");
+eq_or_diff($wise, '["databricks:test","fieldactions:test","file:domain","file:email","file:ip","file:ipcsv","file:ipjson","file:ipjsonl","file:ipjsonnested","file:ja3","file:mac","file:md5","file:sha256","file:url","reversedns","splunk:test","url:aws-ips","url:gcloud-ips4","url:gcloud-ips6","valueactions:test"]',"/sources");
 
 # Types
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/types")->content;
-eq_or_diff($wise, '["domain","email","ip","ja3","mac","md5","sha256","url"]',"types");
+eq_or_diff($wise, '["databrickstest","domain","email","ip","ja3","mac","md5","sha256","splunktest","url"]',"types");
 
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/types/file:ip")->content;
 eq_or_diff($wise, '["ip"]',"types file:ip");

--- a/wiseService/source.databricks.js
+++ b/wiseService/source.databricks.js
@@ -17,6 +17,7 @@ class DatabricksSource extends WISESource {
     super(api, section, { typeSetting: true, tagsSetting: true });
 
     this.host = api.getConfig(section, 'host');
+    this.port = api.getConfig(section, 'port');
     this.path = api.getConfig(section, 'path');
     this.token = api.getConfig(section, 'token');
     this.query = api.getConfig(section, 'query');
@@ -46,6 +47,7 @@ class DatabricksSource extends WISESource {
 
     client.connect({
       host: this.host,
+      port: this.port,
       path: this.path,
       token: this.token
     }).then(async (client2) => {
@@ -196,6 +198,7 @@ exports.initSource = function (api) {
       { name: 'type', required: true, help: 'The wise query type this source supports' },
       { name: 'tags', required: false, help: 'Comma separated list of tags to set for matches', regex: '^[-a-z0-9,]+' },
       { name: 'host', required: true, help: 'The Databricks hostname' },
+      { name: 'port', required: false, help: 'The Databricks port (defaults to 443)' },
       { name: 'path', required: true, help: 'The Databricks path' },
       { name: 'token', required: true, password: true, help: 'The Databricks token' },
       { name: 'keyPath', required: true, help: 'The path to use from the returned data to use as the key' },


### PR DESCRIPTION
- tests/mini-wise-source.js: Node HTTPS mock emulating Splunk REST and Databricks Thrift (TCLIService via the real thrift lib), with editable fake data
- config.wise.yaml: add splunk:test (non-periodic) and databricks:test (periodic) sources on isolated custom types
- wise.t: add query/miss/dump tests for both sources, update /sources and /types assertions
- tests.pl: launch/shutdown the mock, run WISE with NODE_TLS_REJECT_UNAUTHORIZED=0 for the mock's self-signed cert
- source.databricks.js: support optional port config so a local mock is reachable (SDK otherwise hardcodes 443)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
