### PR TITLE
Fix bugs and security issues found reviewing cont3xt/

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -76,6 +76,13 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           eg db.pl <host:port> users-update '*' --addRole mcpUser --dryrun
   - #4162 Add initorupgrade/initorupgradenoprompt command to init a fresh cluster or upgrade an existing one,
           whichever applies, pair with --ifneeded to no-op when already current
+## Cont3xt
+  - #4204 Fix cont3xt exiting when asked for an integration named after a built-in javascript property
+  - #4204 Fix cont3xt exiting on every link group fetch after invalid settings were saved; general and integration settings are now validated and report a real save failure
+  - #4204 Searching a single integration is now recorded in history, the same as a full search
+  - #4204 Add maxBulkIndicators, default 500, limiting how many indicators one search can query at once
+  - #4204 Fix history paging, sorting and search parameters not being validated for all database backends
+  - #4204 Fix an error while running a search exiting cont3xt instead of being logged
 ## Viewer
   - #4080 Add dbAdmin role that grants Elasticsearch/OpenSearch admin access; the esAdminUsers setting is now deprecated and will be removed in Arkime 7
   - #4081 Let the dbAdmin role use the ES stats action menus (index, shard, and task operations); the ES indices menu now only requires removeEnabled for deleting an index, matching the backend

