### PR TITLE
Fix crash redefining the type of a builtin field (fixes #4184)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,6 +59,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4153 override-ips asn: values are now matched anchored, /^AS\d+ .+/; a value with anything before the AS number used to be accepted and silently recorded with AS number 0, and is now rejected
   - #4153 Fix DTLS ja4 being computed over a truncated string when a ClientHello had many extensions or signature algorithms
   - #4153 Fix TLS/DTLS ClientHello parsing desyncing when the cipher suites length was odd, which could hide the SNI and give a wrong ja3/ja4
+  - #4187 Fix crash when redefining the type of a builtin field via wise or custom-fields
 ## Cont3xt/Viewer
   - #4134 Add an MCP server at POST /mcp for viewer and cont3xt, off by default, enable with mcpEnabled.
   - #4134 Add mcpUser role, required per user on top of the service role to use /mcp; superAdmin includes it, arkimeAdmin does not

--- a/capture/db.c
+++ b/capture/db.c
@@ -599,6 +599,8 @@ LOCAL ARKIME_LOCK_DEFINE(outputted);
 
 #define SAVE_FIELD_STR_HASH(POS, FLAGS) \
 do { \
+    if (config.fields[POS]->type != ARKIME_FIELD_TYPE_STR_HASH) \
+        break; \
     shash = session->fields[POS]->shash; \
     if (FLAGS & ARKIME_FIELD_FLAG_CNT) { \
         BSB_EXPORT_sprintf(jbsb, "\"%sCnt\":%d,", config.fields[POS]->dbField, HASH_COUNT(s_, *shash)); \
@@ -1084,7 +1086,7 @@ void arkime_db_save_session(ArkimeSession_t *session, int final)
         g_free(communityId);
     }
 
-    if (session->fields[vlanField]) {
+    if (session->fields[vlanField] && config.fields[vlanField]->type == ARKIME_FIELD_TYPE_INT_ARRAY_UNIQUE) {
         BSB_EXPORT_cstr(jbsb, ",\"vlan\":{");
         BSB_EXPORT_sprintf(jbsb, "\"id-cnt\":%u,", session->fields[vlanField]->iarray->len);
         BSB_EXPORT_sprintf(jbsb, "\"id\":[");

--- a/capture/field.c
+++ b/capture/field.c
@@ -450,6 +450,16 @@ int arkime_field_define(const char *group, const char *kind, const char *express
         }
     }
 
+    if (minfo->pos != -1) {
+        // Once storage is assigned the type/flags can't change - the session
+        // field union and db.c save code depend on them staying fixed
+        if (minfo->type != type) {
+            LOG("WARNING - Field '%s' (db:%s) is already defined with a different type, ignoring type change", expression, minfo->dbFieldFull);
+        }
+        type  = minfo->type;
+        flags = minfo->flags;
+    }
+
     minfo->type     = type;
     minfo->flags    = flags;
 

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -414,6 +414,8 @@ ASDF=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&
 ALLTEST=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%;name:All Field Action %FIELDNAME%!;all:true
 
 [custom-fields]
+# Tries to change the type of a builtin field, must be ignored (issue #4184)
+network.vlan.id=db:network.vlan.id;kind:integer;friendly:VLAN;help:vlan value
 iscool=kind:termfield;count:true;friendly:Is cool;db:iscool;help:Is Cool String;viewerOnly:true
 sample.md5=db:sample.md5;kind:lotermfield;friendly:Sample MD5;count:true;help:MD5 of the sample
 asset.src=kind:lotermfield;count:true;friendly:Asset Src;db:assetName.src;help:Asset Name Src


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
