### PR TITLE
Fix security issues found reviewing common/

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -44,6 +44,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4134 Fix a cleared (null) user permission being treated as a denial instead of falling back to the roles' value
   - #4183 Add !role search filter on the Users tab to list users that don't have a matching role
   - #4194 Add Microsoft Teams notifier (uses Power Automate Workflows webhooks)
+  - #4202 Exit at startup when a header authMode has no userNameHeader instead of failing every request
 ## Capture
   - #4120 Fix offline pcap runs (-r/-R) loading the stopped-sessions state file
   - #4121 Fix DNS HTTPS/SVCB records dropping a valid trailing zero-length SvcParam

--- a/common/auth.js
+++ b/common/auth.js
@@ -302,6 +302,12 @@ class Auth {
       process.exit(1);
     }
 
+    // Every header mode reads the userId (or the JWT) out of this header
+    if (Auth.#strategies.includes('header') && !ArkimeUtil.isString(Auth.#userNameHeader)) {
+      console.log(`ERROR - userNameHeader missing from config file, required for authMode=${ArkimeUtil.sanitizeStr(options.mode)}`);
+      process.exit(1);
+    }
+
     // Add basic to beginning
     if (addBasic) {
       Auth.#strategies.unshift('basic');
@@ -927,9 +933,17 @@ class Auth {
     // address, not req.ip: when trust proxy is enabled req.ip is derived from the
     // client-supplied X-Forwarded-For header and is therefore spoofable, which
     // would let an attacker bypass userAuthIps (e.g. the header-auth loopback default).
+    // No peer address (destroyed socket, or a synthetic one that doesn't set it)
+    // means we can't check, so deny
     const ip = req.socket?.remoteAddress;
     if (ip === undefined) {
-      return 0;
+      res.status(403);
+      res.json({ success: false, text: 'Not allowed by ip' });
+      // debug only, an unauthenticated peer can trigger this at will
+      if (ArkimeConfig.debug > 0) {
+        console.log('Blocked (userAuthIps setting), no peer address', ArkimeUtil.sanitizeStr(req.url));
+      }
+      return 1;
     }
 
     if (ip.includes(':')) {
@@ -974,6 +988,8 @@ class Auth {
       nuser = JSON.parse(new Function('return `' + Auth.#userAutoCreateTmpl + '`;').call(vars));
     } else {
       nuser = {};
+      // No user record exists yet, so `this` is undefined in these expressions,
+      // unlike [user-role-mappings] which binds the existing user
       for (const [field, func] of Auth.#userAutoCreateFuncs) {
         try {
           nuser[field] = func(vars);

--- a/common/notifier.snmp.js
+++ b/common/notifier.snmp.js
@@ -9,29 +9,30 @@
 
 const snmp = require('net-snmp');
 
-const VERSIONS = {
-  1: snmp.Version1,
-  '2c': snmp.Version2c,
-  3: snmp.Version3
-};
+// Use maps for security
+const VERSIONS = new Map([
+  ['1', snmp.Version1],
+  ['2c', snmp.Version2c],
+  ['3', snmp.Version3]
+]);
 
-const AUTH_PROTOCOLS = {
-  none: snmp.AuthProtocols.none,
-  md5: snmp.AuthProtocols.md5,
-  sha: snmp.AuthProtocols.sha,
-  sha224: snmp.AuthProtocols.sha224,
-  sha256: snmp.AuthProtocols.sha256,
-  sha384: snmp.AuthProtocols.sha384,
-  sha512: snmp.AuthProtocols.sha512
-};
+const AUTH_PROTOCOLS = new Map([
+  ['none', snmp.AuthProtocols.none],
+  ['md5', snmp.AuthProtocols.md5],
+  ['sha', snmp.AuthProtocols.sha],
+  ['sha224', snmp.AuthProtocols.sha224],
+  ['sha256', snmp.AuthProtocols.sha256],
+  ['sha384', snmp.AuthProtocols.sha384],
+  ['sha512', snmp.AuthProtocols.sha512]
+]);
 
-const PRIV_PROTOCOLS = {
-  none: snmp.PrivProtocols.none,
-  des: snmp.PrivProtocols.des,
-  aes: snmp.PrivProtocols.aes,
-  aes256b: snmp.PrivProtocols.aes256b,
-  aes256r: snmp.PrivProtocols.aes256r
-};
+const PRIV_PROTOCOLS = new Map([
+  ['none', snmp.PrivProtocols.none],
+  ['des', snmp.PrivProtocols.des],
+  ['aes', snmp.PrivProtocols.aes],
+  ['aes256b', snmp.PrivProtocols.aes256b],
+  ['aes256r', snmp.PrivProtocols.aes256r]
+]);
 
 // Default enterprise OID for Arkime Parliament alerts
 const DEFAULT_TRAP_OID = '1.3.6.1.4.1.79054.1.1';
@@ -89,8 +90,9 @@ exports.sendSnmpAlert = function (config, message, links, cb) {
     return;
   }
 
-  const versionStr = config.version || '2c';
-  const version = VERSIONS[versionStr];
+  // String() since map keys are strings and config can be a number
+  const versionStr = String(config.version || '2c');
+  const version = VERSIONS.get(versionStr);
   if (version === undefined) {
     if (cb) { cb({ errors: { snmp: 'Version must be 1, 2c, or 3' } }); }
     return;
@@ -124,8 +126,8 @@ exports.sendSnmpAlert = function (config, message, links, cb) {
 
   let session;
   if (version === snmp.Version3) {
-    const authProto = AUTH_PROTOCOLS[config.v3AuthProtocol] ?? snmp.AuthProtocols.none;
-    const privProto = PRIV_PROTOCOLS[config.v3PrivProtocol] ?? snmp.PrivProtocols.none;
+    const authProto = AUTH_PROTOCOLS.get(config.v3AuthProtocol) ?? snmp.AuthProtocols.none;
+    const privProto = PRIV_PROTOCOLS.get(config.v3PrivProtocol) ?? snmp.PrivProtocols.none;
 
     let level = snmp.SecurityLevel.noAuthNoPriv;
     if (authProto !== snmp.AuthProtocols.none && privProto !== snmp.PrivProtocols.none) {

--- a/common/notifier.syslog.js
+++ b/common/notifier.syslog.js
@@ -11,19 +11,19 @@ const dgram = require('dgram');
 const net = require('net');
 const tls = require('tls');
 
-// RFC 5424 facility codes
-const FACILITIES = {
-  kern: 0, user: 1, mail: 2, daemon: 3, auth: 4, syslog: 5,
-  lpr: 6, news: 7, uucp: 8, cron: 9, authpriv: 10, ftp: 11,
-  local0: 16, local1: 17, local2: 18, local3: 19,
-  local4: 20, local5: 21, local6: 22, local7: 23
-};
+// RFC 5424 facility codes, use maps for security
+const FACILITIES = new Map([
+  ['kern', 0], ['user', 1], ['mail', 2], ['daemon', 3], ['auth', 4], ['syslog', 5],
+  ['lpr', 6], ['news', 7], ['uucp', 8], ['cron', 9], ['authpriv', 10], ['ftp', 11],
+  ['local0', 16], ['local1', 17], ['local2', 18], ['local3', 19],
+  ['local4', 20], ['local5', 21], ['local6', 22], ['local7', 23]
+]);
 
 // RFC 5424 severity codes
-const SEVERITIES = {
-  emerg: 0, alert: 1, crit: 2, err: 3,
-  warning: 4, notice: 5, info: 6, debug: 7
-};
+const SEVERITIES = new Map([
+  ['emerg', 0], ['alert', 1], ['crit', 2], ['err', 3],
+  ['warning', 4], ['notice', 5], ['info', 6], ['debug', 7]
+]);
 
 exports.init = function (api) {
   api.register('syslog', {
@@ -63,8 +63,8 @@ exports.init = function (api) {
  * Build an RFC 5424 syslog message
  */
 exports.buildSyslogMessage = function (config, message) {
-  const facility = FACILITIES[config.facility] ?? FACILITIES.local0;
-  const severity = SEVERITIES[config.severity] ?? SEVERITIES.warning;
+  const facility = FACILITIES.get(config.facility) ?? FACILITIES.get('local0');
+  const severity = SEVERITIES.get(config.severity) ?? SEVERITIES.get('warning');
   const pri = (facility * 8) + severity;
   const tag = config.tag || 'arkime';
   const timestamp = new Date().toISOString();

--- a/common/user.js
+++ b/common/user.js
@@ -14,20 +14,21 @@ const { LRUCache } = require('lru-cache');
 const otplib = require('otplib');
 const QRCode = require('qrcode');
 
-const systemRolesMapping = {
-  superAdmin: ['usersAdmin', 'arkimeAdmin', 'arkimeUser', 'parliamentAdmin', 'parliamentUser', 'wiseAdmin', 'wiseUser', 'cont3xtAdmin', 'cont3xtUser', 'dbAdmin', 'mcpUser'],
-  usersAdmin: [],
-  arkimeAdmin: ['arkimeUser'],
-  arkimeUser: [],
-  mcpUser: [],
-  parliamentAdmin: ['parliamentUser'],
-  parliamentUser: [],
-  wiseAdmin: ['wiseUser'],
-  wiseUser: [],
-  cont3xtAdmin: ['cont3xtUser'],
-  cont3xtUser: [],
-  dbAdmin: []
-};
+// Use map for security
+const systemRolesMapping = new Map([
+  ['superAdmin', ['usersAdmin', 'arkimeAdmin', 'arkimeUser', 'parliamentAdmin', 'parliamentUser', 'wiseAdmin', 'wiseUser', 'cont3xtAdmin', 'cont3xtUser', 'dbAdmin', 'mcpUser']],
+  ['usersAdmin', []],
+  ['arkimeAdmin', ['arkimeUser']],
+  ['arkimeUser', []],
+  ['mcpUser', []],
+  ['parliamentAdmin', ['parliamentUser']],
+  ['parliamentUser', []],
+  ['wiseAdmin', ['wiseUser']],
+  ['wiseUser', []],
+  ['cont3xtAdmin', ['cont3xtUser']],
+  ['cont3xtUser', []],
+  ['dbAdmin', []]
+]);
 
 const adminRoles = ['usersAdmin', 'arkimeAdmin', 'parliamentAdmin', 'wiseAdmin', 'cont3xtAdmin', 'dbAdmin'];
 const adminRolesWithSuper = ['superAdmin', 'usersAdmin', 'arkimeAdmin', 'parliamentAdmin', 'wiseAdmin', 'cont3xtAdmin', 'dbAdmin'];
@@ -129,7 +130,7 @@ class User {
     if (userRoleMappings) {
       User.#dynamicRolesFuncs = new Map();
       for (const [role, func] of Object.entries(userRoleMappings)) {
-        if (!systemRolesMapping[role] && !role.startsWith('role:')) {
+        if (!systemRolesMapping.has(role) && !role.startsWith('role:')) {
           console.log(`ERROR - user-role-mappings ${role} must start with role: or be a system role`);
           process.exit(1);
         }
@@ -438,7 +439,7 @@ class User {
 
     User.#rolesCache._timeStamp = Date.now();
     const userAllRoles = await User.#implementation.allRoles();
-    User.#rolesCache.roles = new Set([...Object.keys(systemRolesMapping), ...userAllRoles]);
+    User.#rolesCache.roles = new Set([...systemRolesMapping.keys(), ...userAllRoles]);
     return User.#rolesCache.roles;
   }
 
@@ -768,7 +769,7 @@ class User {
       return res.serverError(403, 'Username can not be empty');
     }
 
-    if (systemRolesMapping[req.body.userId]) {
+    if (systemRolesMapping.has(req.body.userId)) {
       return res.serverError(403, `User ID can't be a system role id`);
     }
 
@@ -953,7 +954,7 @@ class User {
       return res.serverError(403, "_moloch_shared is a shared user. This user's settings cannot be updated");
     }
 
-    if (systemRolesMapping[userId]) {
+    if (systemRolesMapping.has(userId)) {
       return res.serverError(403, `User ID can't be a system role id`);
     }
 
@@ -1415,9 +1416,9 @@ class User {
       const r = rolesQ.pop();
 
       // Deal with system roles first, they are easy
-      if (systemRolesMapping[r]) {
+      if (systemRolesMapping.has(r)) {
         allRoles.add(r);
-        systemRolesMapping[r].forEach(allRoles.add, allRoles);
+        systemRolesMapping.get(r).forEach(allRoles.add, allRoles);
         continue;
       }
 
@@ -1447,7 +1448,7 @@ class User {
    */
   static validateRoles (roles) {
     for (const r of roles) {
-      if (!systemRolesMapping[r] && !r.startsWith('role:')) {
+      if (!systemRolesMapping.has(r) && !r.startsWith('role:')) {
         return false;
       }
     }
@@ -1494,7 +1495,7 @@ class User {
 
     // We only look at our direct roles for settings, since those should already be expanded
     for (const r of rolesQ) {
-      if (systemRolesMapping[r]) {
+      if (systemRolesMapping.has(r)) {
         continue;
       }
 
@@ -1533,9 +1534,9 @@ class User {
       const r = rolesQ.pop();
 
       // Deal with system roles first, they are easy
-      if (systemRolesMapping[r]) {
+      if (systemRolesMapping.has(r)) {
         allRoles.add(r);
-        systemRolesMapping[r].forEach(allRoles.add, allRoles);
+        systemRolesMapping.get(r).forEach(allRoles.add, allRoles);
         continue;
       }
 
@@ -1790,10 +1791,14 @@ class User {
   async updateDynamicRoles (vals) {
     if (!User.#dynamicRolesFuncs) { return; }
 
+    // Expressions get a curated copy as `this`, not the raw record, so they
+    // can't read passStore/totpSecret/cont3xt keys
+    const thisView = Object.freeze(Object.fromEntries(searchColumns.map(c => [c, this[c]])));
+
     const newRoles = [];
     for (const [role, func] of User.#dynamicRolesFuncs) {
       try {
-        const result = await func.call(this, vals);
+        const result = await func.call(thisView, vals);
         if (result) {
           newRoles.push(role);
         }


### PR DESCRIPTION
- Use a Map for systemRolesMapping, prototype names like toString passed validateRoles and then threw
- Use Maps for the snmp/syslog notifier lookup tables so the ?? fallbacks work
- Deny in checkIps when the socket has no peer address instead of allowing
- Exit at startup when a header authMode has no userNameHeader
- Give user-role-mappings expressions a curated this, not the raw user record

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
