### PR TITLE
Polish stats sub-navbars, users/roles search, and sticky sessions

### DIFF
--- a/common/vueapp/Roles.vue
+++ b/common/vueapp/Roles.vue
@@ -4,27 +4,39 @@ SPDX-License-Identifier: Apache-2.0
 -->
 <template>
   <div class="container-fluid roles-page">
-    <div class="d-flex align-items-center mt-3 mb-2">
-      <div class="me-2 flex-grow-1">
-        <v-text-field
-          autofocus
-          density="compact"
-          variant="outlined"
-          hide-details
-          clearable
-          prepend-inner-icon="fa:fa-search"
-          v-model="searchTerm"
-          :placeholder="$t('users.rolesSearchPlaceholder')" />
+    <div class="d-flex align-center mt-2 mb-2">
+      <div class="ms-1 me-1 flex-grow-1">
+        <div class="arkime-input-group arkime-input-group--fluid">
+          <span class="arkime-input-label arkime-input-label-fw">
+            <v-icon icon="mdi-magnify" />
+          </span>
+          <input
+            type="text"
+            class="arkime-input-control"
+            v-focus="true"
+            v-model="searchTerm"
+            :placeholder="$t('users.rolesSearchPlaceholder')">
+          <v-btn
+            v-if="searchTerm"
+            variant="text"
+            size="x-small"
+            density="comfortable"
+            icon
+            class="arkime-input-append-btn"
+            :aria-label="$t('common.clear')"
+            @click="searchTerm = ''">
+            <v-icon icon="mdi-close" />
+          </v-btn>
+        </div>
       </div>
-      <h4>
-        <v-icon
-          icon="mdi-information"
-          class="ms-2 cursor-help"
-          id="roles-page-tip" />
-        <v-tooltip activator="#roles-page-tip">
-          <span v-html="$t('roles.pageTip')" />
-        </v-tooltip>
-      </h4>
+      <v-icon
+        icon="mdi-information"
+        size="large"
+        class="me-1 cursor-help align-self-center"
+        id="roles-page-tip" />
+      <v-tooltip activator="#roles-page-tip">
+        <span v-html="$t('roles.pageTip')" />
+      </v-tooltip>
     </div>
 
     <!-- loading -->
@@ -80,6 +92,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+import Focus from './Focus.vue';
 import UserDropdown from './UserDropdown.vue';
 import UserService from './UserService';
 import { parseRoles, searchRoles } from './vueFilters.js';
