### PR TITLE
Blacksmith CI updates

### DIFF
--- a/.github/workflows/versions
+++ b/.github/workflows/versions
@@ -26,7 +26,7 @@ include:
     fpmdeps: "-d perl-libwww-perl -d perl-JSON -d ethtool -d libyaml -d perl-LWP-Protocol-https -d python3.12-libs -d curl"
     uitest: true
     python: python3.12
-    runson: blacksmith-2vcpu-ubuntu-2404
+    runson: blacksmith-4vcpu-ubuntu-2404
     prbuild: true
 
   - version: el9.x86_64
@@ -69,7 +69,7 @@ include:
     python: python3
     viewertest: sanitize
     sanitizebuild: "make -j SANITIZE_LDFLAGS='-fno-common -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer' sanitize"
-    runson: blacksmith-2vcpu-ubuntu-2404
+    runson: blacksmith-4vcpu-ubuntu-2404
     prbuild: true
 
   - version: ubuntu2604_amd64
@@ -80,7 +80,7 @@ include:
     python: python3
     viewertest: normal
     sanitizebuild: "make -j SANITIZE_LDFLAGS='-fno-common -fsanitize=address -fsanitize=undefined -fno-omit-frame-pointer' sanitize"
-    runson: blacksmith-2vcpu-ubuntu-2404
+    runson: blacksmith-4vcpu-ubuntu-2404
     prbuild: true
 
   - version: "arch-x86_64"
@@ -90,7 +90,7 @@ include:
     package: arch
     viewertest: normal
     otherdbtest: "true"
-    runson: blacksmith-2vcpu-ubuntu-2404
+    runson: blacksmith-4vcpu-ubuntu-2404
     prbuild: true
 
   - version: al2023.x86_64

--- a/README.md
+++ b/README.md
@@ -118,3 +118,7 @@ The best way to reach us is on Slack.  Please request an invitation to join the 
 ## License
 
 This project is licensed under the terms of the Apache 2.0 open source license. Please refer to [LICENSE](LICENSE) for the full terms.
+
+## Thanks
+
+<a href="https://www.blacksmith.sh/"><img src="https://arkime.com/assets/blacksmith.png" height="50" align="middle" alt="Blacksmith"></a>&nbsp;&nbsp;<a href="https://greynoise.io"><img src="https://arkime.com/assets/greynoise.svg" height="20" align="middle" alt="GreyNoise"></a>

--- a/README.md
+++ b/README.md
@@ -16,8 +16,21 @@ Arkime is built to be deployed across many systems and can scale to handle tens 
 
 [Learn more on arkime.com](https://arkime.com)
 
+## Arkimeet 2026
+
+Join us for **[Arkimeet 2026](https://arkime.com/arkimeet)**, our Arkime community gathering!
+
+* **When:** Tuesday, October 6, 2026, 9:00 AM - 5:00 PM EDT (happy hour to follow)
+* **Where:** Amazon IAD28, 13200 Woodland Park Rd, Herndon, VA 20171
+* **Cost:** Free, but **registration is required by September 22, 2026** - space is limited
+
+The day includes an Arkime keynote covering new features and demos, community talks, and an open discussion about the features you want to see next. Everyone is welcome, whether you are brand new to Arkime or have been running it for years.
+
+Interested in speaking? A call for presentations is open - see the [Arkimeet page](https://arkime.com/arkimeet) to register or submit a talk. Chat with us in the `#arkimeet` channel on [Slack](https://slackinvite.arkime.com).
+
 ## Table of Contents
 
+- [Arkimeet 2026](#arkimeet-2026)
 - [Background](#background)
 - [Installation](#installation)
 - [Configuration](#configuration)


### PR DESCRIPTION
- Bump several blacksmith runners from 2vcpu to 4vcpu
- Add Thanks section to README with Blacksmith and GreyNoise logos

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
