### PR TITLE
Capture fixes from security scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,9 @@ ja4plus.c
 
 # vite
 components.d.ts
+
+# claude
+docs/superpowers/
+
+# supacode
+supacode.json

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,12 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4121 Fix DNS HTTPS/SVCB records dropping a valid trailing zero-length SvcParam
   - #4121 Fix diameter parser not unregistering when its reassembly buffer overflowed
   - #4126 Add --sorted option to process offline pcap directories in alphabetical order
+  - #4143 Fix an over-long request URL (from a remote S3/SQS object key or IMDS role name) exiting capture instead of dropping the single request
+  - #4143 Fix SCTP in-order reassembly not bounding queued fragments, letting a stream of begin-without-end fragments grow memory unbounded
+  - #4143 Fix IPv4 fragment reassembly not recognizing the last fragment when it carried a DF or reserved flag bit, which could skip reassembly
+  - #4143 Fix the SQS reader holding a credentials pointer across its poll loop that could be freed after a credential refresh
+  - #4143 Fix a malformed or unreachable WISE server killing capture; WISE responses are now logged and skipped instead of exiting
+  - #4143 Fix a remote HTTP response's Content-Length pre-allocating up to 2GB; the response buffer now grows as data arrives
 ## Cont3xt/Viewer
   - #4134 Add an MCP server at POST /mcp for viewer and cont3xt, off by default, enable with mcpEnabled.
   - #4134 Add mcpUser role, required per user on top of the service role to use /mcp; superAdmin includes it, arkimeAdmin does not

--- a/capture/bsb.h
+++ b/capture/bsb.h
@@ -13,13 +13,13 @@
 
 #define BSB_INIT(b, buffer, size)                 \
 do {                                              \
-    (b).buf = (unsigned char*)buffer;             \
+    (b).buf = (unsigned char*)(buffer);           \
     (b).ptr = (b).buf;                            \
-    int s = (int)size;                            \
+    int s = (int)(size);                          \
     if (((b).buf == NULL) || (s < 0))             \
         (b).end = 0;                              \
     else                                          \
-        (b).end = (b).buf + size;                 \
+        (b).end = (b).buf + s;                    \
 } while (0)
 
 #define BSB_SET_ERROR(b) ((b).end = NULL)
@@ -33,15 +33,15 @@ do {                                              \
 
 #define BSB_SHRINK_REMAINING(b, rem)              \
 do {                                              \
-    if ((b).end && ((b).ptr + rem < (b).end)) {   \
-        (b).end = (b).ptr + rem;                  \
+    if ((b).end && ((b).ptr + (rem) < (b).end)) { \
+        (b).end = (b).ptr + (rem);                \
     }                                             \
 } while (0)
 
 #define BSB_EXPORT_u08(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 1 <= (b).end) {      \
-        *(((b).ptr)++) = (unsigned char)x;        \
+        *(((b).ptr)++) = (unsigned char)(x);      \
     } else                                        \
         BSB_SET_ERROR(b);                         \
 } while (0)
@@ -49,7 +49,7 @@ do {                                              \
 #define BSB_EXPORT_u16(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 2 <= (b).end) {      \
-        uint16_t t = (uint16_t)x;                 \
+        uint16_t t = (uint16_t)(x);               \
         *(((b).ptr)++) = (t & 0xff00) >> 8;       \
         *(((b).ptr)++) = (t & 0x00ff);            \
     } else                                        \
