### PR TITLE
Packet portal: enforce s2s over portals, fix prototype name auth bypasses, drop the loopback bridge

### DIFF
--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -526,39 +526,56 @@ class ArkimeUtil {
   }
 
   // ----------------------------------------------------------------------------
-  /**
-   * Callback when one of the cert files changes
-   */
-  static #fsWait;
   static #httpsServer;
-  static #watchHttpsFile (e, filename) {
-    if (ArkimeUtil.#fsWait) { clearTimeout(ArkimeUtil.#fsWait); }
 
-    // We wait 10s from last event in case there are more events
-    ArkimeUtil.#fsWait = setTimeout(() => {
-      ArkimeUtil.#fsWait = null;
-      try { // try to get the new cert files
-        const keyFileData = fs.readFileSync(ArkimeConfig.get('keyFile'));
-        const certFileData = fs.readFileSync(ArkimeConfig.get('certFile'));
+  /**
+   * Watch a https server's key/cert files and setSecureContext when either
+   * changes, so a rotated cert is picked up without a restart. Per server and
+   * per file pair, so a service with more than one listener (see the viewer's
+   * packet portal port) can watch its own files.
+   *
+   * @param {object} server The https server to update
+   * @param {string} keyFile Path to the key file to watch
+   * @param {string} certFile Path to the cert file to watch
+   */
+  static watchCertFiles (server, keyFile, certFile) {
+    let fsWait;
+
+    const changed = () => {
+      if (fsWait) { clearTimeout(fsWait); }
+
+      // We wait 10s from last event in case there are more events
+      fsWait = setTimeout(() => {
+        fsWait = null;
+        let keyFileData, certFileData;
+        try { // try to get the new cert files
+          keyFileData = fs.readFileSync(keyFile);
+          certFileData = fs.readFileSync(certFile);
+        } catch (err) { // don't continue if we can't read them
+          console.log('Missing cert or key files. Cannot reload cert.');
+          return;
+        }
 
         console.log('Reloading cert...');
 
-        const options = { // set new server cert options
-          key: keyFileData,
-          cert: certFileData,
-          secureOptions: crypto.constants.SSL_OP_NO_TLSv1
-        };
-
         try {
-          ArkimeUtil.#httpsServer.setSecureContext(options);
+          server.setSecureContext({
+            key: keyFileData,
+            cert: certFileData,
+            secureOptions: crypto.constants.SSL_OP_NO_TLSv1
+          });
         } catch (err) {
           console.log('ERROR cert not reloaded: ', err.toString());
         }
-      } catch (err) { // don't continue if we can't read them
-        console.log('Missing cert or key files. Cannot reload cert.');
-        return;
-      }
-    }, 10000);
+      }, 10000);
+    };
+
+    fs.watch(keyFile, { persistent: false }, changed);
+    fs.watch(certFile, { persistent: false }, changed);
+
+    if (ArkimeConfig.debug > 1) {
+      console.log(`Watching ${keyFile} and ${certFile}. If either is changed, the server will be updated with the new files.`);
+    }
   }
 
   // ----------------------------------------------------------------------------
@@ -572,19 +589,13 @@ class ArkimeUtil {
       const keyFileData = fs.readFileSync(ArkimeConfig.get('keyFile'));
       const certFileData = fs.readFileSync(ArkimeConfig.get('certFile'));
 
-      // watch the cert and key files
-      fs.watch(ArkimeConfig.get('keyFile'), { persistent: false }, ArkimeUtil.#watchHttpsFile);
-      fs.watch(ArkimeConfig.get('certFile'), { persistent: false }, ArkimeUtil.#watchHttpsFile);
-
-      if (ArkimeConfig.debug > 1) {
-        console.log('Watching cert and key files. If either is changed, the server will be updated with the new files.');
-      }
-
       server = ArkimeUtil.#httpsServer = https.createServer({
         key: keyFileData,
         cert: certFileData,
         secureOptions: crypto.constants.SSL_OP_NO_TLSv1
       }, app);
+
+      ArkimeUtil.watchCertFiles(server, ArkimeConfig.get('keyFile'), ArkimeConfig.get('certFile'));
     } else {
       server = http.createServer(app);
     }

--- a/common/auth.js
+++ b/common/auth.js
@@ -1054,13 +1054,15 @@ class Auth {
       return;
     }
 
