### PR TITLE
Fix security issues found reviewing viewer/

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -87,6 +87,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4160 Fix date expression values ending in a timezone abbreviation (2026/07/27 09:33:05 UTC) generating an Invalid date ES query
   - #4163 Add Packet Portal (experimental), a second viewer-to-viewer transport where a NAT'd sensor viewer dials out to a central viewer, which then sends its normal node-to-node requests (pcap, hunts, crons, proxying) back over that link; see packetPortal* settings
   - #4172 Fix Download Entire PCAP failing on sensors behind esProxy; the rootId session search is now allowed through esProxy, and a failed search returns a 500 instead of an unhandled rejection
+  - #4203 Fix scrubbing pcap on a session held by a remote node exiting the viewer
+  - #4203 Fix a repeated query parameter (order, startTime, stopTime) never answering
 
 6.6.0 2026/07/09
 ## Breaking

--- a/tests/api-scrub.t
+++ b/tests/api-scrub.t
@@ -1,4 +1,4 @@
-use Test::More tests => 41;
+use Test::More tests => 51;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -78,6 +78,43 @@ countTest(3, "date=-1&expression=" . uri_escape("file=$copytest"));
     esGet("/_refresh");
 
     countTest(0, "date=-1&expression=" . uri_escape("file=$copytest"));
+
+# scrub a session on a REMOTE node
+# Everything above scrubs through the viewer that owns the node, so it only ever
+# takes #scrubList's local branch. On a one host test rig every node looks local
+# to every normal viewer (Db.isLocalView compares hostnames), so the multiviewer
+# on 8125 is the only way in here: multiES sets Db.isLocalView to always false,
+# which sends the scrub out over ViewerUtils.makeRequest to the owning node.
+    system("../db/db.pl --prefix tests $ArkimeTest::elasticsearch rm $copytest 2>&1 1>/dev/null");
+    viewerPost("/regressionTests/flushCache");
+    system("/bin/cp pcap/socks-http-example.pcap copytest.pcap");
+    system("../capture/capture $ArkimeTest::es -c config.test.ini -n test -r copytest.pcap $ENV{INSECURE} $ENV{SCHEME}");
+    esGet("/_flush");
+    esGet("/_refresh");
+
+    countTest(3, "date=-1&expression=" . uri_escape("file=$copytest"));
+    countTest(0, "date=-1&expression=" . uri_escape("file=$copytest&&scrubbed.by==anonymous"));
+
+# the multiviewer can't resolve file= (lookupQueryItems is a no-op for multiES),
+# so pick the session up by id, which is the same id on both viewers
+    $idQuery = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("file=$copytest"));
+
+    $result = multiPostToken("/api/delete?removePcap=true&removeSpi=false&date=-1", "ids=" . $idQuery->{data}->[0]->{id}, $token);
+    eq_or_diff($result, from_json('{"success":true,"text":"Scrubbing PCAP of 1 sessions complete"}'));
+
+# A remote scrub must not take the multiviewer down. The reply above is sent
+# before the owning node's response comes back, so give that response time to
+# land before asking whether the multiviewer survived handling it.
+    sleep 1;
+    my $health = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8125/health");
+    ok ($health->is_success, "multiviewer still up after remote scrub");
+
+    esGet("/_flush");
+    esGet("/_refresh");
+
+# ...and it must actually have scrubbed, not just reported success
+    countTest(1, "date=-1&expression=" . uri_escape("file=$copytest&&scrubbed.by==anonymous"));
+    countTest(2, "date=-1&expression=" . uri_escape("file=$copytest&&scrubbed.by!=anonymous"));
 
 # cleanup
     unlink("copytest.pcap");

--- a/tests/api-sessionDetail.t
+++ b/tests/api-sessionDetail.t
@@ -1,4 +1,4 @@
-use Test::More tests => 44;
+use Test::More tests => 48;
 
 use Cwd;
 use URI::Escape;
@@ -115,6 +115,21 @@ my $pwd = "*/pcap";
 
     $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/sessions/bodyhash/a4a7b8b5eaf4c2cf356b105c6cdb?date=-1&expression=http.md5=a4a7b8b5eaf4c2cf356b1052133c6cdb")->content;
     is($sd, "No match", "No Match");
