### PR TITLE
Add changePasswordSecret.js to re-encrypt users after passwordSecret change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,8 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 6.6.1 2026/08/xx
+## All
+  - #4128 Add changePasswordSecret.js to re-encrypt all users' passwords and cont3xt keys after changing the passwordSecret
 ## Capture
   - #4120 Fix offline pcap runs (-r/-R) loading the stopped-sessions state file
   - #4121 Fix DNS HTTPS/SVCB records dropping a valid trailing zero-length SvcParam

--- a/common/changePasswordSecret.js
+++ b/common/changePasswordSecret.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/******************************************************************************/
+/* changePasswordSecret.js -- Re-encrypt every user's stored password and
+ *   cont3xt keys after the passwordSecret has been changed.
+ *
+ * Prompts for the OLD and NEW passwordSecret, then walks every document in the
+ * users index. For each user it decrypts the stored password (passStore) and
+ * cont3xt keys with the old secret and re-encrypts them with the new secret,
+ * keeping the same document _id.
+ *
+ *   - If a user's passStore can't be decrypted with the old secret it is logged
+ *     and left completely unchanged.
+ *   - If a user is re-encrypted it is logged.
+ *
+ * This lives in JavaScript (not db.pl) because the encryption schemes
+ * (aes-256-cbc for passStore, aes-256-gcm + pbkdf2 for cont3xt keys) reuse the
+ * exact crypto in common/auth.js and can't be done in Perl without new deps.
+ *
+ * Copyright Andy Wick
+ * SPDX-License-Identifier: Apache-2.0
+ */
+'use strict';
+
+const cryptoLib = require('crypto');
+const readline = require('readline');
+const version = require('./version');
+const ArkimeConfig = require('./arkimeConfig');
+const Auth = require('./auth');
+const User = require('./user');
+
+// ----------------------------------------------------------------------------
+function help (msg) {
+  if (msg) { console.log(`${msg}\n`); }
+  console.log('changePasswordSecret.js [<config options>] [<oldSecret> <newSecret>]');
+  console.log('');
+  console.log('Re-encrypts every user\'s stored password and cont3xt keys in the users');
+  console.log('index after you change the passwordSecret. Stop all Arkime processes,');
+  console.log('update passwordSecret in the config, then run this once against the users index.');
+  console.log('');
+  console.log('Give the old and new passwordSecret as arguments, or omit them to be');
+  console.log('prompted (prompting keeps the secrets out of the process list).');
+  console.log('');
+  console.log('Config Options:');
+  console.log('  -c, --config <file|url>     Where to fetch the config file from');
+  console.log('  -o <section>.<key>=<value>  Override the config file');
+  console.log('  --insecure                  Disable certificate verification for https calls');
+  process.exit(msg ? 1 : 0);
+}
+
+// ----------------------------------------------------------------------------
+// Prompt for a secret without echoing the typed characters
+function promptHidden (label) {
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl._writeToOutput = (s) => { if (s === label) { process.stdout.write(s); } };
+    rl.question(label, (answer) => {
+      rl.close();
+      console.log();
+      resolve(answer);
+    });
+  });
+}
+
+// ----------------------------------------------------------------------------
+// passStore crypto, matching Auth.store2ha1 / Auth.ha12store:
+//   aes-256-cbc, key = sha256(secret), stored as "<iv hex>.<encrypted hex>"
+function decryptPassStore (passStore, key256) {
+  const parts = passStore.split('.');
+  if (parts.length !== 2) { throw new Error('unsupported passStore format'); }
+  const c = cryptoLib.createDecipheriv('aes-256-cbc', key256, Buffer.from(parts[0], 'hex'));
+  let d = c.update(parts[1], 'hex', 'binary');
+  d += c.final('binary');
+  return d;
+}
+
+function encryptPassStore (ha1, key256) {
+  const iv = cryptoLib.randomBytes(16);
+  const c = cryptoLib.createCipheriv('aes-256-cbc', key256, iv);
+  let e = c.update(ha1, 'binary', 'hex');
+  e += c.final('hex');
+  return iv.toString('hex') + '.' + e;
+}
+
+// ----------------------------------------------------------------------------
+async function run (oldArg, newArg) {
+  const oldSecret = oldArg ?? await promptHidden('Old passwordSecret: ');
+  const newSecret = newArg ?? await promptHidden('New passwordSecret: ');
+
+  if (oldSecret === '') { help('Old passwordSecret must not be empty'); }
+  if (newSecret === '') { help('New passwordSecret must not be empty'); }
+  if (oldSecret === newSecret) { help('Old and new passwordSecret are the same, nothing to do'); }
+
+  // sha256(secret) is both the aes-256-cbc key for passStore and the pbkdf2
+  // secret used by Auth.obj2auth/auth2obj for cont3xt keys.
+  const oldKey = cryptoLib.createHash('sha256').update(oldSecret).digest();
+  const newKey = cryptoLib.createHash('sha256').update(newSecret).digest();
+
+  const users = await User.getAllUsers();
+
+  let scanned = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const user of users) {
+    scanned++;
+    const userId = user.userId;
+    const changed = [];
+
+    // passStore is the gate: if present but it won't decrypt with the old
+    // secret, don't touch this user at all.
+    if (typeof user.passStore === 'string' && user.passStore.length > 0) {
+      let ha1;
+      try {
+        ha1 = decryptPassStore(user.passStore, oldKey);
+      } catch (e) {
+        console.log(`SKIP   - ${userId}: passStore could not be decrypted with the old passwordSecret, leaving unchanged`);
+        skipped++;
+        continue;
+      }
+      user.passStore = encryptPassStore(ha1, newKey);
+      changed.push('passStore');
+    }
+
+    // cont3xt keys, encrypted with Auth.obj2auth(secret = sha256(passwordSecret))
+    if (typeof user.cont3xt?.keys === 'string' && user.cont3xt.keys.length > 0) {
+      try {
+        const obj = Auth.auth2obj(user.cont3xt.keys, oldKey);
+        user.cont3xt.keys = Auth.obj2auth(obj, newKey);
+        changed.push('cont3xt keys');
+      } catch (e) {
+        if (changed.length > 0) {
+          console.log(`WARN   - ${userId}: passStore re-encrypted but cont3xt keys could not be decrypted, leaving cont3xt keys unchanged`);
+        } else {
+          console.log(`SKIP   - ${userId}: cont3xt keys could not be decrypted with the old passwordSecret, leaving unchanged`);
+          skipped++;
+          continue;
+        }
+      }
+    }
+
+    // Nothing encrypted to migrate (e.g. a role or header-only user)
+    if (changed.length === 0) { continue; }
+
+    await User.setUser(userId, user);
+    console.log(`UPDATE - ${userId}: re-encrypted ${changed.join(', ')}`);
+    updated++;
+  }
+
+  await User.flush();
+
+  console.log(`\nDone. Scanned ${scanned} users, updated ${updated}, skipped ${skipped}.`);
+  process.exit(0);
+}
+
+// ----------------------------------------------------------------------------
+// Parse -o overrides and --help. ArkimeConfig has already stripped -c/--insecure
+// from process.argv, so what remains here is our -o pairs and the optional
+// positional <oldSecret> <newSecret>.
+function processArgs () {
+  const positional = [];
+  for (let i = 2; i < process.argv.length; i++) {
+    if (process.argv[i] === '-o' || process.argv[i] === '--option') {
+      i++;
+      const kv = process.argv[i] ?? '';
+      const equal = kv.indexOf('=');
+      if (equal === -1) { help(`Missing equal sign in ${kv}`); }
+      const key = kv.slice(0, equal);
+      const value = kv.slice(equal + 1);
+      // dotless keys go into the default section, matching viewer/config.js
+      ArkimeConfig.setOverride(key.includes('.') ? key : `default.${key}`, value);
+    } else if (process.argv[i] === '--help' || process.argv[i] === '-h') {
+      help();
+    } else {
+      positional.push(process.argv[i]);
+    }
+  }
+
+  if (positional.length === 1 || positional.length > 2) {
+    help('Provide both <oldSecret> and <newSecret>, or neither to be prompted');
+  }
+
+  return positional;
+}
+
+// ----------------------------------------------------------------------------
+async function premain () {
+  const [oldSecret, newSecret] = processArgs();
+
+  await ArkimeConfig.initialize({
+    defaultConfigFile: `${version.config_prefix}/etc/config.ini`,
+    defaultSections: 'default'
+  });
+
+  const es = ArkimeConfig.getArray('elasticsearch', 'http://localhost:9200');
+  const usersUrl = ArkimeConfig.get('usersUrl');
+  const usersEs = ArkimeConfig.getArray('usersElasticsearch') ?? es;
+
+  // Match viewer/db.js: users prefix is usersPrefix falling back to the main prefix.
+  const usersPrefix = ArkimeConfig.get('usersPrefix') ?? ArkimeConfig.get('prefix', 'arkime');
+
+  await Auth.initialize({ passwordSecretSection: 'default' });
+
+  User.initialize({
+    insecure: ArkimeConfig.isInsecure([usersUrl, usersEs]),
+    requestTimeout: ArkimeConfig.get('elasticsearchTimeout', 300),
+    url: usersUrl,
+    node: usersEs,
+    caTrustFile: ArkimeConfig.get('caTrustFile'),
+    clientKey: ArkimeConfig.get('esClientKey'),
+    clientCert: ArkimeConfig.get('esClientCert'),
+    clientKeyPass: ArkimeConfig.get('esClientKeyPass'),
+    prefix: usersPrefix,
+    apiKey: ArkimeConfig.get('usersElasticsearchAPIKey'),
+    basicAuth: ArkimeConfig.get('usersElasticsearchBasicAuth', ArkimeConfig.get('elasticsearchBasicAuth')),
+    noUsersCheck: true
+  });
+
+  await run(oldSecret, newSecret);
+}
+
+premain();

