### PR TITLE
Port fixes: session save, hunt field fetches, viewer error handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,12 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 6.6.1 2026/08/xx
+## Capture
+  - #4120 Fix offline pcap runs (-r/-R) loading the stopped-sessions state file
+## Viewer
+  - #4120 Fix error responses crashing with an unhandled rejection when a session API handler passed an Error object to res.end
+  - #4120 Fix addTagsList/removeTagsList completion callback not being reliably called
+  - #4120 Hunts now fetch only the packet-related session fields instead of all fields, speeding up hunts on sessions with many fields
 
 6.6.0 2026/07/09
 ## Breaking

--- a/capture/session.c
+++ b/capture/session.c
@@ -1331,10 +1331,9 @@ void arkime_session_init()
     arkime_add_can_quit(arkime_session_need_save_outstanding, "session save outstanding");
 
     // The stopped-sessions state file persists "stop saving" decisions across
-    // restarts. In dryRun (e.g. --tests) we never write pcap, so reading/writing
-    // it only makes regression runs non-deterministic; skip it entirely.
+    // restarts. Only write for live captures.
     snprintf(stoppedFilename, sizeof(stoppedFilename), "%s.stoppedsessions", config.nodeName);
-    if (!config.dryRun) {
+    if (!config.dryRun && !config.pcapReadOffline) {
         g_timeout_add_seconds(10, arkime_session_save_stopped, 0);
         arkime_session_load_stopped();
     }

--- a/tests/api-multiunique.t
+++ b/tests/api-multiunique.t
@@ -1,4 +1,4 @@
-use Test::More tests => 40;
+use Test::More tests => 42;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -211,3 +211,11 @@ $txt = get("date=-1&exp=http.user-agent&view=unknown");
 eq_or_diff($txt,
 'Can\'t find view
 ');
+
+# A malformed expression makes arkimeparser.parse throw an Error object. That
+# Error used to be passed straight to res.end, which crashed the compression
+# middleware with an unhandled rejection (PR #4120). It should now come back as
+# a 400 with the parse-error text.
+my $res = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/multiunique.txt?date=-1&exp=node&expression=" . uri_escape("ip.src=="));
+is($res->code, 400, "multiunique malformed expression returns 400");
+ok($res->content =~ /Parse error/, "multiunique malformed expression returns parse-error text, not a crash");

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -100,7 +100,7 @@ class HuntAPIs {
       return cb(null, false);
     } else if (options.type === 'raw') {
       const packets = [];
-      SessionAPIs.processSessionId(sessionId, true, null, (pcap, buffer, processSessionIdCb, i) => {
+      SessionAPIs.processSessionId(sessionId, false, null, (pcap, buffer, processSessionIdCb, i) => {
         if (options.src === options.dst) {
           // strip the 16 byte pcap record header, only packet data should be searched
           packets.push(buffer.slice(16));
@@ -1366,7 +1366,7 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
     // fetch hunt and session
     Promise.all([
       Db.get('hunts', huntId),
-      Db.getSession(sessionId)
+      Db.getSession(sessionId, { _source: false, fields: ['node'] })
     ]).then(([{ body: hunt }, session]) => {
       if (hunt.error || session.error) {
         console.log('HUNT - remoteHunt error', hunt.error || session.error);

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -1434,22 +1434,26 @@ class SessionAPIs {
       return doneCb ? doneCb(null) : null;
     }
 
-    await async.eachLimit(sessionList, 10, async (session) => {
-      if (!session.fields) {
-        console.log('No Fields in addTagsList', session);
-        return;
-      }
+    try {
+      await async.eachLimit(sessionList, 10, async (session) => {
+        if (!session.fields) {
+          console.log('No Fields in addTagsList', session);
+          return;
+        }
 
-      const cluster = (Config.get('multiES', false) && session.cluster) ? session.cluster : undefined;
+        const cluster = (Config.get('multiES', false) && session.cluster) ? session.cluster : undefined;
 
-      try {
-        await Db.addTagsToSession(session._index, session._id, allTagNames, cluster);
-      } catch (err) {
-        console.log('ERROR - addTagsList', session, util.inspect(err, false, 50));
-      }
-    }, (err) => {
-      return doneCb ? doneCb(err) : null;
-    });
+        try {
+          await Db.addTagsToSession(session._index, session._id, allTagNames, cluster);
+        } catch (err) {
+          console.log('ERROR - addTagsList', session, util.inspect(err, false, 50));
+        }
+      });
+    } catch (err) {
+      if (doneCb) { return doneCb(err); }
+      throw err;
+    }
+    if (doneCb) { return doneCb(null); }
   }
 
   // --------------------------------------------------------------------------
@@ -1459,29 +1463,36 @@ class SessionAPIs {
       return doneCb ? doneCb(null) : null;
     }
 
-    await async.eachLimit(sessionList, 10, async (session) => {
-      if (!session.fields) {
-        console.log('No Fields in removeTagsList', session);
-        return;
-      }
+    try {
+      await async.eachLimit(sessionList, 10, async (session) => {
+        if (!session.fields) {
+          console.log('No Fields in removeTagsList', session);
+          return;
+        }
 
-      const cluster = (Config.get('multiES', false) && session.cluster) ? session.cluster : undefined;
+        const cluster = (Config.get('multiES', false) && session.cluster) ? session.cluster : undefined;
 
-      try {
-        await Db.removeTagsFromSession(session._index, session._id, allTagNames, cluster);
-      } catch (err) {
-        console.log('ERROR - removeTagsList', session, util.inspect(err, false, 50));
-      }
-    }, (err) => {
-      return doneCb ? doneCb(err) : null;
-    });
+        try {
+          await Db.removeTagsFromSession(session._index, session._id, allTagNames, cluster);
+        } catch (err) {
+          console.log('ERROR - removeTagsList', session, util.inspect(err, false, 50));
+        }
+      });
+    } catch (err) {
+      if (doneCb) { return doneCb(err); }
+      throw err;
+    }
+    if (doneCb) { return doneCb(null); }
   }
 
   // --------------------------------------------------------------------------
   static async processSessionIdAndDecode (id, numPackets) {
     return new Promise((resolve, reject) => {
       let packets = [];
-      SessionAPIs.processSessionId(id, true, null, (pcap, buffer, cb, i) => {
+      // fullSession=false: decode/reassembly only reads ipProtocol and
+      // source ip/port, all of which are in processSessionId's narrow field
+      // list; the full-field fetch is expensive per session
+      SessionAPIs.processSessionId(id, false, null, (pcap, buffer, cb, i) => {
         let obj = {};
         if (buffer.length > 16) {
           pcap.decode(buffer, obj);
@@ -2218,7 +2229,7 @@ class SessionAPIs {
         if (err) {
           console.log(`ERROR - ${req.method} /api/spigraphhierarchy`, util.inspect(err, false, 50));
           res.status(400);
-          return res.type('text/plain').end(err);
+          return res.type('text/plain').end(String(err.message ?? err));
         }
 
         if (Config.debug > 2) {
@@ -2502,7 +2513,7 @@ class SessionAPIs {
       if (err) {
         console.log(`ERROR - ${req.method} /api/multiunique`, util.inspect(err, false, 50));
         res.status(400);
-        return res.type('text/plain').end(err);
+        return res.type('text/plain').end(String(err.message ?? err));
       }
 
       delete query.sort;
@@ -2529,7 +2540,7 @@ class SessionAPIs {
         if (err) {
           console.log(`ERROR - ${req.method} /api/multiunique`, util.inspect(err, false, 50));
           res.status(400);
-          return res.type('text/plain').end(err);
+          return res.type('text/plain').end(String(err.message ?? err));
         }
 
         if (Config.debug > 2) {
@@ -3384,7 +3395,7 @@ class SessionAPIs {
               SessionAPIs.#localGetItemByHash(nodeName, sessionID, hash, (err, item) => {
                 if (err) {
                   res.status(400);
-                  return res.type('text/plain').end(err);
+                  return res.type('text/plain').end(String(err.message ?? err));
                 } else if (item) {
                   ArkimeUtil.noCache(req, res, 'application/force-download');
                   res.setHeader('content-disposition', contentDisposition(item.bodyName + '.pellet'));
@@ -3437,7 +3448,7 @@ class SessionAPIs {
     SessionAPIs.#localGetItemByHash(req.params.nodeName, req.params.id, req.params.hash, (err, item) => {
       if (err) {
         res.status(400);
-        return res.type('text/plain').end(err);
+        return res.type('text/plain').end(String(err.message ?? err));
       } else if (item) {
         ArkimeUtil.noCache(req, res, 'application/force-download');
         res.setHeader('content-disposition', contentDisposition(item.bodyName + '.pellet'));


### PR DESCRIPTION
- capture: offline pcap runs no longer load/save the stopped-sessions state file, which could silently skip saving SPI for sessions whose tuple a previous run marked with _dontSaveSPI
- hunts fetch only packet-related session fields instead of all fields
- fix session API error responses passing an Error object to res.end, crashing in the compression middleware as an unhandled rejection
- fix addTagsList/removeTagsList completion callback reliability

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