+
+# Global bodyHash on a remote node. The multiviewer treats every node as remote
+# (multiES forces Db.isLocalView false), so this takes getBodyHash's proxy
+# branch rather than reading the pellet off local disk.
+    my $rsp = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8125/api/sessions/bodyhash/87b94c6c763d2ae6e47cfb9c35e6d54d8a84bf125cbc9430082a9f1b3e592bec?date=-1&expression=http.sha256=87b94c6c763d2ae6e47cfb9c35e6d54d8a84bf125cbc9430082a9f1b3e592bec");
+    is($rsp->content, "Username=Qggh&Passwd=Bhhhh&Section=Auuu", "Remote Right sha256");
+    is($rsp->header('content-disposition'), 'attachment; filename="post.php.pellet"', "Remote keeps content-disposition");
+
+    $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8125/api/sessions/bodyhash/a4a7b8b5eaf4c2cf356b1052133c6cdb?date=-1&expression=http.md5=a4a7b8b5eaf4c2cf356b1052133c6cdb")->content;
+    is($sd, "Username=Q&Passwd=B&Section=A", "Remote Right md5");
+
+# NOTE: ViewerUtils.proxyRequest forwards content-type and content-disposition
+# but not the upstream status, so this is 200 remotely where 8123 answers 400.
+    $sd = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8125/api/sessions/bodyhash/a4a7b8b5eaf4c2cf356b105c6cdb?date=-1&expression=http.md5=a4a7b8b5eaf4c2cf356b1052133c6cdb")->content;
+    is($sd, "No match", "Remote No Match");
 
 # ipv6/4 port separators
     $sdId = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("file=$pwd/v6.pcap"));

--- a/tests/api-sessions.t
+++ b/tests/api-sessions.t
@@ -1,4 +1,4 @@
-use Test::More tests => 171;
+use Test::More tests => 179;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -132,6 +132,28 @@ my ($url) = @_;
 # expression string
     $json = post("/api/sessions", '{"date":-1, "spi":"ipsrc", "expression": 1}');
     is($json->{error}, "Expression needs to be a string", "expression not a string");
+
+# A repeated query param arrives as an array, which the query builder assumed
+# was a string. BuildQuery.build is async, so the throw rejected a promise
+# nobody listened to - buildPromise only ever settles from its callback - and
+# the request never answered, holding its socket until the 20 minute server
+# timeout. Short client timeout so a regression fails here instead of stalling.
+    my $qua = LWP::UserAgent->new;
+    $qua->timeout(20);
+
+    my $qr = $qua->get("http://$ArkimeTest::host:8123/sessions.json?date=-1&length=1&order=a&order=b");
+    is($qr->code, 200, "array order answers instead of hanging");
+    like($qr->content, qr/order must be a string/, "array order reports a useful error");
+
+    $qr = $qua->get("http://$ArkimeTest::host:8123/sessions.json?length=1&startTime=1&stopTime=a&stopTime=b");
+    is($qr->code, 200, "array stopTime answers instead of hanging");
+    like($qr->content, qr/stopTime must be a string or number/, "array stopTime reports a useful error");
+
+    $qr = $qua->get("http://$ArkimeTest::host:8123/sessions.json?length=1&startTime=a&startTime=b&stopTime=99");
+    like($qr->content, qr/startTime must be a string or number/, "array startTime reports a useful error");
+
+    $qr = $qua->get("http://$ArkimeTest::host:8123/api/unique?date=-1&field=node&order=a&order=b");
+    is($qr->code, 403, "array order on unique answers instead of hanging");
 
 # csv
     my $csv = getBinary("/sessions.csv?date=-1&expression=" . uri_escape("file=$pwd/socks-http-example.pcap"))->content;
@@ -293,6 +315,15 @@ tcp,1386004309468,1386004309478,10.180.156.185,53533,US,10.180.156.249,1080,US,2
     $json = viewerPost("/api/sessions/test/send?saveId=id&remoteCluster=test2", '{}');
     is($json->{success}, 0, "send sessions missing ids");
     is($json->{i18n}, "api.sessions.missingIds", "send sessions missing ids i18n");
