### PR TITLE
Coerce MCP synthetic request query values to strings

### DIFF
--- a/common/mcpServer.js
+++ b/common/mcpServer.js
@@ -368,6 +368,26 @@ class MCPServer {
     return new Promise((resolve, reject) => {
       const url = options.url ?? '/';
 
+      // Express delivers every query value as a string, and handlers compare
+      // against that (buildQuery's date === '-1' for example). Tool arguments
+      // arrive as JSON numbers/booleans, so coerce scalars or those checks
+      // silently fail.
+      const stringifyQuery = (query) => {
+        const out = {};
+        for (const [key, value] of Object.entries(query)) {
+          if (value === undefined) {
+            continue;
+          } else if (Array.isArray(value)) {
+            out[key] = value.map((v) => (v !== null && typeof v === 'object') ? v : String(v));
+          } else if (value !== null && typeof value === 'object') {
+            out[key] = value;
+          } else {
+            out[key] = String(value);
+          }
+        }
+        return out;
+      };
+
       // Inherit from the real request so handlers still see headers, ip, etc,
       // but define our overrides as own data properties. Plain assignment would
       // hit express's getter-only accessors (path, query, ...) and throw.
@@ -378,7 +398,7 @@ class MCPServer {
         originalUrl: own(url),
         path: own(url),
         _parsedUrl: own({ pathname: url }),
-        query: own(options.query ?? {}),
+        query: own(stringifyQuery(options.query ?? {})),
         params: own(options.params ?? {}),
         body: own(options.body ?? {}),
         user: own(req.user),


### PR DESCRIPTION
Express delivers every req.query value as a string and viewer handlers depend on that, eg buildQuery's date === '-1' checks. MCP tool arguments arrive as JSON numbers, so date=-1 missed both the all-data range check and the all-indices check, producing a lastPacket >= 0 filter and querying only the index containing epoch time 0.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/arkime/codesmith/arkime/pr/4137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787185202&installation_model_id=427061&pr_number=4137&repository=arkime%2Farkime&return_to=https%3A%2F%2Fgithub.com%2Farkime%2Farkime%2Fpull%2F4137&signature=4d370dbe87c7a747bfacd4ed48ed874b14960ca330e8d9ae294e027bb68f11f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->