### PR TITLE
Mask packed SCTP stream id to direction before dispatching to parsers

### DIFF
--- a/capture/parsers/sctp.c
+++ b/capture/parsers/sctp.c
@@ -158,14 +158,16 @@ LOCAL void sctp_add_data(ArkimeSCTP_t *sctp, uint32_t tsn, int which, BSB *const
 LOCAL void sctp_send_data(ArkimeSession_t *const session, const uint8_t *data, int len, uint32_t protoId, int which)
 {
     int dir = ARKIME_WHICH_GET_DIR(which);
+    // TODO dev7: multiplexed SCTP streams need per-stream sessions. For now flatten
+    // the packed stream id to direction so parsers don't OOB their [2] arrays.
     if (session->firstBytesLen[dir] == 0) {
         session->firstBytesLen[dir] = MIN(8, len);
         memcpy(session->firstBytes[dir], data, session->firstBytesLen[dir]);
-        arkime_parsers_classify_sctp(session, protoId, data, len, which);
+        arkime_parsers_classify_sctp(session, protoId, data, len, dir);
         arkime_field_int_add(protoIdField, session, (int)protoId);
     }
 
-    arkime_packet_process_data(session, data, len, which);
+    arkime_packet_process_data(session, data, len, dir);
 }
 
 /******************************************************************************/


### PR DESCRIPTION
sctp packs the stream id into the upper bits of which; downstream parsers index per-direction [2] arrays with it, so any stream id > 0 is a heap OOB. Mask to the direction bit at the single classify/process handoff, covering every SCTP-reachable parser (http/http2/websocket, m3ua/SS7, CONNECT tunnels). Reassembly still uses the full which for its stream comparisons.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