+
+# A node-to-node request with a query string must pass s2s auth on the far end.
+# ViewerUtils.makeRequest used to sign only url.pathname, but the token is bound
+# to the path the remote sees in req.url, query string included, so every call
+# with parameters was rejected there - which silently broke sending sessions to
+# a remote cluster from a node the viewer does not own.
+    $json = viewerGet("/regressionTests/makeRequestQuery/test");
+    unlike($json->{response}, qr/Unauthorized based on bad url/, "makeRequest signs the query string");
+    like($json->{response}, qr/"matched":false/, "makeRequest with a query string reaches the s2s handler");
 
 # Test errors for /api/sessions/send
     $json = viewerPostToken("/api/sessions/send", '', $token);

--- a/tests/api-shortcuts.t
+++ b/tests/api-shortcuts.t
@@ -1,4 +1,4 @@
-use Test::More tests => 125;
+use Test::More tests => 135;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -64,9 +64,24 @@ is($json->{text}, "Missing shortcut value", "shortcut value required");
 $json = viewerPostToken("/api/shortcut", '{"name":"bad_type_shortcut","type":"userId","value":"test"}', $token);
 ok(!$json->{success}, "invalid shortcut type rejected on create");
 
+# Object.prototype names must be rejected as types too. The valid type check
+# used a plain [] lookup, so toString/valueOf/etc resolved truthy off the
+# prototype and were used as the field name to store the values under - which
+# only the lookups index's strict mapping stopped, as a 500 rather than a
+# clean rejection. isPP does not cover these names, so nothing else catches it.
+foreach my $badType ("toString", "valueOf", "hasOwnProperty", "isPrototypeOf") {
+    $json = viewerPostToken("/api/shortcut", "{\"name\":\"pp_$badType\",\"type\":\"$badType\",\"value\":\"test\"}", $token);
+    ok(!$json->{success}, "prototype name $badType rejected on create");
+    is($json->{text}, "Invalid shortcut type", "prototype name $badType rejected as a bad type, not a 500");
+}
+
 # update shortcut with invalid type should fail
 $json = viewerPutToken("/api/shortcut/$shortcut1Id", '{"name":"test_shortcut_updated","type":"userId","value":"test"}', $token);
 ok(!$json->{success}, "invalid shortcut type rejected on update");
+
+$json = viewerPutToken("/api/shortcut/$shortcut1Id", '{"name":"test_shortcut_updated","type":"toString","value":"test"}', $token);
+ok(!$json->{success}, "prototype name rejected on update");
+is($json->{text}, "Invalid shortcut type", "prototype name rejected as a bad type on update");
 
 # update shortcut should sanitize name (strip special chars)
 $json = viewerPutToken("/api/shortcut/$shortcut1Id", '{"name":"test_shortcut~!@#$%^&*()","type":"ip","value":"10.0.0.1"}', $token);

--- a/tests/sessionAuth.t
+++ b/tests/sessionAuth.t
@@ -1,5 +1,5 @@
 # Session-authenticated s2s bypass regression tests (#4108)
-use Test::More tests => 18;
+use Test::More tests => 25;
 use ArkimeTest;
 use JSON;
 use strict;
