### PR TITLE
Put cross thread counters on their own cache lines

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -655,6 +655,18 @@ typedef struct {
     uint8_t               readerPos; // used by libpcap reader to set readerPos
 } ArkimePacketBatch_t;
 
+// Global counters bumped with ARKIME_THREAD_INCR* by every reader thread.
+typedef struct {
+    ARKIME_CACHE_ALIGN uint64_t totalPackets;
+    uint64_t                    nextLogPackets; // read/written with totalPackets, same line on purpose
+    ARKIME_CACHE_ALIGN uint64_t totalBytes;
+    ARKIME_CACHE_ALIGN uint64_t totalSessions;
+    ARKIME_CACHE_ALIGN uint64_t totalSessionBytes;
+    ARKIME_CACHE_ALIGN uint64_t packetStats[ARKIME_PACKET_MAX];
+} ARKIME_CACHE_ALIGN ArkimeCounters_t;
+
+extern ArkimeCounters_t       arkimeCounters;
+
 typedef struct {
     char           *filename;
     char           *scheme;

--- a/capture/db.c
+++ b/capture/db.c
@@ -28,9 +28,6 @@ LOCAL MMDB_s           *geoASN;
 #define ARKIME_MIN_DB_VERSION 83
 
 int                     arkimeDbVersion = 0;
-extern uint64_t         totalPackets;
-LOCAL  uint64_t         totalSessions ARKIME_CACHE_ALIGN = 0;
-LOCAL  uint64_t         totalSessionBytes ARKIME_CACHE_ALIGN;
 LOCAL  uint16_t         myPid;
 extern uint32_t         pluginsCbs;
 
@@ -71,8 +68,6 @@ LOCAL int               arkime_session_save_func;
 
 LOCAL GRegex           *numRegex;
 LOCAL GRegex           *numHexRegex;
-
-extern uint64_t         packetStats[ARKIME_PACKET_MAX];
 
 /******************************************************************************/
 extern ArkimeConfig_t        config;
@@ -681,7 +676,7 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
         }
     }
 
-    ARKIME_THREAD_INCR(totalSessions);
+    ARKIME_THREAD_INCR(arkimeCounters.totalSessions);
     session->segments++;
 
     const int thread = session->thread;
@@ -1482,7 +1477,7 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
         goto cleanup;
     }
 