@@ -87,6 +100,7 @@ import { parseRoles, searchRoles } from './vueFilters.js';
 export default {
   name: 'RolesCommon',
   emits: ['update-current-user'],
+  directives: { Focus },
   components: {
     UserDropdown
   },

--- a/common/vueapp/Users.vue
+++ b/common/vueapp/Users.vue
@@ -5,17 +5,29 @@ SPDX-License-Identifier: Apache-2.0
 <template>
   <div>
     <!-- search/paging/download chrome -->
-    <div class="d-flex align-center mt-3 mb-2 ga-2">
-      <v-text-field
-        autofocus
-        density="compact"
-        variant="outlined"
-        hide-details
-        clearable
-        prepend-inner-icon="mdi:mdi-magnify"
-        v-model="searchTerm"
-        :placeholder="$t('users.searchPlaceholder')"
-        class="flex-grow-1 align-self-center" />
+    <div class="d-flex align-center mt-2 mb-2 ga-2">
+      <div class="arkime-input-group arkime-input-group--fluid align-self-center ms-1">
+        <span class="arkime-input-label arkime-input-label-fw">
+          <v-icon icon="mdi-magnify" />
+        </span>
+        <input
+          type="text"
+          class="arkime-input-control"
+          v-focus="true"
+          v-model="searchTerm"
+          :placeholder="$t('users.searchPlaceholder')">
+        <v-btn
+          v-if="searchTerm"
+          variant="text"
+          size="x-small"
+          density="comfortable"
+          icon
+          class="arkime-input-append-btn"
+          :aria-label="$t('common.clear')"
+          @click="searchTerm = ''">
+          <v-icon icon="mdi-close" />
+        </v-btn>
+      </div>
       <ArkimePaging
         class="align-self-center"
         :records-filtered="recordsFiltered"
@@ -26,7 +38,7 @@ SPDX-License-Identifier: Apache-2.0
         size="small"
         color="secondary"
         variant="outlined"
-        class="align-self-center"
+        class="align-self-center me-1"
         @click="download"
         :title="$t('users.downloadCSVTip')">
         <v-icon icon="mdi:mdi-download" />
@@ -459,6 +471,7 @@ SPDX-License-Identifier: Apache-2.0
 </template>
 
 <script>
+import Focus from './Focus.vue';
 import HasRole from './HasRole.vue';
 import UserCreate from './UserCreate.vue';
 import UserService from './UserService.js';
@@ -474,7 +487,7 @@ let userChangeTimeout;
 
 export default {
   name: 'UsersCommon',
-  directives: { HasRole },
+  directives: { HasRole, Focus },
   components: {
     UserCreate,
     RoleDropdown,

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -762,6 +762,7 @@ SPDX-License-Identifier: Apache-2.0
           class="sticky-sessions"
           v-if="stickySessions.length"
           :ms="user.settings.ms"
+          :viz-visible="vizVisible"
           :sessions="stickySessions"
           @close-session="closeSession"
           @close-all-sessions="closeAllSessions" />
@@ -997,6 +998,14 @@ export default {
     },
     hideViz: function () {
       return this.$store.state.hideViz;
+    },
+    // any visualization (timeline graph and/or map) is showing when there's
+    // graph data, the toolbars/viz are shown, and viz isn't hidden/disabled —
+    // StickySessions drops its tab below the viz then. disabledAggregations
+    // shows a centered "hide graph" alert instead, so the tab stays up there.
+    vizVisible: function () {
+      return !!this.graphData && this.showToolBars && !this.hideViz &&
+        !this.$store.state.disabledAggregations;
     },
     dlWidth: {
       get: function () {

--- a/viewer/vueapp/src/components/sessions/StickySessions.vue
+++ b/viewer/vueapp/src/components/sessions/StickySessions.vue
@@ -11,15 +11,11 @@ SPDX-License-Identifier: Apache-2.0
     <teleport to="body">
       <div
         class="sticky-session-btn bounce"
-        :style="showToolBars ? null : { top: '4px', zIndex: 8 }"
+        :style="btnStyle"
         ref="stickyContainer"
         @click="toggleStickySessions"
-        v-if="sortedSessions && sortedSessions.length > 0">
-        <v-icon
-          icon="mdi-chevron-double-left"
-          v-if="!open" /><v-icon
-            icon="mdi-chevron-double-right"
-            v-else />&nbsp;
+        v-if="!open && sortedSessions && sortedSessions.length > 0">
+        <v-icon icon="mdi-chevron-double-left" />&nbsp;
         <small>{{ sortedSessions.length }}</small>
         <v-tooltip activator="parent">
           {{ $t('sessions.sticky.toggleOpenTip') }}
@@ -37,7 +33,7 @@ SPDX-License-Identifier: Apache-2.0
         <ul class="sticky-list">
           <li class="sticky-list-item sticky-list-header">
             <div class="d-flex align-center gap-1">
-              <h4 class="mb-0 flex-grow-1">
+              <h4 class="mb-0 me-auto">
                 {{ $t('sessions.sticky.openSessionCount', sortedSessions.length) }}
               </h4>
               <div class="arkime-input-group sort-by-select">
@@ -79,6 +75,17 @@ SPDX-License-Identifier: Apache-2.0
                 <v-icon icon="mdi-chevron-down" />
                 <v-tooltip activator="parent">
                   {{ $t('sessions.sticky.sortAscTip') }}
+                </v-tooltip>
+              </v-btn>
+              <v-btn
+                variant="outlined"
+                size="small"
+                density="comfortable"
+                icon
+                @click="toggleStickySessions">
+                <v-icon icon="mdi-chevron-double-right" />
+                <v-tooltip activator="parent">
+                  {{ $t('sessions.sticky.toggleOpenTip') }}
                 </v-tooltip>
               </v-btn>
               <v-btn
@@ -150,6 +157,10 @@ export default {
     ms: {
       type: Boolean,
       default: false
+    },
+    vizVisible: {
+      type: Boolean,
+      default: false
     }
   },
   data: function () {
@@ -191,6 +202,15 @@ export default {
     // button/panel up to the top
     showToolBars: function () {
       return this.$store.state.showToolBars;
+    },
+    // tab position: rides to the top when the toolbar is collapsed; drops
+    // below the visualization (timeline/map) when any viz is showing so it
+    // clears the viz's top-right controls; otherwise sits just below the
+    // toolbar chrome.
+    btnStyle: function () {
+      if (!this.showToolBars) { return { top: '4px', zIndex: 8 }; }
+      if (this.vizVisible) { return { top: 'calc(var(--arkime-navbar-height, 36px) + 300px)' }; }
+      return { top: 'calc(var(--arkime-navbar-height, 36px) + 105px)' };
     },
     /**
      * Orders the sessions by start or stop time
@@ -261,14 +281,16 @@ export default {
 </script>
 
 <style scoped>
-/* viewport-fixed: the button (body-teleported) paints over the toolbar
-   chrome; the panel stays in the overlay and slides under it (chrome z5 >
-   overlay z4). When the toolbar collapses, :style rides both up to the top. */
+/* viewport-fixed tab handle: sits just below the toolbar chrome at the
+   top of the panel so it clears the fetch-viz gear that floats in the
+   paging bar above. Body-teleported; the panel slides in beneath it
+   (btn z5 > panel z4). When the toolbar collapses, :style rides both up
+   to the top. Kept in sync with .sticky-session-detail's top. */
 .sticky-session-btn {
   width: 100px;
   display: block;
   position: fixed;
-  top: 86px;
+  top: calc(var(--arkime-navbar-height, 36px) + 96px);
   right: 0;
   z-index: 5;
   margin-right: -50px;
@@ -287,7 +309,9 @@ export default {
 .sticky-session-detail {
   overflow-y: auto;
   position: fixed;
-  top: 168px;
+  /* navbar height + page-toolbar (search bar + paging bar) so the panel
+     starts right below the chrome */
+  top: calc(var(--arkime-navbar-height, 36px) + 96px);
   right: 0;
   bottom: 0;
   z-index: 4;

--- a/viewer/vueapp/src/components/stats/Stats.vue
+++ b/viewer/vueapp/src/components/stats/Stats.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
       <ArkimeCollapsible>
         <div class="page-toolbar">
           <!-- stats sub navbar -->
-          <v-row class="g-1 stats-form p-1 align-center justify-start page-subnav">
+          <v-row class="g-1 stats-form px-1 pt-2 pb-1 align-center justify-start page-subnav">
             <v-col
               cols="auto"
               class="flex-grow-1"
@@ -924,12 +924,12 @@ export default {
 <style>
 /* The tab strip lives inside its own sub-navbar bar -- a tinted
    horizontal band fixed at the top of the page that contains the
-   pill-style v-btn-toggle. Matches the visual rhythm of stats-form
-   (the search/cluster/refresh row above) but uses a different theme
-   tint so the two rows read as separate strata. */
+   pill-style v-btn-toggle. Uses the same quaternary-lightest tint as
+   the sub-navbars on sessions/spiview/arkime; the border + shadow keep
+   it visually distinct from the stats-form row above. */
 .stats-tabs .stats-tab-bar {
   padding: 6px 12px;
-  background-color: rgb(var(--v-theme-secondary-lightest));
+  background-color: rgb(var(--v-theme-quaternary-lightest));
   border-bottom: 1px solid rgb(var(--v-theme-neutral-light));
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
 }
@@ -1002,10 +1002,12 @@ export default {
 
 <style scoped>
 
-/* apply theme colors to subnavbar */
+/* search sub-navbar: secondary-lightest to match the search band on
+   sessions/spiview/arkime (the tab strip below is the quaternary-lightest
+   sub-sub navbar) */
 .stats-form {
   z-index : 6;
-  background-color: rgb(var(--v-theme-quaternary-lightest));
+  background-color: rgb(var(--v-theme-secondary-lightest));
 }
 
 /* remove browser styles on select box (mostly for border-radius) */

--- a/viewer/vueapp/src/components/users/Users.vue
+++ b/viewer/vueapp/src/components/users/Users.vue
@@ -3,7 +3,7 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div class="arkime-container-fluid">
+  <div>
     <UsersCommon
       :roles="userRoles"
       parent-app="Arkime"


### PR DESCRIPTION
Viewer UI polish on dev7:
- Stats: two-tone search + tab sub-navbars, more top padding
- Users/Roles: Arkime-style search input and aligned margins
- Sticky sessions: viz-aware tab position, hide tab when open, header collapse button