### PR TITLE
Add !role search filter on Users tab to list users without a matching role

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -41,6 +41,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## All
   - #4128 Add changePasswordSecret.js to re-encrypt all users' passwords and cont3xt keys after changing the passwordSecret
   - #4134 Fix a cleared (null) user permission being treated as a denial instead of falling back to the roles' value
+  - #4183 Add !role search filter on the Users tab to list users that don't have a matching role
 ## Capture
   - #4120 Fix offline pcap runs (-r/-R) loading the stopped-sessions state file
   - #4121 Fix DNS HTTPS/SVCB records dropping a valid trailing zero-length SvcParam

--- a/common/user.js
+++ b/common/user.js
@@ -238,7 +238,7 @@ class User {
    * search against user index, promise only
    * @param query.from first index
    * @param query.size number of items
-   * @param query.filter search userId userName for
+   * @param query.filter search userId userName for; a leading ! excludes users that have a matching role (when "roles" is in searchFields)
    * @param query.sortField the field to sort on, default userId
    * @param query.sortDescending sort descending, default false
    * @param query.noRoles filters out users with ids starting with 'role:', default false
@@ -1924,15 +1924,20 @@ function sortUsers (users, sortField, sortDescending) {
 function filterUsers (users, filter, searchFields, noRoles) {
   const validSearchFields = searchFields
     ?.filter(field => field === 'userId' || field === 'userName' || field === 'roles') || [];
+  // a leading ! excludes users that have a matching role
+  const negateRoles = filter?.startsWith('!') && validSearchFields.includes('roles');
+  if (negateRoles) { filter = filter.slice(1); }
   const usingFilter = filter && validSearchFields.length;
-  if (!noRoles && !usingFilter) {
+  if (!noRoles && !usingFilter && !negateRoles) {
     return users; // nothing to filter on
   }
-  const re = usingFilter ? ArkimeUtil.wildcardToRegexp(`*${filter}*`) : null;
+  const re = (usingFilter || negateRoles) ? ArkimeUtil.wildcardToRegexp(`*${filter}*`) : null;
 
   return users.filter(user => {
     // exclude roles
     if (noRoles && user.userId.startsWith('role:')) { return false; }
+
+    if (negateRoles) { return !user.roles?.some(v => v.match(re)); }
 
     // filter searched fields
     return (!usingFilter || validSearchFields.some(field => Array.isArray(user[field]) ? user[field].some(v => v.match(re)) : user[field]?.match(re)));
@@ -2026,10 +2031,17 @@ class UserESImplementation {
     }
 
     if (query.filter && query.searchFields.length) {
-      const searchFilters = query.searchFields
-        .filter(field => field === 'userId' || field === 'userName' || field === 'roles')
-        .map(validField => { return { wildcard: { [validField]: '*' + query.filter + '*' } }; });
-      if (searchFilters.length) { esQuery.query.bool.should = searchFilters; }
+      if (query.filter.startsWith('!') && query.searchFields.includes('roles')) {
+        // a leading ! excludes users that have a matching role
+        esQuery.query.bool.must_not.push({
+          wildcard: { roles: '*' + query.filter.slice(1) + '*' }
+        });
+      } else {
+        const searchFilters = query.searchFields
+          .filter(field => field === 'userId' || field === 'userName' || field === 'roles')
+          .map(validField => { return { wildcard: { [validField]: '*' + query.filter + '*' } }; });
+        if (searchFilters.length) { esQuery.query.bool.should = searchFilters; }
+      }
     }
 
     if (query.sortField && !ArkimeUtil.isPP(query.sortField)) {

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -953,7 +953,7 @@
     "uploadWorked": "Datei erfolgreich hochgeladen"
   },
   "users": {
-    "searchPlaceholder": "Beginnen Sie mit der Eingabe, um nach Benutzern nach Name, ID oder Rolle zu suchen",
+    "searchPlaceholder": "Beginnen Sie mit der Eingabe, um nach Benutzern nach Name, ID oder Rolle zu suchen (!Rolle schließt Benutzer mit dieser Rolle aus)",
     "searchUserPlaceholder": "Beginnen Sie mit der Eingabe, um nach Benutzern nach Name oder ID zu suchen",
     "downloadCSVTip": "CSV herunterladen",
     "downloadCSVMsg": "CSV heruntergeladen!",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -953,7 +953,7 @@
     "uploadWorked": "File sucessfully uploaded"
   },
   "users": {
-    "searchPlaceholder": "Begin typing to search for users by name, id, or role",
+    "searchPlaceholder": "Begin typing to search for users by name, id, or role (!role excludes users with that role)",
     "searchUserPlaceholder": "Begin typing to search for users by name or id",
     "downloadCSVTip": "Download CSV",
     "downloadCSVMsg": "Downloaded CVS!",

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -953,7 +953,7 @@
     "uploadWorked": "Archivo subido exitosamente"
   },
   "users": {
-    "searchPlaceholder": "Comience a escribir para buscar usuarios por nombre, ID o rol",
+    "searchPlaceholder": "Comience a escribir para buscar usuarios por nombre, ID o rol (!rol excluye usuarios con ese rol)",
     "searchUserPlaceholder": "Comience a escribir para buscar usuarios por nombre o ID",
     "downloadCSVTip": "Descargar CSV",
     "downloadCSVMsg": "¡CSV descargado!",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -953,7 +953,7 @@
     "uploadWorked": "Fail edukalt üles laaditud"
   },
   "users": {
-    "searchPlaceholder": "Alusta tippimist, et otsida kasutajaid nime, ID või rolli järgi",
+    "searchPlaceholder": "Alusta tippimist, et otsida kasutajaid nime, ID või rolli järgi (!roll välistab selle rolliga kasutajad)",
     "searchUserPlaceholder": "Alusta tippimist, et otsida kasutajaid nime või ID järgi",
     "downloadCSVTip": "Laadi alla CSV",
     "downloadCSVMsg": "CSV alla laaditud!",

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -953,7 +953,7 @@
     "uploadWorked": "Fichier téléchargé avec succès"
   },
   "users": {
-    "searchPlaceholder": "Commencer à taper pour rechercher des utilisateurs par nom, ID ou rôle",
+    "searchPlaceholder": "Commencer à taper pour rechercher des utilisateurs par nom, ID ou rôle (!rôle exclut les utilisateurs ayant ce rôle)",
     "searchUserPlaceholder": "Commencer à taper pour rechercher des utilisateurs par nom ou ID",
     "downloadCSVTip": "Télécharger CSV",
     "downloadCSVMsg": "CSV téléchargé!",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -953,7 +953,7 @@
     "uploadWorked": "ファイルが正常にアップロードされました"
   },
   "users": {
-    "searchPlaceholder": "名前、ID、またはロールでユーザーを検索するには入力を開始してください",
+    "searchPlaceholder": "名前、ID、またはロールでユーザーを検索するには入力を開始してください（!ロールでそのロールを持つユーザーを除外）",
     "searchUserPlaceholder": "名前または ID でユーザーを検索するには入力を開始してください",
     "downloadCSVTip": "CSV をダウンロード",
     "downloadCSVMsg": "CSV をダウンロードしました！",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -953,7 +953,7 @@
     "uploadWorked": "파일이 성공적으로 업로드되었습니다"
   },
   "users": {
-    "searchPlaceholder": "이름, ID 또는 역할로 사용자 검색을 위해 입력을 시작하세요",
+    "searchPlaceholder": "이름, ID 또는 역할로 사용자 검색을 위해 입력을 시작하세요 (!역할은 해당 역할을 가진 사용자를 제외합니다)",
     "searchUserPlaceholder": "이름 또는 ID로 사용자 검색을 위해 입력을 시작하세요",
     "downloadCSVTip": "CSV 다운로드",
     "downloadCSVMsg": "CSV 다운로드됨!",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -953,7 +953,7 @@
     "uploadWorked": "Arquivo enviado com sucesso"
   },
   "users": {
-    "searchPlaceholder": "Comece a digitar para pesquisar usuários por nome, ID ou função",
+    "searchPlaceholder": "Comece a digitar para pesquisar usuários por nome, ID ou função (!função exclui usuários com essa função)",
     "searchUserPlaceholder": "Comece a digitar para pesquisar usuários por nome ou ID",
     "downloadCSVTip": "Baixar CSV",
     "downloadCSVMsg": "CSV baixado!",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -954,7 +954,7 @@
     "uploadWorked": "IleFay ucessfullysay uploadedway"
   },
   "users": {
-    "searchPlaceholder": "EginBay ypingtay otay earchsay orfay usersway ybay amenay, idway, orway oleray",
+    "searchPlaceholder": "EginBay ypingtay otay earchsay orfay usersway ybay amenay, idway, orway oleray (!oleray excludesway usersway ithway atthay oleray)",
     "searchUserPlaceholder": "EginBay ypingtay otay earchsay orfay usersway ybay amenay orway idway",
     "downloadCSVTip": "Ownloadday SVCAY",
     "downloadCSVMsg": "OwnloadedDay VSCAY!",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -953,7 +953,7 @@
     "uploadWorked": "文件成功上传"
   },
   "users": {
-    "searchPlaceholder": "开始输入以按名称、ID 或角色搜索用户",
+    "searchPlaceholder": "开始输入以按名称、ID 或角色搜索用户（!角色可排除具有该角色的用户）",
     "searchUserPlaceholder": "开始输入以按名称或 ID 搜索用户",
     "downloadCSVTip": "下载 CSV",
     "downloadCSVMsg": "已下载 CVS！",

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,7 +1,7 @@
 # Many of these test user/roles start with sac- (skip auto create) because
 # otherwise viewer in regression mode would auto create the user.
 # Some day should remove all autocreate code.
-use Test::More tests => 266;
+use Test::More tests => 278;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -242,6 +242,23 @@ anonymous,,true,true,false,"arkimeAdmin, cont3xtUser, parliamentUser, usersAdmin
     $users = viewerPost("/api/users", "filter=nonExistentRole");
     is (@{$users->{data}}, 0, "filter by non-existent role");
     is ($users->{recordsFiltered}, 0);
+
+# Filter by !role (users without that role)
+    $users = viewerPost("/api/users", "filter=!arkimeUser");
+    is (@{$users->{data}}, 3, "filter by !arkimeUser");
+    is ($users->{recordsFiltered}, 3);
+
+    $users = viewerPost("/api/users", "filter=!usersAdmin");
+    is (@{$users->{data}}, 3, "filter by !usersAdmin");
+    is ($users->{recordsFiltered}, 3);
+
+    $users = viewerPost("/api/users", "filter=!nonExistentRole");
+    is (@{$users->{data}}, 5, "filter by !non-existent role");
+    is ($users->{recordsFiltered}, 5);
+
+    $users = viewerPost("/api/users", "filter=!");
+    is (@{$users->{data}}, 1, "filter by bare ! (users with no roles)");
+    is ($users->{data}->[0]->{userId}, "sac-test2", "bare ! matches only sac-test2");
 
 # users/min with noRoles and no filter (should not crash)
     $json = viewerPostToken("/api/users/min", "", $token);
@@ -628,6 +645,15 @@ superAdmin,,true,true,false,"superAdmin",true,true,true,,,,,,
 test100,,true,true,false,"arkimeUser, cont3xtUser, parliamentUser, wiseUser",true,true,true,,,,,,
 test101,,true,true,false,"arkimeUser, cont3xtUser, parliamentUser, wiseUser",true,true,true,,,,,,
 ', "CSV Users 2");
+
+# Filter by !role works for user-defined roles (stored with role: prefix), with or without the prefix
+    $users = viewerPost("/api/users", "filter=!role:sac-test1");
+    is (@{$users->{data}}, 8, "filter by !role:sac-test1 excludes role:sac-test2");
+    is ($users->{recordsFiltered}, 8);
+
+    $users = viewerPost("/api/users", "filter=!sac-test1");
+    is (@{$users->{data}}, 8, "filter by !sac-test1 without role: prefix");
+    is ($users->{recordsFiltered}, 8);
 
 # Delete Users
     $json = viewerDeleteToken("/api/user/notadmin", $token);


### PR DESCRIPTION
- ES and in-memory user search treat a leading ! as a roles-only exclusion
- Works for user-defined roles with or without the role: prefix; bare ! lists users with no roles
- Update search placeholder in all locales
- Add api-users.t coverage for the negation filter

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