-    // Requests delivered over a packet portal come from a remote peer through a
-    // loopback bridge socket. Their loopback source IP, any userNameHeader and
-    // any session cookie they carry are therefore untrustworthy (the first would
-    // otherwise satisfy the header-auth userAuthIps loopback default, the last
-    // would skip authentication entirely below). They authenticate with the s2s
-    // token only -- see PacketPortal, which additionally requires a valid s2s
-    // token on every portal request before it reaches the app at all.
+    // A packet portal request comes from a remote peer but is served on a
+    // synthetic socket (see H2Socket) whose 127.0.0.1 source address is a
+    // stand-in, not a connection from anywhere. That address, any userNameHeader
+    // and any session cookie the peer sends are therefore all untrustworthy: the
+    // first two would let header auth take the peer's word for the user, since
+    // what gates it is the userAuthIps loopback default, and the last would skip
+    // authentication entirely at the isAuthenticated() check below. Authenticate
+    // with the s2s token only -- on top of PacketPortal's own gate, which
+    // required a valid s2s token before the request ever reached the app.
     const portal = req.socket?.arkimePacketPortal === true;
 
     if (!portal && typeof (req.isAuthenticated) === 'function' && req.isAuthenticated()) {

--- a/common/auth.js
+++ b/common/auth.js
@@ -877,26 +877,13 @@ class Auth {
 
     // ----------------------------------------------------------------------------
     passport.use('s2s', new CustomStrategy(async (req, done) => {
-      let obj = req.headers['x-arkime-auth'];
-
-      if (obj === undefined) {
+      if (req.headers['x-arkime-auth'] === undefined) {
         return done(null, false);
       }
 
-      try {
-        if (Auth.#s2sRegressionTests) {
-          obj = JSON.parse(obj);
-        } else {
-          obj = Auth.auth2obj(obj);
-        }
-      } catch (e) {
-        console.log('AUTH: x-arkime-auth corrupt', e);
-        return done('S2S auth header corrupt');
-      }
-
-      const s2sError = Auth.validateS2SObj(obj, req);
-      if (s2sError) {
-        return done(s2sError);
+      const { obj, error } = Auth.parseS2SRequest(req);
+      if (error) {
+        return done(error);
       }
 
       // Don't look up user for receiveSession
@@ -1067,7 +1054,16 @@ class Auth {
       return;
     }
 
-    if (typeof (req.isAuthenticated) === 'function' && req.isAuthenticated()) {
+    // Requests delivered over a packet portal come from a remote peer through a
+    // loopback bridge socket. Their loopback source IP, any userNameHeader and
+    // any session cookie they carry are therefore untrustworthy (the first would
+    // otherwise satisfy the header-auth userAuthIps loopback default, the last
+    // would skip authentication entirely below). They authenticate with the s2s
+    // token only -- see PacketPortal, which additionally requires a valid s2s
+    // token on every portal request before it reaches the app at all.
+    const portal = req.socket?.arkimePacketPortal === true;
+
+    if (!portal && typeof (req.isAuthenticated) === 'function' && req.isAuthenticated()) {
       return next();
     }
 
@@ -1075,7 +1071,9 @@ class Auth {
       req.url = req.url.replace('/', Auth.#basePath);
     }
 
-    if (req.url.toLowerCase() !== '/api/login' && req.originalUrl !== '/' && req.session && req._parsedUrl.pathname !== '/auth/login/callback') {
+    // A portal request is never a browser being sent to a login page, and must
+    // not write to whatever session a cookie it carries happens to name
+    if (!portal && req.url.toLowerCase() !== '/api/login' && req.originalUrl !== '/' && req.session && req._parsedUrl.pathname !== '/auth/login/callback') {
       // save the original url so we can redirect after successful login
       // the ogurl is saved in the form login page and accessed using req.body.ogurl
       req.session.ogurl = Buffer.from(Auth.obj2authNext(req.originalUrl)).toString('base64');
@@ -1092,11 +1090,10 @@ class Auth {
       passportAuthOptionsExtra.session = false;
     }
 
-    // Requests delivered over a packet portal arrive from a remote peer through a
-    // loopback bridge socket. Their loopback source IP and any userNameHeader are
-    // therefore untrustworthy (they would otherwise satisfy the header-auth
-    // userAuthIps loopback default). Authenticate them with the s2s token only.
-    const strategies = req.socket?.arkimePacketPortal ? ['s2s'] : Auth.#strategies;
+    // A portal request must never mint or attach a session either
+    if (portal) { passportAuthOptionsExtra.session = false; }
+
+    const strategies = portal ? ['s2s'] : Auth.#strategies;
 
     passport.authenticate(strategies, { ...Auth.#passportAuthOptions, ...passportAuthOptionsExtra })(req, res, function (err) {
       if (req.session !== undefined && req.authInfo?.id_token !== undefined) {
@@ -1350,6 +1347,33 @@ class Auth {
       console.log(error);
       throw new Error('Incorrect auth supplied');
     }
+  }
+
+  // ----------------------------------------------------------------------------
+  // Parse and fully validate a request's x-arkime-auth header. Returns
+  // { obj } when it is a genuine s2s token for this request, otherwise
+  // { error }. Anything that needs to make its own s2s decision (the s2s
+  // passport strategy, the packet portal) should use this rather than calling
+  // auth2obj on its own, which only proves the token decrypts.
+  static parseS2SRequest (req) {
+    const auth = req.headers['x-arkime-auth'];
+    if (auth === undefined) { return { error: 'Missing x-arkime-auth' }; }
+
+    // Anything present but unusable (empty, duplicated header, not a string) is
+    // a corrupt token rather than a missing one -- auth2obj throws on all of it
+    let obj;
+    try {
+      obj = Auth.#s2sRegressionTests ? JSON.parse(auth) : Auth.auth2obj(auth);
+    } catch (e) {
+      // debug only, an unauthenticated peer can trigger this at will
+      if (ArkimeConfig.debug > 0) { console.log('AUTH: x-arkime-auth corrupt', e); }
+      return { error: 'S2S auth header corrupt' };
+    }
+
+    const error = Auth.validateS2SObj(obj, req);
+    if (error) { return { error }; }
+
+    return { obj };
   }
 
   // ----------------------------------------------------------------------------

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -185,7 +185,9 @@ simpleKEKId=test
 [test2]
 viewPort=8124
 # user is this node's name, pass is checked against [esproxy-sensors] test2
-packetPortalConnect=http://test2:test2@localhost:8123
+# 127.0.0.1 not localhost: where localhost resolves to ::1 first the source ip
+# does not match the sensor's configured ip list and the portal is refused
+packetPortalConnect=http://test2:test2@127.0.0.1:8123
 mcpEnabled=true
 mcpAuthMode=regressionTests
 prefix=tests2

--- a/tests/esProxy.t
+++ b/tests/esProxy.t
@@ -1,5 +1,5 @@
 # ESProxy
-use Test::More tests => 37;
+use Test::More tests => 41;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
@@ -19,6 +19,14 @@ is ($response->code, 401);
 
 $response = $ArkimeTest::userAgent->get("http://test:test\@$ArkimeTest::host:7200");
 is ($response->code, 200);
+
+# A sensor name that resolves on Object.prototype is not a configured sensor. It
+# has no pass and no ip, so a plain [] lookup would authenticate it with any
+# password and proxy its requests (user docs, session docs) to elasticsearch.
+foreach my $name ("__proto__", "constructor", "toString", "hasOwnProperty") {
+    $response = $ArkimeTest::userAgent->get("http://$name:anything\@$ArkimeTest::host:7200/tests_users/_doc/formtestuser");
+    is ($response->code, 401, "sensor '$name' is not authenticated");
+}
 
 $response = $ArkimeTest::userAgent->get("http://test:test\@$ArkimeTest::host:7200/_search");
 is ($response->code, 400);

--- a/tests/packetPortal.t
+++ b/tests/packetPortal.t
@@ -1,6 +1,6 @@
 # Test the packet portal transport: test2 (Sensor) opens an outbound link to the
 # central (test) viewer, which can then reach test2 back over that link.
-use Test::More tests => 2;
+use Test::More tests => 3;
 use ArkimeTest;
 use Data::Dumper;
 use strict;
@@ -21,3 +21,9 @@ ok($connected, "test2 established a packet portal to the central (test) viewer")
 # (test2 is behind a link, so there is no direct fallback) -- confirm it works.
 my $result = viewerGet("/regressionTests/packetPortalRequest/test2");
 ok($result->{success}, "central reached test2 over the packet portal") or diag(Dumper($result));
+
+# Everything over a link must carry an s2s token, including routes that need no
+# auth on a normal connection -- the peer is remote but arrives on a loopback
+# bridge socket, so nothing about where it came from can be trusted.
+my $noauth = viewerGet("/regressionTests/packetPortalNoAuth/test2");
+is($noauth->{status}, 401, "unauthenticated request over the packet portal is rejected") or diag(Dumper($noauth));

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -173,13 +173,19 @@ class Config {
   }
 
   // ----------------------------------------------------------------------------
+  // Both levels are null prototype on purpose. Callers look these maps up by a
+  // name that often comes from a request (a sensor, node or cluster name), and a
+  // plain {} would answer __proto__ / constructor / toString with an inherited
+  // value instead of undefined -- which reads as "this name is configured".
+  // It also keeps a literal __proto__ key in the config file an ordinary entry
+  // rather than something that silently replaces the map's prototype.
   static configMap (section, dSection, d) {
     const data = ArkimeConfig.getSection(section) ?? ArkimeConfig.getSection(dSection) ?? d;
-    if (data === undefined) { return {}; }
+    if (data === undefined) { return Object.create(null); }
     const keys = Object.keys(data);
-    const map = {};
+    const map = Object.create(null);
     for (const key of keys) {
-      const obj = {};
+      const obj = Object.create(null);
       for (const element of data[key].split(';')) {
         const i = element.indexOf(':');
         if (i === -1) {

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -203,21 +203,31 @@ app.use((req, res, next) => {
     return res.set('WWW-Authenticate', 'Basic').status(401).send();
   }
 
-  if (!sensors[credentials.name]) {
-    console.log(`Unknown sensor ${credentials.name}`);
+  // Own properties only. The name is whatever the client put in Basic auth, and
+  // a plain [] lookup with __proto__ or constructor returns something truthy off
+  // Object.prototype that has no pass and no ip -- authenticating a sensor that
+  // was never configured. configMap now hands back a null prototype map too.
+  // isPP is the codebase's usual guard but is not sufficient on its own here:
+  // toString, valueOf and hasOwnProperty are not on its list yet resolve just
+  // the same, which is what the own property check covers.
+  const sensor = !ArkimeUtil.isPP(credentials.name) && Object.hasOwn(sensors, credentials.name)
+    ? sensors[credentials.name]
+    : undefined;
+  if (!sensor) {
+    console.log(`Unknown sensor ${ArkimeUtil.sanitizeStr(credentials.name)}`);
     return res.set('WWW-Authenticate', 'Basic').status(401).send();
   }
 
-  if (sensors[credentials.name].pass !== undefined &&
+  if (sensor.pass !== undefined &&
       !cryptoLib.timingSafeEqual(
-        cryptoLib.createHmac('sha256', 'compare').update(sensors[credentials.name].pass).digest(),
+        cryptoLib.createHmac('sha256', 'compare').update(sensor.pass).digest(),
         cryptoLib.createHmac('sha256', 'compare').update(credentials.pass).digest())) {
-    console.log(`Incorrect password for ${credentials.name}`);
+    console.log(`Incorrect password for ${ArkimeUtil.sanitizeStr(credentials.name)}`);
     return res.set('WWW-Authenticate', 'Basic').status(401).send();
   }
 
-  req.sensor = sensors[credentials.name];
-  if (!sensors[credentials.name].ip) {
+  req.sensor = sensor;
+  if (!sensor.ip) {
     return next();
   }
 

--- a/viewer/packetPortal.js
+++ b/viewer/packetPortal.js
@@ -66,8 +66,9 @@ const REQUEST_TIMEOUT = 20 * 60 * 1000;
  */
 class H2Socket extends streamLib.Duplex {
   #h2;
+  #timeoutMs = 0;
 
-  constructor (h2stream, options = {}) {
+  constructor (h2stream) {
     super({
       // net.Socket semantics: when the peer stops sending, end our write side
       // too. A bare Duplex is half open by default, which would leave both ends
@@ -88,10 +89,9 @@ class H2Socket extends streamLib.Duplex {
     this.remoteFamily = 'IPv4';
     this.localAddress = '127.0.0.1';
     this.localPort = 0;
-    // the portal peer's real address, for logging -- never for authorization
-    this.portalPeer = options.peer;
 
     h2stream.on('data', (chunk) => {
+      this.#touch();
       // h2 has its own flow control, so pausing it here applies real
       // backpressure to the peer rather than buffering without bound
       if (this.push(chunk) === false) { h2stream.pause(); }
@@ -104,13 +104,14 @@ class H2Socket extends streamLib.Duplex {
   }
 
   _write (chunk, enc, cb) {
+    this.#touch();
     if (chunk.length === 0) { return cb(); } // http core does this, h2 dislikes it
     // copy: the buffer we were handed may be reused before h2 serializes it
     this.#h2.write(Buffer.from(chunk), cb);
   }
 
   _final (cb) {
-    if (!this.#h2.writableEnded) { this.#h2.end(); }
+    if (!this.#h2.destroyed && !this.#h2.writableEnded) { this.#h2.end(); }
     cb();
   }
 
@@ -123,7 +124,7 @@ class H2Socket extends streamLib.Duplex {
 
     if (err) {
       this.#h2.destroy(err);
-    } else if (!this.#h2.writableEnded) {
+    } else if (!this.#h2.destroyed && !this.#h2.writableEnded) {
       // End rather than destroy: a clean teardown must not discard bytes the h2
       // stream is still flushing, which is exactly what truncates a large pcap
       // download to a slow client.
@@ -134,13 +135,22 @@ class H2Socket extends streamLib.Duplex {
   }
 
   // --------------------------------------------------------------------------
+  // A socket timeout is an IDLE timeout: net.Socket restarts it on every read
+  // and write. A plain deadline instead would kill a pcap download that is
+  // transferring perfectly happily, just for taking longer than the timeout.
+  #touch () {
+    if (this.#timeoutMs <= 0) { return; }
+    clearTimeout(this._portalTimer);
+    this._portalTimer = setTimeout(() => this.emit('timeout'), this.#timeoutMs);
+    if (this._portalTimer.unref) { this._portalTimer.unref(); }
+  }
+
+  // --------------------------------------------------------------------------
   // The rest of what http core expects a socket to have
   setTimeout (ms, cb) {
+    this.#timeoutMs = ms > 0 ? ms : 0;
     clearTimeout(this._portalTimer);
-    if (ms > 0) {
-      this._portalTimer = setTimeout(() => this.emit('timeout'), ms);
-      if (this._portalTimer.unref) { this._portalTimer.unref(); }
-    }
+    this.#touch();
     if (cb) { this.once('timeout', cb); }
     return this;
   }

--- a/viewer/packetPortal.js
+++ b/viewer/packetPortal.js
@@ -23,7 +23,9 @@
  *      a genuine socket, and we pipe that socket <-> the Http2Stream. The
  *      dialer feeds its bridged socket into the existing Express app via
  *      http.createServer(app).emit('connection', socket) -- Express, its
- *      middleware, and the existing x-arkime-auth S2S check all run unchanged.
+ *      middleware, and the existing x-arkime-auth S2S check all run unchanged,
+ *      behind a gate (see #gate) that requires a valid s2s token on everything
+ *      arriving over a portal, including routes that need no auth normally.
  *
  * Copyright Andy Wick
  *
@@ -92,8 +94,8 @@ class PacketPortal {
 
     // Inner HTTP/1.1 server sharing the same Express app. Never .listen()s; it
     // only ever receives sockets via emit('connection'). Used on the DIALER to
-    // serve requests that arrive over a portal.
-    PacketPortal.#innerServer = http.createServer(app);
+    // serve requests that arrive over a portal, behind the s2s gate.
+    PacketPortal.#innerServer = http.createServer(PacketPortal.#gate(app));
     PacketPortal.#innerServer.setTimeout(REQUEST_TIMEOUT);
 
     // DIALER h2 server: each inbound stream is one HTTP/1.1 request.
@@ -111,14 +113,32 @@ class PacketPortal {
     // Per node credentials for inbound portals. [packetportal-nodes] wins,
     // [esproxy-sensors] is the fallback -- same 'pass:X;ip:A,B' shape, and a
     // deployment locking sensors down at esProxy wants the same list here.
-    PacketPortal.#nodes = Config.configMap('packetportal-nodes', 'esproxy-sensors');
-    for (const nodeName in PacketPortal.#nodes) {
-      const entry = PacketPortal.#nodes[nodeName];
+    // Whether the section had any entries at all is what makes it an allow list,
+    // so dropping the unusable ones below can never turn the allow list off.
+    const nodes = Config.configMap('packetportal-nodes', 'esproxy-sensors');
+    PacketPortal.#nodesConfigured = Object.keys(nodes).length > 0;
+    PacketPortal.#nodes = {};
+
+    for (const nodeName of Object.keys(nodes)) {
+      const entry = nodes[nodeName];
       if (typeof entry.ip === 'string') {
         entry.ip = entry.ip.split(',').map(s => s.trim()).filter(s => s.length > 0);
       }
+      // An entry with neither is no better than no entry at all -- it would fall
+      // through to trust on first use, silently, for a node the admin believes
+      // they configured. Drop it so it is rejected instead.
+      if (entry.pass === undefined && (entry.ip === undefined || entry.ip.length === 0)) {
+        console.log(`WARNING - packetPortal: ignoring node '${ArkimeUtil.sanitizeStr(nodeName)}', it has no pass or ip; it will not be allowed to open a portal`);
+        continue;
+      }
+      // A name that resolves to something on Object.prototype can never be a real
+      // node, and looking it up would find an inherited value instead of an entry
+      if (ArkimeUtil.isPP(nodeName)) {
+        console.log(`WARNING - packetPortal: ignoring node '${ArkimeUtil.sanitizeStr(nodeName)}', it is not a usable node name`);
+        continue;
+      }
+      PacketPortal.#nodes[nodeName] = entry;
     }
-    PacketPortal.#nodesConfigured = Object.keys(PacketPortal.#nodes).length > 0;
 
     // ACCEPTOR listener. A dedicated port is recommended when the main viewer
     // port is fronted by a proxy, uses header auth, or is IP locked down --
@@ -148,7 +168,8 @@ class PacketPortal {
   // --------------------------------------------------------------------------
   // ACCEPTOR: stand up a dedicated listener that only accepts portal upgrades.
   // Reuses the viewer's key/cert for TLS when configured. Independent of the
-  // main viewer server (its cert hot-reload is unaffected).
+  // main viewer server, including its own cert watch so a rotated cert is
+  // picked up here too instead of being served until the viewer restarts.
   static #startAcceptorPort (port, host) {
     const reject = (req, res) => { res.statusCode = 404; res.end('packet portal endpoint\n'); };
 
@@ -166,6 +187,7 @@ class PacketPortal {
         cert: fs.readFileSync(certFile),
         secureOptions: cryptoLib.constants.SSL_OP_NO_TLSv1
       }, reject);
+      ArkimeUtil.watchCertFiles(server, keyFile, certFile);
     } else {
       server = http.createServer(reject);
       console.log('packetPortal: dedicated port is PLAIN (no TLS) - set packetPortalKeyFile/packetPortalCertFile for encryption');
@@ -310,7 +332,7 @@ class PacketPortal {
     // of blocking event loop per unseen salt. It is only a claim at this point;
     // #checkNode is what decides whether this peer may make it.
     const node = req.headers['x-arkime-node'];
-    if (!ArkimeUtil.isString(node) || !PacketPortal.#hostnameRE.test(node)) {
+    if (!ArkimeUtil.isString(node) || !PacketPortal.#hostnameRE.test(node) || ArkimeUtil.isPP(node)) {
       console.log('packetPortal: rejecting upgrade, missing or bad x-arkime-node');
       socket.destroy();
       return;
@@ -323,18 +345,9 @@ class PacketPortal {
       return;
     }
 
-    let obj;
-    try {
-      obj = Auth.auth2obj(req.headers['x-arkime-auth']);
-    } catch (e) {
-      console.log('packetPortal: rejecting upgrade, bad auth -', e.message);
-      socket.destroy();
-      return;
-    }
-
-    const s2sError = Auth.validateS2SObj(obj, req);
-    if (s2sError) {
-      console.log('packetPortal: rejecting upgrade -', s2sError);
+    const { obj, error } = Auth.parseS2SRequest(req);
+    if (error) {
+      console.log('packetPortal: rejecting upgrade -', error);
       socket.destroy();
       return;
     }
@@ -415,7 +428,10 @@ class PacketPortal {
   // claim (and so hijack or deny) any other node's traffic. This is what binds
   // the claim to the peer.
   static #checkNode (node, req) {
-    const entry = PacketPortal.#nodes[node];
+    // Own properties only. A plain [] lookup with a name like __proto__ or
+    // constructor finds something on Object.prototype, which is not undefined and
+    // so would sail past the allow list check below with no pass and no ip.
+    const entry = Object.hasOwn(PacketPortal.#nodes, node) ? PacketPortal.#nodes[node] : undefined;
 
     // A configured section is an allow list, so an unlisted node is never ok
     if (PacketPortal.#nodesConfigured && entry === undefined) {
@@ -487,7 +503,18 @@ class PacketPortal {
       method: 'GET',
       agent: PacketPortal.agent,
       packetPortalSession: session,
-      timeout: 30000
+      timeout: 30000,
+      // /health needs no auth over a normal connection, but the dialer requires
+      // an s2s token on everything arriving over a portal (see #gate)
+      headers: {
+        'x-arkime-auth': Auth.obj2auth({
+          date: Date.now(),
+          user: 'packetPortal',
+          node,
+          path: '/health',
+          method: 'GET'
+        })
+      }
     };
 
     const req = http.request('http://arkime-portal.invalid/health', options, (res) => {
@@ -499,6 +526,33 @@ class PacketPortal {
       try { session.close(); } catch (ignore) { /* ignore */ }
     });
     req.end();
+  }
+
+  // --------------------------------------------------------------------------
+  // DIALER: gate every request arriving over a portal on a valid s2s token,
+  // before the app sees it.
+  //
+  // The peer is remote but reaches us through a loopback bridge socket, so any
+  // check based on the source ip (userAuthIps' loopback default, mcpAllowedIps)
+  // or on a header a proxy would normally set (userNameHeader) would wrongly
+  // trust it. Auth.doAuth knows about this (see arkimePacketPortal), but routes
+  // mounted before Auth.app() -- /mcp with its own header auth, pre-auth
+  // /plugin/*, /health, the parliament and eshealth endpoints -- never reach it.
+  // Nothing legitimately arrives over a portal without a token, so require one
+  // for everything, which also keeps the unauthenticated surface identical no
+  // matter what a deployment mounts early.
+  static #gate (app) {
+    return (req, res) => {
+      const { error } = Auth.parseS2SRequest(req);
+      if (error) {
+        console.log(`packetPortal: rejecting portal request for ${ArkimeUtil.sanitizeStr(req.url)} -`, error);
+        res.statusCode = 401;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ success: false, text: 'Packet portal requests require s2s auth' }));
+        return;
+      }
+      app(req, res);
+    };
   }
 
   // --------------------------------------------------------------------------
@@ -518,9 +572,10 @@ class PacketPortal {
         return;
       }
       // Mark the request as arriving over a packet portal. It is delivered through
-      // a loopback bridge socket, so its 127.0.0.1 source address and any
-      // userNameHeader it carries are NOT trustworthy -- Auth forces these
-      // requests to authenticate with the s2s token only (see Auth.doAuth).
+      // a loopback bridge socket, so its 127.0.0.1 source address, any session
+      // cookie and any userNameHeader it carries are NOT trustworthy -- Auth
+      // authenticates these requests with the s2s token only (see Auth.doAuth),
+      // on top of the #gate check every portal request has already passed.
       socket.arkimePacketPortal = true;
       PacketPortal.#innerServer.emit('connection', socket);
     });

--- a/viewer/packetPortal.js
+++ b/viewer/packetPortal.js
@@ -16,12 +16,14 @@
  *      socket, the acceptor (which only accepted the TCP connection) can now
  *      open request streams to the dialer.
  *   3. Each logical request is one HTTP/2 stream carrying an ordinary HTTP/1.1
- *      conversation in its DATA frames. Node's http client/server cannot use an
- *      Http2Stream directly as a socket (it hands http core pooled Buffers that
- *      get reused before the stream serializes them, corrupting the bytes), so
- *      each stream is bridged to a real net.Socket loopback pair: http talks to
- *      a genuine socket, and we pipe that socket <-> the Http2Stream. The
- *      dialer feeds its bridged socket into the existing Express app via
+ *      conversation in its DATA frames, which is what lets the existing Express
+ *      app and node's own http client drive it. HTTP/2 is here for its stream
+ *      multiplexing and per stream flow control: one connection survives NAT,
+ *      and a slow pcap download cannot stall the other requests on it. Each
+ *      stream is wrapped in an H2Socket (see below) to look like a socket, since
+ *      http core cannot write to an Http2Stream directly.
+ *
+ *      The dialer feeds each wrapped stream into the existing Express app via
  *      http.createServer(app).emit('connection', socket) -- Express, its
  *      middleware, and the existing x-arkime-auth S2S check all run unchanged,
  *      behind a gate (see #gate) that requires a valid s2s token on everything
@@ -33,7 +35,6 @@
  */
 'use strict';
 
-const net = require('net');
 const fs = require('fs');
 const streamLib = require('stream');
 const http = require('http');
@@ -49,6 +50,113 @@ const ArkimeConfig = require('../common/arkimeConfig');
 const PORTAL_PATH = '/packetPortal';
 const UPGRADE_TOKEN = 'arkime-portal';
 const REQUEST_TIMEOUT = 20 * 60 * 1000;
+
+// ----------------------------------------------------------------------------
+/**
+ * An Http2Stream dressed up as a socket, so node's http client and server will
+ * drive it: `server.emit('connection', h2socket)` runs the real Express app on
+ * one, and an http.Agent whose createConnection returns one lets an ordinary
+ * http.request() talk over a portal.
+ *
+ * http core cannot use an Http2Stream directly because it hands the socket
+ * buffers it is free to reuse the moment write() returns, and an Http2Stream
+ * serializes later -- which corrupts the bytes. That is the only real
+ * incompatibility, and copying in _write settles it. Everything else here is
+ * plumbing to look enough like a net.Socket.
+ */
+class H2Socket extends streamLib.Duplex {
+  #h2;
+
+  constructor (h2stream, options = {}) {
+    super({
+      // net.Socket semantics: when the peer stops sending, end our write side
+      // too. A bare Duplex is half open by default, which would leave both ends
+      // of a finished request waiting on each other.
+      allowHalfOpen: false,
+      writableHighWaterMark: 64 * 1024
+    });
+
+    this.#h2 = h2stream;
+
+    // Requests arriving over a portal come from a remote peer, but nothing about
+    // this socket is real. Keep the address loopback: Auth.#checkIps (userAuthIps,
+    // loopback by default) runs before the s2s narrowing and would otherwise
+    // reject every portal request. What marks these requests untrustworthy is
+    // arkimePacketPortal, not this address.
+    this.remoteAddress = '127.0.0.1';
+    this.remotePort = 0;
+    this.remoteFamily = 'IPv4';
+    this.localAddress = '127.0.0.1';
+    this.localPort = 0;
+    // the portal peer's real address, for logging -- never for authorization
+    this.portalPeer = options.peer;
+
+    h2stream.on('data', (chunk) => {
+      // h2 has its own flow control, so pausing it here applies real
+      // backpressure to the peer rather than buffering without bound
+      if (this.push(chunk) === false) { h2stream.pause(); }
+    });
+    h2stream.on('end', () => this.push(null));
+    h2stream.on('error', (err) => this.destroy(err));
+    h2stream.on('close', () => {
+      if (!this.destroyed) { this.push(null); }
+    });
+  }
+
+  _write (chunk, enc, cb) {
+    if (chunk.length === 0) { return cb(); } // http core does this, h2 dislikes it
+    // copy: the buffer we were handed may be reused before h2 serializes it
+    this.#h2.write(Buffer.from(chunk), cb);
+  }
+
+  _final (cb) {
+    if (!this.#h2.writableEnded) { this.#h2.end(); }
+    cb();
+  }
+
+  _read () {
+    this.#h2.resume();
+  }
+
+  _destroy (err, cb) {
+    clearTimeout(this._portalTimer);
+
+    if (err) {
+      this.#h2.destroy(err);
+    } else if (!this.#h2.writableEnded) {
+      // End rather than destroy: a clean teardown must not discard bytes the h2
+      // stream is still flushing, which is exactly what truncates a large pcap
+      // download to a slow client.
+      this.#h2.end();
+    }
+
+    cb(err);
+  }
+
+  // --------------------------------------------------------------------------
+  // The rest of what http core expects a socket to have
+  setTimeout (ms, cb) {
+    clearTimeout(this._portalTimer);
+    if (ms > 0) {
+      this._portalTimer = setTimeout(() => this.emit('timeout'), ms);
+      if (this._portalTimer.unref) { this._portalTimer.unref(); }
+    }
+    if (cb) { this.once('timeout', cb); }
+    return this;
+  }
+
+  setNoDelay () { return this; }
+  setKeepAlive () { return this; }
+  address () { return { address: this.remoteAddress, port: this.remotePort, family: this.remoteFamily }; }
+  ref () { return this; }
+  unref () { return this; }
+
+  // net.Socket ends, then destroys once the write side has flushed. Destroying
+  // outright here would drop whatever the h2 stream has not sent yet.
+  destroySoon () {
+    if (this.writable) { this.end(); } else { this.destroy(); }
+  }
+}
 
 class PacketPortal {
   // acceptor side: node name -> { session, timer } for every live inbound portal
@@ -286,7 +394,8 @@ class PacketPortal {
   // --------------------------------------------------------------------------
   // ACCEPTOR: shared http.Agent that turns each outbound request into a fresh
   // portal stream. The caller puts the portal session on
-  // options.packetPortalSession; createConnection bridges it to a real socket.
+  // options.packetPortalSession; createConnection wraps a new stream on it in an
+  // H2Socket, which is all http core needs to treat it as a connection.
   static get agent () {
     if (!PacketPortal.#agent) {
       PacketPortal.#agent = new http.Agent({ keepAlive: false, maxSockets: Infinity });
@@ -296,14 +405,25 @@ class PacketPortal {
           cb(new Error('packetPortal session is gone'));
           return;
         }
-        const stream = session.request({
-          ':method': 'POST',
-          ':scheme': 'http',
-          ':authority': 'arkime-portal.invalid',
-          ':path': '/'
-        });
+        // request() throws once the session is gone, and the checks above cannot
+        // rule that out -- the portal can die between them and here. Letting it
+        // throw escapes createConnection, which surfaces as an unhandled
+        // rejection and leaves the request hanging forever instead of failing.
+        let stream;
+        try {
+          stream = session.request({
+            ':method': 'POST',
+            ':scheme': 'http',
+            ':authority': 'arkime-portal.invalid',
+            ':path': '/'
+          });
+        } catch (err) {
+          cb(err);
+          return;
+        }
+
         stream.on('error', () => {});
-        PacketPortal.#bridge(stream, cb);
+        cb(null, new H2Socket(stream));
       };
     }
     return PacketPortal.#agent;
@@ -566,68 +686,15 @@ class PacketPortal {
       return;
     }
     stream.on('error', () => {});
-    PacketPortal.#bridge(stream, (err, socket) => {
-      if (err) {
-        try { stream.destroy(); } catch (ignore) { /* ignore */ }
-        return;
-      }
-      // Mark the request as arriving over a packet portal. It is delivered through
-      // a loopback bridge socket, so its 127.0.0.1 source address, any session
-      // cookie and any userNameHeader it carries are NOT trustworthy -- Auth
-      // authenticates these requests with the s2s token only (see Auth.doAuth),
-      // on top of the #gate check every portal request has already passed.
-      socket.arkimePacketPortal = true;
-      PacketPortal.#innerServer.emit('connection', socket);
-    });
-  }
 
-  // --------------------------------------------------------------------------
-  // Bridge an Http2Stream to a real net.Socket via a one-shot loopback pair,
-  // then hand the other end to deliver(err, socket). Real sockets copy writes
-  // synchronously, which the http client/server require and an Http2Stream does
-  // not provide. deliver receives a still-connecting socket (net.connect), which
-  // http core handles natively.
-  static #bridge (h2stream, deliver) {
-    let settled = false;
-    let end;
-    const finish = (err, sock) => {
-      if (settled) { return; }
-      settled = true;
-      clearTimeout(timer);
-      deliver(err, sock);
-    };
-    const bridge = net.createServer((pipeEnd) => {
-      // Accept ONLY our own connector. The listener is on a random loopback port,
-      // but a local process could still race to connect to it first; matching the
-      // connector's local port ensures we bridge our own end, not an impostor's.
-      if (!end || pipeEnd.remotePort !== end.localPort) { pipeEnd.destroy(); return; }
-      clearTimeout(timer);
-      try { bridge.close(); } catch (e) { /* ignore */ }
-      // Tear the counterpart down only on ABNORMAL termination (error / premature
-      // close), never on a clean finish. Destroying on a clean close would drop an
-      // h2 stream's still-buffered outbound data whenever the peer reads slowly,
-      // truncating large transfers (e.g. a pcap download to a slow client).
-      // stream.finished() reports err only on abnormal end, so a normal completion
-      // is left to flush and end gracefully via the pipes.
-      pipeEnd.on('error', () => {});
-      h2stream.on('error', () => {});
-      streamLib.finished(pipeEnd, (err) => { if (err) { try { h2stream.destroy(); } catch (e) { /* ignore */ } } });
-      streamLib.finished(h2stream, (err) => { if (err) { try { pipeEnd.destroy(); } catch (e) { /* ignore */ } } });
-      pipeEnd.pipe(h2stream);
-      h2stream.pipe(pipeEnd);
-    });
-    // Close the listener (and fail) if our own connection never lands, so a
-    // failed request cannot leak a listening socket / fd.
-    const timer = setTimeout(() => {
-      try { bridge.close(); } catch (e) { /* ignore */ }
-      finish(new Error('packetPortal bridge timed out'));
-    }, 10000);
-    bridge.on('error', (e) => finish(e));
-    bridge.listen(0, '127.0.0.1', () => {
-      end = net.connect(bridge.address().port, '127.0.0.1');
-      end.on('error', (e) => { try { bridge.close(); } catch (x) { /* ignore */ } finish(e); });
-      end.on('connect', () => finish(null, end));
-    });
+    const socket = new H2Socket(stream);
+    // Mark the request as arriving over a packet portal. Its source address is a
+    // stand-in, so that address, any session cookie and any userNameHeader it
+    // carries are NOT trustworthy -- Auth authenticates these requests with the
+    // s2s token only (see Auth.doAuth), on top of the #gate check every portal
+    // request has already passed.
+    socket.arkimePacketPortal = true;
+    PacketPortal.#innerServer.emit('connection', socket);
   }
 
   // --------------------------------------------------------------------------

--- a/viewer/packetPortal.js
+++ b/viewer/packetPortal.js
@@ -79,11 +79,11 @@ class H2Socket extends streamLib.Duplex {
 
     this.#h2 = h2stream;
 
-    // Requests arriving over a portal come from a remote peer, but nothing about
-    // this socket is real. Keep the address loopback: Auth.#checkIps (userAuthIps,
-    // loopback by default) runs before the s2s narrowing and would otherwise
-    // reject every portal request. What marks these requests untrustworthy is
-    // arkimePacketPortal, not this address.
+    // There is no socket under this, so the address is invented. Loopback
+    // specifically, because Auth.#checkIps runs before the s2s narrowing and
+    // would reject portal requests wherever userAuthIps is set explicitly or
+    // defaults to loopback (the header auth modes). It is evidence of nothing --
+    // what marks these requests untrustworthy is arkimePacketPortal.
     this.remoteAddress = '127.0.0.1';
     this.remotePort = 0;
     this.remoteFamily = 'IPv4';
@@ -195,7 +195,7 @@ class PacketPortal {
   static #innerServer;
   // dialer side: shared h2 server that accepts inbound streams from acceptors
   static #dialerH2Server;
-  // acceptor side: shared agent whose createConnection bridges to a portal
+  // acceptor side: shared agent whose createConnection opens a portal stream
   static #agent;
   static #listenEnabled = false;
   static #initialized = false;
@@ -662,10 +662,10 @@ class PacketPortal {
   // DIALER: gate every request arriving over a portal on a valid s2s token,
   // before the app sees it.
   //
-  // The peer is remote but reaches us through a loopback bridge socket, so any
-  // check based on the source ip (userAuthIps' loopback default, mcpAllowedIps)
-  // or on a header a proxy would normally set (userNameHeader) would wrongly
-  // trust it. Auth.doAuth knows about this (see arkimePacketPortal), but routes
+  // The peer is remote but reaches us on a synthetic socket carrying a stand-in
+  // loopback address, so any check based on the source ip (userAuthIps,
+  // mcpAllowedIps) or on a header a proxy would normally set (userNameHeader)
+  // would wrongly trust it. Auth.doAuth knows about this (see arkimePacketPortal), but routes
   // mounted before Auth.app() -- /mcp with its own header auth, pre-auth
   // /plugin/*, /health, the parliament and eshealth endpoints -- never reach it.
   // Nothing legitimately arrives over a portal without a token, so require one

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -215,6 +215,26 @@ if (ArkimeConfig.regressionTests) {
     });
   });
 
+  // send a request over :node's packet portal with NO s2s auth and report the
+  // status, to check the far end rejects it even for a no-auth route
+  app.get('/regressionTests/packetPortalNoAuth/:node', (req, res) => {
+    const session = PacketPortal.get(req.params.node);
+    if (!session) { return res.send({ status: 0, error: 'no portal' }); }
+
+    const preq = http.request('http://arkime-portal.invalid/health', {
+      method: 'GET',
+      agent: PacketPortal.agent,
+      packetPortalSession: session,
+      timeout: 10000
+    }, (pres) => {
+      pres.resume();
+      return res.send({ status: pres.statusCode });
+    });
+    preq.on('timeout', () => preq.destroy(new Error('timeout')));
+    preq.on('error', (err) => res.send({ status: 0, error: '' + err }));
+    preq.end();
+  });
+
   app.post('/regressionTests/shutdown', function (req, res) {
     Db.close();
     process.exit(0);


### PR DESCRIPTION
Two separable commits, reviewable independently.

## 1. Security (`672d9aa`)

Findings from a targeted review of the packet portal, plus two the review missed.

**Prototype-named auth bypasses.** `#checkNode` looked up `#nodes[node]` with the attacker-supplied `x-arkime-node`. `__proto__`, `constructor`, `toString` and friends all return something non-`undefined` off `Object.prototype`, so the `[packetportal-nodes]`/`[esproxy-sensors]` allow list never fired, `pass`/`ip` were both `undefined`, and the peer fell through to trust-on-first-use. It also reopened the unauthenticated 300k-iteration pbkdf2 that the allow list exists to gate. Fixed with `Object.hasOwn` plus `ArkimeUtil.isPP`, and at the root in `Config.configMap`, which now returns null-prototype maps for all four of its callers.

`isPP` alone is not sufficient here: it matches `__`-prefixed names plus `constructor`/`prototype`/`eval`/`Function`, but `toString`/`valueOf`/`hasOwnProperty` resolve identically. Hence both checks.

**Same bug in esProxy, without needing `serverSecret`.** `esProxy.js` does the same lookup against the same config section behind HTTP Basic. `__proto__` with any password authenticated, and the surviving path allowlist does not depend on `req.sensor.node` for `/{prefix}users/_doc/*`, `/{prefix}hunts/_doc/*` or `sessions2-*`/`sessions3-*` reads. Verified against the test config: it returned a real user document including `passStore`. This is in shipped code, not the unreleased portal.

**s2s was not actually enforced over portals.** `socket.arkimePacketPortal` only governs `Auth.doAuth`, and `/mcp`, pre-auth `/plugin/*`, `/health`, `/api/parliament` and `/api/eshealth` are mounted before `Auth.app(app)`. `/mcp` defaults to `mcpAuthMode=header` with `mcpAllowedIps` allow-all, and the bridge socket's `127.0.0.1` satisfies the `userAuthIps` loopback default — a full auth bypass as any username, no token. Enforcement moved to the portal boundary: `#gate` requires a valid s2s token on every portal request before Express sees it. Separately, `doAuth`'s `req.isAuthenticated()` short circuit ran *before* the s2s-only narrowing, so a session cookie carried over a portal skipped it; the portal condition is now evaluated first, and portal requests never mint or write a session.

**Credential-less allow-list entries** are dropped with a named startup `WARNING` instead of silently becoming trust-on-first-use. `#nodesConfigured` is computed before filtering, so dropping every entry cannot turn the allow list off.

**Portal TLS never hot-reloaded.** `ArkimeUtil`'s cert reload was hardcoded to one server and to the global `keyFile`/`certFile`. Extracted as `watchCertFiles(server, keyFile, certFile)`; the portal's dedicated listener now watches its own pair. Verified live: rotating the files swapped the served cert from `CN=portal-cert-A` to `CN=portal-cert-B` without a restart.

## 2. Transport (`20385df`)

Every request over a portal built a `net.createServer()` on an ephemeral loopback port plus a connector — a listening socket and two descriptors per in-flight request — purely because http core cannot write to an `Http2Stream` (it hands the socket buffers it may reuse before the stream serializes them). That is the only real incompatibility, and copying in `_write` settles it.

`H2Socket` wraps an `Http2Stream` as a Duplex that http core drives. `#bridge` is deleted: no listener, no ephemeral port, no descriptors per request, no 10s bridge timeout. HTTP/2 stays, so its per-stream flow control still keeps a slow pcap reader from stalling other requests — that was the reason not to hand-roll framing.

Also fixes a pre-existing hang: `session.request()` throws if the portal dies after the liveness check, and the exception escaped `createConnection` as an unhandled rejection, leaving the request unsettled forever.

## Testing

`tests/packetPortal.t` gained a check that an unauthenticated request over a portal is rejected — **RED on unmodified code (200), GREEN here (401)**. `tests/esProxy.t` gained four checks that prototype-named sensors are not authenticated.

Full `--api-fast` suite, 5399 tests: only `api-files.t` (8) and `api-fresh.t` (4) fail, with identical test numbers on unmodified `main` — they depend on the data reload `--api-fast` skips.

Transport verified against a real h2 session: 8MB responses byte exact, 2MB request bodies, a stalled reader that neither blocks the session nor truncates its own transfer, 40 concurrent requests with no descriptor growth, and mid-response abort plus the portal dying under a transfer with no uncaught errors.

## Not addressed

- **Plaintext portal port** still leaks the per-node Basic password and a replayable s2s token when `packetPortalKeyFile`/`CertFile` are unset. Refusing to start without an explicit opt-in would break anyone already running one, so it wants a deliberate decision.
- **Concurrency is still unbounded** (`maxConcurrentStreams` is effectively unlimited, agent is `maxSockets: Infinity`). Descriptor exhaustion is gone, so this is now memory pressure rather than an `EMFILE` that breaks the whole process. One line on the dialer's `http2.createServer({ settings: { maxConcurrentStreams: N } })` would bound it.
- `#pinnedIps` is still memory-only, so a restart reopens the first-sight window for every credential-less node at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)