### PR TITLE
Fix bugs and security issues found reviewing wiseService/

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -96,6 +96,17 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4172 Fix Download Entire PCAP failing on sensors behind esProxy; the rootId session search is now allowed through esProxy, and a failed search returns a 500 instead of an unhandled rejection
   - #4203 Fix scrubbing pcap on a session held by a remote node exiting the viewer
   - #4203 Fix a repeated query parameter (order, startTime, stopTime) never answering
+## WISE
+  - #4205 Fix intel files downloaded to /tmp being written through, or loaded from, a symlink or a file owned by another user
+  - #4205 Fix looked up values being able to inject into threatstream api requests, splunk searches, and redis key templates
+  - #4205 Fix threatstream sqlite3 mode failing on an itype name containing a quote
+  - #4205 Fix wiseService exiting on a valueactions or fieldactions file that has a section header in it
+  - #4205 Fix wiseService exiting on a csv url source whose rows are shorter than the key column
+  - #4205 Fix wiseService exiting on unexpected threatstream, threatq or alienvault data; a load that finds nothing now keeps the previous data
+  - #4205 Fix virustotal, opendns and passivetotal never looking a value up again when the service returned no result for it
+  - #4205 Fix isepxgrid returning nothing for the length of its session cache refresh
+  - #4205 Fix a phpipam url containing a quote breaking every right click action in viewer
+  - #4205 Fix the config UI erroring instead of rejecting a section named after a javascript property
 
 6.6.0 2026/07/09
 ## Breaking

--- a/tests/fieldactions.ini
+++ b/tests/fieldactions.ini
@@ -1,2 +1,7 @@
 ASDFWISE=url:https://www.asdf.com?expression=%EXPRESSION%&date=%DATE%&field=%FIELD%&dbField=%DBFIELD%;name:Field Action %FIELDNAME%!;category:ip;users:admin,sac-test1;notUsers:test101
 ALLTESTWISE=url:http://www.example.com;name:AllWiseTest;all:true
+
+# A section header here isn't a field action, wise must skip it instead of
+# crashing on startup. The /fieldActions test must not list IGNOREDWISE.
+[ignored-section]
+IGNOREDWISE=url:http://www.example.com;name:IgnoredWiseTest

--- a/tests/valueactions.ini
+++ b/tests/valueactions.ini
@@ -3,3 +3,8 @@ VTHOST=url:https://www.virustotal.com/en/domain/%HOST%/information/;name:Virus T
 VTURL=url:https://www.virustotal.com/latest-scan/%URL%;name:Virus Total URL;category:url
 USERTEST=url:https://example.com;name:usertest;category:url;users:sac-test1;notUsers:test101
 ALLTESTWISE=url:http://www.example.com;name:AllWiseTest;all:true
+
+# A section header here isn't a value action, wise must skip it instead of
+# crashing on startup. The /valueActions test must not list IGNOREDWISE.
+[ignored-section]
+IGNOREDWISE=url:http://www.example.com;name:IgnoredWiseTest

--- a/tests/wise.t
+++ b/tests/wise.t
@@ -1,5 +1,5 @@
 # WISE tests
