### PR TITLE
Fix changePasswordSecret.js sometimes accepting the wrong old secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ capture/arkimeconfig.h.in
 capture/moloch-capture
 capture/capture
 
+# release
+release/afterinstall.sh
 
 # tests
 tests/GeoLite2*

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,6 +45,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4183 Add !role search filter on the Users tab to list users that don't have a matching role
   - #4194 Add Microsoft Teams notifier (uses Power Automate Workflows webhooks)
   - #4202 Exit at startup when a header authMode has no userNameHeader instead of failing every request
+  - #4206 Fix changePasswordSecret.js sometimes accepting a wrong old passwordSecret for a user, re-encrypting their password from garbage instead of leaving them alone
 ## Capture
   - #4120 Fix offline pcap runs (-r/-R) loading the stopped-sessions state file
   - #4121 Fix DNS HTTPS/SVCB records dropping a valid trailing zero-length SvcParam

--- a/common/changePasswordSecret.js
+++ b/common/changePasswordSecret.js
@@ -64,12 +64,21 @@ function promptHidden (label) {
 // ----------------------------------------------------------------------------
 // passStore crypto, matching Auth.store2ha1 / Auth.ha12store:
 //   aes-256-cbc, key = sha256(secret), stored as "<iv hex>.<encrypted hex>"
+// The stored value is always an ha1, an md5 hex digest from Auth.pass2ha1
+const ha1Regex = /^[0-9a-f]{32}$/;
+
 function decryptPassStore (passStore, key256) {
   const parts = passStore.split('.');
   if (parts.length !== 2) { throw new Error('unsupported passStore format'); }
   const c = cryptoLib.createDecipheriv('aes-256-cbc', key256, Buffer.from(parts[0], 'hex'));
   let d = c.update(parts[1], 'hex', 'binary');
   d += c.final('binary');
+
+  // aes-256-cbc isn't authenticated, so a wrong key is only caught by the
+  // padding check, which random plaintext passes about 1 time in 256. Without
+  // this the user would be re-encrypted from garbage and their password lost.
+  if (!ha1Regex.test(d)) { throw new Error('decrypted passStore is not an ha1'); }
+
   return d;
 }
 


### PR DESCRIPTION
## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
