### PR TITLE
Add --sorted option for offline pcap directory processing (fixes #4125)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,6 +40,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4120 Fix offline pcap runs (-r/-R) loading the stopped-sessions state file
   - #4121 Fix DNS HTTPS/SVCB records dropping a valid trailing zero-length SvcParam
   - #4121 Fix diameter parser not unregistering when its reassembly buffer overflowed
+  - #4126 Add --sorted option to process offline pcap directories in alphabetical order
 ## Viewer
   - #4120 Fix error responses crashing with an unhandled rejection when a session API handler passed an Error object to res.end
   - #4120 Fix addTagsList/removeTagsList completion callback not being reliably called

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -510,6 +510,7 @@ typedef struct arkime_config {
     char      noRefresh;
     char    **commandList;
     char      noConfigOption;
+    gboolean  pcapSorted;
 } ArkimeConfig_t;
 
 typedef struct {
@@ -1700,7 +1701,8 @@ typedef enum {
     ARKIME_SCHEME_FLAG_MONITOR   = 0x0002,
     ARKIME_SCHEME_FLAG_RECURSIVE = 0x0004,
     ARKIME_SCHEME_FLAG_SKIP      = 0x0008,
-    ARKIME_SCHEME_FLAG_DELETE    = 0x0010
+    ARKIME_SCHEME_FLAG_DELETE    = 0x0010,
+    ARKIME_SCHEME_FLAG_SORTED    = 0x0020
 } ArkimeSchemeFlags;
 
 typedef struct {

--- a/capture/main.c
+++ b/capture/main.c
@@ -118,6 +118,7 @@ LOCAL  GOptionEntry entries[] = {
     { "skip",      's',                    0, G_OPTION_ARG_NONE,           &config.pcapSkip,      "Used with -R option and without --copy, skip files already processed", NULL },
     { "reprocess",   0,                    0, G_OPTION_ARG_NONE,           &config.pcapReprocess, "In offline mode reprocess files, use the same files table entry", NULL },
     { "recursive",   0,                    0, G_OPTION_ARG_NONE,           &config.pcapRecursive, "When in offline pcap directory mode, recurse sub directories", NULL },
+    { "sorted",      0,                    0, G_OPTION_ARG_NONE,           &config.pcapSorted,    "When in offline pcap directory mode, sort files alphabetically before processing", NULL },
     { "node",      'n',                    0, G_OPTION_ARG_STRING,         &config.nodeName,      "Our node name, defaults to hostname.  Multiple nodes can run on same host", NULL },
     { "host",        0,                    0, G_OPTION_ARG_STRING,         &config.hostName,      "Override hostname, this is what remote viewers will use to connect", NULL },
     { "tag",       't',                    0, G_OPTION_ARG_STRING_ARRAY,   &config.extraTags,     "Extra tag to add to all packets, can be used multiple times", NULL },
@@ -342,6 +343,11 @@ LOCAL void parse_args(int argc, char **argv)
 
     if (config.pcapMonitor && !config.pcapReadDirs && !config.commandSocket && !config.commandList) {
         printf("Must specify directories to monitor with -R\n");
+        exit(1);
+    }
+
+    if (config.pcapSorted && config.pcapMonitor) {
+        printf("--sorted cannot be used with --monitor\n");
         exit(1);
     }
 

--- a/capture/reader-scheme-file.c
+++ b/capture/reader-scheme-file.c
@@ -169,6 +169,12 @@ LOCAL void scheme_file_monitor_dir(const char UNUSED(*dirname), ArkimeSchemeFlag
 }
 #endif
 /******************************************************************************/
+// g_ptr_array_sort passes pointers to the array elements (gchar **)
+LOCAL int scheme_file_name_cmp(gconstpointer a, gconstpointer b)
+{
+    return g_strcmp0(*(const gchar * const *)a, *(const gchar * const *)b);
+}
+/******************************************************************************/
 LOCAL int scheme_file_dir(const char *dirname, ArkimeSchemeFlags flags, ArkimeSchemeAction_t *actions)
 {
     GDir   *pcapGDir;
@@ -184,6 +190,7 @@ LOCAL int scheme_file_dir(const char *dirname, ArkimeSchemeFlags flags, ArkimeSc
         return 1;
     }
 
+    GPtrArray *files = (flags & ARKIME_SCHEME_FLAG_SORTED) ? g_ptr_array_new_with_free_func(g_free) : NULL;
     while (1) {
         const gchar *filename = g_dir_read_name(pcapGDir);
 
@@ -195,6 +202,11 @@ LOCAL int scheme_file_dir(const char *dirname, ArkimeSchemeFlags flags, ArkimeSc
         // Skip hidden files/directories
         if (filename[0] == '.')
             continue;
+
+        if (flags & ARKIME_SCHEME_FLAG_SORTED) {
+            g_ptr_array_add(files, g_strdup(filename));
+            continue;
+        }
 
         gchar *fullfilename = g_build_filename (dirname, filename, NULL);
 
@@ -214,6 +226,32 @@ LOCAL int scheme_file_dir(const char *dirname, ArkimeSchemeFlags flags, ArkimeSc
         g_free(fullfilename);
     }
     g_dir_close(pcapGDir);
+
+    // Not sorted mode, everything was already processed above
+    if ((flags & ARKIME_SCHEME_FLAG_SORTED) == 0)
+        return 1;
+
+    g_ptr_array_sort(files, scheme_file_name_cmp);
+    for (guint i = 0; i < files->len; i++) {
+        const gchar *filename = files->pdata[i];
+        gchar *fullfilename = g_build_filename (dirname, filename, NULL);
+
+        // If recursive option and a directory then process all the files in that dir
+        if ((flags & ARKIME_SCHEME_FLAG_RECURSIVE)  && g_file_test(fullfilename, G_FILE_TEST_IS_DIR)) {
+            scheme_file_dir(fullfilename, flags, actions);
+            g_free(fullfilename);
+            continue;
+        }
+
+        if (!g_regex_match(config.offlineRegex, filename, 0, NULL)) {
+            g_free(fullfilename);
+            continue;
+        }
+
+        arkime_reader_scheme_load(fullfilename, flags & (ArkimeSchemeFlags)(~ARKIME_SCHEME_FLAG_DIRHINT), actions);
+        g_free(fullfilename);
+    }
+    g_ptr_array_free(files, TRUE);
     return 1;
 }
 /******************************************************************************/

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -396,6 +396,9 @@ LOCAL void *reader_scheme_thread(void *UNUSED(arg))
     if (config.pcapDelete) {
         flags |= ARKIME_SCHEME_FLAG_DELETE;
     }
+    if (config.pcapSorted) {
+        flags |= ARKIME_SCHEME_FLAG_SORTED;
+    }
 
     // Load files
     for (int i = 0; config.pcapReadFiles && config.pcapReadFiles[i]; i++) {
@@ -1133,6 +1136,9 @@ LOCAL int arkime_scheme_cmd_add(int argc, char **argv, gpointer cc, ArkimeScheme
     if (config.pcapDelete) {
         flags |= ARKIME_SCHEME_FLAG_DELETE;
     }
+    if (config.pcapSorted) {
+        flags |= ARKIME_SCHEME_FLAG_SORTED;
+    }
 
     for (int i = 1; i < argc - 1; i++) {
         const char *cmp = argv[i];
@@ -1156,6 +1162,10 @@ LOCAL int arkime_scheme_cmd_add(int argc, char **argv, gpointer cc, ArkimeScheme
             flags |= ARKIME_SCHEME_FLAG_DELETE;
         } else if (strcmp(cmp, "-nodelete") == 0) {
             flags &= (ArkimeSchemeFlags)(~ARKIME_SCHEME_FLAG_DELETE);
+        } else if (strcmp(cmp, "-sorted") == 0) {
+            flags |= ARKIME_SCHEME_FLAG_SORTED;
+        } else if (strcmp(cmp, "-nosorted") == 0) {
+            flags &= (ArkimeSchemeFlags)(~ARKIME_SCHEME_FLAG_SORTED);
         } else if (strcmp(cmp, "-notify") == 0) {
             notify = TRUE;
         } else if (strcmp(cmp, "-nonotify") == 0) {
@@ -1176,6 +1186,11 @@ LOCAL int arkime_scheme_cmd_add(int argc, char **argv, gpointer cc, ArkimeScheme
             arkime_command_respond(cc, err, -1);
             return 1;
         }
+    }
+
+    if ((flags & ARKIME_SCHEME_FLAG_SORTED) && (flags & ARKIME_SCHEME_FLAG_MONITOR)) {
+        arkime_command_respond(cc, "--sorted cannot be used with --monitor\n", -1);
+        return 1;
     }
 
     ArkimeSchemeAction_t *actions = NULL;
@@ -1290,6 +1305,7 @@ void arkime_reader_scheme_init()
                                  "[--skip|--noskip]", "Override command line skip files already processed",
                                  "[--monitor|--nomonitor]", "Override command line monitor the directory for new files option",
                                  "[--recursive|--norecursive]", "Override command line Recurse subdirectories option",
+                                 "[--sorted|--nosorted]", "Override command line sort files alphabetically before processing (incompatible with --monitor)",
                                  "<dir>", "Directory to process",
                                  NULL);
 }


### PR DESCRIPTION
- New --sorted command line flag and add-dir --sorted/--nosorted override
- Sorts scheme-mode directory entries alphabetically before processing
- Rejects --sorted combined with monitor mode on both paths

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arkime/codesmith/arkime/pr/4126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786630568&installation_id=146169293&pr_number=4126&repository=arkime%2Farkime&return_to=https%3A%2F%2Fgithub.com%2Farkime%2Farkime%2Fpull%2F4126&signature=387bcc4a9143542327df829e80e719210d34031302fed619499e6e29da7860f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->