-use Test::More tests => 167;
+use Test::More tests => 171;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
@@ -283,6 +283,15 @@ eq_or_diff($wise, from_json('[{"field":"tags","len":13,"value":"splunk-botnet"},
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/splunktest/1.2.3.4")->content;
 eq_or_diff($wise, '[]', "splunk miss");
 
+# A key with whitespace could add search terms when the query doesn't quote
+# %%SEARCHTERM%%, so it must never be searched for. Without this the mini splunk
+# sees both ips in the search and returns both rows.
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/splunktest/66.66.66.66%2066.66.66.67")->content;
+eq_or_diff($wise, '[]', "splunk key with space not searched");
+
+$wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/splunktest/66.66.66.66%22%20OR%20ip%3D%2266.66.66.67")->content;
+eq_or_diff($wise, '[]', "splunk key with quote and spaces not searched");
+
 # Databricks source (periodic full-table query, cached at startup, against mini-wise-source.js)
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/databrickstest/77.77.77.77")->content;
 $wise = [sort { $a->{value} cmp $b->{value}} @{from_json($wise)}];
@@ -469,6 +478,13 @@ eq_or_diff($wise, '{"success":false,"text":"Missing config"}');
 
 $wise = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8081/config/save", Content => to_json({config => $config, configCode => "thecode"}), "Content-Type" => "application/json;charset=UTF-8")->content;
 eq_or_diff($wise, '{"success":true,"text":"Would save, but regressionTests"}');
+
+# save config - section type that is an Object property must be unknown, not a 500
+$wise = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8081/config/save", Content => to_json({config => {"__proto__:test" => {"type" => "ip"}}, configCode => "thecode"}), "Content-Type" => "application/json;charset=UTF-8")->content;
+eq_or_diff($wise, '{"success":false,"text":"Unknown section type __proto__"}');
+
+$wise = $ArkimeTest::userAgent->put("http://$ArkimeTest::host:8081/config/save", Content => to_json({config => {"constructor:test" => {"type" => "ip"}}, configCode => "thecode"}), "Content-Type" => "application/json;charset=UTF-8")->content;
+eq_or_diff($wise, '{"success":false,"text":"Unknown section type constructor"}');
 
 $wise = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8081/source/file:ip/get")->content;
 is($wise, '{"success":true,"raw":"10.0.0.3;tags=wisebyip1;irc.channel=wisebyip1channel;email.x-priority=999;asset=wtest1\\n192.168.177.160;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21;asset=wtest2\\n128.128.128.0/24;tags=wisebyip2;mysql.ver=wisebyip2mysqlversion;test.ip=21.21.21.21;asset=wtest3\\nfe80::211:25ff:fe82:95b5;tags=wisebyip3;mysql.ver=wisebyip3mysqlversion;test.ip=22.22.22.22;asset=wtest4\\n"}');

--- a/wiseService/simpleSource.js
+++ b/wiseService/simpleSource.js
@@ -136,6 +136,7 @@ class SimpleSource extends WISESource {
       newCache = new Map();
       if (this.type === 'url') {
         setFunc = (key, value) => {
+          if (!key) { return; }
           if (key.lastIndexOf('http://', 0) === 0) {
             key = key.substring(7);
           }
@@ -144,6 +145,7 @@ class SimpleSource extends WISESource {
         };
       } else {
         setFunc = function (key, value) {
+          if (!key) { return; }
           newCache.set(key, value);
           count++;
         };

--- a/wiseService/source.alienvault.js
+++ b/wiseService/source.alienvault.js
@@ -45,13 +45,19 @@ class AlienVaultSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   parseFile () {
+    if (!WISESource.isSafeFile('/tmp/alienvault.data')) {
+      console.log(this.section, "- ERROR - /tmp/alienvault.data isn't a plain file we own, not loading");
+      return;
+    }
+
     const parser = csv.parse({ delimiter: '#', skip_empty_lines: true }, (err, data) => {
       if (err) {
         console.log(this.section, "- Couldn't parse csv", err);
         return;
       }
+      // Build into a fresh map and swap at the end so a failed load keeps prior data
+      const ips = new Map();
       let count = 0;
-      this.ips.clear();
       for (let i = 0; i < data.length; i++) {
         if (data[i].length < 8) {
           continue;
@@ -63,12 +69,15 @@ class AlienVaultSource extends WISESource {
           this.threatlevelField, data[i][2],
           this.activityField, data[i][3]
         );
-        this.ips.set(data[i][0], encoded);
+        ips.set(data[i][0], encoded);
         count++;
       }
+      this.ips = ips;
       console.log(this.section, '- Done Loading', count, 'elements');
     });
-    fs.createReadStream('/tmp/alienvault.data').pipe(parser);
+    fs.createReadStream('/tmp/alienvault.data').on('error', (err) => {
+      console.log(this.section, "- Couldn't read /tmp/alienvault.data", err);
+    }).pipe(parser);
   }
 
   // ----------------------------------------------------------------------------
@@ -78,7 +87,7 @@ class AlienVaultSource extends WISESource {
     let revision = -1;
 
     // If we already have the rev and data files, find out what revision the data file is
-    if (fs.existsSync('/tmp/alienvault.rev') && fs.existsSync('/tmp/alienvault.data')) {
+    if (WISESource.isSafeFile('/tmp/alienvault.rev') && WISESource.isSafeFile('/tmp/alienvault.data')) {
       revision = +fs.readFileSync('/tmp/alienvault.rev').toString();
     }
 

--- a/wiseService/source.emergingthreats.js
+++ b/wiseService/source.emergingthreats.js
@@ -45,6 +45,11 @@ class EmergingThreatsSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   parseCategories (fn) {
+    if (!WISESource.isSafeFile(fn)) {
+      console.log(this.section, `- ERROR - ${fn} isn't a plain file we own, not loading`);
+      return;
+    }
+
     const parser = csv.parse({ skip_empty_lines: true }, (err, data) => {
       if (err) {
         console.log(this.section, "- Couldn't parse", fn, 'csv', err);
@@ -63,6 +68,11 @@ class EmergingThreatsSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   parseRepData (fn, hashName) {
+    if (!WISESource.isSafeFile(fn)) {
+      console.log(this.section, `- ERROR - ${fn} isn't a plain file we own, not loading`);
+      return;
+    }
+
     const parser = csv.parse({ skip_empty_lines: true }, (err, data) => {
       if (err) {
         console.log(this.section, "- Couldn't parse", fn, 'csv', err);

--- a/wiseService/source.fieldactions.js
+++ b/wiseService/source.fieldactions.js
@@ -84,6 +84,12 @@ class FieldActionsSource extends WISESource {
     if (keys.length === 0) { return; }
 
     keys.forEach((key) => {
+      // A nested object means an ini section header, which isn't a field action
+      if (!ArkimeUtil.isString(data[key])) {
+        console.log(this.section, `- WARNING ignoring '${key}', field actions must be key=value lines`);
+        return;
+      }
+
       const obj = {};
       data[key].split(';').forEach((element) => {
         const i = element.indexOf(':');

--- a/wiseService/source.isepxgrid.js
+++ b/wiseService/source.isepxgrid.js
@@ -59,9 +59,10 @@ const WSClient = require('ws');
 class StompClient {
   constructor (ws) {
     this.ws = ws;
-    this._handlers = {};
+    // Maps since both are keyed by strings ISE sends us
+    this._handlers = new Map();
     this._idsub = 0;
-    this._subscriptions = {}; // id → callback
+    this._subscriptions = new Map(); // id → callback
     ws.on('message', (raw) => this._onRaw(raw));
   }
 
@@ -69,7 +70,7 @@ class StompClient {
   // Returns the subscription id.
   subscribe (topic, cb) {
     const id = `sub-${++this._idsub}`;
-    this._subscriptions[id] = cb;
+    this._subscriptions.set(id, cb);
     this._send('SUBSCRIBE', { id, destination: topic, ack: 'auto' }, '');
     return id;
   }
@@ -105,8 +106,8 @@ class StompClient {
   }
 
   _onceFrame (command, cb) {
-    if (!this._handlers[command]) this._handlers[command] = [];
-    this._handlers[command].push({ once: true, cb });
+    if (!this._handlers.has(command)) this._handlers.set(command, []);
+    this._handlers.get(command).push({ once: true, cb });
   }
 
   _onRaw (raw) {
@@ -132,13 +133,13 @@ class StompClient {
     }
 
     // Dispatch once-handlers (CONNECTED, ERROR)
-    const once = (this._handlers[command] || []).filter(h => h.once);
-    for (const h of once) h.cb(headers, body);
-    this._handlers[command] = (this._handlers[command] || []).filter(h => !h.once);
+    const handlers = this._handlers.get(command) ?? [];
+    this._handlers.set(command, handlers.filter(handler => !handler.once));
+    for (const h of handlers.filter(handler => handler.once)) h.cb(headers, body);
 
     // Dispatch subscription callbacks for MESSAGE frames
     if (command === 'MESSAGE') {
-      const cb = this._subscriptions[headers.subscription];
+      const cb = this._subscriptions.get(headers.subscription);
       if (cb) cb(headers, body);
     }
   }
@@ -389,7 +390,11 @@ class ISEPxGridSource extends WISESource {
   // Bulk-load all currently active sessions from ISE REST on startup
   // -------------------------------------------------------------------------
 
-  async _loadAllSessions () {
+  // Loads into the live maps unless caller passes maps to fill instead
+  async _loadAllSessions (sessionMap, sidMap) {
+    sessionMap ??= this.sessionMap;
+    sidMap ??= this.sidMap;
+
     const doRequest = (secret) => {
       const creds = Buffer.from(`${this.nodeName}:${secret}`).toString('base64');
       return axios.post(
@@ -435,13 +440,13 @@ class ISEPxGridSource extends WISESource {
       const sid = s.auditSessionId || '';
       for (const ip of ips) {
         // Only set if not already written by a concurrent STOMP event
-        if (!this.sessionMap.has(ip)) {
-          this.sessionMap.set(ip, s);
+        if (!sessionMap.has(ip)) {
+          sessionMap.set(ip, s);
           count++;
         }
         if (sid) {
-          if (!this.sidMap.has(sid)) this.sidMap.set(sid, new Set());
-          this.sidMap.get(sid).add(ip);
+          if (!sidMap.has(sid)) sidMap.set(sid, new Set());
+          sidMap.get(sid).add(ip);
         }
       }
     }
@@ -459,18 +464,17 @@ class ISEPxGridSource extends WISESource {
   async _refreshCache () {
     this._refreshTimer = null;
     console.log(this.section, `- Cache age reached ${this.cacheAgeMin}min, refreshing from ISE…`);
-    // Swap in fresh maps only after a successful load so a failed refresh
-    // keeps serving the existing data instead of destroying it
-    const oldSessionMap = this.sessionMap;
-    const oldSidMap = this.sidMap;
-    this.sessionMap = new Map();
-    this.sidMap = new Map();
+    // Fill fresh maps and only swap them in once the load worked, so getIp keeps
+    // answering from the current data for the whole refresh instead of finding
+    // empty maps, and a failed refresh changes nothing
+    const sessionMap = new Map();
+    const sidMap = new Map();
     try {
-      await this._loadAllSessions();
+      await this._loadAllSessions(sessionMap, sidMap);
+      this.sessionMap = sessionMap;
+      this.sidMap = sidMap;
     } catch (err) {
       console.log(this.section, '- WARN: cache refresh failed, keeping previous data:', err.message);
-      this.sessionMap = oldSessionMap;
-      this.sidMap = oldSidMap;
       this._scheduleRefresh(); // retry on next interval
     }
   }

--- a/wiseService/source.opendns.js
+++ b/wiseService/source.opendns.js
@@ -96,9 +96,9 @@ class OpenDNSSource extends WISESource {
     const sent = this.waiting.slice(); // for error cleanup
     this.waiting.length = 0;
 
-    // On failure invoke and remove all callbacks for this batch so queries
-    // don't hang in processing forever
-    const failBatch = (err) => {
+    // Invoke and remove any callbacks for this batch still outstanding, otherwise
+    // the domain is stuck in processing forever and never looked up again
+    const finishBatch = (err) => {
       for (const domain of sent) {
         const cbs = this.processing.get(domain);
         if (!cbs) { continue; }
@@ -133,7 +133,7 @@ class OpenDNSSource extends WISESource {
           results = JSON.parse(response);
         } catch (e) {
           console.log(this.section, 'Error parsing for request:\n', postData, '\nresponse:\n', response);
-          failBatch('opendns parse error');
+          finishBatch('opendns parse error');
           return;
         }
 
@@ -173,11 +173,14 @@ class OpenDNSSource extends WISESource {
             cb(null, result);
           }
         }
+
+        // Anything opendns didn't return a result for
+        finishBatch(null);
       });
     });
     request.on('error', (err) => {
       console.log(this.section, err);
-      failBatch(err);
+      finishBatch(err);
     });
 
     // post the data

--- a/wiseService/source.passivetotal.js
+++ b/wiseService/source.passivetotal.js
@@ -58,6 +58,20 @@ class PassiveTotalSource extends WISESource {
     const sent = this.waiting.slice();
     this.waiting.length = 0;
 
+    // Invoke and remove any callbacks for this batch still outstanding, otherwise
+    // the key is stuck in processing forever and never looked up again
+    const finishBatch = (err) => {
+      for (const key of sent) {
+        const cbs = this.processing.get(key);
+        if (!cbs) { continue; }
+        this.processing.delete(key);
+        let cb;
+        while ((cb = cbs.shift())) {
+          cb(err);
+        }
+      }
+    };
+
     const options = {
       url: 'https://api.passivetotal.org/v2/enrichment/bulk',
       data: {
@@ -101,19 +115,12 @@ class PassiveTotalSource extends WISESource {
             cb(null, wiseResult);
           }
         }
+
+        // Anything passivetotal didn't return a result for
+        finishBatch(null);
       }).catch((err) => {
         console.log(this.section, err);
-        // Invoke and remove all callbacks for this batch so queries don't
-        // hang in processing forever
-        for (const key of sent) {
-          const cbs = this.processing.get(key);
-          if (!cbs) { continue; }
-          this.processing.delete(key);
-          let cb;
-          while ((cb = cbs.shift())) {
-            cb(err);
-          }
-        }
+        finishBatch(err);
       });
   };
 

--- a/wiseService/source.phpipam.js
+++ b/wiseService/source.phpipam.js
@@ -122,30 +122,32 @@ class PHPIPAMSource extends WISESource {
     // ---- Value actions (right-click links into phpIPAM UI) -----------------
     // Use func (not url) so the viewer puts them in menuItems and opens
     // them as target="_blank" links instead of fetching inline.
-    const searchUrl = this.searchUrlOverride || `${this.url}/tools/search/`;
+    // JSON.stringify so a quote in the url can't break the js the viewer builds
+    // from this with new Function(), which would take out ALL value actions
+    const searchUrl = JSON.stringify(this.searchUrlOverride || `${this.url}/tools/search/`);
     api.addValueAction(`${section}_search_ip`, {
       name: 'phpIPAM: Search IP',
-      func: `return { url: '${searchUrl}' + encodeURIComponent(value), name: 'phpIPAM: Search IP', value: value };`,
+      func: `return { url: ${searchUrl} + encodeURIComponent(value), name: 'phpIPAM: Search IP', value: value };`,
       category: 'ip'
     });
     api.addValueAction(`${section}_search_hostname`, {
       name: 'phpIPAM: Search Hostname',
-      func: `return { url: '${searchUrl}' + encodeURIComponent(value), name: 'phpIPAM: Search Hostname', value: value };`,
+      func: `return { url: ${searchUrl} + encodeURIComponent(value), name: 'phpIPAM: Search Hostname', value: value };`,
       fields: 'ipam.src.hostname,ipam.dst.hostname'
     });
     api.addValueAction(`${section}_search_subnet`, {
       name: 'phpIPAM: Search Subnet',
-      func: `return { url: '${searchUrl}' + encodeURIComponent(value), name: 'phpIPAM: Search Subnet', value: value };`,
+      func: `return { url: ${searchUrl} + encodeURIComponent(value), name: 'phpIPAM: Search Subnet', value: value };`,
       fields: 'ipam.src.subnet,ipam.dst.subnet'
     });
     api.addValueAction(`${section}_search_vlan`, {
       name: 'phpIPAM: Search VLAN',
-      func: `return { url: '${searchUrl}' + encodeURIComponent(value), name: 'phpIPAM: Search VLAN', value: value };`,
+      func: `return { url: ${searchUrl} + encodeURIComponent(value), name: 'phpIPAM: Search VLAN', value: value };`,
       fields: 'ipam.src.vlan,ipam.dst.vlan'
     });
     api.addValueAction(`${section}_search_vrf`, {
       name: 'phpIPAM: Search VRF',
-      func: `return { url: '${searchUrl}' + encodeURIComponent(value), name: 'phpIPAM: Search VRF', value: value };`,
+      func: `return { url: ${searchUrl} + encodeURIComponent(value), name: 'phpIPAM: Search VRF', value: value };`,
       fields: 'ipam.src.vrf,ipam.dst.vrf'
     });
 

--- a/wiseService/source.redis.js
+++ b/wiseService/source.redis.js
@@ -39,7 +39,9 @@ class RedisSource extends WISESource {
   // ----------------------------------------------------------------------------
   fetch (key, cb) {
     if (this.template !== undefined) {
-      key = this.template.replace('%key%', key).replace('%type%', this.type);
+      // Replace with a function, otherwise a $' or $& in the key is treated as a
+      // replacement pattern and copies parts of the template into the key
+      key = this.template.replace('%key%', () => key).replace('%type%', this.type);
     }
 
     this.client[this.redisMethod](key, (err, reply) => {

--- a/wiseService/source.splunk.js
+++ b/wiseService/source.splunk.js
@@ -164,8 +164,18 @@ class SplunkSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   async sendResult (key, cb) {
-    const sanitizedKey = key.replace(/[\\"|[\]()]/g, '\\$&');
-    const query = this.query.replace('%%SEARCHTERM%%', sanitizedKey);
+    // Keys are ips/domains/hashes/emails/urls, whitespace or control characters
+    // can only be an attempt to add search terms when the query doesn't quote
+    // %%SEARCHTERM%%, so never search for them
+    if (key === '' || /[\s\u0000-\u001f\u007f]/.test(key)) {
+      return cb(null, undefined);
+    }
+
+    // Backticks expand macros in SPL
+    const sanitizedKey = key.replace(/[\\"|[\]()`]/g, '\\$&');
+    // Replace with a function, otherwise a $' or $& in the key is treated as a
+    // replacement pattern and copies unescaped parts of the query into itself
+    const query = this.query.replace('%%SEARCHTERM%%', () => sanitizedKey);
 
     try {
       const results = await this.service.oneshotSearch(query, { output_mode: 'json', count: 0 });

--- a/wiseService/source.threatq.js
+++ b/wiseService/source.threatq.js
@@ -10,6 +10,7 @@
 const fs = require('fs');
 const unzipper = require('unzipper');
 const WISESource = require('./wiseSource.js');
+const ArkimeUtil = require('../common/arkimeUtil');
 
 class ThreatQSource extends WISESource {
   // ----------------------------------------------------------------------------
@@ -61,6 +62,11 @@ class ThreatQSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   parseFile () {
+    if (!WISESource.isSafeFile('/tmp/threatquotient.zip')) {
+      console.log(this.section, "- ERROR - /tmp/threatquotient.zip isn't a plain file we own, not loading");
+      return;
+    }
+
     // Build into fresh maps and swap at the end so a failed load keeps prior data
     const ips = new Map();
     const domains = new Map();
@@ -91,16 +97,26 @@ class ThreatQSource extends WISESource {
             console.log(this.section, '- Error parsing', err);
             return;
           }
+          // An entry with no indicators in it, like a manifest, isn't a failure
+          if (!Array.isArray(json)) {
+            console.log(this.section, '- Skipping', entry.path, 'no array');
+            return;
+          }
+
           json.forEach((item) => {
+            if (!ArkimeUtil.isString(item?.type) || !ArkimeUtil.isString(item.indicator)) {
+              return;
+            }
+
             const args = [this.idField, '' + item.id, this.typeField, item.type];
 
-            if (item.source) {
+            if (Array.isArray(item.source)) {
               item.source.forEach((str) => {
                 args.push(this.sourceField, str);
               });
             }
 
-            if (item.campaign) {
+            if (Array.isArray(item.campaign)) {
               item.campaign.forEach((str) => {
                 args.push(this.campaignField, str);
               });
@@ -122,7 +138,8 @@ class ThreatQSource extends WISESource {
         });
       })
       .on('close', () => {
-        if (bad) {
+        // Nothing loaded means every entry was skipped, don't wipe what we have
+        if (bad || count === 0) {
           console.log(this.section, '- Load failed, keeping previous data');
           return;
         }

--- a/wiseService/source.threatstream.js
+++ b/wiseService/source.threatstream.js
@@ -118,6 +118,11 @@ class ThreatStreamSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   parseFile () {
+    if (!WISESource.isSafeFile('/tmp/threatstream.zip')) {
+      console.log(this.section, "- ERROR - /tmp/threatstream.zip isn't a plain file we own, not loading");
+      return;
+    }
+
     // Build into fresh maps and swap at the end so a failed load keeps prior data
     const ips = new Map();
     const domains = new Map();
@@ -126,6 +131,7 @@ class ThreatStreamSource extends WISESource {
     const urls = new Map();
 
     let bad = false;
+    let count = 0;
     fs.createReadStream('/tmp/threatstream.zip')
       .on('error', (err) => {
         console.log(this.section, "- Couldn't read /tmp/threatstream.zip", err);
@@ -148,13 +154,19 @@ class ThreatStreamSource extends WISESource {
             console.log(this.section, 'ERROR - parsing', entry.path, e);
             return;
           }
+          // An entry with no indicators in it, like a manifest, isn't a failure
+          if (!Array.isArray(json.objects)) {
+            console.log(this.section, '- Skipping', entry.path, 'no objects array');
+            return;
+          }
+
           json.objects.forEach((item) => {
-            if (item.state !== 'active') {
+            if (item?.state !== 'active' || !ArkimeUtil.isString(item.itype)) {
               return;
             }
 
             // Figure out where the item goes and its indicator value first
-            let hash, indicator;
+            let hash, indicator, isUrl;
             if (item.itype.match(/(_ip|anon_proxy|anon_vpn)/)) {
               hash = ips; indicator = item.srcip;
             } else if (item.itype.match(/_domain|_dns/)) {
@@ -164,14 +176,21 @@ class ThreatStreamSource extends WISESource {
             } else if (item.itype.match(/_md5/)) {
               hash = md5s; indicator = item.md5;
             } else if (item.itype.match(/_url/)) {
-              hash = urls; indicator = item.url;
+              hash = urls; indicator = item.url; isUrl = true;
+            } else {
+              return;
+            }
+
+            if (!ArkimeUtil.isString(indicator)) {
+              return;
+            }
+
+            if (isUrl) {
               if (indicator.startsWith('http://')) {
                 indicator = indicator.substring(7);
               } else if (indicator.startsWith('https://')) {
                 indicator = indicator.substring(8);
               }
-            } else {
-              return;
             }
 
             let encoded;
@@ -202,12 +221,14 @@ class ThreatStreamSource extends WISESource {
             }
 
             hash.set(indicator, encoded);
+            count++;
           });
           // console.log(this.section, "- Done", entry.path);
         });
       })
       .on('close', () => {
-        if (bad) {
+        // Nothing loaded means every entry was skipped, don't wipe what we have
+        if (bad || count === 0) {
           console.log(this.section, '- Load failed, keeping previous data');
           return;
         }
@@ -216,14 +237,14 @@ class ThreatStreamSource extends WISESource {
         this.emails = emails;
         this.md5s = md5s;
         this.urls = urls;
-        console.log(this.section, '- Done Loading');
+        console.log(this.section, '- Done Loading', count, 'elements');
       });
   }
 
   // ----------------------------------------------------------------------------
   loadFile () {
     console.log(this.section, '- Downloading files');
-    WISESource.request('https://api.threatstream.com/api/v1/intelligence/snapshot/download/?username=' + this.user + '&api_key=' + this.key, '/tmp/threatstream.zip', (statusCode) => {
+    WISESource.request(`https://api.threatstream.com/api/v1/intelligence/snapshot/download/?username=${encodeURIComponent(this.user)}&api_key=${encodeURIComponent(this.key)}`, '/tmp/threatstream.zip', (statusCode) => {
       if (statusCode === 200 || !this.loaded) {
         this.loaded = true;
         this.parseFile();
@@ -279,9 +300,23 @@ class ThreatStreamSource extends WISESource {
 
   // ----------------------------------------------------------------------------
   getApi (type, value, cb) {
+    // No itypes for this type means nothing can ever match
+    const itypes = this.types[type];
+    if (itypes === undefined) {
+      return cb(null, WISESource.emptyResult);
+    }
+
+    // Use params so values from the network can't inject extra query parameters
     const options = {
-      url: `https://api.threatstream.com/api/v2/intelligence/?username=${this.user}&api_key=${this.key}&status=active&${type}=${value}&itype=${this.types[type]}`,
-      method: 'GET'
+      url: 'https://api.threatstream.com/api/v2/intelligence/',
+      method: 'GET',
+      params: {
+        username: this.user,
+        api_key: this.key,
+        status: 'active',
+        [type]: value,
+        itype: itypes
+      }
     };
 
     if (this.inProgress > 50) {
@@ -317,7 +352,7 @@ class ThreatStreamSource extends WISESource {
         const result = WISESource.encodeResult.apply(null, args);
         return cb(null, result);
       }).catch((err) => {
-        console.log(this.section, 'problem fetching ', options, err);
+        console.log(this.section, 'problem fetching', options.url, type, err);
         return cb(null, WISESource.emptyResult);
       }).finally(() => {
         this.inProgress--;
@@ -350,8 +385,15 @@ class ThreatStreamSource extends WISESource {
       return cb('dropped');
     }
 
+    // itype names come from the threatstream api, bind them instead of inlining
+    const itypes = this.itypes[type];
+    if (itypes === undefined || itypes.length === 0) {
+      return cb('dropped');
+    }
+
     try {
-      const data = this.db.prepare(`SELECT * FROM ts WHERE ${field} = ? AND state != 'falsepos' AND itype IN (${this.typesWithQuotes[type]})`).all(value);
+      const placeholders = itypes.map(() => '?').join(',');
+      const data = this.db.prepare(`SELECT * FROM ts WHERE ${field} = ? AND state != 'falsepos' AND itype IN (${placeholders})`).all(value, ...itypes);
 
       if (!data || data.length === 0) {
         return cb(null, WISESource.emptyResult);
@@ -419,21 +461,24 @@ class ThreatStreamSource extends WISESource {
   // ----------------------------------------------------------------------------
   loadTypes (includeUrl) {
     // Threatstream doesn't have a way to just ask for type matches, so we need to figure out which itypes are various types.
-    this.types = {};
-    this.typesWithQuotes = {};
-    axios({ url: 'https://api.threatstream.com/api/v1/impact/?username=' + this.user + '&api_key=' + this.key + '&limit=1000' })
+    // Null prototype since value_type is whatever the api returns
+    this.itypes = Object.create(null); // wise type => array of itype names
+    this.types = Object.create(null); // wise type => itype names joined for the api
+    axios({
+      url: 'https://api.threatstream.com/api/v1/impact/',
+      params: { username: this.user, api_key: this.key, limit: 1000 }
+    })
       .then((response) => {
         const body = response.data;
         body.objects.forEach((item) => {
-          if (this.types[item.value_type] === undefined) {
-            this.types[item.value_type] = [item.name];
+          if (this.itypes[item.value_type] === undefined) {
+            this.itypes[item.value_type] = [item.name];
           } else {
-            this.types[item.value_type].push(item.name);
+            this.itypes[item.value_type].push(item.name);
           }
         });
-        for (const key in this.types) {
-          this.typesWithQuotes[key] = this.types[key].map((v) => { return "'" + v + "'"; }).join(',');
-          this.types[key] = this.types[key].join(',');
+        for (const key in this.itypes) {
+          this.types[key] = this.itypes[key].join(',');
         }
 
         // Wait to register until request is done

--- a/wiseService/source.valueactions.js
+++ b/wiseService/source.valueactions.js
@@ -84,6 +84,12 @@ class ValueActionsSource extends WISESource {
     if (keys.length === 0) { return; }
 
     keys.forEach((key) => {
+      // A nested object means an ini section header, which isn't a value action
+      if (!ArkimeUtil.isString(data[key])) {
+        console.log(this.section, `- WARNING ignoring '${key}', value actions must be key=value lines`);
+        return;
+      }
+
       const obj = {};
       data[key].split(';').forEach((element) => {
         const i = element.indexOf(':');

--- a/wiseService/source.virustotal.js
+++ b/wiseService/source.virustotal.js
@@ -81,19 +81,25 @@ class VirusTotalSource extends WISESource {
 
     this.waiting = [];
 
+    // Answer and remove anything from this batch still outstanding, otherwise
+    // the md5 is stuck in processing forever and never looked up again
+    const finishBatch = () => {
+      sent.forEach((md5) => {
+        const cb = this.processing.get(md5);
+        if (!cb) {
+          return;
+        }
+        this.processing.delete(md5);
+        cb(undefined, undefined);
+      });
+    };
+
     axios(options)
       .then((response) => {
         let results = response.data;
         if (response.status !== 200) {
           console.log(this.section, 'Error for request:\n', options, '\n', '\nresults:\n', results);
-          sent.forEach((md5) => {
-            const cb = this.processing.get(md5);
-            if (!cb) {
-              return;
-            }
-            this.processing.delete(md5);
-            cb(undefined, undefined);
-          });
+          finishBatch();
           return;
         }
 
@@ -129,17 +135,12 @@ class VirusTotalSource extends WISESource {
 
           cb(null, wiseResult);
         });
+
+        // Anything virustotal didn't return a result for
+        finishBatch();
       }).catch((err) => {
         console.log(this.section, err);
-        // Invoke and remove this batch's callbacks so queries don't hang
-        sent.forEach((md5) => {
-          const cb = this.processing.get(md5);
-          if (!cb) {
-            return;
-          }
-          this.processing.delete(md5);
-          cb(undefined, undefined);
-        });
+        finishBatch();
       });
   };
 

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -1548,7 +1548,7 @@ if (internals.webconfig) {
   app.get('/config/get', [isWiseUser, ArkimeUtil.noCacheJson], (req, res) => {
     const config = ArkimeConfig.getSections()
       .sort()
-      .filter(key => internals.configDefs[key.split(':')[0]])
+      .filter(key => Object.hasOwn(internals.configDefs, key.split(':')[0]))
       .reduce((obj, key) => {
         // Deep Copy
         obj[key] = JSON.parse(JSON.stringify(ArkimeConfig.getSection(key)));
@@ -1590,7 +1590,8 @@ if (internals.webconfig) {
 
     for (const section in config) {
       const sectionType = section.split(':')[0];
-      const configDef = internals.configDefs[sectionType];
+      // hasOwn so a section named __proto__ doesn't find Object.prototype
+      const configDef = Object.hasOwn(internals.configDefs, sectionType) ? internals.configDefs[sectionType] : undefined;
       if (configDef === undefined) {
         return res.send({ success: false, text: `Unknown section type ${sectionType}` });
       }

--- a/wiseService/wiseSource.js
+++ b/wiseService/wiseSource.js
@@ -582,6 +582,58 @@ class WISESource {
   }
 
   // ----------------------------------------------------------------------------
+  // Sources download into shared directories like /tmp, where anyone can create
+  // the path before we do. Only ever use a plain file that we own with no extra
+  // links to it, so we can't be tricked into following a symlink or writing to
+  // (or loading) someone else's file.
+  static #statIsSafe (stat) {
+    const uid = process.getuid?.();
+    return stat.isFile() && stat.nlink === 1 && (uid === undefined || stat.uid === uid);
+  }
+
+  // ----------------------------------------------------------------------------
+  /**
+   * Is the file a plain file that we own, so safe to use in a shared directory.
+   *
+   * @param {string} file - The file to check
+   * @returns {boolean}
+   */
+  static isSafeFile (file) {
+    try {
+      return WISESource.#statIsSafe(fs.lstatSync(file));
+    } catch (err) {
+      return false;
+    }
+  }
+
+  // ----------------------------------------------------------------------------
+  // Open file for writing without following symlinks, replacing anything in the
+  // way that isn't a plain file we own. Returns the fd or throws.
+  static #openSafe (file) {
+    /* eslint-disable no-bitwise */
+    const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW;
+    /* eslint-enable no-bitwise */
+
+    let fd;
+    try {
+      fd = fs.openSync(file, flags, 0o600);
+    } catch (err) {
+      // O_NOFOLLOW found a symlink, remove it and try once more
+      if (err.code !== 'ELOOP' && err.code !== 'EMLINK') { throw err; }
+      fs.unlinkSync(file);
+      fd = fs.openSync(file, flags, 0o600);
+    }
+
+    // The open created or truncated something, make sure it's really ours
+    if (!WISESource.#statIsSafe(fs.fstatSync(fd))) {
+      fs.closeSync(fd);
+      throw new Error(`${file} isn't a plain file owned by this user`);
+    }
+
+    return fd;
+  }
+
+  // ----------------------------------------------------------------------------
   /**
    * Download a url and save to a file, if we already have the file and less than a minute old use that file.
    *
@@ -592,9 +644,11 @@ class WISESource {
   static request (url, file, cb) {
     const headers = {};
     if (file) {
-      if (fs.existsSync(file)) {
-        const stat = fs.statSync(file);
+      // lstat so a symlink left at file is never mistaken for our copy
+      let stat;
+      try { stat = fs.lstatSync(file); } catch (err) { }
 
+      if (stat && WISESource.#statIsSafe(stat)) {
         // Don't download again if file is less than 1 minute old
         if (Date.now() - stat.mtime.getTime() < 60000) {
           return setImmediate(cb, 304);
@@ -608,7 +662,16 @@ class WISESource {
       responseType: 'stream',
       headers
     }).then((response) => {
-      response.data.pipe(fs.createWriteStream(file)).on('close', () => {
+      let fd;
+      try {
+        fd = WISESource.#openSafe(file);
+      } catch (err) {
+        console.log(`ERROR - not saving ${file} -`, err.message);
+        response.data.destroy();
+        return setTimeout(cb, 100, 403);
+      }
+
+      response.data.pipe(fs.createWriteStream(null, { fd })).on('close', () => {
         setTimeout(cb, 100, 200);
       });
     }).catch((err) => {


### PR DESCRIPTION
- Only write and load /tmp intel files that are plain files we own
- Stop looked up values injecting into threatstream, splunk and redis queries
- Bind threatstream itype names in sqlite3 queries instead of inlining them
- Stop wiseService exiting on unexpected source data or config files
- Answer batch keys virustotal, opendns and passivetotal leave out of a response
- Keep serving isepxgrid sessions while the cache refreshes
- Quote the phpipam url in the value actions it builds
- Reject config sections named after javascript properties
- Add wise.t coverage for the splunk and config section fixes

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
