### PR TITLE
dbAdmin is the only ES admin gate, remove esAdminUsers (#4080)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - Capture arkime_packet_set_dltsnap() was replaced by arkime_packet_set_interface(), so custom readers/plugins must be updated and rebuilt
   - #4080 Removed the esAdminUsers setting; the ES admin page and the ES index/shard/task actions now require the dbAdmin role
           (superAdmin includes it, arkimeAdmin no longer grants it), eg db.pl <host:port> users-update '<userId glob>' --addRole dbAdmin
+  - #4080 Removed the derived esAdminUser field from /api/user/current, check the user's roles for dbAdmin instead
 ## Capture/Viewer
   - pcapng support greatly improved: read/write files with multiple interfaces (up to 255) and different link types (DLTs), write pcapng when copying pcapng input, and download/export sessions as pcapng
 ## Capture

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,7 +40,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - offlineFilenameRegex default now also matches .pcapng files (previously .pcap/.cap only)
   - Capture arkime_packet_set_dltsnap() was replaced by arkime_packet_set_interface(), so custom readers/plugins must be updated and rebuilt
   - #4080 Removed the esAdminUsers setting; the ES admin page and the ES index/shard/task actions now require the dbAdmin role
-          (superAdmin includes it, arkimeAdmin no longer grants it), eg db.pl <host:port> users-update '<userId glob>' --addRole dbAdmin
+          (superAdmin includes it, arkimeAdmin no longer grants it), eg db.pl <host:port> users-update '<userId glob>' --addRole dbAdmin.
+          dbAdmin implies no other role, so pair it with arkimeUser, which viewer requires for any access
   - #4080 Removed the derived esAdminUser field from /api/user/current, check the user's roles for dbAdmin instead
 ## Capture/Viewer
   - pcapng support greatly improved: read/write files with multiple interfaces (up to 255) and different link types (DLTs), write pcapng when copying pcapng input, and download/export sessions as pcapng

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -39,11 +39,15 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Breaking
   - offlineFilenameRegex default now also matches .pcapng files (previously .pcap/.cap only)
   - Capture arkime_packet_set_dltsnap() was replaced by arkime_packet_set_interface(), so custom readers/plugins must be updated and rebuilt
+  - #4080 Removed the esAdminUsers setting; the ES admin page and the ES index/shard/task actions now require the dbAdmin role
+          (superAdmin includes it, arkimeAdmin no longer grants it), eg db.pl <host:port> users-update '<userId glob>' --addRole dbAdmin
 ## Capture/Viewer
   - pcapng support greatly improved: read/write files with multiple interfaces (up to 255) and different link types (DLTs), write pcapng when copying pcapng input, and download/export sessions as pcapng
 ## Capture
   - Support multiple GeoIP vendors (MaxMind GeoLite2/GeoIP2, GeoOpen, ipinfo, db-ip)
   - Renamed geoLite2Country/geoLite2ASN config settings to geoFile/geoASNFile (deprecated names still accepted)
+## Viewer
+  - #4080 Fix the ES Tasks "Cancel All" button posting to a non-existent route, it has 404ed since 6.0.0
 
 
 6.7.0 2026/08/xx

--- a/common/auth.js
+++ b/common/auth.js
@@ -920,7 +920,7 @@ class Auth {
           packetSearch: true,
           settings: {},
           welcomeMsgNum: 1,
-          roles: ['arkimeAdmin', 'cont3xtUser', 'parliamentUser', 'usersAdmin', 'wiseUser']
+          roles: ['arkimeAdmin', 'cont3xtUser', 'dbAdmin', 'parliamentUser', 'usersAdmin', 'wiseUser']
         });
         await user.expandFromRoles();
         return done(null, user);

