### PR TITLE
Fix crashes and out of bounds reads found scanning capture

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -53,6 +53,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4149 Add 24 new magicMode=basic matches, including ELF, Mach-O, java class, wasm, OLE, lnk, 7z, zstd, sqlite and pcap
   - #4149 Fix magicMode=basic returning audio/x-wav for every RIFF body, webp and avi are now identified correctly
   - #4150 Add autoGenerateId=sequential, a lock free per thread session id generator that is much faster on session heavy traffic
+  - #4153 override-ips asn: values are now matched anchored, /^AS\d+ .+/; a value with anything before the AS number used to be accepted and silently recorded with AS number 0, and is now rejected
+  - #4153 Fix DTLS ja4 being computed over a truncated string when a ClientHello had many extensions or signature algorithms
+  - #4153 Fix TLS/DTLS ClientHello parsing desyncing when the cipher suites length was odd, which could hide the SNI and give a wrong ja3/ja4
 ## Cont3xt/Viewer
   - #4134 Add an MCP server at POST /mcp for viewer and cont3xt, off by default, enable with mcpEnabled.
   - #4134 Add mcpUser role, required per user on top of the service role to use /mcp; superAdmin includes it, arkimeAdmin does not

--- a/capture/config.c
+++ b/capture/config.c
@@ -192,7 +192,7 @@ LOCAL int config_ipprotocol_cmp(const void *keyv, const void *entryv)
 LOCAL int config_ipprotocol_lookup(const char *str)
 {
     // If it starts with a digit, just parse as number
-    if (isdigit(str[0]))
+    if (isdigit((uint8_t)str[0]))
         return atoi(str);
 
     const IpProtocolEntry_t *entry = bsearch(str, ipProtocols,
@@ -268,7 +268,7 @@ LOCAL int config_ethertype_cmp(const void *keyv, const void *entryv)
 LOCAL int config_ethertype_lookup(const char *str)
 {
     // If it starts with a digit, just parse as number
-    if (isdigit(str[0]))
+    if (isdigit((uint8_t)str[0]))
         return strtol(str, NULL, 0);
 
     const EthertypeEntry_t *entry = bsearch(str, ethertypes,
@@ -315,7 +315,7 @@ gchar **arkime_config_section_str_list(GKeyFile *keyfile, const char *section, c
         char *str = strs[i];
 
         /* Remove leading and trailing spaces */
-        while (isspace(*str))
+        while (isspace((uint8_t) *str))
             str++;
         g_strchomp(str);
 
@@ -467,7 +467,7 @@ gchar **arkime_config_str_list(GKeyFile *keyfile, const char *key, const char *d
         char *str = strs[i];
 
         /* Remove leading and trailing spaces */
-        while (isspace(*str))
+        while (isspace((uint8_t) *str))
             str++;
         g_strchomp(str);
 
@@ -657,16 +657,18 @@ LOCAL char arkime_config_key_sep(const char *key)
 /******************************************************************************/
 LOCAL gboolean arkime_config_load_json(GKeyFile *keyfile, char *data, GError **UNUSED(error))
 {
-    uint32_t sections[4 * 100]; // Can have up to 100 sections
+    uint32_t sections[4 * 100 + 2]; // Can have up to 100 sections
     memset(sections, 0, sizeof(sections));
-    js0n((uint8_t *)data, strlen(data), sections, sizeof(sections));
+    if (js0n((uint8_t *)data, strlen(data), sections, sizeof(sections)) != 0)
+        LOG("WARNING - Couldn't parse all of the JSON config, some sections may be missing");
 
     for (int s = 0; sections[s]; s += 4) {
         char *section = g_strndup(data + sections[s], sections[s + 1]);
 
-        uint32_t keys[4 * 500]; // Can have up to 500 keys
+        uint32_t keys[4 * 500 + 2]; // Can have up to 500 keys
         memset(keys, 0, sizeof(keys));
-        js0n((uint8_t *)data + sections[s + 2], sections[s + 3], keys, sizeof(keys));
+        if (js0n((uint8_t *)data + sections[s + 2], sections[s + 3], keys, sizeof(keys)) != 0)
+            LOG("WARNING - Couldn't parse all of JSON config section %s, some keys may be missing", section);
 
         for (int k = 0; keys[k]; k += 4) {
             char *key = g_strndup(data + sections[s + 2] + keys[k], keys[k + 1]);
@@ -674,12 +676,14 @@ LOCAL gboolean arkime_config_load_json(GKeyFile *keyfile, char *data, GError **U
 
             // HACK - Convert arrays back into strings
             if (value[0] == '[') {
-                uint32_t parts[2 * 100]; // Can have up to 100 keys
+                uint32_t parts[2 * 100 + 2]; // Can have up to 100 elements
                 memset(parts, 0, sizeof(parts));
-                js0n((uint8_t *)value, keys[k + 3], parts, sizeof(parts));
+                if (js0n((uint8_t *)value, keys[k + 3], parts, sizeof(parts)) != 0)
+                    LOG("WARNING - Couldn't parse all of JSON config array %s.%s, some elements may be missing", section, key);
 
                 char sep = arkime_config_key_sep(key);
-                char *buf = malloc(keys[k + 3]);
+                // Alloc 1 extra so the null terminator below always has room
+                char *buf = malloc(keys[k + 3] + 1);
                 BSB bsb;
                 BSB_INIT(bsb, buf, keys[k + 3]);
                 for (int p = 0; parts[p]; p += 2) {
@@ -687,7 +691,9 @@ LOCAL gboolean arkime_config_load_json(GKeyFile *keyfile, char *data, GError **U
                         BSB_EXPORT_u08(bsb, sep);
                     BSB_EXPORT_ptr(bsb, value + parts[p], parts[p + 1]);
                 }
-                BSB_EXPORT_u08(bsb, 0);
+                if (BSB_IS_ERROR(bsb))
+                    LOG("WARNING - JSON array value too long for %s:%s, truncating", section, key);
+                buf[BSB_LENGTH(bsb)] = 0;
                 g_key_file_set_string(keyfile, section, key, buf);
                 free(buf);
             } else {
@@ -1395,7 +1401,8 @@ LOCAL void arkime_config_parse_override_ips(GKeyFile *keyFile)
         CONFIGEXIT("Error with override-ips: %s", error->message ? error->message : "unknown error");
     }
 
-    GRegex *asnRegex = g_regex_new("AS\\d+ .+", 0, 0, &error);
+    // Anchored so the AS number is always at values[v] + 6 for the parsing below
+    GRegex *asnRegex = g_regex_new("^AS\\d+ .+", 0, 0, &error);
     gsize k, v;
     for (k = 0 ; k < keys_len; k++) {
         gsize values_len;
@@ -1408,7 +1415,7 @@ LOCAL void arkime_config_parse_override_ips(GKeyFile *keyFile)
         for (v = 0; v < values_len; v++) {
             if (strncmp(values[v], "asn:", 4) == 0) {
                 if (!g_regex_match(asnRegex, values[v] + 4, 0, NULL)) {
-                    CONFIGEXIT("Value for override-ips doesn't match ASN format of /AS\\d+ .*/ '%s'", values[v] + 4);
+                    CONFIGEXIT("Value for override-ips doesn't match ASN format of /^AS\\d+ .+/ '%s'", values[v] + 4);
                 }
                 char *sp = strchr(values[v] + 6, ' ');
                 *sp = 0;

--- a/capture/db.c
+++ b/capture/db.c
@@ -2626,7 +2626,8 @@ LOCAL void arkime_db_load_fields()
 
     uint32_t out[2 * 8000];
     memset(out, 0, sizeof(out));
-    js0n(ahits, ahits_len, out, sizeof(out));
+    if (js0n(ahits, ahits_len, out, sizeof(out)) != 0)
+        LOG("WARNING - Couldn't parse all of the %sfields response, some fields may be missing", config.prefix);
     for (int i = 0; out[i]; i += 2) {
         uint32_t           id_len;
         const uint8_t     *id = 0;

--- a/capture/field.c
+++ b/capture/field.c
@@ -508,6 +508,8 @@ int arkime_field_define(const char *group, const char *kind, const char *express
     }
 
     if (flags & ARKIME_FIELD_FLAG_IPPRE) {
+        if (strncmp(expression, "ip.", 3) != 0 || strlen(dbField) < 2)
+            LOGEXIT("ERROR - IPPRE field '%s' needs an expression starting with 'ip.' and a dbField ending with 'ip'", expression);
         int l = strlen(dbField) - 2;
         int fnlen = strlen(friendlyName);
         snprintf(dbField2, sizeof(dbField2), "%.*sGEO", l, dbField);
@@ -1941,6 +1943,8 @@ LOCAL gboolean arkime_field_load_field_remap(gpointer UNUSED(user_data))
             continue;
         }
         gchar *info = arkime_config_section_str(NULL, "custom-fields-remap", keys[i], NULL);
+        if (!info)
+            CONFIGEXIT("Invalid value for '%s' in section [custom-fields-remap]", keys[i]);
 
         char **kvs = g_strsplit(info, ";", 0);
         for (int k = 0; kvs[k]; k++) {
@@ -1950,9 +1954,9 @@ LOCAL gboolean arkime_field_load_field_remap(gpointer UNUSED(user_data))
                 continue;
             *value = 0;
             value++;
-            while (isspace(*key)) key++;
+            while (isspace((uint8_t) *key)) key++;
             g_strchomp(key);
-            while (isspace(*value)) value++;
+            while (isspace((uint8_t) *value)) value++;
             g_strchomp(value);
             int matchPos = arkime_field_by_exp_ignore_error(key);
             if (matchPos == -1) {

--- a/capture/http.c
+++ b/capture/http.c
@@ -574,7 +574,7 @@ LOCAL size_t arkime_http_curlm_header_function(char *buffer, size_t size, size_t
     const char *end = buffer + i;
     *colon = 0;
     colon++;
-    while (colon < end && isspace((unsigned char) * colon)) colon++;
+    while (colon < end && isspace((unsigned char) *colon)) colon++;
 
     int valueLen = (int)(end - colon);
     if (valueLen < 0) valueLen = 0;

--- a/capture/main.c
+++ b/capture/main.c
@@ -630,11 +630,11 @@ const char *arkime_memcasestr(const char *haystack, int haysize, const char *nee
     const char firstNeedle = needle[0];
 
     for (p = haystack; p <= end; p++) {
-        if (tolower(p[0]) != firstNeedle)
+        if (tolower((uint8_t)p[0]) != firstNeedle)
             continue;
         int i;
         for (i = 1; i < needlesize; i++) {
-            if (tolower(p[i]) != needle[i]) {
+            if (tolower((uint8_t)p[i]) != needle[i]) {
                 break;
             }
         }
@@ -731,7 +731,7 @@ int arkime_atoin(const char *str, int len)
     int sign = 1;
     int i = 0;
 
-    while (i < len && isspace(str[i]))
+    while (i < len && isspace((uint8_t)str[i]))
         i++;
 
     if (i >= len)
@@ -744,7 +744,7 @@ int arkime_atoin(const char *str, int len)
         i++;
     }
 
-    while (i < len && isdigit(str[i])) {
+    while (i < len && isdigit((uint8_t)str[i])) {
         result = result * 10 + (str[i] - '0');
         i++;
     }

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -1227,6 +1227,9 @@ void arkime_parsers_init()
 
     for (int i = 0; i < (int)keys_len; i++) {
         char *value = arkime_config_section_str(NULL, "custom-fields", keys[i], NULL);
+        if (!value)
+            CONFIGEXIT("Invalid value for '%s' in section [custom-fields]", keys[i]);
+
         arkime_field_define_text_full(keys[i], value, NULL);
         g_free(value);
     }

--- a/capture/parsers/adb.c
+++ b/capture/parsers/adb.c
@@ -406,7 +406,7 @@ LOCAL void adb_parse_client_server(ArkimeSession_t *session, const uint8_t *data
             /* Validate hex string */
             int valid = 1;
             for (int i = 0; i < 4; i++) {
-                if (!isxdigit(hex_str[i])) {
+                if (!isxdigit((uint8_t)hex_str[i])) {
                     valid = 0;
                     break;
                 }

--- a/capture/parsers/dns.c
+++ b/capture/parsers/dns.c
@@ -865,7 +865,10 @@ LOCAL void dns_parser(ArkimeSession_t *session, int kind, const uint8_t *data, i
             }
             ARKIME_RULES_RUN_FIELD_SET(session, dnsQueryHostField, dns->query.hostname);
         }
-        arkime_field_object_add(dnsField, session, fobject, jsonLen);
+        if (!arkime_field_object_add(dnsField, session, fobject, jsonLen)) {
+            dns_free_object(fobject);
+            return;
+        }
     } else {
         if (key.query.hostname != root)
             g_free(key.query.hostname);

--- a/capture/parsers/dtls.c
+++ b/capture/parsers/dtls.c
@@ -135,7 +135,7 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
     BSB_IMPORT_skip(cbsb, skiplen);  // Cookie
 
     BSB_IMPORT_u16(cbsb, skiplen);   // Cipher Suites Length
-    while (BSB_NOT_ERROR(cbsb) && skiplen > 0) {
+    while (BSB_NOT_ERROR(cbsb) && skiplen >= 2) {
         uint16_t c = 0;
         BSB_IMPORT_u16(cbsb, c);
         if (!dtls_is_grease_value(c)) {
@@ -146,6 +146,7 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
         }
         skiplen -= 2;
     }
+    BSB_IMPORT_skip(cbsb, skiplen);  // Odd declared length leaves a trailing byte
     BSB_IMPORT_u08(cbsb, skiplen);   // Compression Length
     BSB_IMPORT_skip(cbsb, skiplen);  // Compressions
 
@@ -205,12 +206,12 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
 
                 uint16_t llen = 0;
                 BSB_IMPORT_u16(bsb, llen); // list len
-                while (llen > 0 && !BSB_IS_ERROR(bsb)) {
+                BSB_SHRINK_REMAINING(bsb, llen);
+                while (BSB_REMAINING(bsb) >= 2) {
                     uint16_t a = 0;
                     BSB_IMPORT_u16(bsb, a);
                     if (ja4NumAlgos < ARRAY_LEN(ja4Algos))
                         ja4Algos[ja4NumAlgos++] = a;
-                    llen -= 2;
                 }
             } else if (etype == 0x10) { // ALPN
                 if (ja4NumExtensionsSome > 0)
@@ -232,7 +233,8 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
 
                 uint16_t llen = 0;
                 BSB_IMPORT_u08(bsb, llen); // list len
-                while (llen > 0 && !BSB_IS_ERROR(bsb)) {
+                BSB_SHRINK_REMAINING(bsb, llen);
+                while (BSB_REMAINING(bsb) >= 2) {
                     uint16_t supported_version = 0;
                     BSB_IMPORT_u16(bsb, supported_version);
                     if (!dtls_is_grease_value(supported_version)) {
@@ -244,7 +246,6 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
                         else
                             ver = MIN(supported_version, ver);
                     }
-                    llen -= 2;
                 }
             } else {
                 BSB_IMPORT_skip(ebsb, elen);
@@ -273,7 +274,8 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
 
     BSB_EXPORT_ptr(ja4_rbsb, ja4, 11);
 
-    char tmpBuf[5 * 256];
+    // Sized for the larger of the cipher leg and the extensions+algos leg
+    char tmpBuf[5 * ARRAY_LEN(ja4Extensions) + 1 + 5 * ARRAY_LEN(ja4Algos) + 5 * ARRAY_LEN(ja4Ciphers)];
     BSB tmpBSB;
 
     // Sort ciphers, convert to hex, first 12 bytes of sha256
@@ -332,8 +334,8 @@ LOCAL uint32_t dtls_process_client_hello(ArkimeSession_t *session, const uint8_t
 
     // Add the field
     arkime_field_string_add(ja4Field, session, ja4, 36, TRUE);
-    if (ja4Raw) {
-        arkime_field_string_add(ja4RawField, session, ja4_r, BSB_LENGTH(ja4_rbsb), TRUE);
+    if (ja4Raw && BSB_NOT_ERROR(ja4_rbsb)) {
+        arkime_field_string_add(ja4RawField, session, ja4_r, BSB_LENGTH(ja4_rbsb) - 1, TRUE);
     }
     return 0;
 }

--- a/capture/parsers/http.c
+++ b/capture/parsers/http.c
@@ -97,7 +97,7 @@ void http_common_parse_cookie(ArkimeSession_t *session, char *cookie, int len)
     char *start = cookie;
     char *end = cookie + len;
     while (start < end) {
-        while (start < end && isspace(*start)) start++;
+        while (start < end && isspace((unsigned char) *start)) start++;
         char *equal = memchr(start, '=', end - start);
         if (!equal)
             break;
@@ -105,7 +105,7 @@ void http_common_parse_cookie(ArkimeSession_t *session, char *cookie, int len)
         start = memchr(equal + 1, ';', end - (equal + 1));
         if (config.parseCookieValue) {
             equal++;
-            while (equal < end && isspace(*equal)) equal++;
+            while (equal < end && isspace((unsigned char) *equal)) equal++;
             if (equal < end && equal != start)
                 arkime_field_string_add(cookieValueField, session, equal, start ? start - equal : end - equal, TRUE);
         }
@@ -118,7 +118,7 @@ void http_common_parse_cookie(ArkimeSession_t *session, char *cookie, int len)
 /******************************************************************************/
 LOCAL void http_common_add_header_value(ArkimeSession_t *session, int pos, const char *s, int l)
 {
-    while (l > 0 && isspace(*s)) {
+    while (l > 0 && isspace((unsigned char) *s)) {
         s++;
         l--;
     }
@@ -364,7 +364,7 @@ LOCAL void arkime_http_parse_authorization(ArkimeSession_t *session, char *str)
 {
     gsize olen;
 
-    while (isspace(*str)) str++;
+    while (isspace((unsigned char) *str)) str++;
 
     const char *space = strchr(str, ' ');
 
@@ -376,7 +376,7 @@ LOCAL void arkime_http_parse_authorization(ArkimeSession_t *session, char *str)
     if (strncasecmp("ntlm", str, 4) == 0 || strncasecmp("negotiate", str, 9) == 0) {
         const char *scheme_end = space;
         const char *b64 = scheme_end;
-        while (*b64 && isspace((unsigned char) * b64)) b64++;
+        while (*b64 && isspace((unsigned char) *b64)) b64++;
         if (*b64)
             arkime_parsers_ntlm_decode_base64(session, b64, strlen(b64));
         return;
@@ -384,7 +384,7 @@ LOCAL void arkime_http_parse_authorization(ArkimeSession_t *session, char *str)
 
     if (strncasecmp("basic", str, 5) == 0) {
         str += 5;
-        while (isspace(*str)) str++;
+        while (isspace((unsigned char) *str)) str++;
 
         int len = strlen(str);
         if (len < 2)
@@ -402,15 +402,15 @@ LOCAL void arkime_http_parse_authorization(ArkimeSession_t *session, char *str)
         }
     } else if (strncasecmp("digest", str, 6) == 0) {
         str += 5;
-        while (isspace(*str)) str++;
+        while (isspace((unsigned char) *str)) str++;
 
         char *username = strstr(str, "username");
         if (!username) return;
         str = username + 8;
-        while (isspace(*str)) str++;
+        while (isspace((unsigned char) *str)) str++;
         if (*str != '=') return;
         str++; // equal
-        while (isspace(*str)) str++;
+        while (isspace((unsigned char) *str)) str++;
 
         int quote = 0;
         if (*str == '"') {

--- a/capture/parsers/imap.c
+++ b/capture/parsers/imap.c
@@ -27,7 +27,7 @@ LOCAL void imap_parse_email_address(int field, ArkimeSession_t *session, const c
     const char *end = data + len;
 
     while (data < end) {
-        while (data < end && isspace(*data)) data++;
+        while (data < end && isspace((uint8_t) *data)) data++;
         const char *start = data;
 
         /* Handle quoted strings */
@@ -35,7 +35,7 @@ LOCAL void imap_parse_email_address(int field, ArkimeSession_t *session, const c
             data++;
             while (data < end && *data != '"') data++;
             data++;
-            while (data < end && isspace(*data)) data++;
+            while (data < end && isspace((uint8_t) *data)) data++;
             start = data;
         }
 
@@ -77,7 +77,7 @@ LOCAL void imap_parse_header_line(IMAPInfo_t UNUSED(*imap), ArkimeSession_t *ses
     else if (len > 8 && strncasecmp(line, "Subject:", 8) == 0) {
         const char *s = line + 8;
         const char *end = line + len;
-        while (s < end && isspace(*s)) s++;
+        while (s < end && isspace((uint8_t) *s)) s++;
         arkime_field_string_add(subjectField, session, s, len - (s - line), TRUE);
     }
 }
@@ -88,8 +88,8 @@ LOCAL void imap_process_line(IMAPInfo_t *imap, ArkimeSession_t *session, const c
     if (which != imap->serverWhich && len > 16) {
         /* Client: "<tag> AUTHENTICATE NTLM [<base64>]" */
         const char *cmd = line;
-        while (cmd < line + len && !isspace(*cmd)) cmd++;
-        while (cmd < line + len && isspace(*cmd)) cmd++;
+        while (cmd < line + len && !isspace((uint8_t) *cmd)) cmd++;
+        while (cmd < line + len && isspace((uint8_t) *cmd)) cmd++;
         if (line + len - cmd >= 17 && strncasecmp(cmd, "AUTHENTICATE NTLM", 17) == 0) {
             imap->inNtlmAuth = 1;
             const char *rest = cmd + 17;
@@ -132,12 +132,12 @@ LOCAL void imap_process_line(IMAPInfo_t *imap, ArkimeSession_t *session, const c
     else {
         if (len > 7) {
             const char *cmd = line;
-            while (cmd < line + len && !isspace(*cmd)) cmd++;
-            while (cmd < line + len && isspace(*cmd)) cmd++;
+            while (cmd < line + len && !isspace((uint8_t) *cmd)) cmd++;
+            while (cmd < line + len && isspace((uint8_t) *cmd)) cmd++;
 
             if (strncasecmp(cmd, "SELECT ", 7) == 0 || strncasecmp(cmd, "EXAMINE ", 8) == 0) {
                 const char *folder = cmd + (strncasecmp(cmd, "SELECT", 6) == 0 ? 7 : 8);
-                while (folder < line + len && isspace(*folder)) folder++;
+                while (folder < line + len && isspace((uint8_t) *folder)) folder++;
 
                 const char *folderEnd = line + len;
                 if (folder < line + len && *folder == '"') {
@@ -145,7 +145,7 @@ LOCAL void imap_process_line(IMAPInfo_t *imap, ArkimeSession_t *session, const c
                     folderEnd = memchr(folder, '"', folderEnd - folder);
                     if (!folderEnd) folderEnd = line + len;
                 } else {
-                    while (folderEnd > folder && isspace(folderEnd[-1])) folderEnd--;
+                    while (folderEnd > folder && isspace((uint8_t)folderEnd[-1])) folderEnd--;
                 }
 
                 if (folderEnd > folder) {

--- a/capture/parsers/pop3.c
+++ b/capture/parsers/pop3.c
@@ -53,7 +53,7 @@ LOCAL void pop3_process_line(POP3Info_t *pop3, ArkimeSession_t *session, const c
         strncasecmp(line, "USER ", 5) == 0) {
         const char *u = line + 5;
         int ulen = len - 5;
-        while (ulen > 0 && isspace((unsigned char) * u)) {
+        while (ulen > 0 && isspace((unsigned char) *u)) {
             u++;
             ulen--;
         }

--- a/capture/parsers/smtp.c
+++ b/capture/parsers/smtp.c
@@ -92,7 +92,7 @@ enum {
 /******************************************************************************/
 LOCAL char *smtp_remove_matching(char *str, char start, char stop)
 {
-    while (isspace(*str))
+    while (isspace((uint8_t) *str))
         str++;
 
     if (*str == start)
@@ -112,7 +112,7 @@ LOCAL char *smtp_remove_matching(char *str, char start, char stop)
 // value in place and returns a pointer to its start.
 LOCAL char *smtp_parse_param_value(char *str)
 {
-    while (isspace(*str))
+    while (isspace((uint8_t) *str))
         str++;
 
     if (*str == '"') {
@@ -125,7 +125,7 @@ LOCAL char *smtp_parse_param_value(char *str)
     }
 
     char *startstr = str;
-    while (*str && *str != ';' && !isspace(*str))
+    while (*str && *str != ';' && !isspace((uint8_t) *str))
         str++;
     *str = 0;
 
@@ -134,7 +134,7 @@ LOCAL char *smtp_parse_param_value(char *str)
 /******************************************************************************/
 LOCAL void smtp_email_add_value(ArkimeSession_t *session, int pos, const char *s, int l)
 {
-    while (l > 0 && isspace(*s)) {
+    while (l > 0 && isspace((uint8_t) *s)) {
         s++;
         l--;
     }
@@ -386,7 +386,7 @@ LOCAL void smtp_parse_email_addresses(int field, ArkimeSession_t *session, char 
     const char *end = data + len;
 
     while (data < end) {
-        while (data < end && isspace(*data)) data++;
+        while (data < end && isspace((uint8_t) *data)) data++;
         const char *start = data;
 
         /* Starts with quote is easy */
@@ -394,7 +394,7 @@ LOCAL void smtp_parse_email_addresses(int field, ArkimeSession_t *session, char 
             data++;
             while (data < end && *data != '"') data++;
             data++;
-            while (data < end && isspace(*data)) data++;
+            while (data < end && isspace((uint8_t) *data)) data++;
             start = data;
         }
 
@@ -422,7 +422,7 @@ LOCAL void smtp_parse_email_received(ArkimeSession_t *session, char *data, int l
         if (end - data > 10) {
             if (memcmp("from ", data, 5) == 0 && (data == start || data[-1] != '-')) {
                 data += 5;
-                while (data < end && isspace(*data)) data++;
+                while (data < end && isspace((uint8_t) *data)) data++;
 
                 if (*data == '[') {
                     data++;
@@ -444,7 +444,7 @@ LOCAL void smtp_parse_email_received(ArkimeSession_t *session, char *data, int l
                 arkime_field_string_add_lower(hostField, session, (char *)fromstart, data - fromstart);
             } else if (memcmp("by ", data, 3) == 0) {
                 data += 3;
-                while (data < end && isspace(*data)) data++;
+                while (data < end && isspace((uint8_t) *data)) data++;
                 char *fromstart = data;
                 while (data < end && *data != ' ' && *data != ')') {
                     if (*data == '@')
@@ -705,7 +705,7 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                     smtp_parse_email_received(session, line->str + cpos, line->len - cpos);
                 } else if ((long)emailHeader->uw == ctField) {
                     const char *s = line->str + 13;
-                    while (isspace(*s)) s++;
+                    while (isspace((uint8_t) *s)) s++;
 
                     arkime_field_string_add(ctField, session, s, -1, TRUE);
                     char *boundary = (char *)arkime_memcasestr(s, line->len - (s - line->str), "boundary=", 9);
@@ -907,7 +907,7 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
 
             if (strncasecmp(line->str, "content-type:", 13) == 0) {
                 const char *s = line->str + 13;
-                while (isspace(*s)) s++;
+                while (isspace((uint8_t) *s)) s++;
                 char *boundary = (char *)arkime_memcasestr(s, line->len - (s - line->str), "boundary=", 9);
                 if (boundary && DLL_COUNT(s_, &email->boundaries) < SMTP_MAX_BOUNDARIES) {
                     ArkimeString_t *string = ARKIME_TYPE_ALLOC0(ArkimeString_t);
@@ -917,7 +917,7 @@ LOCAL int smtp_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, i
                 }
             } else if (strncasecmp(line->str, "content-disposition:", 20) == 0) {
                 const char *s = line->str + 20;
-                while (isspace(*s)) s++;
+                while (isspace((uint8_t) *s)) s++;
                 char *filename = (char *)arkime_memcasestr(s, line->len - (s - line->str), "filename=", 9);
                 if (filename) {
                     char *matching = smtp_remove_matching(filename + 9, '"', '"');

--- a/capture/parsers/tls.c
+++ b/capture/parsers/tls.c
@@ -362,7 +362,7 @@ LOCAL uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uin
         BSB_IMPORT_skip(cbsb, skiplen);  // Session Id
 
         BSB_IMPORT_u16(cbsb, skiplen);   // Cipher Suites Length
-        while (BSB_NOT_ERROR(cbsb) && skiplen > 0) {
+        while (BSB_NOT_ERROR(cbsb) && skiplen >= 2) {
             uint16_t c = 0;
             BSB_IMPORT_u16(cbsb, c);
             if (!tls_is_grease_value(c)) {
@@ -374,6 +374,7 @@ LOCAL uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uin
             }
             skiplen -= 2;
         }
+        BSB_IMPORT_skip(cbsb, skiplen);  // Odd declared length leaves a trailing byte
         BSB_EXPORT_rewind(ja3bsb, 1); // Remove last -
         BSB_EXPORT_u08(ja3bsb, ',');
 
@@ -618,7 +619,7 @@ LOCAL uint32_t tls_process_client_hello_data(ArkimeSession_t *session, const uin
     // Add the field
     arkime_field_string_add(ja4Field, session, ja4, 36, TRUE);
     if (ja4Raw && BSB_NOT_ERROR(ja4_rbsb)) {
-        arkime_field_string_add(ja4RawField, session, ja4_r, BSB_LENGTH(ja4_rbsb), TRUE);
+        arkime_field_string_add(ja4RawField, session, ja4_r, BSB_LENGTH(ja4_rbsb) - 1, TRUE);
     }
 
     return 0;

--- a/capture/python.c
+++ b/capture/python.c
@@ -553,7 +553,7 @@ PyMODINIT_FUNC PyInit_arkime(void)
         return NULL;
     }
     // Get the per-interpreter state pointer and initialize it
-    ArkimeState* state = (ArkimeState*)PyModule_GetState(m);
+    ArkimeState* state = (ArkimeState *)PyModule_GetState(m);
     if (state == NULL) {
         // This should not happen if m_size is set correctly
         Py_DECREF(m);
@@ -1231,7 +1231,7 @@ PyMODINIT_FUNC PyInit_arkime_session(void)
         return NULL;
     }
     // Get the per-interpreter state pointer and initialize it
-    ArkimeSessionState* state = (ArkimeSessionState*)PyModule_GetState(m);
+    ArkimeSessionState* state = (ArkimeSessionState *)PyModule_GetState(m);
     if (state == NULL) {
         Py_DECREF(m);
         return NULL;
@@ -1694,7 +1694,7 @@ PyMODINIT_FUNC PyInit_arkime_packet(void)
         return NULL;
     }
     // Get the per-interpreter state pointer and initialize it
-    ArkimePacketState* state = (ArkimePacketState*)PyModule_GetState(m);
+    ArkimePacketState* state = (ArkimePacketState *)PyModule_GetState(m);
     if (state == NULL) {
         Py_DECREF(m);
         return NULL;

--- a/capture/session.c
+++ b/capture/session.c
@@ -1271,6 +1271,9 @@ LOCAL void arkime_session_load_collapse()
     }
     for (int i = 0; i < (int)keys_len; i++) {
         char *value = arkime_config_section_str(NULL, "vlan-vni-collapse", keys[i], NULL);
+        if (!value)
+            CONFIGEXIT("Invalid value for '%s' in section [vlan-vni-collapse]", keys[i]);
+
         char **values = g_strsplit(value, ",", 0);
 
         uint64_t key = atoi(keys[i]) + 1;


### PR DESCRIPTION
- Fix crash on the first DNS response when the dns field is disabled
- Fix crash instead of a config error when a custom-fields, custom-fields-remap or vlan-vni-collapse value can't be parsed
- Fix a json config with over 99 sections, or 499 keys in a section, reading past the end of a stack array; js0n reserves 2 entries for its terminator
- Check every js0n return so truncated or malformed json is logged instead of silently dropping config and fields
- Anchor the override-ips asn regex so the AS number is read from the right offset
- Fix DTLS ja4 hashed over a truncated buffer when a ClientHello had many extensions or signature algorithms
- Fix TLS/DTLS ClientHello desync on an odd cipher suites length
- Fix ja4_r field length including its null terminator
- Cast ctype arguments to uint8_t/unsigned char, they are undefined for a negative plain char
- Guard IPPRE field definitions that assume an ip. expression prefix

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
