### PR TITLE
esProxy: allow the rootId session search download entire pcap needs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,6 +77,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4160 Add dbTimestamp field to search on when a session was written to the database (@timestamp); session detail shows it after the stop time
   - #4160 Fix date expression values ending in a timezone abbreviation (2026/07/27 09:33:05 UTC) generating an Invalid date ES query
   - #4163 Add Packet Portal (experimental), a second viewer-to-viewer transport where a NAT'd sensor viewer dials out to a central viewer, which then sends its normal node-to-node requests (pcap, hunts, crons, proxying) back over that link; see packetPortal* settings
+  - #4172 Fix Download Entire PCAP failing on sensors behind esProxy; the rootId session search is now allowed through esProxy, and a failed search returns a 500 instead of an unhandled rejection
 
 6.6.0 2026/07/09
 ## Breaking

--- a/tests/esProxy.t
+++ b/tests/esProxy.t
@@ -1,5 +1,5 @@
 # ESProxy
-use Test::More tests => 41;
+use Test::More tests => 46;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
@@ -165,4 +165,30 @@ $req->header('Content-Type' => 'application/x-ndjson');
 $req->content($bulk_multi_op);
 $response = $ArkimeTest::userAgent->request($req);
 is ($response->code, 400, "bulk with multiple ops in one line rejected");
+is ($response->content, "Not authorized for API");
+
+# Sessions search - rootId term query is allowed
+my $search_rootid = qq({"size":1000,"_source":["rootId"],"query":{"term":{"rootId":"240101-abc"}}});
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/tests_sessions3-2024/_search");
+$req->header('Content-Type' => 'application/json');
+$req->content($search_rootid);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 200, "sessions search by rootId allowed");
+
+# Sessions search - term on any other field is rejected
+my $search_other = qq({"query":{"term":{"node":"foo"}}});
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/tests_sessions3-2024/_search");
+$req->header('Content-Type' => 'application/json');
+$req->content($search_other);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "sessions search by other term rejected");
+is ($response->content, "Not authorized for API");
+
+# Sessions search - rootId alongside another clause is rejected
+my $search_extra = qq({"query":{"term":{"rootId":"240101-abc"},"match_all":{}}});
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/tests_sessions3-2024/_search");
+$req->header('Content-Type' => 'application/json');
+$req->content($search_extra);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "sessions search with extra query clause rejected");
 is ($response->content, "Not authorized for API");

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -3264,6 +3264,10 @@ class SessionAPIs {
     }
 
     Db.searchSessions(Db.getSessionIndices(true), query, null, (err, data) => {
+      if (err || !data?.hits?.hits) {
+        console.log('ERROR - /api/session/entire query', util.inspect(err, false, 50));
+        return res.status(500).end();
+      }
       async.forEachSeries(data.hits.hits, (item, nextCb) => {
         SessionAPIs.#writePcap(res, Db.session2Sid(item), writerOptions, nextCb);
       }, (err) => {

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -500,6 +500,19 @@ function validateSearchIds (req) {
     return false;
   }
 }
+// getEntirePCAP looks up every session sharing a rootId
+const searchRootIdKeys = ['size', '_source', 'sort', 'query', 'profile'];
+function validateSearchRootId (req) {
+  try {
+    const json = JSON.parse(req.body.toString('utf8'));
+    return Object.keys(json).every(key => searchRootIdKeys.includes(key)) &&
+      Object.keys(json.query).length === 1 &&
+      Object.keys(json.query.term).length === 1 &&
+      ArkimeUtil.isString(json.query.term.rootId);
+  } catch (e) {
+    return false;
+  }
+}
 function validateUpdate (req) {
   try {
     const json = JSON.parse(req.body.toString('utf8'));
@@ -523,7 +536,7 @@ app.post('*', saveBody, (req, res) => {
   } else if (path.startsWith(`/${prefix}files/_doc/${req.sensor.node}`)) {
   } else if (path.startsWith('/_bulk') && validateBulk(req)) {
   } else if (path.startsWith(`/${prefix}files/_search`) && validateFilesSearch(req)) {
-  } else if ((path.startsWith(`/${oldprefix}sessions2`) || path.startsWith(`/${prefix}sessions3`)) && path.endsWith('/_search') && validateSearchIds(req)) {
+  } else if ((path.startsWith(`/${oldprefix}sessions2`) || path.startsWith(`/${prefix}sessions3`)) && path.endsWith('/_search') && (validateSearchIds(req) || validateSearchRootId(req))) {
   } else if (path.match(/^\/[^/]*history_v[^/]*\/_doc$/)) {
   } else if (path.match(/^\/[^/]*sessions[23]-[^/]+\/_update\/[^/]+$/) && validateUpdate(req)) {
     console.log(`UPDATE : ${req.sensor.node} path:>%s<:`, ArkimeUtil.sanitizeStr(path));


### PR DESCRIPTION
Download entire pcap is broken for any sensor behind esProxy.

`getEntirePCAP` searches sessions by `rootId` to find the sub-sessions, but esProxy only permits a single-`ids` session search, so the search returns `400 Not authorized for API`:

```
POST /sessions2-*,arkime_sessions3-*/_search  ->  400 "Not authorized for API"
{"size":1000,"_source":["rootId"],"sort":{...},"query":{"term":{"rootId":"..."}},"profile":false}
```

`getEntirePCAP` then ignores that error and dereferences `data.hits.hits`, so it becomes an unhandled rejection and the download hangs instead of failing:

```
TypeError: Cannot read properties of undefined (reading 'hits')
    at apiSessions.js:3267
```

Segment pcap, src/dst raw and export pcap all work because they only ever search by id — entire pcap is the one path that makes the sensor run a non-id search.

Two changes: `validateSearchRootId` permits a sessions `_search` whose query is a single `term.rootId`, OR'd in next to `validateSearchIds`; and `getEntirePCAP` returns 500 on a failed search. The validator also restricts the top-level keys to the ones the query actually uses, so `aggs`/`script_fields` can't ride along.

Note `rootId` is a session identifier rather than a node-scoped one, so this permits reading sessions whose rootId a sensor knows — the same trust level as the existing by-id search, but worth a look if you'd rather scope it.

Found while running PacketPortal, but not portal-specific — it affects any esProxy deployment.