--- a/common/arkimeUtil.js
+++ b/common/arkimeUtil.js
@@ -162,6 +162,15 @@ class ArkimeUtil {
 
   // ----------------------------------------------------------------------------
   /**
+   * Is obj a plain object - typeof says 'object' for both null and arrays,
+   * which is almost never what a request body validator wants
+   */
+  static isPlainObject (obj) {
+    return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
+  }
+
+  // ----------------------------------------------------------------------------
+  /**
    * Is arr an array of strings, with each string being at least minLen
    */
   static isStringArray (arr, minLen = 1) {

--- a/cont3xt/audit.js
+++ b/cont3xt/audit.js
@@ -8,8 +8,13 @@
 'use strict';
 
 const ArkimeConfig = require('../common/arkimeConfig');
+const ArkimeUtil = require('../common/arkimeUtil');
 
 class Audit {
+  // the only fields an audit can be sorted on
+  static SORT_FIELDS = ['issuedAt', 'indicator', 'iType'];
+  static MAX_ITEMS_PER_PAGE = 10000;
+
   constructor (data) {
     Object.assign(this, data);
   }
@@ -118,13 +123,21 @@ class Audit {
    */
   static async apiGet (req, res, next) {
     const roles = await req.user.getRoles();
-    // default query parameters
+
+    // normalize the values that reach an ES size, a sql LIMIT, a sort field
+    // name or an array index - the Db implementations don't all validate.
+    // startMs/stopMs only ever become a range bound or a bound sql param, so
+    // they are passed through as-is.
     const query = { ...req.query };
-    query.page ??= 1;
-    query.itemsPerPage ??= 100;
-    if (query.itemsPerPage === '-1') { query.itemsPerPage = 10000; }
-    query.sortBy ??= 'issuedAt';
-    query.sortOrder ??= 'desc';
+    query.sortBy = Audit.SORT_FIELDS.includes(query.sortBy) ? query.sortBy : 'issuedAt';
+    query.sortOrder = query.sortOrder === 'asc' ? 'asc' : 'desc';
+    if (!ArkimeUtil.isString(query.searchTerm)) { query.searchTerm = undefined; }
+    query.page = Math.abs(parseInt(query.page, 10)) || 1;
+    // must land in [1, MAX] - a negative LIMIT means no limit in sqlite, and
+    // ES rejects a from+size past max_result_window
+    query.itemsPerPage = query.itemsPerPage === '-1'
+      ? Audit.MAX_ITEMS_PER_PAGE
+      : Math.min(Math.abs(parseInt(query.itemsPerPage, 10)) || 100, Audit.MAX_ITEMS_PER_PAGE);
 
     const { audits, total } = await Db.getMatchingAudits(req.user.userId, [...roles], query);
     res.send({ success: true, audits, total });

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -307,9 +307,26 @@ function apiGetSettings (req, res, next) {
   });
 }
 
+// verify linkGroup settings, on error returns { msg: <errorMsg> }, on success returns { linkGroup }
+// these are read back by LinkGroup.apiGet, so a wrong shape here breaks every
+// later link group fetch for this user
+function verifyLinkGroupSettings (linkGroup) {
+  if (!ArkimeUtil.isPlainObject(linkGroup)) {
+    return { msg: 'linkGroup must be an object' };
+  }
+
+  linkGroup = (({ order }) => ({ order }))(linkGroup); // only allow order
+
+  if (linkGroup.order !== undefined && !ArkimeUtil.isStringArray(linkGroup.order)) {
+    return { msg: 'linkGroup.order must be an array of strings' };
+  }
+
+  return { linkGroup };
+}
+
 // verify selectedOverviews, on error returns { msg: <errorMsg> }, on success returns { selectedOverviews }
 function verifySelectedOverviews (selectedOverviews) {
-  if (typeof selectedOverviews !== 'object' || selectedOverviews === null || Array.isArray(selectedOverviews)) {
+  if (!ArkimeUtil.isPlainObject(selectedOverviews)) {
     return { msg: 'selectedOverviews must be an object' };
   }
 
@@ -347,12 +364,18 @@ function apiPutSettings (req, res, next) {
     if (user.cont3xt === undefined) { user.cont3xt = {}; }
 
     if (req.body?.settings) {
+      if (!ArkimeUtil.isPlainObject(req.body.settings)) {
+        return res.send({ success: false, text: 'settings must be an object' });
+      }
       user.cont3xt.settings = req.body.settings;
       save = true;
     }
 
     if (req.body?.linkGroup) {
-      user.cont3xt.linkGroup = req.body.linkGroup;
+      const { msg, linkGroup } = verifyLinkGroupSettings(req.body.linkGroup);
+      if (msg) { return res.send({ success: false, text: msg }); }
+
+      user.cont3xt.linkGroup = linkGroup;
       save = true;
     }
 
@@ -481,7 +504,12 @@ User.prototype.setCont3xtKeys = function (v) {
     this.cont3xt = {};
   }
   this.cont3xt.keys = Auth.obj2auth(v, Auth.passwordSecret256);
-  this.save((err) => { console.log('SAVED', err); });
+  return new Promise((resolve, reject) => {
+    this.save((err) => {
+      if (err) { return reject(err); }
+      resolve();
+    });
+  });
 };
 
 // ----------------------------------------------------------------------------

--- a/cont3xt/db.js
+++ b/cont3xt/db.js
@@ -159,6 +159,21 @@ class Db {
 }
 
 /******************************************************************************/
+// Shared helpers
+/******************************************************************************/
+// Sort audits for the implementations that do it in memory. Records predating
+// a field (or with it unset) must not throw here.
+function sortAudits (audits, sortBy, sortOrder) {
+  const dir = sortOrder === 'asc' ? 1 : -1;
+  return audits.sort((a, b) => {
+    if (sortBy === 'indicator' || sortBy === 'iType') {
+      return dir * (a[sortBy] ?? '').localeCompare(b[sortBy] ?? '');
+    }
+    return dir * ((a[sortBy] ?? 0) - (b[sortBy] ?? 0));
+  });
+}
+
+/******************************************************************************/
 // ES Implementation of Cont3xt DB
 /******************************************************************************/
 class DbESImplementation {
@@ -419,21 +434,26 @@ class DbESImplementation {
       }
     }
 
-    const results = await this.client.search({
-      index: 'cont3xt_links',
-      body: query,
-      rest_total_hits_as_int: true
-    });
+    try {
+      const results = await this.client.search({
+        index: 'cont3xt_links',
+        body: query,
+        rest_total_hits_as_int: true
+      });
 
-    const hits = results.body.hits.hits;
-    const linkGroups = [];
-    for (let i = 0; i < hits.length; i++) {
-      const linkGroup = new LinkGroup(hits[i]._source);
-      linkGroup._id = hits[i]._id;
-      linkGroups.push(linkGroup);
+      const hits = results.body.hits.hits;
+      const linkGroups = [];
+      for (let i = 0; i < hits.length; i++) {
+        const linkGroup = new LinkGroup(hits[i]._source);
+        linkGroup._id = hits[i]._id;
+        linkGroups.push(linkGroup);
+      }
+
+      return linkGroups;
+    } catch (err) {
+      console.log('ERROR FETCHING LINKGROUPS', util.inspect(err, false, 10));
+      return [];
     }
-
-    return linkGroups;
   }
 
   async putLinkGroup (id, linkGroup) {
@@ -655,7 +675,7 @@ class DbESImplementation {
       });
     }
 
-    if (searchTerm != null && typeof searchTerm === 'string') {
+    if (ArkimeUtil.isString(searchTerm)) {
       filter.push({ // apply search term across whitelisted fields only
         bool: {
           should: ['indicator', 'iType', 'tags'].map(field => ({
@@ -727,21 +747,26 @@ class DbESImplementation {
       }
     }
 
-    const results = await this.client.search({
-      index: 'cont3xt_overviews',
-      body: query,
-      rest_total_hits_as_int: true
-    });
+    try {
+      const results = await this.client.search({
+        index: 'cont3xt_overviews',
+        body: query,
+        rest_total_hits_as_int: true
+      });
 
-    const hits = results.body.hits.hits;
-    const overviews = [];
-    for (let i = 0; i < hits.length; i++) {
-      const overview = new Overview(hits[i]._source);
-      overview._id = hits[i]._id;
-      overviews.push(overview);
+      const hits = results.body.hits.hits;
+      const overviews = [];
+      for (let i = 0; i < hits.length; i++) {
+        const overview = new Overview(hits[i]._source);
+        overview._id = hits[i]._id;
+        overviews.push(overview);
+      }
+
+      return overviews;
+    } catch (err) {
+      console.log('ERROR FETCHING OVERVIEWS', util.inspect(err, false, 10));
+      return [];
     }
-
-    return overviews;
   }
 
   async putOverview (id, overview) {
@@ -920,11 +945,11 @@ class DbLMDBImplementation {
         }
 
         // apply search term
-        if (searchTerm != null) {
+        if (ArkimeUtil.isString(searchTerm)) {
           const containsTerm = (
-            value.indicator.includes(searchTerm) ||
-            value.iType.includes(searchTerm) ||
-            value.tags.some(tag => tag.includes(searchTerm))
+            value.indicator?.includes(searchTerm) ||
+            value.iType?.includes(searchTerm) ||
+            value.tags?.some(tag => tag.includes(searchTerm))
           );
           if (!containsTerm) { return false; }
         }
@@ -939,12 +964,7 @@ class DbLMDBImplementation {
     const total = audits.length; // save this for paging
 
     // sort and page the audits
-    audits = audits.sort((a, b) => {
-      if (sortBy === 'indicator' || sortBy === 'iType') {
-        return sortOrder === 'asc' ? a[sortBy].localeCompare(b[sortBy]) : b[sortBy].localeCompare(a[sortBy]);
-      }
-      return sortOrder === 'asc' ? a[sortBy] - b[sortBy] : b[sortBy] - a[sortBy];
-    }).slice((page - 1) * itemsPerPage, page * itemsPerPage);
+    audits = sortAudits(audits, sortBy, sortOrder).slice((page - 1) * itemsPerPage, page * itemsPerPage);
 
     return { audits, total };
   }
@@ -1158,7 +1178,7 @@ class DbSQLiteImplementation {
       params.push(userId);
     }
 
-    if (searchTerm != null && typeof searchTerm === 'string') {
+    if (ArkimeUtil.isString(searchTerm)) {
       conditions.push("(json_extract(json, '$.indicator') LIKE ? OR json_extract(json, '$.iType') LIKE ? OR json_extract(json, '$.tags') LIKE ?)");
       const likeTerm = `%${searchTerm}%`;
       params.push(likeTerm, likeTerm, likeTerm);
@@ -1363,7 +1383,7 @@ class DbRedisImplementation {
         continue;
       }
 
-      if (searchTerm != null && typeof searchTerm === 'string') {
+      if (ArkimeUtil.isString(searchTerm)) {
         const containsTerm = (
           (item.indicator && item.indicator.includes(searchTerm)) ||
           (item.iType && item.iType.includes(searchTerm)) ||
@@ -1381,12 +1401,7 @@ class DbRedisImplementation {
 
     const total = audits.length;
 
-    audits = audits.sort((a, b) => {
-      if (sortBy === 'indicator' || sortBy === 'iType') {
-        return sortOrder === 'asc' ? a[sortBy].localeCompare(b[sortBy]) : b[sortBy].localeCompare(a[sortBy]);
-      }
-      return sortOrder === 'asc' ? a[sortBy] - b[sortBy] : b[sortBy] - a[sortBy];
-    }).slice((page - 1) * itemsPerPage, page * itemsPerPage);
+    audits = sortAudits(audits, sortBy, sortOrder).slice((page - 1) * itemsPerPage, page * itemsPerPage);
 
     return { audits, total };
   }

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -32,7 +32,9 @@ class Integration {
 
   static #cache;
   static #cont3xtStartTime = Date.now();
-  static #integrationsByName = {};
+  // a Map so a request can't reach Object.prototype members (constructor,
+  // __proto__, toString, ...) by asking for an integration with that name
+  static #integrationsByName = new Map();
   static #integrations = {
     all: [],
     ip: [],
@@ -154,7 +156,7 @@ class Integration {
     integration.normalizeTidbits();
     // console.log(integration.name, JSON.stringify(integration.card, false, 2));
 
-    Integration.#integrationsByName[integration.name] = integration;
+    Integration.#integrationsByName.set(integration.name, integration);
     Integration.#integrations.all.push(integration);
     for (const itype in integration.itypes) {
       Integration.#integrations[itype].push(integration);
@@ -402,8 +404,23 @@ class Integration {
     return res.send({ success: true, integrations: results });
   }
 
+  // runIntegrationsList is deliberately never awaited, so it has to swallow its
+  // own failures. An unhandled rejection here exits cont3xt for every user.
+  static #startIntegrationsList (shared, indicator, parentIndicator, integrations) {
+    Integration.runIntegrationsList(shared, indicator, parentIndicator, integrations)
+      .catch((err) => {
+        console.log('ERROR - running %s integrations:', ArkimeUtil.sanitizeStr(indicator?.itype), err);
+      });
+  }
+
   static async runIntegrationsList (shared, indicator, parentIndicator, integrations) {
     const { query, itype } = indicator;
+
+    // an integration's addMoreIntegrations can hand back an unknown itype
+    if (integrations === undefined) {
+      console.log('WARNING - unknown itype "%s" from a sub-indicator', ArkimeUtil.sanitizeStr(itype));
+      return;
+    }
 
     // initial write for sub-indicators (ensures dependable tracking of indicator tree)
     if (parentIndicator != null) {
@@ -429,7 +446,7 @@ class Integration {
             shared.res.write(JSON.stringify({ purpose: 'enhance', indicator: moreIndicator, enhanceInfo }));
             shared.res.write(',\n');
           }
-          Integration.runIntegrationsList(shared, moreIndicator, indicator, Integration.#integrations[moreIndicator.itype]);
+          Integration.#startIntegrationsList(shared, moreIndicator, indicator, Integration.#integrations[moreIndicator.itype]);
         });
       }
 
@@ -664,6 +681,13 @@ class Integration {
       return res.send({ purpose: 'error', text: 'query must contain at least one non-whitespace indicator' });
     }
 
+    // each indicator fans out to every integration (plus a child lookup for
+    // emails/urls), so cap how much work one request can ask for
+    const maxBulkIndicators = +ArkimeConfig.get('maxBulkIndicators', 500);
+    if (queries.length > maxBulkIndicators) {
+      return res.send({ purpose: 'error', text: `query must contain at most ${maxBulkIndicators} indicators` });
+    }
+
     const indicators = queries.map((query) => {
       const { itype, decoded } = Integration.classify(query);
       return { query, itype, decoded };
@@ -713,18 +737,18 @@ class Integration {
       const { query, itype } = indicator;
       const integrations = Integration.#integrations[itype];
 
-      Integration.runIntegrationsList(shared, indicator, undefined, integrations);
+      Integration.#startIntegrationsList(shared, indicator, undefined, integrations);
       if (!shared.skipChildren) {
         if (itype === 'email') {
           const dquery = query.slice(query.indexOf('@') + 1);
-          Integration.runIntegrationsList(shared, { query: dquery, itype: 'domain' }, indicator, Integration.#integrations.domain);
+          Integration.#startIntegrationsList(shared, { query: dquery, itype: 'domain' }, indicator, Integration.#integrations.domain);
         } else if (itype === 'url') {
           const url = new URL(query);
           if (Integration.classify(url.hostname).itype === 'ip') {
-            Integration.runIntegrationsList(shared, { query: url.hostname, itype: 'ip' }, indicator, Integration.#integrations.ip);
+            Integration.#startIntegrationsList(shared, { query: url.hostname, itype: 'ip' }, indicator, Integration.#integrations.ip);
           } else {
             const equery = await extractDomain(query, { tld: true });
-            Integration.runIntegrationsList(shared, { query: equery, itype: 'domain' }, indicator, Integration.#integrations.domain);
+            Integration.#startIntegrationsList(shared, { query: equery, itype: 'domain' }, indicator, Integration.#integrations.domain);
           }
         }
       }
@@ -767,7 +791,7 @@ class Integration {
       }
     }
 
-    const integration = Integration.#integrationsByName[req.params.integration];
+    const integration = Integration.#integrationsByName.get(req.params.integration);
 
     if (integration === undefined || integration.itypes[itype] === undefined) {
       return res.send({ purpose: 'error', text: `integration ${itype} ${req.params.integration} not found` });
@@ -794,24 +818,46 @@ class Integration {
     stats.directLookup++;
     istats.directLookup++;
     const dStartTime = Date.now();
+
+    // this endpoint queries the same external sources as /integration/search,
+    // so it must leave the same history behind - otherwise it is a way to look
+    // an indicator up without being audited
+    const issuedAt = dStartTime;
+    const audit = (resultCount) => {
+      Audit.create({
+        userId: req.user.userId,
+        indicator: query,
+        iType: itype,
+        tags: [],
+        issuedAt,
+        took: Date.now() - issuedAt,
+        resultCount
+      }).catch((err) => {
+        console.log('ERROR - creating audit log.', err);
+      });
+    };
+
     integration[integration.itypes[itype]](req.user, normalizedQuery)
       .then(response => {
         updateTime(stats, istats, Date.now() - dStartTime, 'direct');
         stats.directFound++;
         istats.directFound++;
         if (response === Integration.NoResult) {
+          audit(0);
           res.send({ purpose: 'data', indicator, name: integration.name, data: { _cont3xt: { createTime: Date.now() } } });
         } else if (response) {
           stats.directGood++;
           istats.directGood++;
           if (!response._cont3xt) { response._cont3xt = {}; }
           response._cont3xt.createTime = Date.now();
+          audit(response._cont3xt.count ?? 0);
           res.send({ purpose: 'data', indicator, name: integration.name, data: response });
           if (Integration.#cache && integration.cacheable) {
             const cacheKey = `${integration.sharedCache ? 'shared' : req.user.userId}-${integration.name}-${itype}-${normalizedQuery}`;
             Integration.#cache.set(cacheKey, response);
           }
         } else {
+          audit(0);
           res.send({ purpose: 'data', indicator, name: integration.name, data: { _cont3xt: { createTime: Date.now() } } });
         }
       })
@@ -819,6 +865,7 @@ class Integration {
         console.log(integration.name, itype, query, err);
         stats.directError++;
         istats.directError++;
+        audit(0);
         res.status(500).send({ purpose: 'fail', indicator, name: integration.name });
       });
   }
@@ -898,10 +945,23 @@ class Integration {
    * @returns {IntegrationSetting[]} settings - The integration settings to update for the logged in user
    */
   static async apiPutSettings (req, res, next) {
-    if (typeof req.body.settings !== 'object') {
+    // typeof null and typeof [] are both 'object'
+    if (!ArkimeUtil.isPlainObject(req.body.settings)) {
       return res.send({ success: false, text: 'Missing settings' });
     }
-    req.user.setCont3xtKeys(req.body.settings);
+
+    for (const iname in req.body.settings) {
+      if (!ArkimeUtil.isPlainObject(req.body.settings[iname])) {
+        return res.send({ success: false, text: `settings.${ArkimeUtil.sanitizeStr(iname)} must be an object` });
+      }
+    }
+
+    try {
+      await req.user.setCont3xtKeys(req.body.settings);
+    } catch (err) {
+      console.log('ERROR - saving cont3xt keys', err);
+      return res.send({ success: false, text: 'Save failed' });
+    }
     res.send({ success: true, text: 'Saved' });
   }
 

--- a/cont3xt/linkGroup.js
+++ b/cont3xt/linkGroup.js
@@ -68,7 +68,8 @@ class LinkGroup {
     const reordered = [];
     const unordered = [];
     const settings = req.user.cont3xt ?? {};
-    if (settings.linkGroup && settings.linkGroup.order) {
+    // don't trust the stored shape, older/hand edited users may have anything
+    if (Array.isArray(settings.linkGroup?.order)) {
       for (const group of linkGroups) {
         if (settings.linkGroup.order.indexOf(group._id) === -1) {
           unordered.push(group);

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -1,5 +1,5 @@
 # Test cont3xt.js
-use Test::More tests => 227;
+use Test::More tests => 269;
 use Test::Differences;
 use Data::Dumper;
 use ArkimeTest;
@@ -944,6 +944,13 @@ $json = cont3xtPost('/api/integration/search', to_json({
 }));
 eq_or_diff($json, from_json('{"purpose": "error", "text": "query must contain at least one non-whitespace indicator"}'));
 
+# a single search must not be able to fan out unbounded
+$json = cont3xtPost('/api/integration/search', to_json({
+    query => join(" ", map { sprintf("10.0.%d.%d", int($_ / 250), $_ % 250) } (0..500))
+}));
+eq_or_diff($json, from_json('{"purpose": "error", "text": "query must contain at most 500 indicators"}'), "too many indicators rejected");
+
+
 esGet("/_flush");
 esGet("/_refresh");
 ################################################################################
@@ -960,6 +967,29 @@ $json = cont3xtPost('/api/integration/ip/bar/search', to_json({
   query => "8.8.8.8"
 }));
 eq_or_diff($json, from_json('{"purpose": "error", "text": "integration ip bar not found"}'));
+
+# integration names must not resolve through Object.prototype, these used to
+# throw inside the handler and take the whole process down.
+# __proto__/constructor never get this far, auth's path checker stops them
+foreach my $proto ("constructor", "__proto__") {
+  $json = cont3xtPost("/api/integration/ip/$proto/search", to_json({
+    query => "8.8.8.8"
+  }));
+  is($json->{success}, 0, "integration name $proto blocked by path checker");
+  ok($json->{text} =~ /^Bad path/, "integration name $proto bad path");
+}
+
+# these do reach the handler
+foreach my $proto ("toString", "hasOwnProperty", "valueOf", "isPrototypeOf") {
+  $json = cont3xtPost("/api/integration/ip/$proto/search", to_json({
+    query => "8.8.8.8"
+  }));
+  eq_or_diff($json, from_json("{\"purpose\": \"error\", \"text\": \"integration ip $proto not found\"}"), "integration name $proto not found");
+}
+
+# and the service is still alive afterwards
+$json = cont3xtGet('/api/health');
+is($json->{success}, 1, "still up after prototype named integration lookups");
 
 # wrong itype for query value
 $json = cont3xtPost('/api/integration/domain/Maxmind/search', to_json({
@@ -1019,6 +1049,12 @@ is($json->{data}->{results}->[0]->{key}, "tags");
 
 ################################################################################
 ### HISTORY
+# the single integration searches above are audited after their response is
+# sent, give those writes a moment to land
+sleep(1);
+esGet("/_flush");
+esGet("/_refresh");
+
 $json = cont3xtGet('/api/audits?searchTerm=goodtag');
 is($json->{success}, 1);
 is (scalar @{$json->{audits}}, 1);
@@ -1027,9 +1063,17 @@ $json = cont3xtGet('/api/audits?searchTerm=foo');
 is($json->{success}, 1);
 is (scalar @{$json->{audits}}, 0);
 
+# a single integration search must leave history behind, exactly like a full
+# search - whois.apnic.net was only ever queried via /:itype/:integration/search
+$json = cont3xtGet('/api/audits?searchTerm=whois.apnic.net');
+is($json->{success}, 1);
+is (scalar @{$json->{audits}}, 1, "single integration search is audited");
+is ($json->{audits}->[0]->{indicator}, "whois.apnic.net", "single search audit records the indicator");
+is ($json->{audits}->[0]->{iType}, "domain", "single search audit records the itype");
+
 $json = cont3xtGet('/api/audits');
 is($json->{success}, 1);
-is (scalar @{$json->{audits}}, 4);
+is (scalar @{$json->{audits}}, 11, "4 bulk searches + 7 single integration searches audited");
 $id = $json->{audits}->[0]->{_id};
 
 $json = cont3xtDelete("/api/audit/$id", '{}');
@@ -1043,7 +1087,7 @@ eq_or_diff($json, from_json('{"success": false, "text": "History log not found"}
 
 $json = cont3xtGet('/api/audits');
 is($json->{success}, 1);
-is (scalar @{$json->{audits}}, 3);
+is (scalar @{$json->{audits}}, 10);
 
 # use actual issuedAt from results to build reliable date ranges
 my @timestamps = sort map { $_->{issuedAt} } @{$json->{audits}};
@@ -1053,7 +1097,7 @@ my $maxTime = $timestamps[-1];
 # date range covering all audits
 $json = cont3xtGet("/api/audits?startMs=" . ($minTime - 1) . "&stopMs=" . ($maxTime + 1));
 is($json->{success}, 1);
-is (scalar @{$json->{audits}}, 3, "all audits in range");
+is (scalar @{$json->{audits}}, 10, "all audits in range");
 
 # date range before all audits
 $json = cont3xtGet("/api/audits?startMs=" . ($minTime - 2000) . "&stopMs=" . ($minTime - 1000));
@@ -1084,21 +1128,52 @@ ok($json->{audits}->[0]->{issuedAt} >= $json->{audits}->[-1]->{issuedAt}, "defau
 $json = cont3xtGet('/api/audits?page=1&itemsPerPage=2');
 is($json->{success}, 1);
 is (scalar @{$json->{audits}}, 2, "page 1 has 2 items");
-is ($json->{total}, 3, "total is still 3");
+is ($json->{total}, 10, "total is still 10");
 
 $json = cont3xtGet('/api/audits?page=2&itemsPerPage=2');
 is($json->{success}, 1);
-is (scalar @{$json->{audits}}, 1, "page 2 has 1 item");
+is (scalar @{$json->{audits}}, 2, "page 2 has 2 items");
 
 # itemsPerPage=-1 returns all audits
 $json = cont3xtGet('/api/audits?itemsPerPage=-1');
 is($json->{success}, 1);
-is (scalar @{$json->{audits}}, 3, "itemsPerPage=-1 returns all items");
+is (scalar @{$json->{audits}}, 10, "itemsPerPage=-1 returns all items");
 
 # combined date range + search
 $json = cont3xtGet("/api/audits?startMs=" . ($minTime - 1) . "&stopMs=" . ($maxTime + 1) . "&searchTerm=goodtag");
 is($json->{success}, 1);
 is (scalar @{$json->{audits}}, 1, "date range + searchTerm combined");
+
+# query param validation - an unknown sortBy falls back to issuedAt rather
+# than reaching the backend, and paging values are clamped
+$json = cont3xtGet('/api/audits?sortBy=userId');
+is($json->{success}, 1, "unknown sortBy ignored");
+is (scalar @{$json->{audits}}, 10, "unknown sortBy still returns audits");
+
+$json = cont3xtGet('/api/audits?sortBy[]=issuedAt&sortOrder[]=asc');
+is($json->{success}, 1, "array sortBy/sortOrder ignored");
+
+$json = cont3xtGet('/api/audits?itemsPerPage=99999999999');
+is($json->{success}, 1, "huge itemsPerPage clamped");
+is (scalar @{$json->{audits}}, 10, "huge itemsPerPage still returns audits");
+
+$json = cont3xtGet('/api/audits?page=-5&itemsPerPage=-20');
+is($json->{success}, 1, "negative paging clamped");
+
+$json = cont3xtGet('/api/audits?page=notanumber&itemsPerPage=notanumber');
+is($json->{success}, 1, "non numeric paging defaulted");
+is (scalar @{$json->{audits}}, 10, "non numeric paging returns defaults");
+
+$json = cont3xtGet('/api/audits?searchTerm[]=goodtag');
+is($json->{success}, 1, "non string searchTerm ignored");
+
+# 500 indicators is still allowed (no integrations selected, so no lookups)
+$json = cont3xtPost('/api/integration/search', to_json({
+    query => join(" ", map { sprintf("10.0.%d.%d", int($_ / 250), $_ % 250) } (0..499)),
+    doIntegrations => ["nosuchintegration"]
+}));
+is($json->[0]->{purpose}, "init", "500 indicators allowed");
+is(scalar @{$json->[0]->{indicators}}, 500, "500 indicators classified");
 # Bad
 $json = cont3xtPostToken('/api/view', to_json({
 }), $token);
@@ -1213,6 +1288,25 @@ ok($json =~ /SyntaxError: Unexpected token/);
 $json = cont3xtPutToken('/api/integration/settings', '{"__proto__": {"foo": 1}}', $token);
 is ($json, "SyntaxError: Object contains forbidden prototype property");
 
+# typeof null and typeof [] are both 'object', neither is a settings map
+$json = cont3xtPutToken('/api/integration/settings', '{"settings": null}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Missing settings"}'), "null integration settings rejected");
+
+$json = cont3xtPutToken('/api/integration/settings', '{"settings": []}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Missing settings"}'), "array integration settings rejected");
+
+$json = cont3xtPutToken('/api/integration/settings', '{"settings": "hi"}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "Missing settings"}'), "string integration settings rejected");
+
+$json = cont3xtPutToken('/api/integration/settings', '{"settings": {"Twilio": "notanobject"}}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "settings.Twilio must be an object"}'), "non object integration setting rejected");
+
+$json = cont3xtPutToken('/api/integration/settings', '{"settings": {"Twilio": {"disabled": true}}}', $token);
+eq_or_diff($json, from_json('{"success": true, "text": "Saved"}'), "valid integration settings saved");
+
+$json = cont3xtPutToken('/api/integration/settings', '{"settings": {}}', $token);
+eq_or_diff($json, from_json('{"success": true, "text": "Saved"}'), "integration settings cleared");
+
 ################################################################################
 ### General Settings (not integration settings)
 $json = cont3xtGet('/api/settings');
@@ -1232,6 +1326,45 @@ eq_or_diff($json, from_json('{"success": false, "text": "Nothing sent to change"
 # PUT settings with actual settings
 $json = cont3xtPutToken('/api/settings', '{"settings": {"foo": "bar"}}', $token);
 is($json->{success}, 1, "put settings success");
+
+# settings must be an object, not a scalar or array
+$json = cont3xtPutToken('/api/settings', '{"settings": "bar"}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "settings must be an object"}'), "string settings rejected");
+
+$json = cont3xtPutToken('/api/settings', '{"settings": [1,2]}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "settings must be an object"}'), "array settings rejected");
+
+# linkGroup.order is read back by GET /api/linkGroup - a bad shape used to be
+# stored happily and then crash every later fetch for this user
+$json = cont3xtPutToken('/api/settings', '{"linkGroup": {"order": 1}}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "linkGroup.order must be an array of strings"}'), "numeric linkGroup order rejected");
+
+$json = cont3xtPutToken('/api/settings', '{"linkGroup": {"order": "abc"}}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "linkGroup.order must be an array of strings"}'), "string linkGroup order rejected");
+
+$json = cont3xtPutToken('/api/settings', '{"linkGroup": {"order": [1, 2]}}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "linkGroup.order must be an array of strings"}'), "non string linkGroup order entries rejected");
+
+$json = cont3xtPutToken('/api/settings', '{"linkGroup": [1]}', $token);
+eq_or_diff($json, from_json('{"success": false, "text": "linkGroup must be an object"}'), "array linkGroup rejected");
+
+# fetching link groups still works after all of those
+$json = cont3xtGet('/api/linkGroup');
+is($json->{success}, 1, "link groups still fetchable");
+
+# a valid order is accepted, and only order is kept
+$json = cont3xtPutToken('/api/settings', '{"linkGroup": {"order": ["abc", "def"], "evil": 1}}', $token);
+is($json->{success}, 1, "valid linkGroup order saved");
+
+$json = cont3xtGet('/api/settings');
+eq_or_diff($json->{linkGroup}, from_json('{"order": ["abc", "def"]}'), "only linkGroup order stored");
+
+$json = cont3xtGet('/api/linkGroup');
+is($json->{success}, 1, "link groups fetchable with an order set");
+
+# put it back
+$json = cont3xtPutToken('/api/settings', '{"linkGroup": {"order": []}}', $token);
+is($json->{success}, 1, "linkGroup order reset");
 
 ################################################################################
 ### Integration Stats


### PR DESCRIPTION
- Fix an integration name that matches an Object.prototype member (toString, valueOf, ...) throwing in apiSingleSearch and exiting cont3xt
- Fix an invalid linkGroup order saved via PUT /api/settings crashing every later GET /api/linkGroup; validate general and integration settings, and report a real failure when the save fails instead of always saying Saved
- Audit single integration searches, they queried the same external sources as a full search but left no history behind
- Add maxIndicatorsPerSearch, default 100, so one search can't fan out unbounded
- Validate the history query params that reach an ES size, a sql LIMIT, a sort field or an array index; the lmdb and redis backends didn't validate at all
- Catch ES errors when fetching link groups and overviews
- Catch errors from runIntegrationsList, it is started without being awaited so a throw there was an unhandled rejection that exited cont3xt
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
