### PR TITLE
Let dbAdmin use the ES stats action menus (#4081)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4120 Fix addTagsList/removeTagsList completion callback not being reliably called
   - #4120 Hunts now fetch only the packet-related session fields instead of all fields, speeding up hunts on sessions with many fields
   - #4080 Add dbAdmin role that grants Elasticsearch/OpenSearch admin access; the esAdminUsers setting is now deprecated and will be removed in Arkime 7
+  - #4081 Let the dbAdmin role use the ES stats action menus (index, shard, and task operations); the ES indices menu now only requires removeEnabled for deleting an index, matching the backend
 
 6.6.0 2026/07/09
 ## Breaking

--- a/common/user.js
+++ b/common/user.js
@@ -1629,6 +1629,19 @@ class User {
   }
 
   /**
+   * Denies access unless the requesting user has at least one of the required roles (OR logic)
+   */
+  static checkAnyRole (roles) {
+    return async (req, res, next) => {
+      if (!req.user.hasRole(roles)) {
+        console.log(`Permission denied to ${req.user.userId} while requesting resource: ${req._parsedUrl.pathname}, using any role ${roles}`);
+        return res.serverError(403, 'You do not have permission to access this resource');
+      }
+      next();
+    };
+  }
+
+  /**
    * Denies access if the setting user lacks ANY of the required roles (OR logic)
    */
   static checkSettingUserAnyRole (roles) {

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -1614,31 +1614,31 @@ app.get( // OpenSearch/Elasticsearch indices endpoint
 
 app.delete( // delete OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, User.checkRole('arkimeAdmin'), User.checkPermissions(['removeEnabled']), setCookie],
+  [ArkimeUtil.noCacheJson, recordResponseTime, User.checkAnyRole(['arkimeAdmin', 'dbAdmin']), User.checkPermissions(['removeEnabled']), setCookie],
   StatsAPIs.deleteESIndex
 );
 
 app.post( // optimize OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index/optimize'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.optimizeESIndex
 );
 
 app.post( // close OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index/close'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.closeESIndex
 );
 
 app.post( // open OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index/open'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.openESIndex
 );
 
 app.post( // shrink OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index/shrink'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.shrinkESIndex
 );
 
@@ -1650,7 +1650,7 @@ app.get( // OpenSearch/Elasticsearch tasks endpoint
 
 app.post( // cancel OpenSearch/Elasticsearch task endpoint
   ['/api/estasks/:id/cancel'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.cancelESTask
 );
 
@@ -1663,7 +1663,7 @@ app.post( // cancel OpenSearch/Elasticsearch task by opaque id endpoint
 
 app.post( // cancel all OpenSearch/Elasticsearch tasks endpoint
   ['/api/estasks/cancelall'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.cancelAllESTasks
 );
 
@@ -1717,19 +1717,19 @@ app.get( // OpenSearch/Elasticsearch shards endpoint
 
 app.post( // exclude OpenSearch/Elasticsearch shard endpoint
   ['/api/esshards/:type/:value/exclude'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.excludeESShard
 );
 
 app.post( // include OpenSearch/Elasticsearch shard endpoint
   ['/api/esshards/:type/:value/include'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.includeESShard
 );
 
 app.post( // delete OpenSearch/Elasticsearch shard endpoint
   ['/api/esshards/:index/:shard/delete'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkRole('arkimeAdmin')],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
   StatsAPIs.deleteESShard
 );
 

--- a/viewer/vueapp/src/components/stats/EsIndices.vue
+++ b/viewer/vueapp/src/components/stats/EsIndices.vue
@@ -38,9 +38,9 @@ SPDX-License-Identifier: Apache-2.0
           <b-dropdown
             size="xs"
             class="row-actions-btn"
-            v-has-role="{user:user,roles:'arkimeAdmin'}"
-            v-has-permission="'removeEnabled'">
+            v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}">
             <b-dropdown-item
+              v-has-permission="'removeEnabled'"
               @click.stop.prevent="confirmDeleteIndex(item.item.index)">
               {{ $t('stats.esIndices.deleteIndex') }} {{ item.item.index }}
             </b-dropdown-item>

--- a/viewer/vueapp/src/components/stats/EsNodes.vue
+++ b/viewer/vueapp/src/components/stats/EsNodes.vue
@@ -41,7 +41,7 @@ SPDX-License-Identifier: Apache-2.0
             <b-dropdown
               size="xs"
               class="row-actions-btn d-inline"
-              v-has-role="{user:user,roles:'arkimeAdmin'}">
+              v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}">
               <b-dropdown-item
                 v-if="!item.item.nodeExcluded"
                 @click="exclude('name', item.item)">

--- a/viewer/vueapp/src/components/stats/EsShards.vue
+++ b/viewer/vueapp/src/components/stats/EsShards.vue
@@ -43,7 +43,7 @@ SPDX-License-Identifier: Apache-2.0
                   size="sm"
                   v-if="column.hasDropdown"
                   class="column-actions-btn pull-right mb-1"
-                  v-has-role="{user:user,roles:'arkimeAdmin'}">
+                  v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}">
                   <b-dropdown-item
                     v-if="!column.nodeExcluded"
                     @click="exclude('name', column)">
@@ -92,7 +92,7 @@ SPDX-License-Identifier: Apache-2.0
             :key="stat.name">
             <td>
               <span
-                v-has-role="{user:user,roles:'arkimeAdmin'}"
+                v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}"
                 v-if="stat.nodes && stat.nodes.Unassigned && stat.nodes.Unassigned.length">
                 <transition name="buttons">
                   <BButton

--- a/viewer/vueapp/src/components/stats/EsTasks.vue
+++ b/viewer/vueapp/src/components/stats/EsTasks.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: Apache-2.0
         type="button"
         id="cancelAllTasks"
         @click="cancelTasks"
-        v-has-role="{user:user,roles:'arkimeAdmin'}"
+        v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}"
         class="pull-right btn btn-sm btn-warning">
         <span class="fa fa-ban" />&nbsp;
         {{ $t('stats.esTasks.cancelAll') }}
@@ -50,7 +50,7 @@ SPDX-License-Identifier: Apache-2.0
             v-if="item.item.cancellable"
             class="btn btn-xs btn-danger"
             @click="cancelTask(item.item.taskId)"
-            v-has-role="{user:user,roles:'arkimeAdmin'}">
+            v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}">
             <span class="fa fa-trash-o" />
           </a>
         </template>


### PR DESCRIPTION
- Add User.checkAnyRole middleware (OR logic on the requesting user's roles)
- ES indices/shards/tasks action endpoints now accept arkimeAdmin OR dbAdmin
- Update the ES stats action menu directives to include dbAdmin
- Move the EsIndices removeEnabled gate onto the delete item so optimize/close/open/shrink match the backend (role only)

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arkime/codesmith/arkime/pr/4130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786757279&installation_id=146169293&pr_number=4130&repository=arkime%2Farkime&return_to=https%3A%2F%2Fgithub.com%2Farkime%2Farkime%2Fpull%2F4130&signature=14c8a369ce42c154fe01fd1b115b43610077543a36fe4009a3ce6976c32bc352"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->