### PR TITLE
Fix data races found by ThreadSanitizer

### DIFF
--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -316,6 +316,7 @@ typedef struct {
 
 #define ARKIME_THREAD_ATOMIC_STORE(var, val) __atomic_store_n(&(var), (val), __ATOMIC_RELEASE)
 #define ARKIME_THREAD_ATOMIC_LOAD(var)       __atomic_load_n(&(var), __ATOMIC_ACQUIRE)
+#define ARKIME_THREAD_ATOMIC_OR(var, val)    __atomic_or_fetch(&(var), (val), __ATOMIC_RELEASE)
 
 /* You are probably looking here because you think 24 is too low, really it isn't.
  * Instead, use jemalloc and increase the number of threads used for reading packets.
@@ -1037,7 +1038,7 @@ void arkime_credentials_register(const char *name, ArkimeCredentialsGet func);
 void arkime_credentials_set(const char *id, const char *key, const char *token);
 ArkimeCredentials_t *arkime_credentials_get(const char *service, const char *idName, const char *keyName);
 
-#define ARKIME_HAS_NAMED_FUNC(id) (arkime_has_named_func & (1ULL << id))
+#define ARKIME_HAS_NAMED_FUNC(id) (ARKIME_THREAD_ATOMIC_LOAD(arkime_has_named_func) & (1ULL << id))
 extern uint64_t arkime_has_named_func;
 typedef uint32_t (* ArkimeNamedFunc) (int thread, void *uw, void *cbuw);
 uint32_t arkime_add_named_func(const char *name, ArkimeNamedFunc func, void *cbuw);

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -314,9 +314,11 @@ typedef struct {
 #define ARKIME_THREAD_DECROLD(var)           __sync_fetch_and_sub(&var, 1)
 #define ARKIME_THREAD_DECR_NUM(var, num)     __sync_sub_and_fetch(&var, num)
 
-#define ARKIME_THREAD_ATOMIC_STORE(var, val) __atomic_store_n(&(var), (val), __ATOMIC_RELEASE)
-#define ARKIME_THREAD_ATOMIC_LOAD(var)       __atomic_load_n(&(var), __ATOMIC_ACQUIRE)
-#define ARKIME_THREAD_ATOMIC_OR(var, val)    __atomic_or_fetch(&(var), (val), __ATOMIC_RELEASE)
+#define ARKIME_THREAD_ATOMIC_STORE(var, val)         __atomic_store_n(&(var), (val), __ATOMIC_RELEASE)
+#define ARKIME_THREAD_ATOMIC_LOAD(var)               __atomic_load_n(&(var), __ATOMIC_ACQUIRE)
+#define ARKIME_THREAD_ATOMIC_OR(var, val)            __atomic_or_fetch(&(var), (val), __ATOMIC_RELEASE)
+#define ARKIME_THREAD_ATOMIC_STORE_RELAXED(var, val) __atomic_store_n(&(var), (val), __ATOMIC_RELAXED)
+#define ARKIME_THREAD_ATOMIC_LOAD_RELAXED(var)       __atomic_load_n(&(var), __ATOMIC_RELAXED)
 
 /* You are probably looking here because you think 24 is too low, really it isn't.
  * Instead, use jemalloc and increase the number of threads used for reading packets.

--- a/capture/dedup.c
+++ b/capture/dedup.c
@@ -163,7 +163,7 @@ int arkime_dedup_should_drop (const ArkimePacket_t *packet, int headerLen)
 
     // First see if we need to clean up old slot, and block all new folks while we do
     // In theory no one should be using this slot because we hadn't been searching it for a second.
-    if (seconds[secondSlot].tv_sec != currentTime.tv_sec) {
+    if (ARKIME_THREAD_ATOMIC_LOAD(seconds[secondSlot].tv_sec) != currentTime.tv_sec) {
         ARKIME_LOCK(seconds[secondSlot].lock);
         if (seconds[secondSlot].tv_sec != currentTime.tv_sec) { // Check critical section again inside the lock
             if (seconds[secondSlot].error) {
@@ -173,8 +173,11 @@ int arkime_dedup_should_drop (const ArkimePacket_t *packet, int headerLen)
                 LOG ("WARNING - Ran out of room, increase dedupPackets to %u or above. pcount: %u", (dedupSlots + 1) * DEDUP_SLOT_FACTOR, pcount);
                 seconds[secondSlot].error = 0;
             }
+            // Invalidate before wiping so the lock free searchers below skip
+            // this slot until the wipe is done and published
+            ARKIME_THREAD_ATOMIC_STORE(seconds[secondSlot].tv_sec, 0);
             memset(seconds[secondSlot].counts, 0, dedupSlots);
-            seconds[secondSlot].tv_sec = currentTime.tv_sec;
+            ARKIME_THREAD_ATOMIC_STORE(seconds[secondSlot].tv_sec, (uint32_t)currentTime.tv_sec);
         }
         ARKIME_UNLOCK(seconds[secondSlot].lock);
     }
@@ -182,12 +185,12 @@ int arkime_dedup_should_drop (const ArkimePacket_t *packet, int headerLen)
     // Search all valid slots
     for (uint32_t s = 0; s < dedupSeconds; s++) {
 
-        // If slot is too old just skip it
-        if (currentTime.tv_sec - dedupSeconds + 1 >= seconds[s].tv_sec) {
+        // If slot is too old, or mid wipe (tv_sec 0), just skip it
+        if (currentTime.tv_sec - dedupSeconds + 1 >= ARKIME_THREAD_ATOMIC_LOAD(seconds[s].tv_sec)) {
             continue;
         }
 
-        int count = seconds[s].counts[h];
+        int count = ARKIME_THREAD_ATOMIC_LOAD(seconds[s].counts[h]);
         const uint8_t *ctrl_base = seconds[s].ctrl + h * DEDUP_SIZE_FACTOR;
         for (int c = 0; c < count; c++) {
             if (tag == ctrl_base[c] && memcmp(md, seconds[s].hashes + 16 * (h * DEDUP_SIZE_FACTOR + c), 16) == 0) {
@@ -202,8 +205,11 @@ int arkime_dedup_should_drop (const ArkimePacket_t *packet, int headerLen)
         return 0;
     }
 
-    // Race condition: a reader may see incremented count before stores complete.
-    // This is acceptable - fail-open means a duplicate packet may slip through briefly.
+    // Race condition: a searcher may see the incremented count before the ctrl/hash
+    // stores below complete. Usually the unfinished entry just doesn't match, so a
+    // duplicate can slip through briefly (fail open). The entry may also still hold
+    // the previous occupant from dedupSeconds ago, so a packet identical to one from
+    // back then can very rarely be dropped as a duplicate.
     int c = ARKIME_THREAD_INCROLD(seconds[secondSlot].counts[h]);
     if (c >= DEDUP_SIZE_FACTOR) {
         seconds[secondSlot].error = 1;

--- a/capture/dll.h
+++ b/capture/dll.h
@@ -27,7 +27,7 @@
      (element)->name##prev          = (head)->name##prev, \
      (head)->name##prev->name##next = (element), \
      (head)->name##prev             = (element), \
-     (head)->name##count++ \
+     __atomic_store_n(&(head)->name##count, (head)->name##count + 1, __ATOMIC_RELAXED) \
     )
 
 #define DLL_PUSH_TAIL_DLL(name, head1, head2) \
@@ -35,7 +35,7 @@
      (head2)->name##next->name##prev = (head1)->name##prev, \
      (head1)->name##prev             = (head2)->name##prev, \
      (head2)->name##prev->name##next = (void *)(head1), \
-     (head1)->name##count += (head2)->name##count, \
+     __atomic_store_n(&(head1)->name##count, (head1)->name##count + (head2)->name##count, __ATOMIC_RELAXED), \
      DLL_INIT(name, head2) \
     )
 
@@ -44,7 +44,7 @@
      (element)->name##prev          = (void *)(head), \
      (head)->name##next->name##prev = (element), \
      (head)->name##next             = (element), \
-     (head)->name##count++ \
+     __atomic_store_n(&(head)->name##count, (head)->name##count + 1, __ATOMIC_RELAXED) \
     )
 
 #define DLL_ADD_AFTER(name, head, after, element) \
@@ -52,7 +52,7 @@
      (element)->name##prev            = (after), \
      (after)->name##next->name##prev  = (element), \
      (after)->name##next              = (element), \
-     (head)->name##count++ \
+     __atomic_store_n(&(head)->name##count, (head)->name##count + 1, __ATOMIC_RELAXED) \
     )
 
 #define DLL_ADD_BEFORE(name, head, before, element) \
@@ -60,7 +60,7 @@
      (element)->name##prev             = (before)->name##prev, \
      (before)->name##prev              = (element), \
      (element)->name##prev->name##next = (element), \
-     (head)->name##count++ \
+     __atomic_store_n(&(head)->name##count, (head)->name##count + 1, __ATOMIC_RELAXED) \
     )
 
 
@@ -69,7 +69,7 @@
      (element)->name##next->name##prev = (element)->name##prev, \
      (element)->name##prev             = 0, \
      (element)->name##next             = 0, \
-     (head)->name##count-- \
+     __atomic_store_n(&(head)->name##count, (head)->name##count - 1, __ATOMIC_RELAXED) \
     )
 
 #define DLL_MOVE_TAIL(name, head, element) \
@@ -94,7 +94,7 @@
     ((head)->name##count == 0 ? NULL : (head)->name##prev)
 
 #define DLL_COUNT(name, head) \
-    ((head)->name##count)
+    (__atomic_load_n(&(head)->name##count, __ATOMIC_RELAXED))
 
 #define DLL_FOREACH(name, head, element) \
       for ((element) = (head)->name##next; \

--- a/capture/dll.h
+++ b/capture/dll.h
@@ -27,7 +27,7 @@
      (element)->name##prev          = (head)->name##prev, \
      (head)->name##prev->name##next = (element), \
      (head)->name##prev             = (element), \
-     __atomic_store_n(&(head)->name##count, (head)->name##count + 1, __ATOMIC_RELAXED) \
+     ARKIME_THREAD_ATOMIC_STORE_RELAXED((head)->name##count, (head)->name##count + 1) \
     )
 
 #define DLL_PUSH_TAIL_DLL(name, head1, head2) \
@@ -35,7 +35,7 @@
      (head2)->name##next->name##prev = (head1)->name##prev, \
      (head1)->name##prev             = (head2)->name##prev, \
      (head2)->name##prev->name##next = (void *)(head1), \
-     __atomic_store_n(&(head1)->name##count, (head1)->name##count + (head2)->name##count, __ATOMIC_RELAXED), \
+     ARKIME_THREAD_ATOMIC_STORE_RELAXED((head1)->name##count, (head1)->name##count + (head2)->name##count), \
      DLL_INIT(name, head2) \
     )
 
@@ -44,7 +44,7 @@
      (element)->name##prev          = (void *)(head), \
      (head)->name##next->name##prev = (element), \
      (head)->name##next             = (element), \
-     __atomic_store_n(&(head)->name##count, (head)->name##count + 1, __ATOMIC_RELAXED) \
+     ARKIME_THREAD_ATOMIC_STORE_RELAXED((head)->name##count, (head)->name##count + 1) \
     )
 
 #define DLL_ADD_AFTER(name, head, after, element) \
@@ -52,7 +52,7 @@
      (element)->name##prev            = (after), \
      (after)->name##next->name##prev  = (element), \
      (after)->name##next              = (element), \
-     __atomic_store_n(&(head)->name##count, (head)->name##count + 1, __ATOMIC_RELAXED) \
+     ARKIME_THREAD_ATOMIC_STORE_RELAXED((head)->name##count, (head)->name##count + 1) \
     )
 
 #define DLL_ADD_BEFORE(name, head, before, element) \
@@ -60,7 +60,7 @@
      (element)->name##prev             = (before)->name##prev, \
      (before)->name##prev              = (element), \
      (element)->name##prev->name##next = (element), \
-     __atomic_store_n(&(head)->name##count, (head)->name##count + 1, __ATOMIC_RELAXED) \
+     ARKIME_THREAD_ATOMIC_STORE_RELAXED((head)->name##count, (head)->name##count + 1) \
     )
 
 
@@ -69,7 +69,7 @@
      (element)->name##next->name##prev = (element)->name##prev, \
      (element)->name##prev             = 0, \
      (element)->name##next             = 0, \
-     __atomic_store_n(&(head)->name##count, (head)->name##count - 1, __ATOMIC_RELAXED) \
+     ARKIME_THREAD_ATOMIC_STORE_RELAXED((head)->name##count, (head)->name##count - 1) \
     )
 
 #define DLL_MOVE_TAIL(name, head, element) \
@@ -94,7 +94,7 @@
     ((head)->name##count == 0 ? NULL : (head)->name##prev)
 
 #define DLL_COUNT(name, head) \
-    (__atomic_load_n(&(head)->name##count, __ATOMIC_RELAXED))
+    (ARKIME_THREAD_ATOMIC_LOAD_RELAXED((head)->name##count))
 
 #define DLL_FOREACH(name, head, element) \
       for ((element) = (head)->name##next; \

--- a/capture/main.c
+++ b/capture/main.c
@@ -77,6 +77,7 @@ uint64_t                 arkime_has_named_func;
 LOCAL uint16_t           namedFuncsMax = 0;
 LOCAL ArkimeNamedInfo_t *namedFuncsArr[MAX_NAMED_FUNCS];
 LOCAL GHashTable        *namedFuncsHash;
+LOCAL ARKIME_LOCK_DEFINE(namedFuncs);
 
 /******************************************************************************/
 LOCAL gboolean arkime_debug_flag()
@@ -1037,36 +1038,40 @@ ArkimeCredentials_t *arkime_credentials_get(const char *service, const char *idN
 /******************************************************************************/
 uint32_t arkime_add_named_func(const char *name, ArkimeNamedFunc func, void *cbuw)
 {
+    ARKIME_LOCK(namedFuncs);
     if (!namedFuncsHash)
         namedFuncsHash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
 
     ArkimeNamedInfo_t *info = g_hash_table_lookup(namedFuncsHash, name);
     if (!info) {
-        info = ARKIME_TYPE_ALLOC0(ArkimeNamedInfo_t);
-        info->funcs = g_ptr_array_new();
-        namedFuncsMax++; // Don't use 0
-        if (namedFuncsMax >= MAX_NAMED_FUNCS) {
+        if (namedFuncsMax + 1 >= MAX_NAMED_FUNCS) {
             LOGEXIT("ERROR - Too many named functions %s", name);
             return 0;
         }
-        info->id = namedFuncsMax;
-        namedFuncsArr[namedFuncsMax] = info;
+        info = ARKIME_TYPE_ALLOC0(ArkimeNamedInfo_t);
+        info->funcs = g_ptr_array_new();
+        info->id = namedFuncsMax + 1; // Don't use 0
+        namedFuncsArr[info->id] = info;
         g_hash_table_insert(namedFuncsHash, g_strdup(name), info);
+        // publish only after the arr slot is filled, callers read without the lock
+        ARKIME_THREAD_ATOMIC_STORE(namedFuncsMax, info->id);
     }
-    if (!func)
-        return info->id;
 
-    arkime_has_named_func |= (1ULL << info->id);
-    ArkimeNamedFunc_t *funcInfo = ARKIME_TYPE_ALLOC0(ArkimeNamedFunc_t);
-    funcInfo->cb = func;
-    funcInfo->cbuw = cbuw;
-    g_ptr_array_add(info->funcs, funcInfo);
-    return info->id;
+    uint32_t id = info->id;
+    if (func) {
+        ArkimeNamedFunc_t *funcInfo = ARKIME_TYPE_ALLOC0(ArkimeNamedFunc_t);
+        funcInfo->cb = func;
+        funcInfo->cbuw = cbuw;
+        g_ptr_array_add(info->funcs, funcInfo);
+        ARKIME_THREAD_ATOMIC_OR(arkime_has_named_func, 1ULL << id);
+    }
+    ARKIME_UNLOCK(namedFuncs);
+    return id;
 }
 /******************************************************************************/
 void arkime_call_named_func(uint32_t id, int thread, void *uw)
 {
-    if (id == 0 || id > namedFuncsMax || !ARKIME_HAS_NAMED_FUNC(id))
+    if (id == 0 || id > ARKIME_THREAD_ATOMIC_LOAD(namedFuncsMax) || !ARKIME_HAS_NAMED_FUNC(id))
         return;
     ArkimeNamedInfo_t *info = namedFuncsArr[id];
     for (int i = 0; i < (int)info->funcs->len; i++) {

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -531,7 +531,7 @@ LOCAL void *arkime_packet_thread(void *threadp)
         ArkimePacket_t  *packet;
 
         ARKIME_LOCK(packetThreadData[thread].packetQ.lock);
-        packetThreadData[thread].inProgress = 0;
+        __atomic_store_n(&packetThreadData[thread].inProgress, 0, __ATOMIC_RELAXED);
         if (DLL_COUNT(packet_, &packetThreadData[thread].packetQ) == 0) {
             struct timespec ts;
             clock_gettime(CLOCK_REALTIME_COARSE, &ts);
@@ -547,7 +547,7 @@ LOCAL void *arkime_packet_thread(void *threadp)
                 arkimeThreadData[thread].lastPacketSecs = ts.tv_sec - 10;
             }
         }
-        packetThreadData[thread].inProgress = 1;
+        __atomic_store_n(&packetThreadData[thread].inProgress, 1, __ATOMIC_RELAXED);
         DLL_POP_HEAD(packet_, &packetThreadData[thread].packetQ, packet);
         ARKIME_UNLOCK(packetThreadData[thread].packetQ.lock);
 
@@ -587,7 +587,7 @@ LOCAL void *arkime_packet_thread(void *threadp)
     }
 
     arkime_call_named_func(arkime_packet_thread_exit_func, thread, NULL);
-    packetThreadData[thread].inProgress = 0; // Clear after calling exit function delaying can quit
+    __atomic_store_n(&packetThreadData[thread].inProgress, 0, __ATOMIC_RELAXED); // Clear after calling exit function delaying can quit
 
     return NULL;
 }
@@ -1631,10 +1631,10 @@ void arkime_packet_batch_flush(ArkimePacketBatch_t *batch)
         batch->totalBytes = 0;
     }
     if (batch->totalPackets) {
-        ARKIME_THREAD_INCR_NUM(arkimeCounters.totalPackets, batch->totalPackets);
+        const uint64_t totalPackets = ARKIME_THREAD_INCR_NUM(arkimeCounters.totalPackets, batch->totalPackets);
         batch->totalPackets = 0;
-        if (unlikely(arkimeCounters.totalPackets >= arkimeCounters.nextLogPackets)) {
-            arkimeCounters.nextLogPackets = arkimeCounters.totalPackets + config.logEveryXPackets;
+        if (unlikely(totalPackets >= ARKIME_THREAD_ATOMIC_LOAD(arkimeCounters.nextLogPackets))) {
+            ARKIME_THREAD_ATOMIC_STORE(arkimeCounters.nextLogPackets, totalPackets + config.logEveryXPackets);
             arkime_packet_log(tcpMProtocol);
         }
     }
@@ -1739,8 +1739,7 @@ skip_switch:
 process_packet:
     /* This packet we are going to process */
 
-    if (unlikely(!firstPacket)) {
-        firstPacket = 1;
+    if (unlikely(!ARKIME_THREAD_ATOMIC_LOAD(firstPacket)) && ARKIME_THREAD_INCROLD(firstPacket) == 0) {
         ArkimeReaderStats_t stats;
         if (!arkime_reader_stats(&stats)) {
             initialDropped = stats.dropped;
@@ -1811,7 +1810,7 @@ int arkime_packet_outstanding()
 
     for (int t = 0; t < config.packetThreads; t++) {
         count += DLL_COUNT(packet_, &packetThreadData[t].packetQ);
-        count += packetThreadData[t].inProgress;
+        count += __atomic_load_n(&packetThreadData[t].inProgress, __ATOMIC_RELAXED);
     }
     return count;
 }

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -531,7 +531,7 @@ LOCAL void *arkime_packet_thread(void *threadp)
         ArkimePacket_t  *packet;
 
         ARKIME_LOCK(packetThreadData[thread].packetQ.lock);
-        __atomic_store_n(&packetThreadData[thread].inProgress, 0, __ATOMIC_RELAXED);
+        ARKIME_THREAD_ATOMIC_STORE_RELAXED(packetThreadData[thread].inProgress, 0);
         if (DLL_COUNT(packet_, &packetThreadData[thread].packetQ) == 0) {
             struct timespec ts;
             clock_gettime(CLOCK_REALTIME_COARSE, &ts);
@@ -547,7 +547,7 @@ LOCAL void *arkime_packet_thread(void *threadp)
                 arkimeThreadData[thread].lastPacketSecs = ts.tv_sec - 10;
             }
         }
-        __atomic_store_n(&packetThreadData[thread].inProgress, 1, __ATOMIC_RELAXED);
+        ARKIME_THREAD_ATOMIC_STORE_RELAXED(packetThreadData[thread].inProgress, 1);
         DLL_POP_HEAD(packet_, &packetThreadData[thread].packetQ, packet);
         ARKIME_UNLOCK(packetThreadData[thread].packetQ.lock);
 
@@ -587,7 +587,7 @@ LOCAL void *arkime_packet_thread(void *threadp)
     }
 
     arkime_call_named_func(arkime_packet_thread_exit_func, thread, NULL);
-    __atomic_store_n(&packetThreadData[thread].inProgress, 0, __ATOMIC_RELAXED); // Clear after calling exit function delaying can quit
+    ARKIME_THREAD_ATOMIC_STORE_RELAXED(packetThreadData[thread].inProgress, 0); // Clear after calling exit function delaying can quit
 
     return NULL;
 }
@@ -1810,7 +1810,7 @@ int arkime_packet_outstanding()
 
     for (int t = 0; t < config.packetThreads; t++) {
         count += DLL_COUNT(packet_, &packetThreadData[t].packetQ);
-        count += __atomic_load_n(&packetThreadData[t].inProgress, __ATOMIC_RELAXED);
+        count += ARKIME_THREAD_ATOMIC_LOAD_RELAXED(packetThreadData[t].inProgress);
     }
     return count;
 }

