### PR TITLE
Mask packed SCTP stream id in HTTP/2 parser to fix heap OOB access

### DIFF
--- a/capture/parsers/http2.c
+++ b/capture/parsers/http2.c
@@ -416,6 +416,8 @@ LOCAL int http2_parse(ArkimeSession_t *session, void *uw, const uint8_t *data, i
 {
     HTTP2Info_t            *http2          = uw;
 
+    which = ARKIME_WHICH_GET_DIR(which); // SCTP packs stream id into which; arrays below are [2]
+
 #ifdef HTTPDEBUG
     LOG("HTTPDEBUG which: %d used: %d len: %d", which, http2->used[which], len);
 #endif
@@ -495,7 +497,7 @@ LOCAL void http2_classify(ArkimeSession_t *session, const uint8_t *UNUSED(data),
     arkime_session_add_protocol(session, "http2");
 
     HTTP2Info_t            *http2          = ARKIME_TYPE_ALLOC0(HTTP2Info_t);
-    http2->which = which;
+    http2->which = ARKIME_WHICH_GET_DIR(which);
 
     arkime_parsers_register2(session, http2_parse, http2, http2_free, http2_save);
 }


### PR DESCRIPTION
For SCTP traffic, `which` packs the stream id into its upper bits (`ARKIME_WHICH_SET_ID`). After an HTTP/1.1 `Upgrade: h2c` transition on a non-zero SCTP stream, this packed value reaches `http2_parse` and is used directly to index the `HTTP2Info_t` arrays, which are sized `[2]` (one per direction) — a heap out-of-bounds read/write for any stream id > 0 (e.g. stream 1 → `which` = 256).

Mask `which` back to the direction bit at the top of `http2_parse`, and apply the same mask when storing `http2->which` in `http2_classify` so the request/response direction comparison stays correct. Both are no-ops for plain TCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)