--- a/common/user.js
+++ b/common/user.js
@@ -465,7 +465,7 @@ class User {
    * usersAdmin - has access to configure users<br>
    * wiseAdmin - has administrative access to WISE (can configure and update WISE)<br>
    * wiseUser - has access to WISE<br>
-   * dbAdmin - has access to the ES/DB admin page and the ES index, shard, and task actions
+   * dbAdmin - has access to the ES/DB admin page and the ES index, shard, and task actions, pair with arkimeUser for viewer access
    * @typedef ArkimeRole
    * @type {string}
    */

--- a/common/user.js
+++ b/common/user.js
@@ -310,7 +310,7 @@ class User {
     if (userId === 'superAdmin') {
       user.roles = ['superAdmin'];
     } else if (userId === 'anonymous') {
-      user.roles = ['arkimeAdmin', 'cont3xtUser', 'parliamentUser', 'usersAdmin', 'wiseUser'];
+      user.roles = ['arkimeAdmin', 'cont3xtUser', 'dbAdmin', 'parliamentUser', 'usersAdmin', 'wiseUser'];
     } else {
       user.roles = ['arkimeUser', 'cont3xtUser', 'parliamentUser', 'wiseUser'];
     }
@@ -465,7 +465,7 @@ class User {
    * usersAdmin - has access to configure users<br>
    * wiseAdmin - has administrative access to WISE (can configure and update WISE)<br>
    * wiseUser - has access to WISE<br>
-   * dbAdmin - has access to perform database administration tasks
+   * dbAdmin - has access to the ES/DB admin page and the ES index, shard, and task actions
    * @typedef ArkimeRole
    * @type {string}
    */

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -825,7 +825,7 @@
       "clearCache": "Cache löschen",
       "clearCacheTip": "Versuchen, den Cache für alle Indizes zu löschen",
       "restoreAllocationTip": "Dieser Wert sollte in den meisten Fällen \"all\" sein. Klicken Sie hier, um ihn zurückzusetzen.",
-      "controlHtml": "Sie können steuern, welche Benutzer diese Seite sehen, indem Sie <code>esAdminUsers=</code> in Ihrer <code>config.ini</code> setzen ODER die arkimeAdmin-Rolle hinzufügen."
+      "controlHtml": "Sie können mit der Rolle <code>dbAdmin</code> steuern, welche Benutzer diese Seite sehen."
     },
     "esIndices": {
       "deleteIndex": "Index löschen",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -825,7 +825,7 @@
       "clearCache": "Clear Cache",
       "clearCacheTip": "Try to clear the cache for all indices",
       "restoreAllocationTip": "This value should be \"all\" in most cases. Click here to change it back.",
-      "controlHtml": "You can control which users see this page by setting <code>esAdminUsers=</code> in your <code>config.ini</code> OR add arkimeAdmin role."
+      "controlHtml": "You can control which users see this page with the <code>dbAdmin</code> role."
     },
     "esIndices": {
       "deleteIndex": "Delete Index",

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -825,7 +825,7 @@
       "clearCache": "Limpiar caché",
       "clearCacheTip": "Intentar limpiar el caché para todos los índices",
       "restoreAllocationTip": "Este valor debe ser \"all\" en la mayoría de los casos. Haga clic aquí para cambiarlo de nuevo.",
-      "controlHtml": "Puedes controlar qué usuarios ven esta página configurando <code>esAdminUsers=</code> en tu <code>config.ini</code> O agregando el rol arkimeAdmin."
+      "controlHtml": "Puedes controlar qué usuarios ven esta página con el rol <code>dbAdmin</code>."
     },
     "esIndices": {
       "deleteIndex": "Eliminar índice",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -825,7 +825,7 @@
       "clearCache": "Puhasta vahemälu",
       "clearCacheTip": "Proovi kõigi indeksite vahemälu puhastada",
       "restoreAllocationTip": "See väärtus peaks enamikul juhtudel olema \"all\". Klõpsa siia, et see tagasi muuta.",
-      "controlHtml": "Sa saad kontrollida, millised kasutajad näevad seda lehte, määrates <code>esAdminUsers=</code> oma <code>config.ini</code> VÕI lisades arkimeAdmin rolli."
+      "controlHtml": "Sa saad <code>dbAdmin</code> rolliga kontrollida, millised kasutajad näevad seda lehte."
     },
     "esIndices": {
       "deleteIndex": "Kustuta indeks",

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -825,7 +825,7 @@
       "clearCache": "Vider le cache",
       "clearCacheTip": "Essayer de vider le cache de tous les index",
       "restoreAllocationTip": "Cette valeur devrait être \"all\" dans la plupart des cas. Cliquez ici pour la rétablir.",
-      "controlHtml": "Vous pouvez contrôler quels utilisateurs voient cette page en définissant <code>esAdminUsers=</code> dans votre <code>config.ini</code> OU en ajoutant le rôle arkimeAdmin."
+      "controlHtml": "Vous pouvez contrôler quels utilisateurs voient cette page avec le rôle <code>dbAdmin</code>."
     },
     "esIndices": {
       "deleteIndex": "Supprimer l'Index",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -825,7 +825,7 @@
       "clearCache": "キャッシュをクリア",
       "clearCacheTip": "すべてのインデックスのキャッシュクリアを試行します",
       "restoreAllocationTip": "この値は通常 \"all\" であるべきです。元に戻すにはここをクリックしてください。",
-      "controlHtml": "<code>config.ini</code> の <code>esAdminUsers=</code> を設定するか、arkimeAdmin ロールを追加することで、このページを表示できるユーザーを制御できます。"
+      "controlHtml": "<code>dbAdmin</code> ロールで、このページを表示できるユーザーを制御できます。"
     },
     "esIndices": {
       "deleteIndex": "インデックスを削除",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -825,7 +825,7 @@
       "clearCache": "캐시 삭제",
       "clearCacheTip": "모든 인덱스의 캐시 삭제를 시도합니다.",
       "restoreAllocationTip": "이 값은 대부분의 경우 \"all\"이어야 합니다. 클릭하여 복구하세요.",
-      "controlHtml": "<code>config.ini</code>에서 <code>esAdminUsers=</code>를 설정하거나 arkimeAdmin 역할을 추가하여 이 페이지를 볼 수 있는 사용자를 제어할 수 있습니다."
+      "controlHtml": "<code>dbAdmin</code> 역할로 이 페이지를 볼 수 있는 사용자를 제어할 수 있습니다."
     },
     "esIndices": {
       "deleteIndex": "인덱스 삭제",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -825,7 +825,7 @@
       "clearCache": "Limpar Cache",
       "clearCacheTip": "Tentar limpar o cache de todos os índices",
       "restoreAllocationTip": "Este valor deve ser \"all\" na maioria dos casos. Clique aqui para alterá-lo de volta.",
-      "controlHtml": "Você pode controlar quais usuários veem esta página configurando <code>esAdminUsers=</code> no seu <code>config.ini</code> OU adicionar a função arkimeAdmin."
+      "controlHtml": "Você pode controlar quais usuários veem esta página com a função <code>dbAdmin</code>."
     },
     "esIndices": {
       "deleteIndex": "Excluir Índice",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -826,7 +826,7 @@
       "clearCache": "Earclay Achecay",
       "clearCacheTip": "Ytraysay otay earclay ethay achecay orfay allway indicesway",
       "restoreAllocationTip": "Isthay aluevay ouldshay ebay \"all\" inway ostmay asescay. Ickclay erehay otay angechay itway ackbay.",
-      "controlHtml": "Ouyay ancay ontrolcay hichway usersway eesay isthay agepay ybay ettingsay <code>esAdminUsers=</code> inway ouryay <code>config.ini</code> ORWAY addway arkimeAdminway oleray."
+      "controlHtml": "Ouyay ancay ontrolcay hichway usersway eesay isthay agepay ithway ethay <code>dbAdmin</code> oleray."
     },
     "esIndices": {
       "deleteIndex": "Eleteday Indexway",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -825,7 +825,7 @@
       "clearCache": "清除缓存",
       "clearCacheTip": "尝试清除所有索引的缓存",
       "restoreAllocationTip": "在大多数情况下，此值应为 \"all\"。单击此处将其改回。",
-      "controlHtml": "您可以通过在 <code>config.ini</code> 中设置 <code>esAdminUsers=</code> 或添加 arkimeAdmin 角色来控制哪些用户可以看到此页面。"
+      "controlHtml": "您可以通过 <code>dbAdmin</code> 角色来控制哪些用户可以看到此页面。"
     },
     "esIndices": {
       "deleteIndex": "删除索引",

--- a/tests/api-esadmin.t
+++ b/tests/api-esadmin.t
@@ -1,4 +1,4 @@
-use Test::More tests => 66;
+use Test::More tests => 77;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -7,8 +7,18 @@ use Test::Differences;
 use Data::Dumper;
 use strict;
 
-    my $token = getTokenCookie('adminuser1');
+    my $superAdminToken = getTokenCookie('superAdmin');
+    my $token = getTokenCookie('sac-esadmin-db');
+    my $arkimeAdminToken = getTokenCookie('sac-esadmin-arkime');
     my $json;
+
+# es admin access requires the dbAdmin role, so make a user with it and one without.
+# Only a superAdmin may assign admin roles.
+    $json = viewerPostToken("/api/user?arkimeRegressionUser=superAdmin", '{"userId": "sac-esadmin-db", "userName": "dbAdmin", "enabled":true, "password":"password", "roles":["dbAdmin"]}', $superAdminToken);
+    is($json->{success}, 1, "created dbAdmin user");
+
+    $json = viewerPostToken("/api/user?arkimeRegressionUser=superAdmin", '{"userId": "sac-esadmin-arkime", "userName": "arkimeAdmin", "enabled":true, "password":"password", "roles":["arkimeAdmin"]}', $superAdminToken);
+    is($json->{success}, 1, "created arkimeAdmin user");
 
 # Clear any old setting and make sure nothing set
     $json = esPut('/_cluster/settings', '{"persistent" : {"cluster.max_shards_per_node" : null}}');
@@ -40,52 +50,73 @@ use strict;
     is($json->{success}, 0, "esadmin allocation no permission");
     is($json->{i18n}, "api.viewer.noPermission", "esadmin allocation no permission i18n");
 
+# arkimeAdmin alone doesn't grant es admin, only dbAdmin does. Cover the action
+# endpoints too, they used to accept arkimeAdmin.
+    $json = viewerGet("/api/esadmin?arkimeRegressionUser=sac-esadmin-arkime");
+    is($json->{success}, 0, "esadmin get arkimeAdmin no permission");
+    is($json->{i18n}, "api.viewer.noPermission", "esadmin get arkimeAdmin no permission i18n");
+
+    $json = viewerPostToken("/api/esindices/tests_users/optimize?arkimeRegressionUser=sac-esadmin-arkime", "", $arkimeAdminToken);
+    is($json->{success}, 0, "esindices optimize arkimeAdmin no permission");
+    is($json->{i18n}, "api.viewer.noPermission", "esindices optimize arkimeAdmin no permission i18n");
+
+    $json = viewerPostToken("/api/esshards/name/thenode/exclude?arkimeRegressionUser=sac-esadmin-arkime", "", $arkimeAdminToken);
+    is($json->{success}, 0, "esshards exclude arkimeAdmin no permission");
+    is($json->{i18n}, "api.viewer.noPermission", "esshards exclude arkimeAdmin no permission i18n");
+
+    $json = viewerPostToken("/api/estasks/cancelall?arkimeRegressionUser=sac-esadmin-arkime", "", $arkimeAdminToken);
+    is($json->{success}, 0, "estasks cancelall arkimeAdmin no permission");
+    is($json->{i18n}, "api.viewer.noPermission", "estasks cancelall arkimeAdmin no permission i18n");
+
+    $json = viewerPostToken("/api/esindices/tests_users/optimize?arkimeRegressionUser=sac-esadmin-db", "", $token);
+    is($json->{success}, 1, "esindices optimize dbAdmin success");
+
 # Missing token
-    $json = viewerPost("/api/esadmin/set?arkimeRegressionUser=adminuser1");
+    $json = viewerPost("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db");
     is($json->{success}, 0, "esadmin set missing token");
     is($json->{i18n}, "api.viewer.missingToken", "esadmin set missing token i18n");
 
-    $json = viewerPost("/api/esadmin/reroute?arkimeRegressionUser=adminuser1");
+    $json = viewerPost("/api/esadmin/reroute?arkimeRegressionUser=sac-esadmin-db");
     is($json->{success}, 0, "esadmin reroute missing token");
     is($json->{i18n}, "api.viewer.missingToken", "esadmin reroute missing token i18n");
 
-    $json = viewerPost("/api/esadmin/flush?arkimeRegressionUser=adminuser1");
+    $json = viewerPost("/api/esadmin/flush?arkimeRegressionUser=sac-esadmin-db");
     is($json->{success}, 0, "esadmin flush missing token");
     is($json->{i18n}, "api.viewer.missingToken", "esadmin flush missing token i18n");
 
-    $json = viewerPost("/api/esadmin/unflood?arkimeRegressionUser=adminuser1");
+    $json = viewerPost("/api/esadmin/unflood?arkimeRegressionUser=sac-esadmin-db");
     is($json->{success}, 0, "esadmin unflood missing token");
     is($json->{i18n}, "api.viewer.missingToken", "esadmin unflood missing token i18n");
 
 # good
-    $json = viewerPostToken("/api/esadmin/reroute?arkimeRegressionUser=adminuser1", "", $token);
+    $json = viewerPostToken("/api/esadmin/reroute?arkimeRegressionUser=sac-esadmin-db", "", $token);
     is($json->{success}, 1, "esadmin reroute success");
     is($json->{i18n}, "api.stats.rerouteSuccessful", "esadmin reroute success i18n");
 
-    $json = viewerPostToken("/api/esadmin/flush?arkimeRegressionUser=adminuser1", "", $token);
+    $json = viewerPostToken("/api/esadmin/flush?arkimeRegressionUser=sac-esadmin-db", "", $token);
     is($json->{success}, 1, "esadmin flush success");
     is($json->{i18n}, "api.stats.flushed", "esadmin flush success i18n");
 
-    $json = viewerPostToken("/api/esadmin/unflood?arkimeRegressionUser=adminuser1", "", $token);
+    $json = viewerPostToken("/api/esadmin/unflood?arkimeRegressionUser=sac-esadmin-db", "", $token);
     is($json->{success}, 1, "esadmin unflood success");
     is($json->{i18n}, "api.stats.unflooded", "esadmin unflood success i18n");
 
 # set tests
-    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1", "", $token);
+    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db", "", $token);
     is($json->{success}, 0, "esadmin set missing key");
     is($json->{i18n}, "api.stats.missingKey", "esadmin set missing key i18n");
 
-    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1", "key=foo", $token);
+    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db", "key=foo", $token);
     is($json->{success}, 0, "esadmin set missing value");
     is($json->{i18n}, "api.stats.missingValue", "esadmin set missing value i18n");
 
-    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1", "key=foo&value=bar", $token);
+    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db", "key=foo&value=bar", $token);
     is($json->{success}, 0, "esadmin set failed");
     is($json->{i18n}, "api.stats.setFailed", "esadmin set failed i18n");
 
 
     # set to 1234
-    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1", "key=cluster.max_shards_per_node&value=1234", $token);
+    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db", "key=cluster.max_shards_per_node&value=1234", $token);
     is($json->{success}, 1, "esadmin set settings success");
     is($json->{i18n}, "api.stats.settingsSet", "esadmin set settings i18n");
 
@@ -93,7 +124,7 @@ use strict;
     is ($json->{persistent}->{'cluster.max_shards_per_node'}, 1234);
 
     # clear with space
-    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1", "key=cluster.max_shards_per_node&value=", $token);
+    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db", "key=cluster.max_shards_per_node&value=", $token);
     is($json->{success}, 1, "esadmin set settings success");
     is($json->{i18n}, "api.stats.settingsSet", "esadmin set settings i18n");
 
@@ -107,7 +138,7 @@ use strict;
     ok (!exists $json->{persistent}->{'cluster.routing.allocation.enable'});
 
     # Set to "primaries" (something other than "all")
-    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1", "key=cluster.routing.allocation.enable&value=primaries", $token);
+    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db", "key=cluster.routing.allocation.enable&value=primaries", $token);
     is($json->{success}, 1, "esadmin set settings success");
     is($json->{i18n}, "api.stats.settingsSet", "esadmin set settings i18n");
 
@@ -115,7 +146,7 @@ use strict;
     is ($json->{persistent}->{'cluster.routing.allocation.enable'}, "primaries");
 
     # Restore to "all"
-    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1", "key=cluster.routing.allocation.enable&value=all", $token);
+    $json = viewerPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db", "key=cluster.routing.allocation.enable&value=all", $token);
     is($json->{success}, 1, "esadmin set settings success");
     is($json->{i18n}, "api.stats.settingsSet", "esadmin set settings i18n");
 
@@ -127,51 +158,55 @@ use strict;
 
 # allocation explain tests
     # General allocation explanation (no specific shard)
-    $json = viewerGet("/api/esadmin/allocation?arkimeRegressionUser=adminuser1");
+    $json = viewerGet("/api/esadmin/allocation?arkimeRegressionUser=sac-esadmin-db");
     ok(exists $json->{index} || exists $json->{allocate_explanation}, "Allocation explain returns valid response");
 
     # Allocation explanation with specific index/shard parameters
     # Note: This may fail if there are no unassigned shards, so we just check it doesn't error
-    $json = viewerGet("/api/esadmin/allocation?arkimeRegressionUser=adminuser1&index=sessions2-*&shard=0&primary=true");
+    $json = viewerGet("/api/esadmin/allocation?arkimeRegressionUser=sac-esadmin-db&index=sessions2-*&shard=0&primary=true");
     ok(defined $json, "Allocation explain with parameters returns response");
 
 # multiviewer
     # test cluster
-    $json = multiPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1&cluster=test", "key=cluster.max_shards_per_node&value=4321", $token);
+    $json = multiPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db&cluster=test", "key=cluster.max_shards_per_node&value=4321", $token);
     is($json->{success}, 1, "esadmin set settings success");
     is($json->{i18n}, "api.stats.settingsSet", "esadmin set settings i18n");
 
-    $json = multiGetToken("/api/esadmin?arkimeRegressionUser=adminuser1&cluster=test", $token);
+    $json = multiGetToken("/api/esadmin?arkimeRegressionUser=sac-esadmin-db&cluster=test", $token);
     is ($json->[7]->{'current'}, "4321");
 
-    $json = multiPostToken("/api/esadmin/reroute?arkimeRegressionUser=adminuser1&cluster=test", "", $token);
+    $json = multiPostToken("/api/esadmin/reroute?arkimeRegressionUser=sac-esadmin-db&cluster=test", "", $token);
     is($json->{success}, 1, "esadmin reroute success");
     is($json->{i18n}, "api.stats.rerouteSuccessful", "esadmin reroute i18n");
 
-    $json = multiPostToken("/api/esadmin/flush?arkimeRegressionUser=adminuser1&cluster=test", "", $token);
+    $json = multiPostToken("/api/esadmin/flush?arkimeRegressionUser=sac-esadmin-db&cluster=test", "", $token);
     is($json->{success}, 1, "esadmin flush success");
     is($json->{i18n}, "api.stats.flushed", "esadmin flush i18n");
 
-    $json = multiPostToken("/api/esadmin/unflood?arkimeRegressionUser=adminuser1&cluster=test", "", $token);
+    $json = multiPostToken("/api/esadmin/unflood?arkimeRegressionUser=sac-esadmin-db&cluster=test", "", $token);
     is($json->{success}, 1, "esadmin unflood success");
     is($json->{i18n}, "api.stats.unflooded", "esadmin unflood i18n");
 
     # test2 cluster
-    $json = multiPostToken("/api/esadmin/set?arkimeRegressionUser=adminuser1&cluster=test2", "key=cluster.max_shards_per_node&value=31453", $token);
+    $json = multiPostToken("/api/esadmin/set?arkimeRegressionUser=sac-esadmin-db&cluster=test2", "key=cluster.max_shards_per_node&value=31453", $token);
     is($json->{success}, 1, "esadmin set settings success");
     is($json->{i18n}, "api.stats.settingsSet", "esadmin set settings i18n");
 
-    $json = multiGetToken("/api/esadmin?arkimeRegressionUser=adminuser1&cluster=test2", $token);
+    $json = multiGetToken("/api/esadmin?arkimeRegressionUser=sac-esadmin-db&cluster=test2", $token);
     is ($json->[7]->{'current'}, "31453");
 
-    $json = multiPostToken("/api/esadmin/reroute?arkimeRegressionUser=adminuser1&cluster=test2", "", $token);
+    $json = multiPostToken("/api/esadmin/reroute?arkimeRegressionUser=sac-esadmin-db&cluster=test2", "", $token);
     is($json->{success}, 1, "esadmin reroute success");
     is($json->{i18n}, "api.stats.rerouteSuccessful", "esadmin reroute i18n");
 
-    $json = multiPostToken("/api/esadmin/flush?arkimeRegressionUser=adminuser1&cluster=test2", "", $token);
+    $json = multiPostToken("/api/esadmin/flush?arkimeRegressionUser=sac-esadmin-db&cluster=test2", "", $token);
     is($json->{success}, 1, "esadmin flush success");
     is($json->{i18n}, "api.stats.flushed", "esadmin flush i18n");
 
-    $json = multiPostToken("/api/esadmin/unflood?arkimeRegressionUser=adminuser1&cluster=test2", "", $token);
+    $json = multiPostToken("/api/esadmin/unflood?arkimeRegressionUser=sac-esadmin-db&cluster=test2", "", $token);
     is($json->{success}, 1, "esadmin unflood success");
     is($json->{i18n}, "api.stats.unflooded", "esadmin unflood i18n");
+
+# remove added users
+    viewerDeleteToken("/api/user/sac-esadmin-db?arkimeRegressionUser=superAdmin", $superAdminToken);
+    viewerDeleteToken("/api/user/sac-esadmin-arkime?arkimeRegressionUser=superAdmin", $superAdminToken);

--- a/tests/api-esadmin.t
+++ b/tests/api-esadmin.t
@@ -13,8 +13,10 @@ use strict;
     my $json;
 
 # es admin access requires the dbAdmin role, so make a user with it and one without.
+# Both need arkimeUser since viewer gates the whole app on it and dbAdmin implies
+# nothing, arkimeAdmin brings arkimeUser along itself.
 # Only a superAdmin may assign admin roles.
-    $json = viewerPostToken("/api/user?arkimeRegressionUser=superAdmin", '{"userId": "sac-esadmin-db", "userName": "dbAdmin", "enabled":true, "password":"password", "roles":["dbAdmin"]}', $superAdminToken);
+    $json = viewerPostToken("/api/user?arkimeRegressionUser=superAdmin", '{"userId": "sac-esadmin-db", "userName": "dbAdmin", "enabled":true, "password":"password", "roles":["arkimeUser","dbAdmin"]}', $superAdminToken);
     is($json->{success}, 1, "created dbAdmin user");
 
     $json = viewerPostToken("/api/user?arkimeRegressionUser=superAdmin", '{"userId": "sac-esadmin-arkime", "userName": "arkimeAdmin", "enabled":true, "password":"password", "roles":["arkimeAdmin"]}', $superAdminToken);

--- a/tests/api-stats.t
+++ b/tests/api-stats.t
@@ -174,7 +174,7 @@ my $test1Token = getTokenCookie("test1");
     is($result->{i18n}, "api.stats.unknownExcludeType", "esshard: exclude foobar i18n");
 
     $result = viewerPostToken("/api/esshards/foobar/1.2.3.4/exclude?arkimeRegressionUser=test1", "", $test1Token);
-    eq_or_diff($result, from_json('{"success": false, "text": "You do not have permission to access this resource"}'), "esshard: exclude not admin");
+    eq_or_diff($result, from_json('{"success": false, "text": "You do not have permission to access this resource", "i18n": "api.viewer.noPermission"}'), "esshard: exclude not admin");
 
     $shards = viewerGet("/api/esshards");
     eq_or_diff($shards->{nodeExcludes}, ["thenode"], "esshard: nodeExcludes thenode");
@@ -197,7 +197,7 @@ my $test1Token = getTokenCookie("test1");
     is($result->{i18n}, "api.stats.unknownIncludeType", "esshard: include foodbar i18n");
 
     $result = viewerPostToken("/api/esshards/foobar/1.2.3.4/include?arkimeRegressionUser=test1", "", $test1Token);
-    eq_or_diff($result, from_json('{"success": false, "text": "You do not have permission to access this resource"}'), "esshard: include not admin");
+    eq_or_diff($result, from_json('{"success": false, "text": "You do not have permission to access this resource", "i18n": "api.viewer.noPermission"}'), "esshard: include not admin");
 
     $shards = viewerGet("/api/esshards");
     eq_or_diff($shards->{nodeExcludes}, [], "esshard: nodeExcludes empty");
@@ -223,7 +223,7 @@ my $test1Token = getTokenCookie("test1");
     eq_or_diff($result, from_json('{"success": false, "text": "Deleting shard theindex:0 failed"}'), "esshard: delete failed");
 
     $result = viewerPostToken("/api/esshards/theindex/theshard/delete?arkimeRegressionUser=test1", "", $test1Token);
-    eq_or_diff($result, from_json('{"success": false, "text": "You do not have permission to access this resource"}'), "esshard: delete not admin");
+    eq_or_diff($result, from_json('{"success": false, "text": "You do not have permission to access this resource", "i18n": "api.viewer.noPermission"}'), "esshard: delete not admin");
 
     $result = multiPostToken("/api/esshards/theindex/0/delete", "", $token);
     is($result->{success}, 0, "esshard: delete missing cluster");
@@ -233,7 +233,7 @@ my $test1Token = getTokenCookie("test1");
     eq_or_diff($result, from_json('{"success": false, "text": "Deleting shard theindex:0 failed"}'));
 
     $result = multiPostToken("/api/esshards/theindex/theshard/delete?arkimeRegressionUser=test1&cluster=unknown", "", $test1Token);
-    eq_or_diff($result, from_json('{"success": false, "text": "You do not have permission to access this resource"}'), "esshard: delete not admin");
+    eq_or_diff($result, from_json('{"success": false, "text": "You do not have permission to access this resource", "i18n": "api.viewer.noPermission"}'), "esshard: delete not admin");
 
 # esshards delete - additional comprehensive tests
     # Test invalid shard number (non-numeric)

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -31,7 +31,7 @@ my $json;
     my $csv = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/users.csv", Content => "")->content;
     $csv =~ s/\r//g;
     eq_or_diff ($csv, 'userId,userName,enabled,webEnabled,headerAuthEnabled,roles,emailSearch,removeEnabled,packetSearch,hideStats,hideFiles,hidePcap,disablePcapDownload,expression,timeLimit
-anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
+anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, dbAdmin, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
 ', "CSV Users");
 
 # csv formula injection - userName/expression starting with a trigger char must be neutralized with a leading '
@@ -122,7 +122,7 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
     $json = viewerGetToken("/api/appInfo", $token);
     eq_or_diff(sort($json->{roles}), from_json('["arkimeAdmin", "arkimeUser", "cont3xtAdmin", "cont3xtUser", "dbAdmin", "mcpUser", "parliamentAdmin", "parliamentUser", "superAdmin", "usersAdmin", "wiseAdmin", "wiseUser"]'));
     my @roles = sort @{$json->{user}->{roles}};
-    eq_or_diff(\@roles, from_json('["arkimeAdmin", "arkimeUser", "cont3xtUser", "parliamentUser", "usersAdmin", "wiseUser"]'));
+    eq_or_diff(\@roles, from_json('["arkimeAdmin", "arkimeUser", "cont3xtUser", "dbAdmin", "parliamentUser", "usersAdmin", "wiseUser"]'));
 
 # Check default user settings
     $json = viewerGetToken("/api/appInfo", $token);
@@ -707,7 +707,7 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
     my $csv = $ArkimeTest::userAgent->post("http://$ArkimeTest::host:8123/api/users.csv", Content => "")->content;
     $csv =~ s/\r//g;
     eq_or_diff ($csv, 'userId,userName,enabled,webEnabled,headerAuthEnabled,roles,emailSearch,removeEnabled,packetSearch,hideStats,hideFiles,hidePcap,disablePcapDownload,expression,timeLimit
-anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
+anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, dbAdmin, parliamentUser, usersAdmin, wiseUser",true,true,true,,,,,,
 notadmin,,true,true,false,"arkimeUser, cont3xtUser, parliamentUser, wiseUser",true,true,true,,,,,,
 role:sac-test1,UserName,true,false,false,"",,,,,,,,,
 role:sac-test2,UserName,true,false,false,"role:sac-test1",,,,,,,,,

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -47,8 +47,6 @@ packetThreads=2
 magicMode=basic
 filenameOps=tags=/gre-(.*)\\.pcap%gretest-\\1;tags=dns-error%error-dns
 
-esAdminUsers=adminuser1,admin
-
 scrubspi=http.uri=/sheepskin%20boots/Sheepskin%20Boots/
 
 # Stuff for rules testing
@@ -114,7 +112,6 @@ plugins=test.so;tagger.so;wise.so;zeekintel.so
 cronQueries=true
 dontSaveBPFs=port 12345
 webBasePath = /arkime/
-esAdminUsers=admin
 businessDayStart=9
 businessDayEnd=17
 businessDays=1,2,3,4,5

--- a/viewer/apiStats.js
+++ b/viewer/apiStats.js
@@ -981,7 +981,7 @@ class StatsAPIs {
   /**
    * GET - /api/esadmin
    *
-   * Fetches all OpenSearch/Elasticsearch settings that a user can change (es admin only - set in config with <a href="settings#esadminusers">esAdminUsers</a>).
+   * Fetches all OpenSearch/Elasticsearch settings that a user can change (requires the dbAdmin role).
    * @name /esadmin
    * @returns {array} settings - List of ES settings that a user can change
    */
@@ -1121,7 +1121,7 @@ class StatsAPIs {
   /**
    * POST - /api/esadmin/set
    *
-   * Sets OpenSearch/Elasticsearch settings (es admin only - set in config with <a href="settings#esadminusers">esAdminUsers</a>).
+   * Sets OpenSearch/Elasticsearch settings (requires the dbAdmin role).
    * @name /esadmin/set
    * @returns {boolean} success - Whether saving the settings was successful.
    * @returns {string} text - The success/error message to (optionally) display to the user.
@@ -1259,7 +1259,7 @@ class StatsAPIs {
   /**
    * POST - /api/esadmin/reroute
    *
-   * Try to restart any shard migrations that have failed or paused (es admin only - set in config with <a href="settings#esadminusers">esAdminUsers</a>).
+   * Try to restart any shard migrations that have failed or paused (requires the dbAdmin role).
    * @name /esadmin/reroute
    * @returns {boolean} success - Whether the reroute was successful.
    * @returns {string} text - The success/error message to (optionally) display to the user.
@@ -1277,7 +1277,7 @@ class StatsAPIs {
   /**
    * POST - /api/esadmin/flush
    *
-   * Flush and refresh any data waiting in OpenSearch/Elasticsearch to disk (es admin only - set in config with <a href="settings#esadminusers">esAdminUsers</a>).
+   * Flush and refresh any data waiting in OpenSearch/Elasticsearch to disk (requires the dbAdmin role).
    * @name /esadmin/flush
    * @returns {boolean} success - Always true
    * @returns {string} text - The success message to (optionally) display to the user.
@@ -1296,7 +1296,7 @@ class StatsAPIs {
   /**
    * POST - /api/esadmin/unflood
    *
-   * Try and clear any indices marked as flooded (es admin only - set in config with <a href="settings#esadminusers">esAdminUsers</a>).
+   * Try and clear any indices marked as flooded (requires the dbAdmin role).
    * @name /esadmin/unflood
    * @returns {boolean} success - Always true
    * @returns {string} text - The success message to (optionally) display to the user.
@@ -1315,7 +1315,7 @@ class StatsAPIs {
   /**
    * POST - /api/esadmin/clearcache
    *
-   * Try and clear the cache for all indices (es admin only - set in config with <a href="settings#esadminusers">esAdminUsers</a>).
+   * Try and clear the cache for all indices (requires the dbAdmin role).
    * @name /esadmin/clearcache
    * @returns {boolean} success - Whether clearing the cache was successful.
    * @returns {string} text - The success/error message to (optionally) display to the user.
@@ -1339,7 +1339,7 @@ class StatsAPIs {
   /**
    * GET - /api/esadmin/allocation
    *
-   * Provides an explanation for shard allocation in the cluster (es admin only - set in config with <a href="settings#esadminusers">esAdminUsers</a>).
+   * Provides an explanation for shard allocation in the cluster (requires the dbAdmin role).
    * Returns details about why shards are assigned or unassigned.
    * @name /esadmin/allocation
    * @param {string} index - Optional specific index name to explain

--- a/viewer/apiUsers.js
+++ b/viewer/apiUsers.js
@@ -49,15 +49,7 @@ class UserAPIs {
   static getCurrentUserCB (user, clone) {
     clone.canUpload = internals.allowUploads && user.hasRole(internals.uploadRoles);
 
-    // dbAdmin always grants es admin access; otherwise if esAdminUsers is set use
-    // that, else fall back to arkimeAdmin privilege
-    if (user.hasRole('dbAdmin')) {
-      clone.esAdminUser = true;
-    } else if (internals.esAdminUsersSet) {
-      clone.esAdminUser = internals.esAdminUsers.includes(user.userId);
-    } else {
-      clone.esAdminUser = user.hasRole('arkimeAdmin');
-    }
+    clone.esAdminUser = user.hasRole('dbAdmin');
 
     // If no settings, use defaults
     if (clone.settings === undefined) { clone.settings = internals.settingDefaults; }

--- a/viewer/apiUsers.js
+++ b/viewer/apiUsers.js
@@ -49,8 +49,6 @@ class UserAPIs {
   static getCurrentUserCB (user, clone) {
     clone.canUpload = internals.allowUploads && user.hasRole(internals.uploadRoles);
 
-    clone.esAdminUser = user.hasRole('dbAdmin');
-
     // If no settings, use defaults
     if (clone.settings === undefined) { clone.settings = internals.settingDefaults; }
 

--- a/viewer/internals.js
+++ b/viewer/internals.js
@@ -94,10 +94,8 @@ ArkimeConfig.loaded(() => {
   internals.esQueryTimeout = Config.get('elasticsearchTimeout', 5 * 60) + 's';
   internals.esScrollTimeout = Config.get('elasticsearchScrollTimeout', 5 * 60) + 's';
   internals.userNameHeader = Config.get('userNameHeader');
-  internals.esAdminUsersSet = Config.get('esAdminUsers', false) !== false;
-  internals.esAdminUsers = Config.getArray('esAdminUsers', '');
-  if (internals.esAdminUsersSet) {
-    console.log('WARNING - the esAdminUsers setting is deprecated and will be removed in Arkime 7, assign the dbAdmin role to those users instead');
+  if (Config.get('esAdminUsers', false) !== false) {
+    console.log('WARNING - the esAdminUsers setting has been removed, assign the dbAdmin role to those users instead');
   }
   internals.httpsAgent = new https.Agent({ keepAlive: true, keepAliveMsecs: 20000, maxSockets: 50, maxFreeSockets: 25, rejectUnauthorized: !ArkimeConfig.insecure });
   internals.isLocalViewRegExp = Config.get('isLocalViewRegExp') ? new RE2(Config.get('isLocalViewRegExp')) : undefined;

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -637,19 +637,12 @@ async function checkHuntAccess (req, res, next) {
   }
 }
 
-function checkEsAdminUser (req, res, next) {
+// dbAdmin (and superAdmin, which includes it) may administer the database
+function checkDbAdmin (req, res, next) {
   if (req.user.hasRole('dbAdmin')) {
     return next();
   }
-  if (internals.esAdminUsersSet) {
-    if (internals.esAdminUsers.includes(req.user.userId)) {
-      return next();
-    }
-  } else {
-    if (req.user.hasRole('arkimeAdmin')) {
-      return next();
-    }
-  }
+  console.log(`Permission denied to ${req.user.userId} while requesting resource: ${req._parsedUrl.pathname}, using role dbAdmin`);
   return res.serverError(403, 'You do not have permission to access this resource', 'api.viewer.noPermission');
 }
 
@@ -1677,31 +1670,31 @@ app.get( // OpenSearch/Elasticsearch indices endpoint
 
 app.delete( // delete OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, User.checkAnyRole(['arkimeAdmin', 'dbAdmin']), User.checkPermissions(['removeEnabled']), setCookie],
+  [ArkimeUtil.noCacheJson, recordResponseTime, checkDbAdmin, User.checkPermissions(['removeEnabled']), setCookie],
   StatsAPIs.deleteESIndex
 );
 
 app.post( // optimize OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index/optimize'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.optimizeESIndex
 );
 
 app.post( // close OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index/close'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.closeESIndex
 );
 
 app.post( // open OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index/open'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.openESIndex
 );
 
 app.post( // shrink OpenSearch/Elasticsearch index endpoint
   ['/api/esindices/:index/shrink'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.shrinkESIndex
 );
 
@@ -1713,7 +1706,7 @@ app.get( // OpenSearch/Elasticsearch tasks endpoint
 
 app.post( // cancel OpenSearch/Elasticsearch task endpoint
   ['/api/estasks/:id/cancel'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.cancelESTask
 );
 
@@ -1726,49 +1719,49 @@ app.post( // cancel OpenSearch/Elasticsearch task by opaque id endpoint
 
 app.post( // cancel all OpenSearch/Elasticsearch tasks endpoint
   ['/api/estasks/cancelall'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.cancelAllESTasks
 );
 
 app.get( // OpenSearch/Elasticsearch admin settings endpoint
   ['/api/esadmin'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, checkEsAdminUser, setCookie],
+  [ArkimeUtil.noCacheJson, recordResponseTime, checkDbAdmin, setCookie],
   StatsAPIs.getESAdminSettings
 );
 
 app.post( // set OpenSearch/Elasticsearch admin setting endpoint
   ['/api/esadmin/set'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, checkEsAdminUser, checkCookieToken],
+  [ArkimeUtil.noCacheJson, recordResponseTime, checkDbAdmin, checkCookieToken],
   StatsAPIs.setESAdminSettings
 );
 
 app.post( // reroute OpenSearch/Elasticsearch admin endpoint
   ['/api/esadmin/reroute'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, checkEsAdminUser, checkCookieToken],
+  [ArkimeUtil.noCacheJson, recordResponseTime, checkDbAdmin, checkCookieToken],
   StatsAPIs.rerouteES
 );
 
 app.post( // flush OpenSearch/Elasticsearch admin endpoint
   ['/api/esadmin/flush'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, checkEsAdminUser, checkCookieToken],
+  [ArkimeUtil.noCacheJson, recordResponseTime, checkDbAdmin, checkCookieToken],
   StatsAPIs.flushES
 );
 
 app.post( // unflood OpenSearch/Elasticsearch admin endpoint
   ['/api/esadmin/unflood'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, checkEsAdminUser, checkCookieToken],
+  [ArkimeUtil.noCacheJson, recordResponseTime, checkDbAdmin, checkCookieToken],
   StatsAPIs.unfloodES
 );
 
 app.post( // clear cache OpenSearch/Elasticsearch admin endpoint
   ['/api/esadmin/clearcache'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, checkEsAdminUser, checkCookieToken],
+  [ArkimeUtil.noCacheJson, recordResponseTime, checkDbAdmin, checkCookieToken],
   StatsAPIs.clearCacheES
 );
 
 app.get( // OpenSearch/Elasticsearch allocation explain endpoint
   ['/api/esadmin/allocation'],
-  [ArkimeUtil.noCacheJson, recordResponseTime, checkEsAdminUser, setCookie],
+  [ArkimeUtil.noCacheJson, recordResponseTime, checkDbAdmin, setCookie],
   StatsAPIs.getAllocationExplain
 );
 
@@ -1780,19 +1773,19 @@ app.get( // OpenSearch/Elasticsearch shards endpoint
 
 app.post( // exclude OpenSearch/Elasticsearch shard endpoint
   ['/api/esshards/:type/:value/exclude'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.excludeESShard
 );
 
 app.post( // include OpenSearch/Elasticsearch shard endpoint
   ['/api/esshards/:type/:value/include'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.includeESShard
 );
 
 app.post( // delete OpenSearch/Elasticsearch shard endpoint
   ['/api/esshards/:index/:shard/delete'],
-  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, User.checkAnyRole(['arkimeAdmin', 'dbAdmin'])],
+  [ArkimeUtil.noCacheJson, logAction(), checkCookieToken, checkDbAdmin],
   StatsAPIs.deleteESShard
 );
 

--- a/viewer/vueapp/src/components/help/Help.vue
+++ b/viewer/vueapp/src/components/help/Help.vue
@@ -1293,7 +1293,7 @@ SPDX-License-Identifier: Apache-2.0
           <dt>wiseUser</dt>
           <dd>Can use the WISE UI to do queries and view stats</dd>
           <dt>dbAdmin</dt>
-          <dd>Can use the ES/DB admin page and the ES index, shard, and task actions.</dd>
+          <dd>Can use the ES/DB admin page and the ES index, shard, and task actions. Pair it with arkimeUser, which the viewer requires to let anyone in at all.</dd>
         </dl>
 
         <p>

--- a/viewer/vueapp/src/components/help/Help.vue
+++ b/viewer/vueapp/src/components/help/Help.vue
@@ -1293,7 +1293,7 @@ SPDX-License-Identifier: Apache-2.0
           <dt>wiseUser</dt>
           <dd>Can use the WISE UI to do queries and view stats</dd>
           <dt>dbAdmin</dt>
-          <dd>Can perform database administration tasks.</dd>
+          <dd>Can use the ES/DB admin page and the ES index, shard, and task actions.</dd>
         </dl>
 
         <p>

--- a/viewer/vueapp/src/components/stats/EsIndices.vue
+++ b/viewer/vueapp/src/components/stats/EsIndices.vue
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         table-widths-state-name="esIndicesColWidths"
         table-classes="text-end small mt-2">
         <template #actions="item">
-          <span v-if="isDbAdmin">
+          <span v-has-role="{user:user,roles:'dbAdmin'}">
             <v-menu>
               <template #activator="{ props: activatorProps }">
                 <v-btn
@@ -151,9 +151,6 @@ export default {
     };
   },
   computed: {
-    isDbAdmin () {
-      return this.user?.roles?.includes('dbAdmin');
-    },
     columns: function () {
       const $t = this.$t.bind(this);
       function intl(obj) {

--- a/viewer/vueapp/src/components/stats/EsIndices.vue
+++ b/viewer/vueapp/src/components/stats/EsIndices.vue
@@ -35,9 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         table-widths-state-name="esIndicesColWidths"
         table-classes="text-end small mt-2">
         <template #actions="item">
-          <span
-            v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}"
-            v-has-permission="'removeEnabled'">
+          <span v-if="user?.esAdminUser">
             <v-menu>
               <template #activator="{ props: activatorProps }">
                 <v-btn
@@ -51,7 +49,9 @@ SPDX-License-Identifier: Apache-2.0
                 </v-btn>
               </template>
               <v-list density="compact">
-                <v-list-item @click.stop.prevent="confirmDeleteIndex(item.item.index)">
+                <v-list-item
+                  v-if="user?.removeEnabled"
+                  @click.stop.prevent="confirmDeleteIndex(item.item.index)">
                   {{ $t('stats.esIndices.deleteIndex') }} {{ item.item.index }}
                 </v-list-item>
                 <v-list-item @click="optimizeIndex(item.item.index)">

--- a/viewer/vueapp/src/components/stats/EsIndices.vue
+++ b/viewer/vueapp/src/components/stats/EsIndices.vue
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
         table-widths-state-name="esIndicesColWidths"
         table-classes="text-end small mt-2">
         <template #actions="item">
-          <span v-if="user?.esAdminUser">
+          <span v-if="isDbAdmin">
             <v-menu>
               <template #activator="{ props: activatorProps }">
                 <v-btn
@@ -151,6 +151,9 @@ export default {
     };
   },
   computed: {
+    isDbAdmin () {
+      return this.user?.roles?.includes('dbAdmin');
+    },
     columns: function () {
       const $t = this.$t.bind(this);
       function intl(obj) {

--- a/viewer/vueapp/src/components/stats/EsNodes.vue
+++ b/viewer/vueapp/src/components/stats/EsNodes.vue
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
         table-classes="text-end small mt-2">
         <template #actions="item">
           <span class="no-wrap">
-            <span v-if="user?.esAdminUser">
+            <span v-if="isDbAdmin">
               <v-menu>
                 <template #activator="{ props: activatorProps }">
                   <v-btn
@@ -201,6 +201,9 @@ export default {
     };
   },
   computed: {
+    isDbAdmin () {
+      return this.user?.roles?.includes('dbAdmin');
+    },
     columns: function () {
       const $t = this.$t.bind(this);
       function intl(obj) {

--- a/viewer/vueapp/src/components/stats/EsNodes.vue
+++ b/viewer/vueapp/src/components/stats/EsNodes.vue
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
         table-classes="text-end small mt-2">
         <template #actions="item">
           <span class="no-wrap">
-            <span v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}">
+            <span v-if="user?.esAdminUser">
               <v-menu>
                 <template #activator="{ props: activatorProps }">
                   <v-btn

--- a/viewer/vueapp/src/components/stats/EsNodes.vue
+++ b/viewer/vueapp/src/components/stats/EsNodes.vue
@@ -48,7 +48,7 @@ SPDX-License-Identifier: Apache-2.0
         table-classes="text-end small mt-2">
         <template #actions="item">
           <span class="no-wrap">
-            <span v-if="isDbAdmin">
+            <span v-has-role="{user:user,roles:'dbAdmin'}">
               <v-menu>
                 <template #activator="{ props: activatorProps }">
                   <v-btn
@@ -201,9 +201,6 @@ export default {
     };
   },
   computed: {
-    isDbAdmin () {
-      return this.user?.roles?.includes('dbAdmin');
-    },
     columns: function () {
       const $t = this.$t.bind(this);
       function intl(obj) {

--- a/viewer/vueapp/src/components/stats/EsShards.vue
+++ b/viewer/vueapp/src/components/stats/EsShards.vue
@@ -44,9 +44,7 @@ SPDX-License-Identifier: Apache-2.0
               :width="column.width">
               <div>
                 <!-- column dropdown menu -->
-                <span
-                  v-if="column.hasDropdown"
-                  v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}">
+                <span v-if="column.hasDropdown && user?.esAdminUser">
                   <v-menu location="bottom end">
                     <template #activator="{ props: activatorProps }">
                       <v-btn
@@ -106,9 +104,7 @@ SPDX-License-Identifier: Apache-2.0
             v-for="(stat, index) in stats.indices"
             :key="stat.name">
             <td>
-              <span
-                v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}"
-                v-if="stat.nodes && stat.nodes.Unassigned && stat.nodes.Unassigned.length">
+              <span v-if="user?.esAdminUser && stat.nodes?.Unassigned?.length">
                 <transition name="buttons">
                   <v-btn
                     v-if="!stat.confirmDelete"
@@ -165,7 +161,7 @@ SPDX-License-Identifier: Apache-2.0
                     <span
                       v-if="item.showDetails"
                       class="shard-detail"
-                      :class="{'shard-detail-interactive': node === 'Unassigned' && user.esAdminUser}"
+                      :class="{'shard-detail-interactive': node === 'Unassigned' && user?.esAdminUser}"
                       @mouseenter="keepTooltipOpen(item)"
                       @mouseleave="scheduleTooltipClose(item)">
                       <dl class="dl-horizontal">
@@ -219,7 +215,7 @@ SPDX-License-Identifier: Apache-2.0
                       </dl>
                       <!-- Explain allocation button for unassigned shards (ES Admin only) -->
                       <div
-                        v-if="node === 'Unassigned' && user.esAdminUser"
+                        v-if="node === 'Unassigned' && user?.esAdminUser"
                         class="mt-2 pt-2"
                         style="border-top: 1px solid #555;">
                         <v-btn

--- a/viewer/vueapp/src/components/stats/EsShards.vue
+++ b/viewer/vueapp/src/components/stats/EsShards.vue
@@ -354,7 +354,7 @@ export default {
     };
   },
   computed: {
-    isDbAdmin () {
+    isDbAdmin () { // v-has-role can't feed the shard-detail-interactive class binding
       return this.user?.roles?.includes('dbAdmin');
     },
     loading: {

--- a/viewer/vueapp/src/components/stats/EsShards.vue
+++ b/viewer/vueapp/src/components/stats/EsShards.vue
@@ -44,7 +44,7 @@ SPDX-License-Identifier: Apache-2.0
               :width="column.width">
               <div>
                 <!-- column dropdown menu -->
-                <span v-if="column.hasDropdown && user?.esAdminUser">
+                <span v-if="column.hasDropdown && isDbAdmin">
                   <v-menu location="bottom end">
                     <template #activator="{ props: activatorProps }">
                       <v-btn
@@ -104,7 +104,7 @@ SPDX-License-Identifier: Apache-2.0
             v-for="(stat, index) in stats.indices"
             :key="stat.name">
             <td>
-              <span v-if="user?.esAdminUser && stat.nodes?.Unassigned?.length">
+              <span v-if="isDbAdmin && stat.nodes?.Unassigned?.length">
                 <transition name="buttons">
                   <v-btn
                     v-if="!stat.confirmDelete"
@@ -161,7 +161,7 @@ SPDX-License-Identifier: Apache-2.0
                     <span
                       v-if="item.showDetails"
                       class="shard-detail"
-                      :class="{'shard-detail-interactive': node === 'Unassigned' && user?.esAdminUser}"
+                      :class="{'shard-detail-interactive': node === 'Unassigned' && isDbAdmin}"
                       @mouseenter="keepTooltipOpen(item)"
                       @mouseleave="scheduleTooltipClose(item)">
                       <dl class="dl-horizontal">
@@ -215,7 +215,7 @@ SPDX-License-Identifier: Apache-2.0
                       </dl>
                       <!-- Explain allocation button for unassigned shards (ES Admin only) -->
                       <div
-                        v-if="node === 'Unassigned' && user?.esAdminUser"
+                        v-if="node === 'Unassigned' && isDbAdmin"
                         class="mt-2 pt-2"
                         style="border-top: 1px solid #555;">
                         <v-btn
@@ -354,6 +354,9 @@ export default {
     };
   },
   computed: {
+    isDbAdmin () {
+      return this.user?.roles?.includes('dbAdmin');
+    },
     loading: {
       get: function () {
         return this.$store.state.loadingData;

--- a/viewer/vueapp/src/components/stats/EsTasks.vue
+++ b/viewer/vueapp/src/components/stats/EsTasks.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <div v-show="!error">
       <v-btn
-        v-if="user?.esAdminUser"
+        v-if="isDbAdmin"
         id="cancelAllTasks"
         color="warning"
         variant="flat"
@@ -52,7 +52,7 @@ SPDX-License-Identifier: Apache-2.0
         table-classes="text-end small mt-2">
         <template #actions="item">
           <v-btn
-            v-if="item.item.cancellable && user?.esAdminUser"
+            v-if="item.item.cancellable && isDbAdmin"
             color="error"
             variant="flat"
             size="small"
@@ -134,6 +134,9 @@ export default {
     };
   },
   computed: {
+    isDbAdmin () {
+      return this.user?.roles?.includes('dbAdmin');
+    },
     columns: function () {
       const $t = this.$t.bind(this);
       function intl(obj) {

--- a/viewer/vueapp/src/components/stats/EsTasks.vue
+++ b/viewer/vueapp/src/components/stats/EsTasks.vue
@@ -12,13 +12,13 @@ SPDX-License-Identifier: Apache-2.0
 
     <div v-show="!error">
       <v-btn
-        v-if="isDbAdmin"
         id="cancelAllTasks"
         color="warning"
         variant="flat"
         size="small"
         density="comfortable"
         class="float-right"
+        v-has-role="{user:user,roles:'dbAdmin'}"
         @click="cancelTasks">
         <v-icon
           icon="mdi-cancel"
@@ -52,12 +52,13 @@ SPDX-License-Identifier: Apache-2.0
         table-classes="text-end small mt-2">
         <template #actions="item">
           <v-btn
-            v-if="item.item.cancellable && isDbAdmin"
+            v-if="item.item.cancellable"
             color="error"
             variant="flat"
             size="small"
             density="comfortable"
             icon
+            v-has-role="{user:user,roles:'dbAdmin'}"
             @click="cancelTask(item.item.taskId)">
             <v-icon icon="mdi-trash-can-outline" />
           </v-btn>
@@ -134,9 +135,6 @@ export default {
     };
   },
   computed: {
-    isDbAdmin () {
-      return this.user?.roles?.includes('dbAdmin');
-    },
     columns: function () {
       const $t = this.$t.bind(this);
       function intl(obj) {

--- a/viewer/vueapp/src/components/stats/EsTasks.vue
+++ b/viewer/vueapp/src/components/stats/EsTasks.vue
@@ -12,13 +12,13 @@ SPDX-License-Identifier: Apache-2.0
 
     <div v-show="!error">
       <v-btn
+        v-if="user?.esAdminUser"
         id="cancelAllTasks"
         color="warning"
         variant="flat"
         size="small"
         density="comfortable"
         class="float-right"
-        v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}"
         @click="cancelTasks">
         <v-icon
           icon="mdi-cancel"
@@ -52,13 +52,12 @@ SPDX-License-Identifier: Apache-2.0
         table-classes="text-end small mt-2">
         <template #actions="item">
           <v-btn
-            v-if="item.item.cancellable"
+            v-if="item.item.cancellable && user?.esAdminUser"
             color="error"
             variant="flat"
             size="small"
             density="comfortable"
             icon
-            v-has-role="{user:user,roles:'arkimeAdmin,dbAdmin'}"
             @click="cancelTask(item.item.taskId)">
             <v-icon icon="mdi-trash-can-outline" />
           </v-btn>

--- a/viewer/vueapp/src/components/stats/Stats.vue
+++ b/viewer/vueapp/src/components/stats/Stats.vue
@@ -767,7 +767,7 @@ export default {
     };
   },
   computed: {
-    isDbAdmin () {
+    isDbAdmin () { // v-has-role only adds d-none, es-admin would still mount and fetch
       return this.user?.roles?.includes('dbAdmin');
     },
     user: function () {

--- a/viewer/vueapp/src/components/stats/Stats.vue
+++ b/viewer/vueapp/src/components/stats/Stats.vue
@@ -603,7 +603,7 @@ SPDX-License-Identifier: Apache-2.0
               {{ $t('stats.nav.esRecovery') }}
             </v-btn>
             <v-btn
-              v-if="user.esAdminUser"
+              v-if="isDbAdmin"
               :value="7">
               <v-icon
                 start
@@ -682,7 +682,7 @@ SPDX-License-Identifier: Apache-2.0
           :user="user"
           :cluster="cluster" />
         <es-admin
-          v-else-if="tabIndex === 7 && user.esAdminUser"
+          v-else-if="tabIndex === 7 && isDbAdmin"
           :data-interval="dataInterval"
           :refresh-data="refreshData"
           :user="user"
@@ -767,6 +767,9 @@ export default {
     };
   },
   computed: {
+    isDbAdmin () {
+      return this.user?.roles?.includes('dbAdmin');
+    },
     user: function () {
       return this.$store.state.user;
     },

--- a/viewer/vueapp/src/components/stats/StatsService.js
+++ b/viewer/vueapp/src/components/stats/StatsService.js
@@ -300,7 +300,7 @@ export default {
    * @returns {Promise<Object>} The response data parsed as JSON.
    */
   async cancelAllTasks (params) {
-    return fetchWrapper({ url: 'api/estasks/cancel', method: 'POST', params });
+    return fetchWrapper({ url: 'api/estasks/cancelall', method: 'POST', params });
   },
 
   /**


### PR DESCRIPTION
Closes #4080.

The `dbAdmin` role and the ES stats action menus already landed in 6.7.0 via #4129 and #4130, but the gating ended up split three ways: the action endpoints used `User.checkAnyRole(['arkimeAdmin','dbAdmin'])`, the ES admin endpoints used `checkEsAdminUser` (`dbAdmin` → else the deprecated `esAdminUsers` list → else `arkimeAdmin`), and the UI mixed `v-has-role` with the server-computed `user.esAdminUser` flag. Those disagreed with each other — with `esAdminUsers=` set an `arkimeAdmin` kept the action menus but lost the ES Admin tab, and a user only in the list got the tab but not the menus.

This collapses it to one gate for v7: the `dbAdmin` role.

## Breaking

`arkimeAdmin` alone no longer grants ES admin or the ES index/shard/task actions, and `esAdminUsers` is gone (viewer warns at startup if it is still in the config). `superAdmin` includes `dbAdmin`, so superadmins are unaffected, as is `authMode=anonymous` (that user is `superAdmin`).

```
db.pl <host:port> users-update '<userId glob>' --addRole dbAdmin
```

## Changes

**Server** — new `checkDbAdmin` in `viewer.js` on all 17 ES admin/action routes, replacing both previous gates. It keeps the `api.viewer.noPermission` i18n key that `checkAnyRole` doesn't have, and logs the denial like `checkAnyRole` did. Read-only endpoints (`esstats`, `esindices`, `estasks`, `esshards`, `esrecovery`) stay on `hideStats`; `/api/estasks/:id/cancelwith` stays ungated since it is namespaced per user. `clone.esAdminUser` is now just `user.hasRole('dbAdmin')`.

`User.checkAnyRole` is deliberately left in `common/user.js` unused — `main` still calls it, and removing it here would conflict on the next `main` → `dev7` merge.

**Frontend** — the four ES stats components move from `v-has-role` to `v-if="user?.esAdminUser"`, so there is one flag and it reacts to role changes instead of being evaluated once at `beforeMount` against the `d-none` class.

**Two fixes picked up along the way**

- `EsIndices.vue` had `removeEnabled` on the actions *wrapper*, hiding optimize/close/open/shrink from anyone without it. #4130 fixed this on `main`, but the fix was lost when `main` merged into `dev7` (`1a8c0d9b5`) and the Vuetify markup won the conflict. The gate is back on the delete item only, matching the backend, where only the DELETE route carries `checkPermissions(['removeEnabled'])`.
- `StatsService.cancelAllTasks` posted to `api/estasks/cancel`, which is not a route — the ES Tasks "Cancel All" button has 404ed since 6.0.0 (`6195b6aa8`, #2970). Happy to split this out if you would rather it not ride along.

## Tests

`esAdminUsers` is out of `config.test.ini`. The default regression identity is `anonymous`, not `admin`, so `dbAdmin` was added to the two regression fixtures (`User.#makeRegressionUser` and the s2s fake in `auth.js`) or every existing ES action assertion would 403; three `api-users.t` role-list assertions follow from that.

`api-esadmin.t` now creates a `dbAdmin` user and an `arkimeAdmin` user (only a superAdmin may assign admin roles) and pins the new behaviour with arkimeAdmin-denied cases on `/api/esadmin`, `/api/esindices/:index/optimize`, `/api/esshards/:type/:value/exclude` and `/api/estasks/cancelall`, plus a dbAdmin-allowed optimize. 66 → 77 assertions. The four `api-stats.t` esshards denial assertions gained the i18n key.

## Not run

Draft because `npm run lint` and `./tests.pl --viewer` have not been run yet, and the gating still needs a browser pass: as an `arkimeAdmin`-only user the ES Admin tab and all four action menus should disappear; adding `dbAdmin` restores them; and a `dbAdmin` without `removeEnabled` should still see optimize/close/open/shrink with no delete item.

## Out of scope

The #4081 navbar Admin menu and `/esadmin` route.

Noticed while in here, each wants its own issue: `DELETE /api/esindices/:index` has neither `checkCookieToken` nor `logAction()`, unlike every sibling mutation route, and the `/api/esadmin/*` mutations use `recordResponseTime` instead of `logAction()`, so cluster-setting changes never reach history.