--- a/capture/writer-null.c
+++ b/capture/writer-null.c
@@ -31,8 +31,7 @@ LOCAL void writer_null_exit()
 LOCAL void writer_null_write(const ArkimeSession_t *const UNUSED(session), ArkimePacket_t *const packet)
 {
     packet->writerFileNum = 0;
-    packet->writerFilePos = outputFilePos;
-    outputFilePos += 16 + packet->pktlen;
+    packet->writerFilePos = ARKIME_THREAD_INCROLD_NUM(outputFilePos, 16 + packet->pktlen);
 }
 /******************************************************************************/
 void writer_null_init(const char *UNUSED(name))


### PR DESCRIPTION
- named funcs: reader threads look up ids at thread start while packet threads call funcs, guard the hash/arr with a lock and publish namedFuncsMax / arkime_has_named_func with release/acquire
- dedup: invalidate a slot's tv_sec before wiping its counts and publish it after, so the lock free searchers can no longer scan a slot mid wipe and match entries from dedupSeconds ago
- dll.h: count updates are relaxed atomic stores and DLL_COUNT a relaxed atomic load, making the lock free queue depth reads well defined; same instructions on x86/i686
- packet: only the first reader thread records initialPacket/initialDropped, the log threshold uses the counter value the increment returned, and inProgress is read/written atomically for arkime_packet_outstanding
- writer-null: atomically claim each packet's file position range, two packet threads could hand out the same position

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