@@ -59,7 +59,7 @@ do {                                              \
 #define BSB_EXPORT_u24(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 3 <= (b).end) {      \
-        uint32_t t = x;                           \
+        uint32_t t = (x);                         \
         *(((b).ptr)++) = (t & 0x00ff0000) >> 16;  \
         *(((b).ptr)++) = (t & 0x0000ff00) >> 8;   \
         *(((b).ptr)++) = (t & 0x000000ff);        \
@@ -70,7 +70,7 @@ do {                                              \
 #define BSB_EXPORT_u32(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 4 <= (b).end) {      \
-        uint32_t t = x;                           \
+        uint32_t t = (x);                         \
         *(((b).ptr)++) = (t & 0xff000000) >> 24;  \
         *(((b).ptr)++) = (t & 0x00ff0000) >> 16;  \
         *(((b).ptr)++) = (t & 0x0000ff00) >> 8;   \
@@ -82,7 +82,7 @@ do {                                              \
 #define BSB_EXPORT_u40(b, x)                        \
 do {                                                \
     if ((b).ptr && (b).ptr + 5 <= (b).end) {        \
-        uint64_t t = x;                             \
+        uint64_t t = (x);                           \
         *(((b).ptr)++) = (t & 0xff00000000) >> 32;  \
         *(((b).ptr)++) = (t & 0x00ff000000) >> 24;  \
         *(((b).ptr)++) = (t & 0x0000ff0000) >> 16;  \
@@ -94,11 +94,11 @@ do {                                                \
 
 #define BSB_EXPORT_ptr(b, x, size)                \
 do {                                              \
-    if (((x) != NULL || size == 0) &&             \
-        (b).ptr + size <= (b).end &&              \
-        (b).ptr + size >= (b).buf) {              \
-        memcpy((b).ptr, x, size);                 \
-        (b).ptr += size;                          \
+    if (((x) != NULL || (size) == 0) &&           \
+        (b).ptr + (size) <= (b).end &&            \
+        (b).ptr + (size) >= (b).buf) {            \
+        memcpy((b).ptr, (x), (size));             \
+        (b).ptr += (size);                        \
     } else                                        \
         BSB_SET_ERROR(b);                         \
 } while (0)
@@ -106,25 +106,25 @@ do {                                              \
 #define BSB_EXPORT_ptr_some(b, x, size)           \
 do {                                              \
     if ((x) == NULL) {                            \
-        if (size != 0)                            \
+        if ((size) != 0)                          \
             BSB_SET_ERROR(b);                     \
     } else if ((b).ptr &&                         \
-        (b).ptr + size <= (b).end &&              \
-        (b).ptr + size >= (b).buf) {              \
-        memcpy((b).ptr, x, size);                 \
-        (b).ptr += size;                          \
+        (b).ptr + (size) <= (b).end &&            \
+        (b).ptr + (size) >= (b).buf) {            \
+        memcpy((b).ptr, (x), (size));             \
+        (b).ptr += (size);                        \
     } else if (BSB_NOT_ERROR(b)) {                \
         size_t _bsb_rem = BSB_REMAINING(b);       \
-        memcpy((b).ptr, x, _bsb_rem);             \
+        memcpy((b).ptr, (x), _bsb_rem);           \
         (b).ptr += _bsb_rem;                      \
     }                                             \
 } while (0)
 
 #define BSB_EXPORT_cstr(b, x)                     \
 do {                                              \
-    const int size = sizeof x - 1;                \
+    const int size = sizeof(x) - 1;               \
     if ((b).ptr && (b).ptr + size <= (b).end) {   \
-        memcpy((b).ptr, x, size);                 \
+        memcpy((b).ptr, (x), size);               \
         (b).ptr += size;                          \
     } else                                        \
         BSB_SET_ERROR(b);                         \
@@ -132,18 +132,18 @@ do {                                              \
 
 #define BSB_EXPORT_skip(b, size)                  \
 do {                                              \
-    if ((b).ptr + size <= (b).end &&              \
-        (b).ptr + size >= (b).buf) {              \
-        (b).ptr += size;                          \
+    if ((b).ptr + (size) <= (b).end &&            \
+        (b).ptr + (size) >= (b).buf) {            \
+        (b).ptr += (size);                        \
     } else                                        \
         BSB_SET_ERROR(b);                         \
 } while (0)
 
 #define BSB_EXPORT_rewind(b, size)                \
 do {                                              \
-    if ((b).ptr - size <= (b).end &&              \
-        (b).ptr - size >= (b).buf) {              \
-        (b).ptr -= size;                          \
+    if ((b).ptr - (size) <= (b).end &&            \
+        (b).ptr - (size) >= (b).buf) {            \
+        (b).ptr -= (size);                        \
     } else {                                      \
         BSB_SET_ERROR(b);                         \
     }                                             \
@@ -215,7 +215,7 @@ do {                                              \
 #define BSB_IMPORT_u08(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 1 <= (b).end) {      \
-        x = *(((b).ptr)++);                       \
+        (x) = *(((b).ptr)++);                     \
     } else                                        \
         BSB_SET_ERROR(b);                         \
 } while (0)
@@ -223,7 +223,7 @@ do {                                              \
 #define BSB_IMPORT_u16(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 2 <= (b).end) {      \
-        x = ((uint16_t)((b).ptr)[0]) << 8 |       \
+        (x) = ((uint16_t)((b).ptr)[0]) << 8 |     \
             ((uint16_t)((b).ptr)[1]);             \
         (b).ptr += 2;                             \
     } else                                        \
@@ -233,7 +233,7 @@ do {                                              \
 #define BSB_IMPORT_u24(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 3 <= (b).end) {      \
-        x = ((uint32_t)((b).ptr)[0]) << 16 |      \
+        (x) = ((uint32_t)((b).ptr)[0]) << 16 |    \
             ((uint32_t)((b).ptr)[1]) << 8  |      \
             ((uint32_t)((b).ptr)[2]);             \
         (b).ptr += 3;                             \
@@ -244,7 +244,7 @@ do {                                              \
 #define BSB_IMPORT_u32(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 4 <= (b).end) {      \
-        x = ((uint32_t)((b).ptr)[0]) << 24 |      \
+        (x) = ((uint32_t)((b).ptr)[0]) << 24 |    \
             ((uint32_t)((b).ptr)[1]) << 16 |      \
             ((uint32_t)((b).ptr)[2]) << 8  |      \
             ((uint32_t)((b).ptr)[3]);             \
@@ -256,7 +256,7 @@ do {                                              \
 #define BSB_IMPORT_u64(b, x)                      \
 do {                                              \
     if ((b).ptr && (b).ptr + 8 <= (b).end) {      \
-        x = ((uint64_t)((b).ptr)[0]) << 56 |      \
+        (x) = ((uint64_t)((b).ptr)[0]) << 56 |    \
             ((uint64_t)((b).ptr)[1]) << 48 |      \
             ((uint64_t)((b).ptr)[2]) << 40 |      \
             ((uint64_t)((b).ptr)[3]) << 32 |      \
@@ -274,7 +274,7 @@ do {                                              \
 #define BSB_LEXPORT_u16(b, x)                     \
 do {                                              \
     if ((b).ptr && (b).ptr + 2 <= (b).end) {      \
-        uint16_t t = (uint16_t)x;                 \
+        uint16_t t = (uint16_t)(x);               \
         *(((b).ptr)++) = (t & 0x00ff);            \
         *(((b).ptr)++) = (t & 0xff00) >> 8;       \
     } else                                        \
@@ -284,7 +284,7 @@ do {                                              \
 #define BSB_LEXPORT_u32(b, x)                     \
 do {                                              \
     if ((b).ptr && (b).ptr + 4 <= (b).end) {      \
-        uint32_t t = x;                           \
+        uint32_t t = (x);                         \
         *(((b).ptr)++) = (t & 0x000000ff);        \
         *(((b).ptr)++) = (t & 0x0000ff00) >> 8;   \
         *(((b).ptr)++) = (t & 0x00ff0000) >> 16;  \
@@ -298,7 +298,7 @@ do {                                              \
 #define BSB_LIMPORT_u16(b, x)                     \
 do {                                              \
     if ((b).ptr && (b).ptr + 2 <= (b).end) {      \
-        x = ((uint16_t)((b).ptr)[1]) << 8 |       \
+        (x) = ((uint16_t)((b).ptr)[1]) << 8 |     \
             ((uint16_t)((b).ptr)[0]);             \
         (b).ptr += 2;                             \
     } else                                        \
@@ -308,7 +308,7 @@ do {                                              \
 #define BSB_LIMPORT_u24(b, x)                     \
 do {                                              \
     if ((b).ptr && (b).ptr + 3 <= (b).end) {      \
-        x = ((uint32_t)((b).ptr)[2]) << 16 |      \
+        (x) = ((uint32_t)((b).ptr)[2]) << 16 |    \
             ((uint32_t)((b).ptr)[1]) << 8  |      \
             ((uint32_t)((b).ptr)[0]);             \
         (b).ptr += 3;                             \
@@ -319,7 +319,7 @@ do {                                              \
 #define BSB_LIMPORT_u32(b, x)                     \
 do {                                              \
     if ((b).ptr && (b).ptr + 4 <= (b).end) {      \
-        x = ((uint32_t)((b).ptr)[3]) << 24 |      \
+        (x) = ((uint32_t)((b).ptr)[3]) << 24 |    \
             ((uint32_t)((b).ptr)[2]) << 16 |      \
             ((uint32_t)((b).ptr)[1]) << 8  |      \
             ((uint32_t)((b).ptr)[0]);             \
@@ -331,7 +331,7 @@ do {                                              \
 #define BSB_LIMPORT_u64(b, x)                     \
 do {                                              \
     if ((b).ptr && (b).ptr + 8 <= (b).end) {      \
-        x = ((uint64_t)((b).ptr)[7]) << 56 |      \
+        (x) = ((uint64_t)((b).ptr)[7]) << 56 |    \
             ((uint64_t)((b).ptr)[6]) << 48 |      \
             ((uint64_t)((b).ptr)[5]) << 40 |      \
             ((uint64_t)((b).ptr)[4]) << 32 |      \
@@ -346,22 +346,22 @@ do {                                              \
 
 #define BSB_IMPORT_ptr(b, x, size)                \
 do {                                              \
-    if ((b).ptr + size <= (b).end &&              \
-        (b).ptr + size >= (b).buf) {              \
+    if ((b).ptr + (size) <= (b).end &&            \
+        (b).ptr + (size) >= (b).buf) {            \
         (x) = (b).ptr;                            \
-        (b).ptr += size;                          \
+        (b).ptr += (size);                        \
     } else {                                      \
         BSB_SET_ERROR(b);                         \
-        x = 0;                                    \
+        (x) = 0;                                  \
     }                                             \
 } while (0)
 
 #define BSB_IMPORT_bsb(b, x, size)                \
 do {                                              \
-    if ((b).ptr + size <= (b).end &&              \
-        (b).ptr + size >= (b).buf) {              \
-        BSB_INIT(x, (b).ptr, size);               \
-        (b).ptr += size;                          \
+    if ((b).ptr + (size) <= (b).end &&            \
+        (b).ptr + (size) >= (b).buf) {            \
+        BSB_INIT(x, (b).ptr, (size));             \
+        (b).ptr += (size);                        \
     } else {                                      \
         BSB_SET_ERROR(b);                         \
         (x).ptr = (x).buf = (x).end = NULL;       \
@@ -380,24 +380,24 @@ do {                                              \
         pos = -1;                                 \
         break;                                    \
     }                                             \
-    char *s = memchr((char*)(b).ptr, ch, BSB_REMAINING(b)); \
+    char *s = memchr((char*)(b).ptr, (ch), BSB_REMAINING(b)); \
     if (s)                                        \
         pos = (char *)s - (char *)(b).ptr;        \
     else                                          \
         pos = -1;                                 \
 } while (0)
 
-#define BSB_memcmp(str, b, len) ((b).ptr && (b).ptr + len <= (b).end ? memcmp(str, (b).ptr, len) : -1)
+#define BSB_memcmp(str, b, len) ((b).ptr && (b).ptr + (len) <= (b).end ? memcmp((str), (b).ptr, (len)) : -1)
 
 #define BSB_PEEK(b) ((b).ptr && (b).ptr + 1 <= (b).end ? (b).ptr[0] : -1)
 
 
 #define BSB_IMPORT_byte(b, x, size)               \
 do {                                              \
-    if ((b).ptr && (b).ptr + size <= (b).end &&   \
-        (b).ptr + size >= (b).buf) {              \
-        memcpy(x, (b).ptr, size);                 \
-        (b).ptr += size;                          \
+    if ((b).ptr && (b).ptr + (size) <= (b).end && \
+        (b).ptr + (size) >= (b).buf) {            \
+        memcpy((x), (b).ptr, (size));             \
+        (b).ptr += (size);                        \
     } else {                                      \
         BSB_SET_ERROR(b);                         \
     }                                             \
@@ -405,11 +405,11 @@ do {                                              \
 
 #define BSB_IMPORT_zbyte(b, x, size)              \
 do {                                              \
-    if ((b).ptr && (b).ptr + size <= (b).end &&   \
-        (b).ptr + size >= (b).buf) {              \
-        memcpy(x, (b).ptr, size);                 \
+    if ((b).ptr && (b).ptr + (size) <= (b).end && \
+        (b).ptr + (size) >= (b).buf) {            \
+        memcpy((x), (b).ptr, (size));             \
         (x)[size] = 0;                            \
-        (b).ptr += size;                          \
+        (b).ptr += (size);                        \
     } else {                                      \
         BSB_SET_ERROR(b);                         \
         (x)[0] = 0;                               \

--- a/capture/db.c
+++ b/capture/db.c
@@ -162,6 +162,37 @@ void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
 {
     BSB_EXPORT_u08(*bsb, '"');
     while (*in) {
+        // batch a run of bytes that pass through unchanged
+        const uint8_t *start = in;
+        while (*in) {
+            if (*in >= 0x20 && *in < 0x80 && *in != '"' && *in != '\\') {
+                in++;
+                continue;
+            }
+            if (utf8) {
+                // valid continuation bytes and not overlong/surrogate/>U+10FFFF
+                if ((*in & 0xf8) == 0xf0 && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80 && (in[3] & 0xc0) == 0x80 &&
+                    *in <= 0xf4 && !(*in == 0xf0 && in[1] < 0x90) && !(*in == 0xf4 && in[1] > 0x8f)) {
+                    in += 4;
+                    continue;
+                }
+                if ((*in & 0xf0) == 0xe0 && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80 &&
+                    !(*in == 0xe0 && in[1] < 0xa0) && !(*in == 0xed && in[1] > 0x9f)) {
+                    in += 3;
+                    continue;
+                }
+                if ((*in & 0xe0) == 0xc0 && *in >= 0xc2 && (in[1] & 0xc0) == 0x80) {
+                    in += 2;
+                    continue;
+                }
+            }
+            break;
+        }
+        if (in > start)
+            BSB_EXPORT_ptr(*bsb, start, in - start);
+        if (!*in)
+            break;
+
         switch (*in) {
         case '\b':
             BSB_EXPORT_cstr(*bsb, "\\b");
@@ -184,36 +215,13 @@ void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
         case '\\':
             BSB_EXPORT_cstr(*bsb, "\\\\");
             break;
-        case '/':
-            BSB_EXPORT_cstr(*bsb, "\\/");
-            break;
         default:
             if (*in < 32) {
                 BSB_EXPORT_sprintf(*bsb, "\\u%04x", *in);
-            } else if (utf8) {
-                // require valid continuation bytes; else encode this byte alone
-                if ((*in & 0xf8) == 0xf0 && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80 && (in[3] & 0xc0) == 0x80) {
-                    BSB_EXPORT_ptr(*bsb, in, 4);
-                    in += 3;
-                } else if ((*in & 0xf0) == 0xe0 && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80) {
-                    BSB_EXPORT_ptr(*bsb, in, 3);
-                    in += 2;
-                } else if ((*in & 0xe0) == 0xc0 && (in[1] & 0xc0) == 0x80) {
-                    BSB_EXPORT_ptr(*bsb, in, 2);
-                    in += 1;
-                } else if (*in < 0x80) {
-                    BSB_EXPORT_u08(*bsb, *in);
-                } else {
-                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
-                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
-                }
             } else {
-                if (*in & 0x80) {
-                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
-                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
-                } else {
-                    BSB_EXPORT_u08(*bsb, *in);
-                }
+                // invalid or non-utf8 high byte: latin1 -> utf8
+                BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
+                BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
             }
             break;
         }
@@ -233,6 +241,37 @@ void arkime_db_js0n_str_unquoted(BSB *bsb, uint8_t *in, int len, gboolean utf8)
     const uint8_t *end = in + len;
 
     while (in < end) {
+        // batch a run of bytes that pass through unchanged
+        const uint8_t *start = in;
+        while (in < end) {
+            if (*in >= 0x20 && *in < 0x80 && *in != '"' && *in != '\\') {
+                in++;
+                continue;
+            }
+            if (utf8) {
+                // valid continuation bytes and not overlong/surrogate/>U+10FFFF
+                if ((*in & 0xf8) == 0xf0 && in + 3 < end && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80 && (in[3] & 0xc0) == 0x80 &&
+                    *in <= 0xf4 && !(*in == 0xf0 && in[1] < 0x90) && !(*in == 0xf4 && in[1] > 0x8f)) {
+                    in += 4;
+                    continue;
+                }
+                if ((*in & 0xf0) == 0xe0 && in + 2 < end && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80 &&
+                    !(*in == 0xe0 && in[1] < 0xa0) && !(*in == 0xed && in[1] > 0x9f)) {
+                    in += 3;
+                    continue;
+                }
+                if ((*in & 0xe0) == 0xc0 && *in >= 0xc2 && in + 1 < end && (in[1] & 0xc0) == 0x80) {
+                    in += 2;
+                    continue;
+                }
+            }
+            break;
+        }
+        if (in > start)
+            BSB_EXPORT_ptr(*bsb, start, in - start);
+        if (in >= end)
+            break;
+
         switch (*in) {
         case '\b':
             BSB_EXPORT_cstr(*bsb, "\\b");
@@ -255,36 +294,13 @@ void arkime_db_js0n_str_unquoted(BSB *bsb, uint8_t *in, int len, gboolean utf8)
         case '\\':
             BSB_EXPORT_cstr(*bsb, "\\\\");
             break;
-        case '/':
-            BSB_EXPORT_cstr(*bsb, "\\/");
-            break;
         default:
             if (*in < 32) {
                 BSB_EXPORT_sprintf(*bsb, "\\u%04x", *in);
-            } else if (utf8) {
-                // require valid continuation bytes; else encode this byte alone
-                if ((*in & 0xf8) == 0xf0 && in + 3 < end && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80 && (in[3] & 0xc0) == 0x80) {
-                    BSB_EXPORT_ptr(*bsb, in, 4);
-                    in += 3;
-                } else if ((*in & 0xf0) == 0xe0 && in + 2 < end && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80) {
-                    BSB_EXPORT_ptr(*bsb, in, 3);
-                    in += 2;
-                } else if ((*in & 0xe0) == 0xc0 && in + 1 < end && (in[1] & 0xc0) == 0x80) {
-                    BSB_EXPORT_ptr(*bsb, in, 2);
-                    in += 1;
-                } else if (*in < 0x80) {
-                    BSB_EXPORT_u08(*bsb, *in);
-                } else {
-                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
-                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
-                }
             } else {
-                if (*in & 0x80) {
-                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
-                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
-                } else {
-                    BSB_EXPORT_u08(*bsb, *in);
-                }
+                // invalid or non-utf8 high byte: latin1 -> utf8
+                BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
+                BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
             }
             break;
         }

--- a/capture/db.c
+++ b/capture/db.c
@@ -191,20 +191,21 @@ void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
             if (*in < 32) {
                 BSB_EXPORT_sprintf(*bsb, "\\u%04x", *in);
             } else if (utf8) {
-                if ((*in & 0xf8) == 0xf0) {
-                    if (!in[1] || !in[2] || !in[3]) goto end;
+                // require valid continuation bytes; else encode this byte alone
+                if ((*in & 0xf8) == 0xf0 && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80 && (in[3] & 0xc0) == 0x80) {
                     BSB_EXPORT_ptr(*bsb, in, 4);
                     in += 3;
-                } else if ((*in & 0xf0) == 0xe0) {
-                    if (!in[1] || !in[2]) goto end;
+                } else if ((*in & 0xf0) == 0xe0 && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80) {
                     BSB_EXPORT_ptr(*bsb, in, 3);
                     in += 2;
-                } else if ((*in & 0xe0) == 0xc0) {
-                    if (!in[1]) goto end;
+                } else if ((*in & 0xe0) == 0xc0 && (in[1] & 0xc0) == 0x80) {
                     BSB_EXPORT_ptr(*bsb, in, 2);
                     in += 1;
-                } else {
+                } else if (*in < 0x80) {
                     BSB_EXPORT_u08(*bsb, *in);
+                } else {
+                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
+                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
                 }
             } else {
                 if (*in & 0x80) {
@@ -219,7 +220,6 @@ void arkime_db_js0n_str(BSB *bsb, uint8_t *in, gboolean utf8)
         in++;
     }
 
-end:
     BSB_EXPORT_u08(*bsb, '"');
 }
 
@@ -262,20 +262,21 @@ void arkime_db_js0n_str_unquoted(BSB *bsb, uint8_t *in, int len, gboolean utf8)
             if (*in < 32) {
                 BSB_EXPORT_sprintf(*bsb, "\\u%04x", *in);
             } else if (utf8) {
-                if ((*in & 0xf8) == 0xf0) {
-                    if (in + 3 >= end) return;
+                // require valid continuation bytes; else encode this byte alone
+                if ((*in & 0xf8) == 0xf0 && in + 3 < end && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80 && (in[3] & 0xc0) == 0x80) {
                     BSB_EXPORT_ptr(*bsb, in, 4);
                     in += 3;
-                } else if ((*in & 0xf0) == 0xe0) {
-                    if (in + 2 >= end) return;
+                } else if ((*in & 0xf0) == 0xe0 && in + 2 < end && (in[1] & 0xc0) == 0x80 && (in[2] & 0xc0) == 0x80) {
                     BSB_EXPORT_ptr(*bsb, in, 3);
                     in += 2;
-                } else if ((*in & 0xe0) == 0xc0) {
-                    if (in + 1 >= end) return;
+                } else if ((*in & 0xe0) == 0xc0 && in + 1 < end && (in[1] & 0xc0) == 0x80) {
                     BSB_EXPORT_ptr(*bsb, in, 2);
                     in += 1;
-                } else {
+                } else if (*in < 0x80) {
                     BSB_EXPORT_u08(*bsb, *in);
+                } else {
+                    BSB_EXPORT_u08(*bsb, (0xc0 | (*in >> 6)));
+                    BSB_EXPORT_u08(*bsb, (0x80 | (*in & 0x3f)));
                 }
             } else {
                 if (*in & 0x80) {

--- a/capture/drophash.c
+++ b/capture/drophash.c
@@ -68,7 +68,7 @@ LOCAL void arkime_drophash_make(ArkimeDropHashGroup_t *group, int port)
     hash->num     = size;
     hash->heads   = ARKIME_SIZE_ALLOC0("heads", size * sizeof(ArkimeDropHashItem_t *));
     hash->cnt     = 0;
-    group->drops[port] = hash;
+    ARKIME_THREAD_ATOMIC_STORE(group->drops[port], hash);
 done:
     ARKIME_UNLOCK(group->lock);
 }

--- a/capture/field.c
+++ b/capture/field.c
@@ -274,8 +274,11 @@ int arkime_field_define_text_full(const char *field, const char *text, int *shor
     if (!group) {
         const char *dot = strchr(field, '.');
         if (dot) {
-            if (dot - field >= (int)sizeof(groupbuf) - 1)
-                LOGEXIT("ERROR - field '%s' too long", field);
+            if (dot - field >= (int)sizeof(groupbuf) - 1) {
+                LOG("ERROR - field '%s' too long", field);
+                g_strfreev(elements);
+                return -1;
+            }
             memcpy(groupbuf, field, dot - field);
             groupbuf[dot - field] = 0;
             group = groupbuf;
@@ -342,7 +345,7 @@ LOCAL int arkime_field_group_num(const char *group, int len)
     char       groupName[100];
 
     if (len + 1 >= (int)sizeof(groupName)) {
-        LOGEXIT("ERROR - field '%s' too long", group);
+        LOG("ERROR - field '%s' too long", group);
         return 0;
     }
     memcpy(groupName, group, len);

--- a/capture/http.c
+++ b/capture/http.c
@@ -157,6 +157,8 @@ LOCAL size_t arkime_http_curl_write_callback(void *contents, size_t size, size_t
         curl_easy_getinfo(request->easy, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl);
         if (cl < 0 || cl > 0x7FFFFFFF)
             cl = sz;
+        if (cl > 0x400000)
+            cl = 0x400000;
         request->used = sz;
         request->size = MAX(sz, (uint32_t)cl);
         request->dataIn = ARKIME_SIZE_ALLOC("dataIn", request->size + 1);
@@ -261,7 +263,10 @@ uint8_t *arkime_http_send_sync(void *serverV, const char *method, const char *ke
         key_len = strlen(key);
 
     if (key_len > 1000) {
-        LOGEXIT("ERROR - URL too long %.*s", key_len, key);
+        LOG("ERROR - Dropping request, URL too long: %.*s", key_len, key);
+        if (code)
+            *code = 0;
+        return NULL;
     }
 
     memcpy(server->syncRequest.key, key, key_len);
@@ -818,7 +823,12 @@ gboolean arkime_http_schedule2(void *serverV, const char *method, const char *ke
         key_len = strlen(key);
 
     if (key_len > 1000) {
-        LOGEXIT("ERROR - URL too long %.*s", key_len, key);
+        LOG("ERROR - Dropping request, URL too long: %.*s", key_len, key);
+        ARKIME_THREAD_INCR(server->dropped);
+        if (data) {
+            ARKIME_SIZE_FREE("data", data);
+        }
+        return 1;
     }
 
     // Are we overloaded

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -646,8 +646,8 @@ LOCAL gboolean arkime_packet_frags_process(ArkimePacket_t *const packet)
     ip_off &= IP_OFFMASK;
 
 
-    // we might be done once we receive the packets with no flags
-    if (ip_flags == 0) {
+    // Last fragment = MF clear; ignore DF/reserved bits
+    if ((ip_flags & IP_MF) == 0) {
         frags->haveNoFlags = 1;
     }
 

--- a/capture/parsers/sctp.c
+++ b/capture/parsers/sctp.c
@@ -314,6 +314,11 @@ LOCAL int sctp_packet_process(ArkimeSession_t *const session, ArkimePacket_t *co
                 if (SCTP_DATA_FLAG_SEND_NOW(chunkFlags)) {
                     sctp_send_data(session, BSB_WORK_PTR(cbsb), BSB_REMAINING(cbsb), payloadProtoId, which);
                 } else {
+                    if (DLL_COUNT(sd_, &session->sctpData) > maxSctpOutOfOrderPackets) {
+                        arkime_session_add_tag(session, "incomplete-sctp");
+                        session->stopTCP = 1;
+                        return 1;
+                    }
                     sctp_add_data(&session->sctpData, tsn, which, &cbsb, chunkFlags, payloadProtoId);
                 }
 

--- a/capture/plugins/wise.c
+++ b/capture/plugins/wise.c
@@ -175,14 +175,16 @@ LOCAL void wise_load_fields()
 
     if (ver < 0 || ver > 1) {
         if (wiseURL) {
-            LOGEXIT("ERROR - Verify wiseURL value of `%s` version: %d - %s",
-                    wiseURL, ver,
-                    (ver == -1 ? "Couldn't connect to WISE" : "Unsupported version"));
+            LOG("ERROR - Verify wiseURL value of `%s` version: %d - %s",
+                wiseURL, ver,
+                (ver == -1 ? "Couldn't connect to WISE" : "Unsupported version"));
         } else {
-            LOGEXIT("ERROR - Verify wiseHost:wisePort value of `%s:%d` version: %d - %s",
-                    wiseHost, wisePort, ver,
-                    (ver == -1 ? "Couldn't connect to WISE" : "Unsupported version"));
+            LOG("ERROR - Verify wiseHost:wisePort value of `%s:%d` version: %d - %s",
+                wiseHost, wisePort, ver,
+                (ver == -1 ? "Couldn't connect to WISE" : "Unsupported version"));
         }
+        free(data);
+        return;
     }
 
     if (ver == 0) {
@@ -192,7 +194,9 @@ LOCAL void wise_load_fields()
     }
 
     if (cnt > ARKIME_FIELDS_MAX) {
-        LOGEXIT("ERROR - Wise server is returning too many fields %d > %d", cnt, ARKIME_FIELDS_MAX);
+        LOG("ERROR - Wise server is returning too many fields %d > %d", cnt, ARKIME_FIELDS_MAX);
+        free(data);
+        return;
     }
 
     for (int i = 0; i < cnt; i++) {
@@ -296,7 +300,14 @@ LOCAL void wise_cb(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
         }
 
         if (cnt > ARKIME_FIELDS_MAX) {
-            LOGEXIT("ERROR - Wise server is returning too many fields %d > %d", cnt, ARKIME_FIELDS_MAX);
+            LOG_RATE(30, "ERROR - Wise server is returning too many fields %d > %d", cnt, ARKIME_FIELDS_MAX);
+            ARKIME_LOCK(item);
+            for (i = 0; i < request->numItems; i++) {
+                wise_remove_item_locked(request->items[i]);
+            }
+            ARKIME_UNLOCK(item);
+            ARKIME_TYPE_FREE(WiseRequest_t, request);
+            return;
         }
 
         ARKIME_LOCK(item);
@@ -308,10 +319,18 @@ LOCAL void wise_cb(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
         if (config.debug)
             LOG("WISE Response %32.32s cnt %d pos %d", hash, cnt, hashPos);
 
-        if (hashPos == FIELDS_MAP_MAX)
-            LOGEXIT("ERROR - Too many unique wise hashes");
+        if (hashPos == FIELDS_MAP_MAX) {
+            LOG_RATE(30, "ERROR - Too many unique wise hashes");
+            for (i = 0; i < request->numItems; i++) {
+                wise_remove_item_locked(request->items[i]);
+            }
+            ARKIME_UNLOCK(item);
+            ARKIME_TYPE_FREE(WiseRequest_t, request);
+            return;
+        }
 
-        if (hashPos == fieldsMapCnt) {
+        gboolean newHash = (hashPos == fieldsMapCnt);
+        if (newHash) {
             fieldsMapHash[hashPos] = g_strndup((gchar *)hash, 32);
             fieldsMapCnt++;
             g_strlcpy(wiseGetURI, "/get?ver=2", sizeof(wiseGetURI));
@@ -325,7 +344,8 @@ LOCAL void wise_cb(int UNUSED(code), uint8_t *data, int data_len, gpointer uw)
             }
         }
 
-        if (cnt)
+        // cnt == 0 for an already known hash means reuse the cached map
+        if (cnt || newHash)
             memset(fieldsMap[hashPos], -1, sizeof(fieldsMap[hashPos]));
 
         for (i = 0; i < cnt; i++) {

--- a/capture/pq.c
+++ b/capture/pq.c
@@ -62,7 +62,7 @@ ArkimePQ_t *arkime_pq_alloc(int timeout, ArkimePQ_cb cb)
 
     pq->timeout = timeout;
     for (int t = 0; t < config.packetThreads; t++) {
-        HASH_INIT(pqh_, pq->keys[t], arkime_string_hash, (HASH_CMP_FUNC)arkime_pq_cmp);
+        HASH_INIT(pqh_, pq->keys[t], arkime_session_hash, (HASH_CMP_FUNC)arkime_pq_cmp);
         DLL_INIT(pql_, &pq->lists[t]);
     }
     pq->cb = cb;

--- a/capture/reader-scheme-s3.c
+++ b/capture/reader-scheme-s3.c
@@ -92,9 +92,19 @@ LOCAL void scheme_s3_parse_region(const uint8_t *data, int data_len, const char 
         wrong += 23;
         const char *end = arkime_memstr(wrong, data_len - (wrong - (char *)data), "'", 1);
         if (end) {
-            char *region = g_strndup(wrong, end - wrong);
-            g_hash_table_insert(bucket2Region, g_strdup(bucket), region);
-            req->tryAgain = TRUE;
+            int rlen = end - wrong;
+            gboolean ok = (rlen > 0 && rlen < 40);
+            for (int i = 0; ok && i < rlen; i++) {
+                char c = wrong[i];
+                if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-'))
+                    ok = FALSE;
+            }
+            if (ok) {
+                g_hash_table_insert(bucket2Region, g_strdup(bucket), g_strndup(wrong, rlen));
+                req->tryAgain = TRUE;
+            } else {
+                LOG("ERROR - Ignoring invalid region in S3 response");
+            }
         }
     } else {
         LOG("ERROR - %.*s", data_len, data);

--- a/capture/reader-scheme-sqs.c
+++ b/capture/reader-scheme-sqs.c
@@ -275,6 +275,7 @@ LOCAL int scheme_sqs_load(const char *uri, ArkimeSchemeFlags flags, ArkimeScheme
 
     while (!req->done || DLL_COUNT(item_, req->items) > 0) {
         if (!req->done && DLL_COUNT(item_, req->items) == 0) {
+            creds = arkime_credentials_get("sqs", "sqsAccessKeyId", "sqsSecretAccessKey");
             // Update tokenHeader
             if (creds->token) {
                 snprintf(tokenHeader, sizeof(tokenHeader), "X-Amz-Security-Token: %s", creds->token);


### PR DESCRIPTION
- http: grow response buffer as data arrives instead of pre-allocating Content-Length (up to 2GB)
- http: drop a single over-long request URL instead of exiting capture
- db: reject malformed UTF-8 in the ES JSON string encoder instead of passing it through
- reader-scheme-s3: validate the region from S3 error bodies before re-signing requests
- reader-scheme-sqs: don't hold a credentials pointer across the poll loop (use-after-free on refresh)
- sctp: bound in-order reassembly queue so begin-without-end fragments can't grow memory unbounded
- packet: recognize the last IPv4 fragment when DF/reserved flag bits are set
- pq: use a binary-safe hash for session ids
- drophash: use a release store to fix a publish race
- wise: log and skip on malformed/unreachable WISE server instead of exiting; rate-limit the new error logs
- wise: properly initialize the field map for new hashes on zero-field responses
- field: return errors instead of exiting on over-long field/group names

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
