### PR TITLE
Use OpenSSL instead of glib for hashing

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -991,8 +991,6 @@ typedef struct {
     time_t                       currentTime;
     time_t                       lastPacketSecs;
     ArkimeSessionHead_t          tcpWriteQ;
-    GChecksum                   *checksum1;
-    GChecksum                   *checksum256;
 } ARKIME_CACHE_ALIGN ArkimeThreadData_t;
 extern ArkimeThreadData_t arkimeThreadData[ARKIME_MAX_PACKET_THREADS];
 

--- a/capture/db.c
+++ b/capture/db.c
@@ -5,6 +5,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/sha.h>
 #include "arkime.h"
 #include "arkimeconfig.h"
 #include <sys/types.h>
@@ -450,57 +452,56 @@ void arkime_db_set_send_bulk2(ArkimeDbSendBulkFunc func, gboolean bulkHeader, gb
 /******************************************************************************/
 gchar *arkime_db_community_id(const ArkimeSession_t *session)
 {
-    GChecksum *const checksum = arkimeThreadData[session->thread].checksum1;
+    SHA_CTX checksum;
+    SHA1_Init(&checksum);
 
     static uint16_t seed = 0;
     static uint8_t  zero = 0;
 
-    g_checksum_update(checksum, (guchar *)&seed, 2);
+    SHA1_Update(&checksum, &seed, 2);
 
     // SessionId layout: [len:1][vlan/vni:3][addr1][addr2][port1:2][port2:2]
     // IPv4: addr at +4 and +8 (4 bytes each), ports at +12 and +14
     // IPv6: addr at +4 and +20 (16 bytes each), ports at +36 and +38
     if (ARKIME_SESSION_IS_v6(session)) {
         // For v6 we sort the same as community id
-        g_checksum_update(checksum, (guchar *)session->sessionId + 4, 32);
-        g_checksum_update(checksum, (guchar *)&session->ipProtocol, 1);
-        g_checksum_update(checksum, (guchar *)&zero, 1);
-        g_checksum_update(checksum, (guchar *)session->sessionId + 36, 4);
+        SHA1_Update(&checksum, session->sessionId + 4, 32);
+        SHA1_Update(&checksum, &session->ipProtocol, 1);
+        SHA1_Update(&checksum, &zero, 1);
+        SHA1_Update(&checksum, session->sessionId + 36, 4);
     } else {
         // For v4 because of byte order we have a different sort for ip but not port
         int cmp = memcmp(session->sessionId + 4, session->sessionId + 8, 4);
 
         if (cmp <= 0) {
-            g_checksum_update(checksum, (guchar *)session->sessionId + 4, 8);
-            g_checksum_update(checksum, (guchar *)&session->ipProtocol, 1);
-            g_checksum_update(checksum, (guchar *)&zero, 1);
-            g_checksum_update(checksum, (guchar *)session->sessionId + 12, 4);
+            SHA1_Update(&checksum, session->sessionId + 4, 8);
+            SHA1_Update(&checksum, &session->ipProtocol, 1);
+            SHA1_Update(&checksum, &zero, 1);
+            SHA1_Update(&checksum, session->sessionId + 12, 4);
         }  else {
-            g_checksum_update(checksum, (guchar *)session->sessionId + 8, 4);
-            g_checksum_update(checksum, (guchar *)session->sessionId + 4, 4);
-            g_checksum_update(checksum, (guchar *)&session->ipProtocol, 1);
-            g_checksum_update(checksum, (guchar *)&zero, 1);
-            g_checksum_update(checksum, (guchar *)session->sessionId + 14, 2);
-            g_checksum_update(checksum, (guchar *)session->sessionId + 12, 2);
+            SHA1_Update(&checksum, session->sessionId + 8, 4);
+            SHA1_Update(&checksum, session->sessionId + 4, 4);
+            SHA1_Update(&checksum, &session->ipProtocol, 1);
+            SHA1_Update(&checksum, &zero, 1);
+            SHA1_Update(&checksum, session->sessionId + 14, 2);
+            SHA1_Update(&checksum, session->sessionId + 12, 2);
         }
     }
 
-    guint8 digest[100];
-    gsize  digest_len = 100;
+    uint8_t digest[SHA_DIGEST_LENGTH];
 
-    g_checksum_get_digest(checksum, digest, &digest_len);
-    gchar *b64 = g_base64_encode(digest, digest_len);
-
-    g_checksum_reset(checksum);
-    return b64;
+    SHA1_Final(digest, &checksum);
+    return g_base64_encode(digest, sizeof(digest));
 }
 /******************************************************************************/
 // ICMP is a special case, we need to handle it differently
 // It remaps the ports and is kind of a hot mess.
 gchar *arkime_db_community_id_icmp(const ArkimeSession_t *session)
 {
-    GChecksum *const checksum = arkimeThreadData[session->thread].checksum1;
-    int              cmp;
+    SHA_CTX checksum;
+    int     cmp;
+
+    SHA1_Init(&checksum);
 
     static uint16_t seed = 0;
     static uint8_t  zero = 0;
@@ -508,7 +509,7 @@ gchar *arkime_db_community_id_icmp(const ArkimeSession_t *session)
     uint16_t port1;
     uint16_t port2;
 
-    g_checksum_update(checksum, (guchar *)&seed, 2);
+    SHA1_Update(&checksum, &seed, 2);
 
     port1 = session->icmpInfo[0];
     port2 = session->icmpInfo[1];
@@ -526,21 +527,21 @@ gchar *arkime_db_community_id_icmp(const ArkimeSession_t *session)
         if (cmp < 0 || (cmp == 0 && port1 <= port2)) {
             port1 = htons(port1);
             port2 = htons(port2);
-            g_checksum_update(checksum, (guchar *)session->addr1.s6_addr, 16);
-            g_checksum_update(checksum, (guchar *)session->addr2.s6_addr, 16);
-            g_checksum_update(checksum, (guchar *)&session->ipProtocol, 1);
-            g_checksum_update(checksum, (guchar *)&zero, 1);
-            g_checksum_update(checksum, (guchar *)&port1, 2);
-            g_checksum_update(checksum, (guchar *)&port2, 2);
+            SHA1_Update(&checksum, session->addr1.s6_addr, 16);
+            SHA1_Update(&checksum, session->addr2.s6_addr, 16);
+            SHA1_Update(&checksum, &session->ipProtocol, 1);
+            SHA1_Update(&checksum, &zero, 1);
+            SHA1_Update(&checksum, &port1, 2);
+            SHA1_Update(&checksum, &port2, 2);
         } else {
             port1 = htons(port1);
             port2 = htons(port2);
-            g_checksum_update(checksum, (guchar *)session->addr2.s6_addr, 16);
-            g_checksum_update(checksum, (guchar *)session->addr1.s6_addr, 16);
-            g_checksum_update(checksum, (guchar *)&session->ipProtocol, 1);
-            g_checksum_update(checksum, (guchar *)&zero, 1);
-            g_checksum_update(checksum, (guchar *)&port2, 2);
-            g_checksum_update(checksum, (guchar *)&port1, 2);
+            SHA1_Update(&checksum, session->addr2.s6_addr, 16);
+            SHA1_Update(&checksum, session->addr1.s6_addr, 16);
+            SHA1_Update(&checksum, &session->ipProtocol, 1);
+            SHA1_Update(&checksum, &zero, 1);
+            SHA1_Update(&checksum, &port2, 2);
+            SHA1_Update(&checksum, &port1, 2);
         }
     } else {
         static const uint8_t port2Mapping[19] = {8, 255, 255, 255, 255, 255, 255, 255, 0, 10,
@@ -555,32 +556,28 @@ gchar *arkime_db_community_id_icmp(const ArkimeSession_t *session)
         if (cmp < 0 || (cmp == 0 && port1 < port2)) {
             port1 = htons(port1);
             port2 = htons(port2);
-            g_checksum_update(checksum, (guchar *)session->addr1.s6_addr + 12, 4);
-            g_checksum_update(checksum, (guchar *)session->addr2.s6_addr + 12, 4);
-            g_checksum_update(checksum, (guchar *)&session->ipProtocol, 1);
-            g_checksum_update(checksum, (guchar *)&zero, 1);
-            g_checksum_update(checksum, (guchar *)&port1, 2);
-            g_checksum_update(checksum, (guchar *)&port2, 2);
+            SHA1_Update(&checksum, session->addr1.s6_addr + 12, 4);
+            SHA1_Update(&checksum, session->addr2.s6_addr + 12, 4);
+            SHA1_Update(&checksum, &session->ipProtocol, 1);
+            SHA1_Update(&checksum, &zero, 1);
+            SHA1_Update(&checksum, &port1, 2);
+            SHA1_Update(&checksum, &port2, 2);
         }  else {
             port1 = htons(port1);
             port2 = htons(port2);
-            g_checksum_update(checksum, (guchar *)session->addr2.s6_addr + 12, 4);
-            g_checksum_update(checksum, (guchar *)session->addr1.s6_addr + 12, 4);
-            g_checksum_update(checksum, (guchar *)&session->ipProtocol, 1);
-            g_checksum_update(checksum, (guchar *)&zero, 1);
-            g_checksum_update(checksum, (guchar *)&port2, 2);
-            g_checksum_update(checksum, (guchar *)&port1, 2);
+            SHA1_Update(&checksum, session->addr2.s6_addr + 12, 4);
+            SHA1_Update(&checksum, session->addr1.s6_addr + 12, 4);
+            SHA1_Update(&checksum, &session->ipProtocol, 1);
+            SHA1_Update(&checksum, &zero, 1);
+            SHA1_Update(&checksum, &port2, 2);
+            SHA1_Update(&checksum, &port1, 2);
         }
     }
 
-    guint8 digest[100];
-    gsize  digest_len = 100;
+    uint8_t digest[SHA_DIGEST_LENGTH];
 
-    g_checksum_get_digest(checksum, digest, &digest_len);
-    gchar *b64 = g_base64_encode(digest, digest_len);
-
-    g_checksum_reset(checksum);
-    return b64;
+    SHA1_Final(digest, &checksum);
+    return g_base64_encode(digest, sizeof(digest));
 }
 /******************************************************************************/
 typedef struct {
@@ -2981,9 +2978,6 @@ void arkime_db_init()
     for (int thread = 0; thread < config.packetThreads; thread++) {
         ARKIME_LOCK_INIT(dbInfo[thread].lock);
         dbInfo[thread].prefixTime = -1;
-        arkimeThreadData[thread].checksum1 = g_checksum_new(G_CHECKSUM_SHA1);
-        arkimeThreadData[thread].checksum256 = g_checksum_new(G_CHECKSUM_SHA256);
-
     }
 
     arkime_session_save_func = arkime_parsers_get_named_func("arkime_session_save");

--- a/capture/parsers/certs.c
+++ b/capture/parsers/certs.c
@@ -2,6 +2,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/sha.h>
 #include "arkime.h"
 #include <inttypes.h>
 #include "openssl/objects.h"
@@ -435,8 +437,6 @@ LOCAL void certinfo_process_publickey(ArkimeCertsInfo_t *certs, uint8_t *data, u
 // Returns 0 on success, -1 on failure
 LOCAL int certinfo_process_single_cert(ArkimeSession_t *session, const uint8_t *data, int clen)
 {
-    GChecksum *const checksum = arkimeThreadData[session->thread].checksum1;
-
     int            badreason;
 
     ArkimeFieldObject_t *fobject = ARKIME_TYPE_ALLOC0(ArkimeFieldObject_t);
@@ -458,19 +458,13 @@ LOCAL int certinfo_process_single_cert(ArkimeSession_t *session, const uint8_t *
     BSB            bsb;
     BSB_INIT(bsb, data, clen);
 
-    guchar digest[20];
-    gsize  dlen = sizeof(digest);
+    uint8_t digest[SHA_DIGEST_LENGTH];
 
-    g_checksum_update(checksum, data, clen);
-    g_checksum_get_digest(checksum, digest, &dlen);
-    g_checksum_reset(checksum);
-    if (dlen > 0) {
-        int i;
-        for (i = 0; i < 20; i++) {
-            certs->hash[i * 3] = arkime_char_to_hexstr[digest[i]][0];
-            certs->hash[i * 3 + 1] = arkime_char_to_hexstr[digest[i]][1];
-            certs->hash[i * 3 + 2] = ':';
-        }
+    SHA1(data, clen, digest);
+    for (int i = 0; i < SHA_DIGEST_LENGTH; i++) {
+        certs->hash[i * 3] = arkime_char_to_hexstr[digest[i]][0];
+        certs->hash[i * 3 + 1] = arkime_char_to_hexstr[digest[i]][1];
+        certs->hash[i * 3 + 2] = ':';
     }
     certs->hash[59] = 0;
 

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -2,6 +2,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/sha.h>
 #include "arkime.h"
 
 //#define DTLSDEBUG 1
@@ -287,12 +289,13 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
 
     BSB_EXPORT_u08(ja4_rbsb, '_');
 
-    GChecksum *const checksum = arkimeThreadData[session->thread].checksum256;
+    uint8_t digest[SHA256_DIGEST_LENGTH];
+    char    hex[SHA256_DIGEST_LENGTH * 2 + 1];
 
     if (BSB_LENGTH(tmpBSB) > 0) {
-        g_checksum_update(checksum, (guchar *)tmpBuf, BSB_LENGTH(tmpBSB));
-        memcpy(ja4 + 11, g_checksum_get_string(checksum), 12);
-        g_checksum_reset(checksum);
+        SHA256((uint8_t *)tmpBuf, BSB_LENGTH(tmpBSB), digest);
+        arkime_sprint_hex_string(hex, digest, 6);
+        memcpy(ja4 + 11, hex, 12);
     } else {
         memcpy(ja4 + 11, "000000000000", 12);
     }
@@ -320,9 +323,9 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
     BSB_EXPORT_u08(ja4_rbsb, 0);
 
     if (BSB_LENGTH(tmpBSB) > 0) {
-        g_checksum_update(checksum, (guchar *)tmpBuf, BSB_LENGTH(tmpBSB));
-        memcpy(ja4 + 24, g_checksum_get_string(checksum), 12);
-        g_checksum_reset(checksum);
+        SHA256((uint8_t *)tmpBuf, BSB_LENGTH(tmpBSB), digest);
+        arkime_sprint_hex_string(hex, digest, 6);
+        memcpy(ja4 + 24, hex, 12);
     } else {
         memcpy(ja4 + 24, "000000000000", 12);
     }

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -6,9 +6,6 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
-// OpenSSL's MD5 is ~15% faster than g_checksum and needs no per session alloc.
-// The low level API is deprecated in OpenSSL 3 but is the only one available on
-// EL8's 1.1.1, same as capture/dedup.c.
 #define OPENSSL_SUPPRESS_DEPRECATED
 #include <openssl/md5.h>
 

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -6,6 +6,12 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
+// OpenSSL's MD5 is ~15% faster than g_checksum and needs no per session alloc.
+// The low level API is deprecated in OpenSSL 3 but is the only one available on
+// EL8's 1.1.1, same as capture/dedup.c.
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/md5.h>
+
 //#define HTTPDEBUG 1
 
 #define MAX_URL_LENGTH 4096
@@ -36,7 +42,8 @@ typedef struct {
     http_parser      parsers[2];
     uint16_t         methodCounts[HTTP_MAX_METHOD + 1];
 
-    GChecksum       *checksum[4];
+    MD5_CTX          md5Ctx[2];
+    GChecksum       *sha256[2];
     const char      *magicString[2];
 
     uint16_t         wParsers: 2;
@@ -286,9 +293,9 @@ LOCAL int arkime_hp_cb_on_message_begin (http_parser *parser)
     http->inHeader &= ~(1 << http->which);
     http->inValue  &= ~(1 << http->which);
     http->inBody   &= ~(1 << http->which);
-    g_checksum_reset(http->checksum[http->which]);
+    MD5_Init(&http->md5Ctx[http->which]);
     if (config.supportSha256) {
-        g_checksum_reset(http->checksum[http->which + 2]);
+        g_checksum_reset(http->sha256[http->which]);
     }
 
     if (pluginsCbs & ARKIME_PLUGIN_HP_OMB)
@@ -344,9 +351,9 @@ LOCAL int arkime_hp_cb_on_body (http_parser *parser, const char *at, size_t leng
 
     }
 
-    g_checksum_update(http->checksum[http->which], (guchar *)at, length);
+    MD5_Update(&http->md5Ctx[http->which], at, length);
     if (config.supportSha256) {
-        g_checksum_update(http->checksum[http->which + 2], (guchar *)at, length);
+        g_checksum_update(http->sha256[http->which], (guchar *)at, length);
     }
 
     if (pluginsCbs & ARKIME_PLUGIN_HP_OB)
@@ -434,10 +441,13 @@ LOCAL int arkime_hp_cb_on_message_complete (http_parser *parser)
         arkime_plugins_cb_hp_omc(session, parser);
 
     if (http->inBody & (1 << http->which)) {
-        const char *md5 = g_checksum_get_string(http->checksum[http->which]);
-        arkime_field_string_uw_add(md5Field, session, (char *)md5, 32, (gpointer)http->magicString[http->which], TRUE);
+        uint8_t digest[MD5_DIGEST_LENGTH];
+        char    md5[MD5_DIGEST_LENGTH * 2 + 1];
+        MD5_Final(digest, &http->md5Ctx[http->which]);
+        arkime_sprint_hex_string(md5, digest, MD5_DIGEST_LENGTH);
+        arkime_field_string_uw_add(md5Field, session, md5, 32, (gpointer)http->magicString[http->which], TRUE);
         if (config.supportSha256) {
-            const char *sha256 = g_checksum_get_string(http->checksum[http->which + 2]);
+            const char *sha256 = g_checksum_get_string(http->sha256[http->which]);
             arkime_field_string_uw_add(sha256Field, session, (char *)sha256, 64, (gpointer)http->magicString[http->which], TRUE);
         }
     }
@@ -871,11 +881,9 @@ LOCAL void http_free(ArkimeSession_t UNUSED(*session), void *uw)
         g_string_free(http->valueString[0], TRUE);
     if (http->valueString[1])
         g_string_free(http->valueString[1], TRUE);
-    g_checksum_free(http->checksum[0]);
-    g_checksum_free(http->checksum[1]);
     if (config.supportSha256) {
-        g_checksum_free(http->checksum[2]);
-        g_checksum_free(http->checksum[3]);
+        g_checksum_free(http->sha256[0]);
+        g_checksum_free(http->sha256[1]);
     }
 
     ARKIME_TYPE_FREE(HTTPInfo_t, http);
@@ -890,11 +898,10 @@ LOCAL void http_classify(ArkimeSession_t *session, const uint8_t *UNUSED(data), 
 
     HTTPInfo_t            *http          = ARKIME_TYPE_ALLOC0(HTTPInfo_t);
 
-    http->checksum[0] = g_checksum_new(G_CHECKSUM_MD5);
-    http->checksum[1] = g_checksum_new(G_CHECKSUM_MD5);
+    // md5Ctx lives in the struct, MD5_Init happens per message in on_message_begin
     if (config.supportSha256) {
-        http->checksum[2] = g_checksum_new(G_CHECKSUM_SHA256);
-        http->checksum[3] = g_checksum_new(G_CHECKSUM_SHA256);
+        http->sha256[0] = g_checksum_new(G_CHECKSUM_SHA256);
+        http->sha256[1] = g_checksum_new(G_CHECKSUM_SHA256);
     }
 
     http_parser_init(&http->parsers[0], HTTP_BOTH);

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -895,7 +895,6 @@ LOCAL void http_classify(ArkimeSession_t *session, const uint8_t *UNUSED(data), 
 
     HTTPInfo_t            *http          = ARKIME_TYPE_ALLOC0(HTTPInfo_t);
 
-    // md5Ctx lives in the struct, MD5_Init happens per message in on_message_begin
     if (config.supportSha256) {
         http->sha256[0] = g_checksum_new(G_CHECKSUM_SHA256);
         http->sha256[1] = g_checksum_new(G_CHECKSUM_SHA256);

--- a/capture/parsers/http2.c
+++ b/capture/parsers/http2.c
@@ -9,6 +9,9 @@
 #include <arpa/inet.h>
 #include "nghttp2/nghttp2.h"
 
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/md5.h>
+
 //#define HTTPDEBUG 1
 
 #define MAX_URL_LENGTH 4096
@@ -18,8 +21,10 @@
 typedef struct {
     uint32_t                 id;
     uint8_t                  ended;
+    uint8_t                  md5Started;    // bit per which, streams are memset when reused
     const char              *magicString[2];
-    GChecksum               *checksum[4];
+    MD5_CTX                  md5Ctx[2];
+    GChecksum               *sha256[2];
 } HTTP2Stream_t;
 
 typedef enum {
@@ -99,12 +104,10 @@ LOCAL void http2_spos_free(HTTP2Info_t *http2, uint32_t streamId)
 
     for (int i = 0; i < http2->numStreams; i++) {
         if (streamId == http2->streams[i].id) {
-            g_checksum_free(http2->streams[i].checksum[0]);
-            g_checksum_free(http2->streams[i].checksum[1]);
-            if (config.supportSha256) {
-                g_checksum_free(http2->streams[i].checksum[2]);
-                g_checksum_free(http2->streams[i].checksum[3]);
-            }
+            if (http2->streams[i].sha256[0])
+                g_checksum_free(http2->streams[i].sha256[0]);
+            if (http2->streams[i].sha256[1])
+                g_checksum_free(http2->streams[i].sha256[1]);
             memset(&http2->streams[i], 0, sizeof(http2->streams[i]));
             return;
         }
@@ -304,28 +307,32 @@ LOCAL void http2_parse_frame_data(ArkimeSession_t *session, HTTP2Info_t *http2, 
         http2->streams[spos].magicString[which] = arkime_parsers_magic(session, magicField, (char *)in, inlen);
     }
 
-    // Check if checksums are allocated and update with new data
-    if (!http2->streams[spos].checksum[which]) {
-        http2->streams[spos].checksum[which] = g_checksum_new(G_CHECKSUM_MD5);
-        if (config.supportSha256) {
-            http2->streams[spos].checksum[which + 2] = g_checksum_new(G_CHECKSUM_SHA256);
+    // Start the hashes on the first data for this stream/direction
+    if (!(http2->streams[spos].md5Started & (1 << which))) {
+        MD5_Init(&http2->streams[spos].md5Ctx[which]);
+        http2->streams[spos].md5Started |= (1 << which);
+        if (config.supportSha256 && !http2->streams[spos].sha256[which]) {
+            http2->streams[spos].sha256[which] = g_checksum_new(G_CHECKSUM_SHA256);
         }
     }
 
-    g_checksum_update(http2->streams[spos].checksum[which], (guchar *)in, inlen);
+    MD5_Update(&http2->streams[spos].md5Ctx[which], in, inlen);
     if (config.supportSha256) {
-        g_checksum_update(http2->streams[spos].checksum[which + 2], (guchar *)in, inlen);
+        g_checksum_update(http2->streams[spos].sha256[which], (guchar *)in, inlen);
     }
 
     // If the first packet in the frame said this is end and we've read them all, set the md5/sha fields
     if (http2->isEnd[which] && http2->dataNeeded[which] == 0) {
-        const char *md5 = g_checksum_get_string(http2->streams[spos].checksum[which]);
-        arkime_field_string_uw_add(md5Field, session, (char *)md5, 32, (gpointer)http2->streams[spos].magicString[which], TRUE);
-        g_checksum_reset(http2->streams[spos].checksum[which]);
+        uint8_t digest[MD5_DIGEST_LENGTH];
+        char    md5[MD5_DIGEST_LENGTH * 2 + 1];
+        MD5_Final(digest, &http2->streams[spos].md5Ctx[which]);
+        arkime_sprint_hex_string(md5, digest, MD5_DIGEST_LENGTH);
+        arkime_field_string_uw_add(md5Field, session, md5, 32, (gpointer)http2->streams[spos].magicString[which], TRUE);
+        http2->streams[spos].md5Started &= ~(1 << which);   // re-init on the next body
         if (config.supportSha256) {
-            const char *sha256 = g_checksum_get_string(http2->streams[spos].checksum[which + 2]);
+            const char *sha256 = g_checksum_get_string(http2->streams[spos].sha256[which]);
             arkime_field_string_uw_add(sha256Field, session, (char *)sha256, 64, (gpointer)http2->streams[spos].magicString[which], TRUE);
-            g_checksum_reset(http2->streams[spos].checksum[which + 2]);
+            g_checksum_reset(http2->streams[spos].sha256[which]);
         }
     }
 }
@@ -478,12 +485,10 @@ LOCAL void http2_free(ArkimeSession_t UNUSED(*session), void *uw)
         nghttp2_hd_inflate_del(http2->hd_inflater[1]);
     }
     for (int i = 0; i < http2->numStreams; i++) {
-        g_checksum_free(http2->streams[i].checksum[0]);
-        g_checksum_free(http2->streams[i].checksum[1]);
-        if (config.supportSha256) {
-            g_checksum_free(http2->streams[i].checksum[2]);
-            g_checksum_free(http2->streams[i].checksum[3]);
-        }
+        if (http2->streams[i].sha256[0])
+            g_checksum_free(http2->streams[i].sha256[0]);
+        if (http2->streams[i].sha256[1])
+            g_checksum_free(http2->streams[i].sha256[1]);
     }
     ARKIME_TYPE_FREE(HTTP2Info_t, http2);
 }

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -6,6 +6,11 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
+// OpenSSL's MD5 is ~15% faster than g_checksum and needs no per session alloc,
+// see capture/parsers/http.c and capture/dedup.c
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/md5.h>
+
 //#define EMAILDEBUG
 
 #define SMTP_MAX_LINE_LEN 10000
@@ -50,7 +55,8 @@ typedef struct {
     gint               state64[2];
     guint              save64[2];
     guint              bdatRemaining[2];
-    GChecksum         *checksum[4];
+    MD5_CTX            md5Ctx[2];
+    GChecksum         *sha256[2];
 
     uint16_t           base64Decode: 2;
     uint16_t           firstInContent: 2;
@@ -780,10 +786,13 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
 
                 if (found) {
                     if (email->base64Decode & (1 << which)) {
-                        const char *md5 = g_checksum_get_string(email->checksum[which]);
-                        arkime_field_string_add(md5Field, session, (char *)md5, 32, TRUE);
+                        uint8_t digest[MD5_DIGEST_LENGTH];
+                        char    md5[MD5_DIGEST_LENGTH * 2 + 1];
+                        MD5_Final(digest, &email->md5Ctx[which]);
+                        arkime_sprint_hex_string(md5, digest, MD5_DIGEST_LENGTH);
+                        arkime_field_string_add(md5Field, session, md5, 32, TRUE);
                         if (config.supportSha256) {
-                            const char *sha256 = g_checksum_get_string(email->checksum[which + 2]);
+                            const char *sha256 = g_checksum_get_string(email->sha256[which]);
                             arkime_field_string_add(sha256Field, session, (char *)sha256, 64, TRUE);
                         }
                     }
@@ -791,9 +800,9 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                     email->base64Decode &= ~(1 << which);
                     email->state64[which] = 0;
                     email->save64[which] = 0;
-                    g_checksum_reset(email->checksum[which]);
+                    MD5_Init(&email->md5Ctx[which]);
                     if (config.supportSha256) {
-                        g_checksum_reset(email->checksum[which + 2]);
+                        g_checksum_reset(email->sha256[which]);
                     }
                     *state = EMAIL_MIME;
                 } else if (*state == EMAIL_MIME_DATA_RETURN) {
@@ -803,9 +812,9 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                             gsize  b = g_base64_decode_step (line->str, line->len, buf,
                                                              &(email->state64[which]),
                                                              &(email->save64[which]));
-                            g_checksum_update(email->checksum[which], buf, b);
+                            MD5_Update(&email->md5Ctx[which], buf, b);
                             if (config.supportSha256) {
-                                g_checksum_update(email->checksum[which + 2], buf, b);
+                                g_checksum_update(email->sha256[which], buf, b);
                             }
 
                             if (email->firstInContent & (1 << which)) {
@@ -961,11 +970,9 @@ LOCAL void smtp_free(ArkimeSession_t UNUSED(*session), void *uw)
     g_string_free(email->line[0], TRUE);
     g_string_free(email->line[1], TRUE);
 
-    g_checksum_free(email->checksum[0]);
-    g_checksum_free(email->checksum[1]);
     if (config.supportSha256) {
-        g_checksum_free(email->checksum[2]);
-        g_checksum_free(email->checksum[3]);
+        g_checksum_free(email->sha256[0]);
+        g_checksum_free(email->sha256[1]);
     }
 
     while (DLL_POP_HEAD(s_, &email->boundaries, string)) {
@@ -996,11 +1003,11 @@ LOCAL void smtp_classify(ArkimeSession_t *session, const uint8_t *data, int len,
         email->line[0] = g_string_sized_new(100);
         email->line[1] = g_string_sized_new(100);
 
-        email->checksum[0] = g_checksum_new(G_CHECKSUM_MD5);
-        email->checksum[1] = g_checksum_new(G_CHECKSUM_MD5);
+        MD5_Init(&email->md5Ctx[0]);
+        MD5_Init(&email->md5Ctx[1]);
         if (config.supportSha256) {
-            email->checksum[2] = g_checksum_new(G_CHECKSUM_SHA256);
-            email->checksum[3] = g_checksum_new(G_CHECKSUM_SHA256);
+            email->sha256[0] = g_checksum_new(G_CHECKSUM_SHA256);
+            email->sha256[1] = g_checksum_new(G_CHECKSUM_SHA256);
         }
 
         DLL_INIT(s_, &(email->boundaries));

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -6,8 +6,6 @@
 #include <sys/socket.h>
 #include <arpa/inet.h>
 
-// OpenSSL's MD5 is ~15% faster than g_checksum and needs no per session alloc,
-// see capture/parsers/http.c and capture/dedup.c
 #define OPENSSL_SUPPRESS_DEPRECATED
 #include <openssl/md5.h>
 

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -2,6 +2,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/sha.h>
 #include "arkime.h"
 #include "tls-cipher.h"
 #include "openssl/objects.h"
@@ -572,12 +574,13 @@ LOCAL uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uin
 
     BSB_EXPORT_u08(ja4_rbsb, '_');
 
-    GChecksum *const checksum = arkimeThreadData[session->thread].checksum256;
+    uint8_t digest[SHA256_DIGEST_LENGTH];
+    char    hex[SHA256_DIGEST_LENGTH * 2 + 1];
 
     if (BSB_LENGTH(tmpBSB) > 0) {
-        g_checksum_update(checksum, (guchar *)tmpBuf, BSB_LENGTH(tmpBSB));
-        memcpy(ja4 + 11, g_checksum_get_string(checksum), 12);
-        g_checksum_reset(checksum);
+        SHA256((uint8_t *)tmpBuf, BSB_LENGTH(tmpBSB), digest);
+        arkime_sprint_hex_string(hex, digest, 6);
+        memcpy(ja4 + 11, hex, 12);
     } else {
         memcpy(ja4 + 11, "000000000000", 12);
     }
@@ -605,9 +608,9 @@ LOCAL uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uin
     BSB_EXPORT_u08(ja4_rbsb, 0);
 
     if (BSB_LENGTH(tmpBSB) > 0) {
-        g_checksum_update(checksum, (guchar *)tmpBuf, BSB_LENGTH(tmpBSB));
-        memcpy(ja4 + 24, g_checksum_get_string(checksum), 12);
-        g_checksum_reset(checksum);
+        SHA256((uint8_t *)tmpBuf, BSB_LENGTH(tmpBSB), digest);
+        arkime_sprint_hex_string(hex, digest, 6);
+        memcpy(ja4 + 24, hex, 12);
     } else {
         memcpy(ja4 + 24, "000000000000", 12);
     }


### PR DESCRIPTION
- http/http2/smtp body MD5 uses MD5_CTX in the parser struct, ~15% faster than g_checksum and no longer allocates a checksum per session/stream/email
- community id hashes on a stack SHA_CTX, cert hash and JA4 use one shot SHA1()/SHA256(), so ArkimeThreadData_t no longer holds any GChecksum
- keep the low level OpenSSL API with OPENSSL_SUPPRESS_DEPRECATED like dedup.c, EVP_MD_fetch needs OpenSSL 3 and EL8 still ships 1.1.1
- http2: only free the sha256 checksums that were actually allocated, a stream with headers but no data used to pass NULL to g_checksum_free

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
