### PR TITLE
Packet portal fixes: TOFU pin after auth, portal-route remaining node…

### DIFF
--- a/common/auth.js
+++ b/common/auth.js
@@ -1306,7 +1306,8 @@ class Auth {
 
       return JSON.parse(decrypted);
     } catch (error) {
-      console.log(error);
+      // debug only, an unauthenticated peer can trigger this at will
+      if (ArkimeConfig.debug > 0) { console.log(error); }
       throw new Error('Incorrect auth supplied');
     }
   }
@@ -1346,7 +1347,8 @@ class Auth {
       d += c.final('utf8');
       return JSON.parse(d);
     } catch (error) {
-      console.log(error);
+      // debug only, an unauthenticated peer can trigger this at will
+      if (ArkimeConfig.debug > 0) { console.log(error); }
       throw new Error('Incorrect auth supplied');
     }
   }

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -498,19 +498,33 @@ class CronAPIs {
           await internals.sendSessionQueue.push(options);
         }
       } else {
-        // Send from remote node
-        const { viewUrl, client } = await ViewerUtils.getViewUrl(node);
+        // Send from remote node, over its packet portal when it has one -- a
+        // portal node cannot be dialed directly
+        let viewUrl, client, reqOptions;
+        try {
+          const portal = await ViewerUtils.portalRequest(node);
+          if (portal) {
+            ({ viewUrl, client } = portal);
+            reqOptions = { method: 'POST', ...portal.options };
+          } else {
+            ({ viewUrl, client } = await ViewerUtils.getViewUrl(node));
+            reqOptions = {
+              method: 'POST',
+              agent: client === http ? internals.httpAgent : internals.httpsAgent
+            };
+            ViewerUtils.addCaTrust(reqOptions, node);
+          }
+        } catch (err) {
+          console.log("ERROR - Couldn't reach node for sendSession node=", node, '\nerror=', err);
+          return;
+        }
+
         let sendPath = `api/sessions/${node}/send?saveId=${pOptions.saveId}&remoteCluster=${pOptions.cluster}`;
         if (pOptions.tags) { sendPath += `&tags=${pOptions.tags}`; }
         const url = new URL(sendPath, viewUrl);
-        const reqOptions = {
-          method: 'POST',
-          agent: client === http ? internals.httpAgent : internals.httpsAgent
-        };
 
         // Sign the path exactly as the remote node will see it in req.url
         Auth.addS2SAuth(reqOptions, pOptions.user, node, url.pathname + (url.search ?? ''));
-        ViewerUtils.addCaTrust(reqOptions, node);
 
         await new Promise((resolve) => {
           const preq = client.request(url, reqOptions, (pres) => {

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -787,7 +787,10 @@ class SessionAPIs {
       } else {
         // Get from remote DISK
         try {
-          let result = req.arkimeWriterOptions.nodes.get(fields.node);
+          // A node with a live packet portal cannot be dialed directly, so go
+          // over the portal. Not cached: the portal session must be current.
+          const portal = await ViewerUtils.portalRequest(fields.node);
+          let result = portal ?? req.arkimeWriterOptions.nodes.get(fields.node);
           if (!result) {
             result = await ViewerUtils.getViewUrl(fields.node);
             req.arkimeWriterOptions.nodes.set(fields.node, result);
@@ -807,7 +810,11 @@ class SessionAPIs {
           } else {
             options = {};
           }
-          options.agent = client === http ? internals.httpAgent : internals.httpsAgent;
+          if (portal) {
+            Object.assign(options, portal.options);
+          } else {
+            options.agent = client === http ? internals.httpAgent : internals.httpsAgent;
+          }
 
           let url;
           if (sessionPath.startsWith('/')) {
@@ -817,7 +824,7 @@ class SessionAPIs {
           }
 
           Auth.addS2SAuth(options, req.user, fields.node, url.pathname, ViewerUtils.getClusterSecret(req.query.cluster));
-          options.ca = ca;
+          if (!portal) { options.ca = ca; }
 
           await new Promise((resolve) => {
             const chunks = [];

--- a/viewer/packetPortal.js
+++ b/viewer/packetPortal.js
@@ -50,6 +50,15 @@ const ArkimeConfig = require('../common/arkimeConfig');
 const PORTAL_PATH = '/packetPortal';
 const UPGRADE_TOKEN = 'arkime-portal';
 const REQUEST_TIMEOUT = 20 * 60 * 1000;
+const HANDSHAKE_TIMEOUT = 30 * 1000;
+const PING_INTERVAL = 30 * 1000;
+// h2 flow control receive windows. The per stream window caps how much any one
+// transfer can have in flight, so a big pcap download cannot hog the portal;
+// the session window is the pool all streams share, sized so ~8 streams can
+// run at full per stream rate before anyone waits on it. Node's 64KB defaults
+// would otherwise cap the whole portal at ~64KB per round trip.
+const STREAM_WINDOW = 128 * 1024;
+const SESSION_WINDOW = 1024 * 1024;
 
 // ----------------------------------------------------------------------------
 /**
@@ -217,10 +226,12 @@ class PacketPortal {
     PacketPortal.#innerServer.setTimeout(REQUEST_TIMEOUT);
 
     // DIALER h2 server: each inbound stream is one HTTP/1.1 request.
-    PacketPortal.#dialerH2Server = http2.createServer();
+    PacketPortal.#dialerH2Server = http2.createServer({ settings: { initialWindowSize: STREAM_WINDOW } });
     PacketPortal.#dialerH2Server.on('stream', PacketPortal.#onDialerStream);
     PacketPortal.#dialerH2Server.on('session', (session) => {
       session.on('error', (e) => console.log('packetPortal: dialer session error', e.message));
+      PacketPortal.#setSessionWindow(session);
+      PacketPortal.#watchAcceptorLiveness(session);
     });
 
     for (const target of Config.getArray('packetPortalConnect', '')) {
@@ -242,10 +253,16 @@ class PacketPortal {
       if (typeof entry.ip === 'string') {
         entry.ip = entry.ip.split(',').map(s => s.trim()).filter(s => s.length > 0);
       }
+      // 'ip:' with nothing after it, or a bare 'ip' flag (which parses to true),
+      // must not survive as an unmatchable list -- #checkNode would then reject
+      // the node on source ip forever, even with a correct pass.
+      if (!Array.isArray(entry.ip) || entry.ip.length === 0) { delete entry.ip; }
+      // A bare 'pass' flag parses to true, which is not a password
+      if (!ArkimeUtil.isString(entry.pass)) { delete entry.pass; }
       // An entry with neither is no better than no entry at all -- it would fall
       // through to trust on first use, silently, for a node the admin believes
       // they configured. Drop it so it is rejected instead.
-      if (entry.pass === undefined && (entry.ip === undefined || entry.ip.length === 0)) {
+      if (entry.pass === undefined && entry.ip === undefined) {
         console.log(`WARNING - packetPortal: ignoring node '${ArkimeUtil.sanitizeStr(nodeName)}', it has no pass or ip; it will not be allowed to open a portal`);
         continue;
       }
@@ -313,11 +330,19 @@ class PacketPortal {
 
     server.setTimeout(REQUEST_TIMEOUT);
     server.on('upgrade', (req, socket, head) => PacketPortal.handleUpgrade(req, socket, head));
+    let listening = false;
     server.on('error', (e) => {
+      // Fatal only at startup. Once listening, a runtime error (EMFILE during
+      // an accept, say) must not take the whole viewer down with it.
+      if (listening) {
+        console.log('packetPortal: portal listener error -', e.message);
+        return;
+      }
       console.log(`packetPortal: cannot listen for portals on ${host ?? '*'}:${port} -`, e.message);
       process.exit(1);
     });
     server.on('listening', () => {
+      listening = true;
       console.log(`packetPortal: listening for inbound portals on ${host ?? '*'} port ${port}`);
     });
     server.listen({ port, host });
@@ -489,6 +514,9 @@ class PacketPortal {
       return;
     }
 
+    // Fully authenticated -- now it is safe to record a trust-on-first-use pin
+    PacketPortal.#pinNode(node, req);
+
     socket.setTimeout(0);
     if (head && head.length > 0) { socket.unshift(head); }
 
@@ -506,8 +534,12 @@ class PacketPortal {
   // ACCEPTOR: 101 is on the wire, attach the h2 client session and register it.
   static #registerPortal (node, socket, req) {
     const session = http2.connect('http://arkime-portal.invalid', {
+      settings: { initialWindowSize: STREAM_WINDOW },
       createConnection: () => socket
     });
+    // pcap responses flow dialer -> acceptor, so this side's windows are the
+    // ones that govern download throughput
+    PacketPortal.#setSessionWindow(session);
     session.on('error', (e) => console.log(`packetPortal: client session error for ${node} -`, e.message));
     session.on('close', () => {
       const entry = PacketPortal.#portals.get(node);
@@ -591,18 +623,69 @@ class PacketPortal {
 
     if (authenticated) { return undefined; }
 
-    // Nothing configured for this node, so trust the source ip we first saw it
-    // on and require later portals to match (trust on first use). Weaker than a
-    // pass -- an attacker who gets in before the real node does wins the pin --
-    // but it keeps a no-config deployment from letting anyone claim any node.
+    // Nothing configured for this node, so trust on first use: require later
+    // portals to come from the source ip the first one did. Only the mismatch
+    // REJECTION lives here -- the pin itself is written in #pinNode, after the
+    // s2s token validates. Writing it here, before any auth, would let anyone
+    // with no serverSecret at all pin a node name to their own ip, locking the
+    // real node out (and grow #pinnedIps without bound).
     const pinned = PacketPortal.#pinnedIps.get(node);
-    if (pinned === undefined) {
-      PacketPortal.#pinnedIps.set(node, ip);
-      console.log(`packetPortal: pinning node '${node}' to source ip ${ip}; set a pass for it in [packetportal-nodes] to authenticate properly`);
-      return undefined;
-    }
-    if (pinned !== ip) { return `source ip ${ip} does not match pinned ${pinned}`; }
+    if (pinned !== undefined && pinned !== ip) { return `source ip ${ip} does not match pinned ${pinned}`; }
     return undefined;
+  }
+
+  // --------------------------------------------------------------------------
+  // ACCEPTOR: pin an unconfigured node to the source ip it first connected
+  // from. Called only once the peer's s2s token has validated. Weaker than a
+  // pass -- an attacker holding the serverSecret who gets in before the real
+  // node does wins the pin -- but it keeps a no-config deployment from letting
+  // any node claim any other.
+  static #pinNode (node, req) {
+    if (Object.hasOwn(PacketPortal.#nodes, node)) { return; } // authenticated by config, no pin
+    if (PacketPortal.#pinnedIps.has(node)) { return; }
+    const ip = PacketPortal.#peerIp(req);
+    if (ip === undefined) { return; }
+    PacketPortal.#pinnedIps.set(node, ip);
+    console.log(`packetPortal: pinning node '${node}' to source ip ${ip}; set a pass for it in [packetportal-nodes] to authenticate properly`);
+  }
+
+  // --------------------------------------------------------------------------
+  // Grow a session's shared connection receive window to SESSION_WINDOW.
+  // setLocalWindowSize throws before the session finishes connecting (and on a
+  // destroyed one), so defer or swallow as needed.
+  static #setSessionWindow (session) {
+    const grow = () => {
+      try { session.setLocalWindowSize(SESSION_WINDOW); } catch (e) { /* session already gone */ }
+    };
+    if (session.connecting) { session.once('connect', grow); } else { grow(); }
+  }
+
+  // --------------------------------------------------------------------------
+  // DIALER: the acceptor's keepalives are the only traffic on an idle portal,
+  // and nothing on this side notices if they stop -- a silently dead peer
+  // (machine crash, network partition, NAT rebind) would leave the dialer
+  // believing it is connected forever, never redialing. h2 PINGs are answered
+  // by any live peer regardless of how its keepalive is configured; one
+  // unanswered interval tears the session down, which closes the socket and
+  // triggers the dialer's reconnect.
+  static #watchAcceptorLiveness (session) {
+    let outstanding = false;
+    const timer = setInterval(() => {
+      if (session.destroyed) { clearInterval(timer); return; }
+      if (outstanding) {
+        console.log('packetPortal: acceptor stopped answering pings; closing portal');
+        session.destroy(new Error('ping timeout'));
+        return;
+      }
+      outstanding = true;
+      try {
+        session.ping(() => { outstanding = false; });
+      } catch (e) {
+        session.destroy();
+      }
+    }, PING_INTERVAL);
+    if (timer.unref) { timer.unref(); }
+    session.on('close', () => clearInterval(timer));
   }
 
   // --------------------------------------------------------------------------
@@ -761,6 +844,14 @@ class PacketPortal {
 
       let settled = false;
       const req = client.request(url, options);
+
+      // A blackholed acceptor (something accepts the TCP connection but never
+      // answers) would otherwise leave this request hanging forever, with no
+      // error and no retry. Idle timeout, so it cannot fire once the portal is
+      // up: the upgrade handler below disables the socket timeout.
+      req.setTimeout(HANDSHAKE_TIMEOUT, () => {
+        if (!settled) { req.destroy(new Error('handshake timeout')); }
+      });
 
       req.on('upgrade', (res, socket, head) => {
         settled = true;


### PR DESCRIPTION
… requests, liveness and flow control

- Record trust-on-first-use ip pin only after the s2s token validates, so an unauthenticated peer cannot pin-squat node names
- Route multi-session pcap downloads and cron sendSession over a node's packet portal instead of dialing NAT'd nodes directly
- Add 30s handshake timeout on the dialer's upgrade request so a blackholed acceptor reconnects instead of hanging forever
- Dialer pings its h2 session every 30s and tears down on no ack, so a silently dead acceptor triggers a redial
- Only exit on acceptor listener errors before listening; log runtime errors instead of killing the viewer
- Raise h2 flow control windows (128KB per stream, 1MB per session) so pcap transfers aren't capped at 64KB per RTT
- Treat empty ip: lists and bare ip/pass flags in [packetportal-nodes] as absent instead of rejecting or throwing
- Gate corrupt auth token logging behind debug, an unauthenticated peer can trigger it at will

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