@@ -49,6 +49,40 @@ $response = $ArkimeTest::userAgent->post("http://$host:$port/receiveSession", ':
 $rjson = from_json($response->content);
 is ($rjson->{success}, 0, "no-session s2s call reaches receiveSession handler");
 is ($response->code, 200, "no-session s2s call reaches receiveSession handler code");
+
+# remoteHunt is s2s only too, and had the same hole: it only checked that an
+# x-arkime-auth header was present, never that it was valid. A session
+# authenticated request skips the s2s passport strategy, so any logged in user
+# with packetSearch could drive it with a junk header.
+# The session user must hold packetSearch, otherwise the route's permission
+# check rejects first and the s2s gate is never what is under test.
+addUser("-n test5 hunttestuser hunttestuser hunttestuser --roles arkimeUser --packetSearch");
+esGet("/_refresh");
+
+my $huntLogin = $ArkimeTest::userAgent->post("http://$host:$port/api/login", { username => 'hunttestuser', password => 'hunttestuser' });
+my ($huntCookie) = ($huntLogin->header('Set-Cookie') // '') =~ /^([^;]+)/;
+ok (defined $huntCookie, "packetSearch user has a session cookie");
+
+my $huntPath = "/api/hunt/test5/nosuchhunt/remote/nosuchsession";
+my $huntUrl = "http://$host:$port$huntPath";
+
+$response = $ArkimeTest::userAgent->get($huntUrl, 'Cookie' => $huntCookie, ':x-arkime-auth' => 'garbage');
+is ($response->code, 401, "session + junk token rejected on remote hunt");
+
+$response = $ArkimeTest::userAgent->get($huntUrl, 'Cookie' => $huntCookie, ':x-arkime-auth' => '{"path": "/", "user": "hunttestuser", "date": ' . time() * 1000 . '}');
+is ($response->code, 401, "session + wrong path token rejected on remote hunt");
+
+$response = $ArkimeTest::userAgent->get($huntUrl, 'Cookie' => $huntCookie, ':x-arkime-auth' => '{"path": "' . $huntPath . '", "user": "hunttestuser", "date": 1}');
+is ($response->code, 401, "session + stale token rejected on remote hunt");
+
+$response = $ArkimeTest::userAgent->get($huntUrl, 'Cookie' => $huntCookie);
+is ($response->code, 401, "session + missing token rejected on remote hunt");
+
+# ...and a genuine, correctly scoped s2s token must still reach the handler
+$response = $ArkimeTest::userAgent->get($huntUrl, ':x-arkime-auth' => '{"path": "' . $huntPath . '", "user": "hunttestuser", "date": ' . time() * 1000 . '}');
+is ($response->code, 200, "valid s2s token reaches remote hunt handler");
+$rjson = from_json($response->content);
+is ($rjson->{matched}, 0, "remote hunt handler ran for a hunt that does not exist");
 
 # Open redirect: a protocol-relative ogurl must not be honored on login (only same-origin paths).
 # Seed session.ogurl by hitting an unauthenticated protocol-relative path, then log in with that session.

--- a/viewer/apiHunts.js
+++ b/viewer/apiHunts.js
@@ -1352,10 +1352,6 @@ ${Config.arkimeWebURL()}sessions?expression=huntId==${huntId}&stopTime=${hunt.qu
    * @returns {string} error - If an error occurred, describes the error.
    */
   static async remoteHunt (req, res) {
-    if (req.headers['x-arkime-auth'] === undefined) {
-      return res.status(401).send('remote hunt only allowed s2s');
-    }
-
     const huntId = req.params.huntId;
     const sessionId = req.params.sessionId;
 

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -1257,8 +1257,12 @@ class SessionAPIs {
         await SessionAPIs.#pcapScrub(req, res, Db.session2Sid(item), whatToRemove);
       } else {
         // Get from remote DISK
-        const scrubPath = `${fields.node}/delete/${whatToRemove}/${Db.session2Sid(item)}`;
-        await ViewerUtils.makeRequest(fields.node, scrubPath, req.user);
+        const scrubPath = `/api/session/${fields.node}/${Db.session2Sid(item)}/scrub/${whatToRemove}`;
+        // makeRequest is callback based, awaiting it without one throws in the
+        // response handler, which is an uncaught exception, not a rejection
+        await new Promise((resolve) => {
+          ViewerUtils.makeRequest(fields.node, scrubPath, req.user, () => resolve());
+        });
       }
     });
   }
@@ -3530,6 +3534,29 @@ class SessionAPIs {
         }, (err, count) => {
           sendResult(count);
         });
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  /**
+   * @ignore
+   * GET - /api/session/:nodeName/:id/scrub/:what
+   *
+   * Scrubs/deletes a session's PCAP on the node that holds it.
+   * s2s only, used by SessionAPIs.#scrubList when the session isn't local.
+   * @name /session/:nodeName/:id/scrub/:what
+   */
+  static async scrubSessionOnNode (req, res) {
+    if (!['all', 'spi', 'pcap'].includes(req.params.what)) {
+      return res.serverError(403, 'Bad scrub type', 'api.sessions.badScrubType');
+    }
+
+    try {
+      await SessionAPIs.#pcapScrub(req, res, req.params.id, req.params.what);
+      return res.send({ success: true });
+    } catch (err) {
+      console.log(`ERROR - ${req.method} /api/session/%s/%s/scrub/%s`, ArkimeUtil.sanitizeStr(req.params.nodeName), ArkimeUtil.sanitizeStr(req.params.id), ArkimeUtil.sanitizeStr(req.params.what), util.inspect(err, false, 50));
+      return res.serverError(500, 'Error scrubbing session', 'api.sessions.scrubFailed');
     }
   }
 