-    ARKIME_THREAD_INCR_NUM(totalSessionBytes, (int)(BSB_WORK_PTR(jbsb) - dataPtr));
+    ARKIME_THREAD_INCR_NUM(arkimeCounters.totalSessionBytes, (int)(BSB_WORK_PTR(jbsb) - dataPtr));
 
     if (config.dryRun) {
         if (config.tests) {
@@ -1716,7 +1711,7 @@ LOCAL void arkime_db_update_stats(int n, gboolean sync)
     uint64_t overloadDropped = arkime_packet_dropped_overload();
     uint64_t totalDropped    = arkime_packet_dropped_packets();
     uint64_t fragsDropped    = arkime_packet_dropped_frags();
-    uint64_t dupDropped      = packetStats[ARKIME_PACKET_DUPLICATE_DROPPED];
+    uint64_t dupDropped      = arkimeCounters.packetStats[ARKIME_PACKET_DUPLICATE_DROPPED];
     uint64_t esDropped       = arkime_http_dropped_count(esServer);
     uint64_t totalBytes      = arkime_packet_total_bytes();
     uint64_t writtenBytes    = arkime_packet_written_bytes();
@@ -1761,8 +1756,8 @@ LOCAL void arkime_db_update_stats(int n, gboolean sync)
     uint64_t diffusage = (usage.ru_utime.tv_sec - lastUsage[n].ru_utime.tv_sec) * 1000 + ((int64_t)usage.ru_utime.tv_usec - (int64_t)lastUsage[n].ru_utime.tv_usec) / 1000 +
                          (usage.ru_stime.tv_sec - lastUsage[n].ru_stime.tv_sec) * 1000 + ((int64_t)usage.ru_stime.tv_usec - (int64_t)lastUsage[n].ru_stime.tv_usec) / 1000;
 
-    dbTotalPackets[n] += (totalPackets - lastPackets[n]);
-    dbTotalSessions[n] += (totalSessions - lastSessions[n]);
+    dbTotalPackets[n] += (arkimeCounters.totalPackets - lastPackets[n]);
+    dbTotalSessions[n] += (arkimeCounters.totalSessions - lastSessions[n]);
     dbTotalDropped[n] += (totalDropped - lastDropped[n]);
     dbTotalK[n] += (totalBytes - lastBytes[n]) / 1000;
 
@@ -1855,12 +1850,12 @@ LOCAL void arkime_db_update_stats(int n, gboolean sync)
                                        arkime_session_watch_count(SESSION_SCTP),
                                        arkime_session_watch_count(SESSION_ESP),
                                        arkime_session_watch_count(SESSION_OTHER),
-                                       (totalPackets - lastPackets[n]),
+                                       (arkimeCounters.totalPackets - lastPackets[n]),
                                        (totalBytes - lastBytes[n]),
                                        (writtenBytes - lastWrittenBytes[n]),
                                        (unwrittenBytes - lastUnwrittenBytes[n]),
-                                       (totalSessions - lastSessions[n]),
-                                       (totalSessionBytes - lastSessionBytes[n]),
+                                       (arkimeCounters.totalSessions - lastSessions[n]),
+                                       (arkimeCounters.totalSessionBytes - lastSessionBytes[n]),
                                        (totalDropped - lastDropped[n]),
                                        (fragsDropped - lastFragsDropped[n]),
                                        (overloadDropped - lastOverloadDropped[n]),
@@ -1874,9 +1869,9 @@ LOCAL void arkime_db_update_stats(int n, gboolean sync)
     lastBytes[n]           = totalBytes;
     lastWrittenBytes[n]    = writtenBytes;
     lastUnwrittenBytes[n]  = unwrittenBytes;
-    lastPackets[n]         = totalPackets;
-    lastSessions[n]        = totalSessions;
-    lastSessionBytes[n]    = totalSessionBytes;
+    lastPackets[n]         = arkimeCounters.totalPackets;
+    lastSessions[n]        = arkimeCounters.totalSessions;
+    lastSessionBytes[n]    = arkimeCounters.totalSessionBytes;
     lastDropped[n]         = totalDropped;
     lastFragsDropped[n]    = fragsDropped;
     lastOverloadDropped[n] = overloadDropped;
@@ -3051,15 +3046,15 @@ void arkime_db_exit()
 
     if (config.debug) {
         LOG("totalPackets: %" PRIu64 " totalSessions: %" PRIu64 " writtenBytes: %" PRIu64 " unwrittenBytes: %" PRIu64 " pstats: %" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64,
-            totalPackets, totalSessions, arkime_packet_written_bytes(), arkime_packet_unwritten_bytes(),
-            packetStats[ARKIME_PACKET_DO_PROCESS],
-            packetStats[ARKIME_PACKET_IP_DROPPED],
-            packetStats[ARKIME_PACKET_OVERLOAD_DROPPED],
-            packetStats[ARKIME_PACKET_CORRUPT],
-            packetStats[ARKIME_PACKET_UNKNOWN_ETHER],
-            packetStats[ARKIME_PACKET_UNKNOWN_IP],
-            packetStats[ARKIME_PACKET_IPPORT_DROPPED],
-            packetStats[ARKIME_PACKET_DUPLICATE_DROPPED]
+            arkimeCounters.totalPackets, arkimeCounters.totalSessions, arkime_packet_written_bytes(), arkime_packet_unwritten_bytes(),
+            arkimeCounters.packetStats[ARKIME_PACKET_DO_PROCESS],
+            arkimeCounters.packetStats[ARKIME_PACKET_IP_DROPPED],
+            arkimeCounters.packetStats[ARKIME_PACKET_OVERLOAD_DROPPED],
+            arkimeCounters.packetStats[ARKIME_PACKET_CORRUPT],
+            arkimeCounters.packetStats[ARKIME_PACKET_UNKNOWN_ETHER],
+            arkimeCounters.packetStats[ARKIME_PACKET_UNKNOWN_IP],
+            arkimeCounters.packetStats[ARKIME_PACKET_IPPORT_DROPPED],
+            arkimeCounters.packetStats[ARKIME_PACKET_DUPLICATE_DROPPED]
            );
     }
 }

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -21,12 +21,10 @@ extern ArkimeConfig_t        config;
 
 ArkimePcapFileHdr_t          pcapFileHeader;
 
-uint64_t                     totalPackets;
-LOCAL uint64_t               totalBytes;
+ArkimeCounters_t             arkimeCounters;
 
 LOCAL uint64_t               initialDropped = 0;
 LOCAL uint8_t                firstPacket = 0;
-LOCAL uint64_t               nextLogPackets;
 struct timeval               initialPacket; // Don't make LOCAL for now because of netflow plugin
 
 extern void                 *esServer;
@@ -83,8 +81,6 @@ extern ArkimeOfflineInfo_t   offlineInfo[256];
 ARKIME_LOCK_DEFINE(offlineInfoLock);
 
 /******************************************************************************/
-
-uint64_t                     packetStats[ARKIME_PACKET_MAX];
 
 typedef struct {
     ArkimePacketHead_t    packetQ;
@@ -775,7 +771,7 @@ LOCAL void arkime_packet_log(int mProtocol)
     ArkimeReaderStats_t stats;
     if (arkime_reader_stats(&stats)) {
         stats.dropped = 0;
-        stats.total = totalPackets;
+        stats.total = arkimeCounters.totalPackets;
     }
 
     uint32_t wql = arkime_writer_queue_length();
@@ -784,7 +780,7 @@ LOCAL void arkime_packet_log(int mProtocol)
     arkime_db_memory_info(FALSE, NULL, &memPercent);
 
     LOG("packets: %" PRIu64 " current sessions: %u/%u oldest: %d - recv: %" PRIu64 " drop: %" PRIu64 " (%0.2f) queue: %d disk: %d packet: %d close: %d ns: %d frags: %d/%d pstats: %" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 "/%" PRIu64 " ver: %s mem: %.2f%%",
-        totalPackets,
+        arkimeCounters.totalPackets,
         arkime_session_watch_count(mProtocols[mProtocol].ses),
         arkime_session_monitoring(),
         arkime_session_idle_seconds(mProtocol),
@@ -798,13 +794,13 @@ LOCAL void arkime_packet_log(int mProtocol)
         arkime_session_need_save_outstanding(),
         arkime_packet_frags_outstanding(),
         arkime_packet_frags_size(),
-        packetStats[ARKIME_PACKET_DO_PROCESS],
-        packetStats[ARKIME_PACKET_IP_DROPPED],
-        packetStats[ARKIME_PACKET_OVERLOAD_DROPPED],
-        packetStats[ARKIME_PACKET_CORRUPT],
-        packetStats[ARKIME_PACKET_UNKNOWN_ETHER] + packetStats[ARKIME_PACKET_UNKNOWN_IP],
-        packetStats[ARKIME_PACKET_IPPORT_DROPPED],
-        packetStats[ARKIME_PACKET_DUPLICATE_DROPPED],
+        arkimeCounters.packetStats[ARKIME_PACKET_DO_PROCESS],
+        arkimeCounters.packetStats[ARKIME_PACKET_IP_DROPPED],
+        arkimeCounters.packetStats[ARKIME_PACKET_OVERLOAD_DROPPED],
+        arkimeCounters.packetStats[ARKIME_PACKET_CORRUPT],
+        arkimeCounters.packetStats[ARKIME_PACKET_UNKNOWN_ETHER] + arkimeCounters.packetStats[ARKIME_PACKET_UNKNOWN_IP],
+        arkimeCounters.packetStats[ARKIME_PACKET_IPPORT_DROPPED],
+        arkimeCounters.packetStats[ARKIME_PACKET_DUPLICATE_DROPPED],
         PACKAGE_VERSION,
         memPercent
        );
@@ -823,7 +819,7 @@ LOCAL void arkime_packet_cmd_stats(int UNUSED(argc), char **UNUSED(argv), gpoint
     ArkimeReaderStats_t stats;
     if (arkime_reader_stats(&stats)) {
         stats.dropped = 0;
-        stats.total = totalPackets;
+        stats.total = arkimeCounters.totalPackets;
     }
 
     uint32_t wql = arkime_writer_queue_length();
@@ -860,7 +856,7 @@ LOCAL void arkime_packet_cmd_stats(int UNUSED(argc), char **UNUSED(argv), gpoint
                        "Packets Duplicate Dropped: %" PRIu64 "\n",
 
                        PACKAGE_VERSION,
-                       totalPackets,
+                       arkimeCounters.totalPackets,
                        stats.total,
                        stats.dropped - initialDropped,
                        (stats.total ? (stats.dropped - initialDropped) * (double)100.0 / stats.total : 0),
@@ -882,14 +878,14 @@ LOCAL void arkime_packet_cmd_stats(int UNUSED(argc), char **UNUSED(argv), gpoint
                        arkime_packet_frags_outstanding(),
                        arkime_packet_frags_size(),
 
-                       packetStats[ARKIME_PACKET_DO_PROCESS],
-                       packetStats[ARKIME_PACKET_IP_DROPPED],
-                       packetStats[ARKIME_PACKET_OVERLOAD_DROPPED],
-                       packetStats[ARKIME_PACKET_CORRUPT],
-                       packetStats[ARKIME_PACKET_UNKNOWN_ETHER],
-                       packetStats[ARKIME_PACKET_UNKNOWN_IP],
-                       packetStats[ARKIME_PACKET_IPPORT_DROPPED],
-                       packetStats[ARKIME_PACKET_DUPLICATE_DROPPED]
+                       arkimeCounters.packetStats[ARKIME_PACKET_DO_PROCESS],
+                       arkimeCounters.packetStats[ARKIME_PACKET_IP_DROPPED],
+                       arkimeCounters.packetStats[ARKIME_PACKET_OVERLOAD_DROPPED],
+                       arkimeCounters.packetStats[ARKIME_PACKET_CORRUPT],
+                       arkimeCounters.packetStats[ARKIME_PACKET_UNKNOWN_ETHER],
+                       arkimeCounters.packetStats[ARKIME_PACKET_UNKNOWN_IP],
+                       arkimeCounters.packetStats[ARKIME_PACKET_IPPORT_DROPPED],
+                       arkimeCounters.packetStats[ARKIME_PACKET_DUPLICATE_DROPPED]
                       );
 
     arkime_command_respond(cc, output, BSB_LENGTH(bsb));
@@ -1626,19 +1622,19 @@ void arkime_packet_batch_flush(ArkimePacketBatch_t *batch)
     }
     for (int i = 0; i < ARKIME_PACKET_MAX; i++) {
         if (batch->packetStats[i]) {
-            ARKIME_THREAD_INCR_NUM(packetStats[i], batch->packetStats[i]);
+            ARKIME_THREAD_INCR_NUM(arkimeCounters.packetStats[i], batch->packetStats[i]);
             batch->packetStats[i] = 0;
         }
     }
     if (batch->totalBytes) {
-        ARKIME_THREAD_INCR_NUM(totalBytes, batch->totalBytes);
+        ARKIME_THREAD_INCR_NUM(arkimeCounters.totalBytes, batch->totalBytes);
         batch->totalBytes = 0;
     }
     if (batch->totalPackets) {
-        ARKIME_THREAD_INCR_NUM(totalPackets, batch->totalPackets);
+        ARKIME_THREAD_INCR_NUM(arkimeCounters.totalPackets, batch->totalPackets);
         batch->totalPackets = 0;
-        if (unlikely(totalPackets >= nextLogPackets)) {
-            nextLogPackets = totalPackets + config.logEveryXPackets;
+        if (unlikely(arkimeCounters.totalPackets >= arkimeCounters.nextLogPackets)) {
+            arkimeCounters.nextLogPackets = arkimeCounters.totalPackets + config.logEveryXPackets;
             arkime_packet_log(tcpMProtocol);
         }
     }
@@ -1986,7 +1982,7 @@ void arkime_packet_init()
 {
     arkime_packet_freelist_init();
 
-    nextLogPackets = config.logEveryXPackets;
+    arkimeCounters.nextLogPackets = config.logEveryXPackets;
 
     disableIp4Defrag = arkime_config_boolean(NULL, "disableIp4Defrag", FALSE);
     trimEthernetPadding = arkime_config_boolean(NULL, "trimEthernetPadding", FALSE);
@@ -2335,7 +2331,7 @@ uint64_t arkime_packet_dropped_overload()
 /******************************************************************************/
 uint64_t arkime_packet_total_bytes()
 {
-    return totalBytes;
+    return arkimeCounters.totalBytes;
 }
 /******************************************************************************/
 uint64_t arkime_packet_written_bytes()


### PR DESCRIPTION
- New ArkimeCounters_t holds totalPackets/totalBytes/totalSessions/ totalSessionBytes/packetStats, one cache line each
- These were plain globals next to read-mostly ones (mac1Field, mProtocols, geoCountry, ...) read for every packet, so each ARKIME_THREAD_INCR invalidated those reads on every other core
- perf c2c with 4 reader threads: the mac1Field/totalPackets line went from 2197 remote HITMs to none, capture owned HITMs down 28%
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