--- a/common/user.js
+++ b/common/user.js
@@ -252,6 +252,18 @@ class User {
   }
 
   /**
+   * Return ALL users with their full raw data, including sensitive fields such
+   * as passStore and cont3xt keys. Unlike searchUsers/getUser this does NOT
+   * clean, filter, or expand roles. Intended for admin/maintenance tasks that
+   * need the stored document as-is (e.g. re-encrypting after a passwordSecret
+   * change). Pair with setUser to write changes back.
+   * @returns {Promise<Array>} every stored user/role document, unmodified
+   */
+  static getAllUsers () {
+    return User.#implementation.getAllUsers();
+  }
+
+  /**
    * @private
    * Create a user from thin air!
    */
@@ -2027,6 +2039,29 @@ class UserESImplementation {
     return { users: hits, total: users.hits.total };
   }
 
+  // Return ALL users with full raw data (incl passStore/cont3xt), promise only
+  async getAllUsers () {
+    const users = [];
+    let resp = await this.client.search({
+      index: this.prefix + 'users',
+      scroll: '5m',
+      body: { size: 1000, query: { match_all: {} } }
+    });
+
+    while (resp.body.hits.hits.length > 0) {
+      for (const hit of resp.body.hits.hits) {
+        users.push(hit._source);
+      }
+      resp = await this.client.scroll({ scroll_id: resp.body._scroll_id, scroll: '5m' });
+    }
+
+    if (resp.body?._scroll_id) {
+      try { await this.client.clearScroll({ body: { scroll_id: [resp.body._scroll_id] } }); } catch (err) { /* ignore */ }
+    }
+
+    return users;
+  }
+
   // Return a user from DB, callback only
   getUser (userId, cb) {
     this.client.get({ index: this.prefix + 'users', id: userId }, (err, result) => {
@@ -2164,6 +2199,15 @@ class UserLMDBImplementation {
     };
   }
 
+  // Return ALL users with full raw data (incl passStore/cont3xt), promise only
+  async getAllUsers () {
+    const users = [];
+    this.store.getRange({}).forEach(({ key, value }) => {
+      users.push(value);
+    });
+    return users;
+  }
+
   // Return a user from DB, callback only
   getUser (userId, cb) {
     try {
@@ -2275,6 +2319,18 @@ class UserRedisImplementation {
       total: hits.length,
       users: hits.slice(from, from + size)
     };
+  }
+
+  // Return ALL users with full raw data (incl passStore/cont3xt), promise only
+  async getAllUsers () {
+    const keys = await this.client.keys(this.prefix + '*');
+    const users = [];
+    for (const key of keys) {
+      const data = await this.client.get(key);
+      if (!data) { continue; }
+      users.push(JSON.parse(data));
+    }
+    return users;
   }
 
   // Return a user from DB, callback only
@@ -2395,6 +2451,12 @@ class UserSQLiteImplementation {
       total: hits.length,
       users: hits.slice(from, from + size)
     };
+  }
+
+  // Return ALL users with full raw data (incl passStore/cont3xt), promise only
+  async getAllUsers () {
+    const rows = this.db.prepare('SELECT json FROM users').all();
+    return rows.map(row => JSON.parse(row.json));
   }
 
   // Return a user from DB, callback only

--- a/tests/ArkimeTest.pm
+++ b/tests/ArkimeTest.pm
@@ -4,7 +4,7 @@ use Carp;
 use strict;
 use Test::More;
 @ArkimeTest::ISA = qw(Exporter);
-@ArkimeTest::EXPORT = qw (esGet esPost esPut esDelete esCopy viewerGet viewerGetToken viewerGet2 viewerDelete viewerDeleteToken viewerDeleteToken2 viewerPost viewerPost2 viewerPostToken viewerPostToken2 countTest countTestToken countTest2 countTestMulti errTest bin2hex mesGet mesPost multiGet multiGetToken multiPost multiPostToken getTokenCookie getTokenCookie2 parliamentGet parliamentGetToken parliamentPost parliamentPostToken parliamentPut parliamentPutToken parliamentDelete parliamentDeleteToken getParliamentTokenCookie waitFor viewerPutToken viewerPut getCont3xtTokenCookie cont3xtGet cont3xtGetToken cont3xtPut cont3xtPutToken cont3xtDelete cont3xtDeleteToken cont3xtPost cont3xtPostToken addUser clearIndex generate_totp);
+@ArkimeTest::EXPORT = qw (esGet esPost esPut esDelete esCopy viewerGet viewerGetToken viewerGet2 viewerDelete viewerDeleteToken viewerDeleteToken2 viewerPost viewerPost2 viewerPostToken viewerPostToken2 countTest countTestToken countTest2 countTestMulti errTest bin2hex mesGet mesPost multiGet multiGetToken multiPost multiPostToken getTokenCookie getTokenCookie2 parliamentGet parliamentGetToken parliamentPost parliamentPostToken parliamentPut parliamentPutToken parliamentDelete parliamentDeleteToken getParliamentTokenCookie waitFor viewerPutToken viewerPut getCont3xtTokenCookie cont3xtGet cont3xtGetToken cont3xtPut cont3xtPutToken cont3xtDelete cont3xtDeleteToken cont3xtPost cont3xtPostToken addUser changePasswordSecret clearIndex generate_totp);
 
 use LWP::UserAgent;
 use HTTP::Request::Common;
@@ -569,6 +569,32 @@ sub addUser {
     }
     waitpid($pid, 0);
     return $?;
+}
+
+# Run common/changePasswordSecret.js with the old/new secret given on the
+# command line and return its combined stdout/stderr so callers can check the
+# UPDATE/SKIP log lines.
+sub changePasswordSecret {
+    my ($old, $new) = @_;
+    my @es_args = (
+        '-o', "elasticsearch=$ArkimeTest::elasticsearch",
+        '-o', "usersElasticsearch=$ArkimeTest::usersElasticsearch",
+        '-o', "prefix=tests",
+    );
+    push @es_args, $ENV{INSECURE} if defined $ENV{INSECURE} && $ENV{INSECURE} ne '';
+
+    my $pid = open(my $fh, "-|");
+    die "fork: $!" if !defined $pid;
+    if ($pid == 0) {
+        chdir('../common') or die "chdir ../common: $!";
+        open(STDERR, ">&", STDOUT);
+        exec('node', 'changePasswordSecret.js', @es_args, '-c', '../tests/config.test.ini', $old, $new);
+        die "exec: $!";
+    }
+    local $/;
+    my $out = <$fh>;
+    close($fh);
+    return $out;
 }
 ################################################################################
 sub clearIndex {

--- a/tests/addUser.t
+++ b/tests/addUser.t
@@ -1,5 +1,5 @@
 # Test addUser.js and general authentication
-use Test::More tests => 124;
+use Test::More tests => 129;
 use Test::Differences;
 use Data::Dumper;
 use ArkimeTest;
@@ -371,6 +371,30 @@ is ($response->code, 302, "logout redirects");
 $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8128/", 'Cookie' => $cookie);
 is ($response->code, 200, "logged out session redirected to login page");
 ok ($response->content =~ /LOGIN!/, "logged out session shows login form");
+
+
+#### changePasswordSecret.js tests
+# reuse test1, whose passStore uses the [default] passwordSecret (password)
+my $cpsBefore = viewerGet("/regressionTests/getUser/test1");
+
+# wrong old secret -> user is skipped and left completely unchanged
+my $cpsOut = changePasswordSecret("wrongoldsecret", "whatever");
+like($cpsOut, qr/SKIP\s+- test1/, "test1 skipped when old passwordSecret is wrong");
+esGet("/_refresh");
+my $cpsWrong = viewerGet("/regressionTests/getUser/test1");
+eq_or_diff($cpsWrong->{passStore}, $cpsBefore->{passStore}, "passStore unchanged after wrong old secret");
+
+# correct old secret -> user is re-encrypted and logged
+$cpsOut = changePasswordSecret("password", "password2");
+like($cpsOut, qr/UPDATE - test1/, "test1 updated when old passwordSecret is correct");
+esGet("/_refresh");
+my $cpsAfter = viewerGet("/regressionTests/getUser/test1");
+ok($cpsAfter->{passStore} ne $cpsBefore->{passStore}, "passStore re-encrypted with new passwordSecret");
+
+# re-key back to the original secret so the rest of the suite is unaffected
+$cpsOut = changePasswordSecret("password2", "password");
+like($cpsOut, qr/UPDATE - test1/, "test1 re-keyed back to the original passwordSecret");
+esGet("/_refresh");
 
 
 # cleanup


### PR DESCRIPTION
- New common/changePasswordSecret.js re-encrypts every user's passStore and cont3xt keys when the passwordSecret changes; old/new secret via args or prompt
- Add backend-agnostic User.getAllUsers() (ES/LMDB/Redis/SQLite) returning raw user docs, paired with User.setUser to write changes back
- Add changePasswordSecret test helper and regression test in addUser.t

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arkime/codesmith/arkime/pr/4128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786719264&installation_id=146169293&pr_number=4128&repository=arkime%2Farkime&return_to=https%3A%2F%2Fgithub.com%2Farkime%2Farkime%2Fpull%2F4128&signature=0114c4bee126ce81bc2d3892b08e0fce57e5cbb71c1e35863517dc233cbbcecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->