--- a/viewer/apiShortcuts.js
+++ b/viewer/apiShortcuts.js
@@ -60,9 +60,15 @@ class ShortcutAPIs {
    * @returns {Object} {type, values, invalidUsers} - The shortcut type (ip, string, number),
    *                                                  array of values, and list of invalid users
    */
+  // A Set, not an object: a plain [] lookup finds Object.prototype names like
+  // toString or valueOf, which are truthy and so passed as valid types. The
+  // type is then used as the field name to store the values under, which only
+  // the lookups index's strict mapping stopped, and as a 500 rather than a
+  // clean rejection.
+  static #validTypes = new Set(['ip', 'string', 'number']);
+
   static async #normalizeShortcut (shortcut) {
-    const validTypes = { ip: 1, string: 1, number: 1 };
-    if (!validTypes[shortcut.type]) {
+    if (!ArkimeUtil.isString(shortcut.type) || !ShortcutAPIs.#validTypes.has(shortcut.type)) {
       return { type: shortcut.type, values: [], invalidUsers: [], error: 'Invalid shortcut type' };
     }
 
@@ -166,7 +172,9 @@ class ShortcutAPIs {
           shortcut.type = 'string';
         }
 
-        const values = shortcut[shortcut.type];
+        // A shortcut with none of number/ip/string would otherwise throw on
+        // join below, which 500s the whole list for everyone who can see it
+        const values = shortcut[shortcut.type] ?? [];
 
         if (req.query.fieldFormat && req.query.fieldFormat === 'true') {
           const shortcutName = `$${shortcut.name}`;

--- a/viewer/buildQuery.js
+++ b/viewer/buildQuery.js
@@ -45,6 +45,11 @@ class BuildQuery {
 
     // New Method
     if (info.order) {
+      // a repeated query param arrives as an array, which has no split
+      if (!ArkimeUtil.isString(info.order)) {
+        throw new Error('order must be a string');
+      }
+
       if (info.order.length === 0) {
         addSortDefault();
         return;
@@ -285,6 +290,27 @@ class BuildQuery {
    * @param {object|null} queryOverride=null - override the client query with overriding query
    */
   static async build (req, buildCb, queryOverride = null) {
+    // build is async, so anything it throws rejects a promise no caller is
+    // listening to: buildPromise only ever settles from this callback, and the
+    // plain callback callers never see the rejection either. The request then
+    // never gets a response and holds its socket until the server timeout, so
+    // turn a throw into the error the callers already know how to report.
+    let called = false;
+    const buildCbOnce = (err, query, indices) => {
+      if (called) { return undefined; } // a throwing buildCb must not re-enter
+      called = true;
+      return buildCb(err, query, indices);
+    };
+
+    try {
+      return await BuildQuery.#build(req, buildCbOnce, queryOverride);
+    } catch (err) {
+      return buildCbOnce(err, {});
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  static async #build (req, buildCb, queryOverride = null) {
     // validate time limit is not exceeded
     let timeLimitExceeded = false;
 
@@ -552,6 +578,15 @@ class BuildQuery {
         interval = 60 * 60; // Hour to be safe
       }
     } else if ((reqQuery.startTime !== undefined) && (reqQuery.stopTime !== undefined)) {
+      // numbers are fine, they always pass the digits test below and never
+      // reach replace. A repeated query param arrives as an array, which does
+      // not, and has no replace
+      for (const field of ['startTime', 'stopTime']) {
+        if (!ArkimeUtil.isString(reqQuery[field]) && typeof reqQuery[field] !== 'number') {
+          throw new Error(`${field} must be a string or number`);
+        }
+      }
+
       if (!/^-?[0-9]+$/.test(reqQuery.startTime)) {
         startTimeSec = Date.parse(reqQuery.startTime.replace('+', ' ')) / 1000;
       } else {

--- a/viewer/viewer.js
+++ b/viewer/viewer.js
@@ -235,6 +235,17 @@ if (ArkimeConfig.regressionTests) {
     preq.end();
   });
 
+  // make a node-to-node request carrying a query string to an s2s only route
+  // and report what the far end said. The s2s token is bound to the path the
+  // remote sees in req.url, query string included, so a signature covering only
+  // the pathname is rejected there.
+  app.get('/regressionTests/makeRequestQuery/:node', (req, res) => {
+    const s2sPath = `/api/hunt/${req.params.node}/nosuchhunt/remote/nosuchsession?foo=bar`;
+    ViewerUtils.makeRequest(req.params.node, s2sPath, { userId: 'anonymous' }, (err, response) => {
+      return res.send({ error: err ? '' + err : undefined, response: response ?? '' });
+    });
+  });
+
   app.post('/regressionTests/shutdown', function (req, res) {
     Db.close();
     process.exit(0);
@@ -615,6 +626,19 @@ function checkCookieToken (req, res, next) {
     return res.serverError(500, 'Timeout - Please try reloading page and repeating the action', 'api.viewer.sessionTimeout');
   }
 
+  return next();
+}
+
+// use for node-to-node only APIs, which no browser should ever reach.
+// A session authenticated request skips the s2s passport strategy entirely
+// (Auth.doAuth returns early on isAuthenticated), so merely having an
+// x-arkime-auth header proves nothing - it must be validated here.
+function checkS2SToken (req, res, next) {
+  const { error } = Auth.parseS2SRequest(req);
+  if (error) {
+    console.log('ERROR - s2s only api', ArkimeUtil.sanitizeStr(req.url), error);
+    return res.status(401).send('Only allowed s2s');
+  }
   return next();
 }
 
@@ -1967,6 +1991,12 @@ app.get( // sessions get decodings endpoint
   SessionAPIs.getDecodings
 );
 
+app.get( // session scrub on node endpoint - s2s only, used by SessionAPIs.#scrubList
+  ['/api/session/:nodeName/:id/scrub/:what'],
+  [checkS2SToken, checkProxyRequest, User.checkPermissions(['removeEnabled'])],
+  SessionAPIs.scrubSessionOnNode
+);
+
 app.get( // session send to node endpoint - used by SessionAPIs.#sendSessionsList
   ['/api/session/:nodeName/:id/send'],
   [checkProxyRequest],
@@ -2075,7 +2105,7 @@ app.delete( // remove users from hunt endpoint
 
 app.get( // remote hunt endpoint - s2s only
   ['/api/hunt/:nodeName/:huntId/remote/:sessionId'],
-  [ArkimeUtil.noCacheJson, User.checkPermissions(['packetSearch'])],
+  [ArkimeUtil.noCacheJson, checkS2SToken, User.checkPermissions(['packetSearch'])],
   HuntAPIs.remoteHunt
 );
 

--- a/viewer/viewerUtils.js
+++ b/viewer/viewerUtils.js
@@ -349,7 +349,9 @@ class ViewerUtils {
         url = new URL(nodePath, viewUrl);
       }
 
-      Auth.addS2SAuth(options, user, node, url.pathname, ViewerUtils.getClusterSecret(cluster));
+      // Sign the path exactly as the remote node will see it in req.url, query
+      // string included, otherwise any call with parameters fails s2s auth
+      Auth.addS2SAuth(options, user, node, url.pathname + (url.search ?? ''), ViewerUtils.getClusterSecret(cluster));
       if (!portal) { ViewerUtils.addCaTrust(options, node); }
 
       function responseFunc (pres) {


### PR DESCRIPTION
- Fix scrubbing pcap on a remote node exiting the viewer, makeRequest was awaited without the callback it answers through
- Restore the per node scrub api dropped in the api standardization, remote scrubs have silently done nothing since 3.0.0
- Validate the s2s token on the remote hunt api, it only checked that the header was present
- Sign the query string in node-to-node s2s auth, requests with parameters were rejected by the far end
- Reject shortcut types naming an Object.prototype member such as toString or valueOf
- Report a throw while building a session query instead of leaving the request unanswered until the server timeout
- Add remote node test coverage for scrub, bodyhash and s2s signing, which a single host test rig never reaches

# License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
