### PR TITLE
update urlhaus and malwarebazaar integrations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,6 +62,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4187 Fix crash when redefining the type of a builtin field via wise or custom-fields
   - #4188 Add wiseRequestTimeout setting, default 30 seconds, so a stuck wiseService doesn't delay capture shutdown for minutes
 ## Cont3xt/Viewer
+  - #4190 Cont3xt URLHaus and MalwareBazaar integrations now require an API key (free at https://auth.abuse.ch/)
+  - #4190 Fix Cont3xt URLHaus and MalwareBazaar rendering an empty card by adding their missing card fields
   - #4134 Add an MCP server at POST /mcp for viewer and cont3xt, off by default, enable with mcpEnabled.
   - #4134 Add mcpUser role, required per user on top of the service role to use /mcp; superAdmin includes it, arkimeAdmin does not
 ## db.pl

--- a/cont3xt/integrations/malwarebazaar/index.js
+++ b/cont3xt/integrations/malwarebazaar/index.js
@@ -20,6 +20,11 @@ class MalwareBazaarIntegration extends Integration {
     disabled: {
       help: 'Disable integration for all queries',
       type: 'boolean'
+    },
+    key: {
+      help: 'Your abuse.ch Auth-Key, free at https://auth.abuse.ch/',
+      password: true,
+      required: true
     }
   };
 
@@ -34,7 +39,71 @@ class MalwareBazaarIntegration extends Integration {
       itypes: ['hash'],
       name: 'Search MalwareBazaar for SHA: %{query}'
     }],
-    fields: []
+    fields: [
+      {
+        label: 'query_status',
+        field: 'query_status'
+      },
+      {
+        label: 'Samples',
+        field: 'data',
+        type: 'table',
+        defaultSortField: 'first_seen',
+        defaultSortDirection: 'desc',
+        fields: [
+          {
+            label: 'File Name',
+            field: 'file_name'
+          },
+          {
+            label: 'Signature',
+            field: 'signature'
+          },
+          {
+            label: 'File Type',
+            field: 'file_type'
+          },
+          {
+            label: 'File Size',
+            field: 'file_size'
+          },
+          {
+            label: 'SHA256',
+            field: 'sha256_hash',
+            pivot: true
+          },
+          {
+            label: 'MD5',
+            field: 'md5_hash',
+            pivot: true
+          },
+          {
+            label: 'First Seen',
+            field: 'first_seen',
+            type: 'date'
+          },
+          {
+            label: 'Last Seen',
+            field: 'last_seen',
+            type: 'date'
+          },
+          {
+            label: 'Delivery Method',
+            field: 'delivery_method'
+          },
+          {
+            label: 'Reporter',
+            field: 'reporter'
+          },
+          {
+            label: 'Tags',
+            field: 'tags',
+            type: 'array',
+            join: ', '
+          }
+        ]
+      }
+    ]
   };
 
   constructor () {
@@ -45,9 +114,15 @@ class MalwareBazaarIntegration extends Integration {
 
   async fetch (user, query) {
     try {
+      const key = this.getUserConfig(user, 'key');
+      if (!key) {
+        return undefined;
+      }
+
       const result = await axios.post('https://mb-api.abuse.ch/api/v1/', `query=get_info&hash=${encodeURIComponent(query)}`, {
         headers: {
-          'User-Agent': this.userAgent()
+          'User-Agent': this.userAgent(),
+          'Auth-Key': key
         }
       });
 

--- a/cont3xt/integrations/urlhaus/index.js
+++ b/cont3xt/integrations/urlhaus/index.js
@@ -21,6 +21,11 @@ class URLHausIntegration extends Integration {
     disabled: {
       help: 'Disable integration for all queries',
       type: 'boolean'
+    },
+    key: {
+      help: 'Your abuse.ch Auth-Key, free at https://auth.abuse.ch/',
+      password: true,
+      required: true
     }
   };
 
@@ -31,7 +36,68 @@ class URLHausIntegration extends Integration {
       itypes: ['domain', 'url', 'hash', 'text'],
       name: 'Search URLHaus for %{query}'
     }],
-    fields: []
+    fields: [
+      {
+        label: 'query_status',
+        field: 'query_status'
+      },
+      {
+        label: 'First Seen',
+        field: 'firstseen',
+        type: 'date'
+      },
+      {
+        label: 'URL Count',
+        field: 'url_count'
+      },
+      {
+        label: 'Reference',
+        field: 'urlhaus_reference',
+        type: 'url'
+      },
+      {
+        label: 'URLs',
+        field: 'urls',
+        type: 'table',
+        defaultSortField: 'date_added',
+        defaultSortDirection: 'desc',
+        fields: [
+          {
+            label: 'URL',
+            field: 'url',
+            pivot: true
+          },
+          {
+            label: 'Status',
+            field: 'url_status'
+          },
+          {
+            label: 'Threat',
+            field: 'threat'
+          },
+          {
+            label: 'Date Added',
+            field: 'date_added',
+            type: 'date'
+          },
+          {
+            label: 'Reporter',
+            field: 'reporter'
+          },
+          {
+            label: 'Tags',
+            field: 'tags',
+            type: 'array',
+            join: ', '
+          },
+          {
+            label: 'Reference',
+            field: 'urlhaus_reference',
+            type: 'url'
+          }
+        ]
+      }
+    ]
   };
 
   constructor () {
@@ -42,9 +108,15 @@ class URLHausIntegration extends Integration {
 
   async fetch (user, query) {
     try {
+      const key = this.getUserConfig(user, 'key');
+      if (!key) {
+        return undefined;
+      }
+
       const result = await axios.post('https://urlhaus-api.abuse.ch/v1/host/', `host=${encodeURIComponent(query)}`, {
         headers: {
-          'User-Agent': this.userAgent()
+          'User-Agent': this.userAgent(),
+          'Auth-Key': key
         }
       });
 


### PR DESCRIPTION
abuse.ch now requires an Auth-Key for the URLHaus and MalwareBazaar APIs, the same key ThreatFox already asks for (free at https://auth.abuse.ch/). Neither integration sends one today, so every lookup comes back `401 Unauthorized`.

While fixing that I noticed both integrations also have an empty `card.fields`, so even a successful lookup renders an empty card. This PR addresses both.

## Changes

**Auth-Key support** (mirrors the existing ThreatFox integration)

- add a `key` setting (`password: true`, `required: true`)
- read it with `getUserConfig(user, 'key')` and send it as the `Auth-Key` header
- return early when no key is configured, so the integration is skipped rather than repeatedly failing with 401

**`card.fields`**

- `urlhaus`: `query_status`, `firstseen`, `url_count`, `urlhaus_reference`, plus a table over `urls[]` (url, status, threat, date added, reporter, tags, reference)
- `malwarebazaar`: `query_status` plus a table over `data[]` (file name, signature, file type/size, sha256, md5, first/last seen, delivery method, reporter, tags)

Field names follow the abuse.ch API responses, and the layout follows the ThreatFox card. `pivot: true` is set on the URL and hash columns so they can be searched directly from the results.

## Testing

Verified on a live Arkime 6.6.0 deployment (Cont3xt on EL8, Elasticsearch 7.17.29):

- before: every lookup logged `AxiosError: Request failed with status code 401`
- after, with a key configured: `/api/integration/stats` shows `directError: 0` for both, with `directGood: 5` (URLHaus) and `directGood: 1` (MalwareBazaar), i.e. real results are returned
- results now render in the UI; previously the card came back empty even when data was fetched
- with no key configured the integration is skipped, as intended
- `npm run lint` passes

I did not run `tests.pl` since this only touches Cont3xt integration files.

## License

I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
