### PR TITLE
Fix bugs and security issues found reviewing capture/

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -66,6 +66,11 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4178 Add tcp.synValidated and tcp.synAckValidated fields recording whether each side of the TCP handshake was sequence-validated, and tcp.srcISNCnt counting distinct client ISNs seen (thanks @jeffreygolden)
   - #4187 Fix crash when redefining the type of a builtin field via wise or custom-fields
   - #4188 Add wiseRequestTimeout setting, default 30 seconds, so a stuck wiseService doesn't delay capture shutdown for minutes
+  - #4207 Fix pcap-over-IP counting a 65536 byte packet as corrupt instead of reporting it as too large
+  - #4207 Fix snapLen allowing 65536, one more than capture can represent, which recorded a max size packet as zero length
+  - #4207 Fix tunneled ethernet frames more than 2048 bytes into a packet recording the wrong src/dst MACs
+  - #4207 Fix the add-file and add-dir commands leaking memory, and possibly crashing, when given a bad --op
+  - #4207 Fix a memory leak writing pcap to S3 when the endpoint repeats an ETag header
 ## Cont3xt/Viewer
   - #4190 Cont3xt URLHaus and MalwareBazaar integrations now require an API key (free at https://auth.abuse.ch/)
   - #4190 Fix Cont3xt URLHaus and MalwareBazaar rendering an empty card by adding their missing card fields (thanks @m-jingu)

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -63,7 +63,8 @@
 
 #define ARKIME_V6_TO_V4(_addr) (((uint32_t *)(_addr).s6_addr)[3])
 
-#define ARKIME_PACKET_MAX_LEN 0x10000
+// Limited by ArkimePacket_t.pktlen being a uint16_t
+#define ARKIME_PACKET_MAX_LEN 0xffff
 
 #define ARKIME_ETHERTYPE_ETHER   0
 // If an ethertype is unknown this ethertype will be called

--- a/capture/field.c
+++ b/capture/field.c
@@ -1866,6 +1866,7 @@ void arkime_field_ops_add_match(ArkimeFieldOps_t *ops, int fieldPos, char *value
         case ARKIME_FIELD_SPECIAL_CLOSE_NOW:
         case ARKIME_FIELD_SPECIAL_FLIP_SRC_DST:
             op->strLenOrInt = 1;
+            op->str = 0; // ops array isn't zeroed, arkime_field_ops_free frees str
             break;
         default:
             LOG("WARNING - Unknown special field pos %d", fieldPos);

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -690,7 +690,7 @@ LOCAL gboolean arkime_packet_frags_process(ArkimePacket_t *const packet)
     }
 
     // Packet is too large, hacker
-    if (payloadLen + packet->payloadOffset >= ARKIME_PACKET_MAX_LEN) {
+    if (payloadLen + packet->payloadOffset > ARKIME_PACKET_MAX_LEN) {
         droppedFrags++;
         arkime_packet_frags_free(frags);
         return FALSE;
@@ -1385,6 +1385,11 @@ LOCAL ArkimePacketRC arkime_packet_ether(ArkimePacketBatch_t *batch, ArkimePacke
 #endif
         return ARKIME_PACKET_CORRUPT;
     }
+
+    // Make sure the offset of the ethernet header fits in the 11 bit etherOffset field
+    if ((uint8_t *)data - packet->pkt >= 2048)
+        return ARKIME_PACKET_CORRUPT;
+
     packet->outerEtherOffset = packet->etherOffset; // we need to keep track of the current and the previous mac offset, we don't know if this is the last etherframe here
     packet->etherOffset = (uint8_t *)data - packet->pkt;
 #ifdef DEBUG_PACKET

--- a/capture/parsers.c
+++ b/capture/parsers.c
@@ -35,6 +35,7 @@ typedef struct {
         ArkimeParsersNamedFunc2 cb2;
     };
     void *cbuw;
+    int   isCb2;
 } ArkimeNamedFunc_t;
 
 typedef struct {
@@ -936,10 +937,11 @@ gboolean arkime_parsers_ntlm_decode_base64(ArkimeSession_t *session,
     if (b64len < 11 || memcmp(b64, "TlRMTVNTUA", 10) != 0)
         return FALSE;
 
-    if (b64len > 16384)
-        b64len = 16384;
+#define NTLM_MAX_B64 16384
+    if (b64len > NTLM_MAX_B64)
+        b64len = NTLM_MAX_B64;
 
-    guchar decoded[12288];
+    guchar decoded[(NTLM_MAX_B64 / 4) * 3 + 3];
     gint state = 0;
     guint save = 0;
     gsize out_len = g_base64_decode_step(b64, b64len, decoded, &state, &save);
@@ -1769,6 +1771,7 @@ uint32_t arkime_parsers_add_named_func2(const char *name, ArkimeParsersNamedFunc
     ArkimeNamedFunc_t *funcInfo = ARKIME_TYPE_ALLOC0(ArkimeNamedFunc_t);
     funcInfo->cb2 = func;
     funcInfo->cbuw = cbuw;
+    funcInfo->isCb2 = 1;
     g_ptr_array_add(info->funcs, funcInfo);
     return info->id;
 }
@@ -1780,7 +1783,7 @@ void arkime_parsers_call_named_func(uint32_t id, ArkimeSession_t *session, const
     ArkimeNamedInfo_t *info = namedFuncsArr[id];
     for (int i = 0; i < (int)info->funcs->len; i++) {
         ArkimeNamedFunc_t *funcInfo = g_ptr_array_index(info->funcs, i);
-        if (funcInfo->cbuw) {
+        if (funcInfo->isCb2) {
             funcInfo->cb2(session, data, len, uw, funcInfo->cbuw);
         } else {
             funcInfo->cb(session, data, len, uw);

--- a/capture/parsers/dhcp.c
+++ b/capture/parsers/dhcp.c
@@ -227,7 +227,8 @@ LOCAL int dhcp_process(ArkimeSession_t *session, ArkimePacket_t *const packet)
         switch (t) {
         case 12: // Host Name
             BSB_IMPORT_ptr(bsb, valueStr, l);
-            arkime_field_string_add_lower(hostField, session, (char *)valueStr, l);
+            if (valueStr)
+                arkime_field_string_add_lower(hostField, session, (char *)valueStr, l);
             break;
         case 53: // Message Type
             if (l == 1) {
@@ -276,7 +277,8 @@ LOCAL int dhcp_process(ArkimeSession_t *session, ArkimePacket_t *const packet)
                 BSB_IMPORT_skip(bsb, l - 3);
             else {
                 BSB_IMPORT_ptr(bsb, valueStr, l - 3);
-                arkime_field_string_add_lower(hostField, session, (char *)valueStr, l - 3);
+                if (valueStr)
+                    arkime_field_string_add_lower(hostField, session, (char *)valueStr, l - 3);
             }
             break;
 

--- a/capture/parsers/mysql.c
+++ b/capture/parsers/mysql.c
@@ -55,7 +55,8 @@ LOCAL int mysql_parser(ArkimeSession_t *session, void *uw, const uint8_t *data, 
     }
 
     arkime_session_add_protocol(session, "mysql");
-    arkime_field_string_add(versionField, session, info->version, info->versionLen, FALSE);
+    if (!arkime_field_string_add(versionField, session, info->version, info->versionLen, FALSE))
+        g_free(info->version);
     info->version = 0;
 
     if (ptr > data + 36) {

--- a/capture/plugins/scrubspi.c
+++ b/capture/plugins/scrubspi.c
@@ -108,6 +108,11 @@ LOCAL void scrubspi_add_entry(const char *key, const char *value)
 {
     char spliton[2] = {0, 0};
     spliton[0] = value[0];
+
+    // g_strsplit returns NULL on an empty delimiter
+    if (spliton[0] == 0)
+        CONFIGEXIT("'%s=' has no value, should be '/search pcre/replace literal/', where the '/' can be any char in all three places", key);
+
     char **values = g_strsplit(value + 1, spliton, 0);
 
     if (!values[0] || !values[1])

--- a/capture/plugins/tcphealthcheck.c
+++ b/capture/plugins/tcphealthcheck.c
@@ -23,6 +23,7 @@ LOCAL void tcp_server(void)
     int server_fd, err;
     struct sockaddr_in server, client;
 
+    memset(&server, 0, sizeof(server));
     server.sin_family = AF_INET;
     server.sin_port = htons(tcp_port);
     server.sin_addr.s_addr = htonl(INADDR_ANY);

--- a/capture/plugins/writer-s3.c
+++ b/capture/plugins/writer-s3.c
@@ -434,6 +434,7 @@ LOCAL void writer_s3_header_cb (char *url, const char *field, const char *value,
     if (pn < 0 || pn >= ARRAY_LEN(file->partNumbers))
         return;
 
+    g_free(file->partNumbers[pn]); // a response can repeat the etag header
     if (*value == '"' && valueLen >= 2)
         file->partNumbers[pn] = g_strndup(value + 1, valueLen - 2);
     else

--- a/capture/reader-libpcap-file.c
+++ b/capture/reader-libpcap-file.c
@@ -427,7 +427,7 @@ LOCAL void reader_libpcapfile_pcap_cb(u_char *UNUSED(user), const struct pcap_pk
                 h->caplen, h->len);
     }
 
-    if (unlikely(h->caplen > 0xffff)) {
+    if (unlikely(h->caplen > ARKIME_PACKET_MAX_LEN)) {
         return;
     }
 

--- a/capture/reader-pcapoverip.c
+++ b/capture/reader-pcapoverip.c
@@ -142,7 +142,7 @@ LOCAL gboolean pcapoverip_client_read_cb(gint UNUSED(fd), GIOCondition cond, gpo
         if (unlikely(caplen != origlen) && !config.readTruncatedPackets && !config.ignoreErrors) {
             // Don't exit, a remote peer shouldn't be able to kill the capture process
             if (unlikely(caplen > ARKIME_PACKET_MAX_LEN)) {
-                // Packet too large to ever fit in the buffer, can't skip it, close connection
+                // Packet too large to ever fit in pktlen, can't skip it, close connection
                 LOG("ERROR - Arkime requires full packet captures caplen: %u pktlen: %u, closing connection\n"
                     "See https://arkime.com/faq#arkime_requires_full_packet_captures_error",
                     caplen, origlen);

--- a/capture/reader-scheme.c
+++ b/capture/reader-scheme.c
@@ -772,6 +772,7 @@ LOCAL int arkime_reader_scheme_processNG(const char *uri, uint8_t *data, int len
             data += need;
             len -= need;
             readerState.blockSize -= need;
+            readerState.tmpBufferLen = 0; // header fully buffered, reset before any skip below
 
             // The block holds (blockSize - 4) bytes of 32-bit-padded packet data
             // (blockSize already had 8 subtracted, subtract the trailing block length).
@@ -791,7 +792,7 @@ LOCAL int arkime_reader_scheme_processNG(const char *uri, uint8_t *data, int len
             // 0-3 alignment padding bytes are not treated as captured packet data.
             const uint32_t paddedLen = readerState.blockSize - 4;
             readerState.pktlen = MIN(origLen, paddedLen);
-            if (unlikely(readerState.pktlen > 0xffff)) {
+            if (unlikely(readerState.pktlen > ARKIME_PACKET_MAX_LEN)) {
                 readerState.state = ARKIME_SCHEME_NG_SKIP;
                 continue;
             }
@@ -805,7 +806,6 @@ LOCAL int arkime_reader_scheme_processNG(const char *uri, uint8_t *data, int len
             readerState.packet->ts.tv_sec = 0;
             readerState.packet->ts.tv_usec = 0;
 
-            readerState.tmpBufferLen = 0;
             readerState.state = ARKIME_SCHEME_NG_PACKET;
             continue;
         }
@@ -822,6 +822,7 @@ LOCAL int arkime_reader_scheme_processNG(const char *uri, uint8_t *data, int len
             data += need;
             len -= need;
             readerState.blockSize -= need;
+            readerState.tmpBufferLen = 0; // header fully buffered, reset before any skip below
 
             memcpy(&readerState.pktlen, readerState.tmpBuffer + 12, sizeof(readerState.pktlen));
             if (readerState.needSwap) {
@@ -830,7 +831,7 @@ LOCAL int arkime_reader_scheme_processNG(const char *uri, uint8_t *data, int len
 
             // caplen must fit in the remaining block (data + options + 4 byte trailing length);
             // it is an independent field in EPB so a bad value would underflow blockSize
-            if (unlikely(readerState.pktlen > 0xffff || readerState.pktlen > (uint32_t)(readerState.blockSize - 4))) {
+            if (unlikely(readerState.pktlen > ARKIME_PACKET_MAX_LEN || readerState.pktlen > (uint32_t)(readerState.blockSize - 4))) {
                 readerState.state = ARKIME_SCHEME_NG_SKIP;
                 continue;
             }
@@ -854,7 +855,6 @@ LOCAL int arkime_reader_scheme_processNG(const char *uri, uint8_t *data, int len
             readerState.packet->ts.tv_sec = ts / readerState.tsresol;
             readerState.packet->ts.tv_usec = (ts % readerState.tsresol) * 1000000 / readerState.tsresol;
 
-            readerState.tmpBufferLen = 0;
             readerState.state = ARKIME_SCHEME_NG_PACKET;
             continue;
         }
@@ -1040,7 +1040,7 @@ int arkime_reader_scheme_process(const char *uri, uint8_t *data, int len, const 
             readerState.packet->readerPos = readerState.readerPos;
             readerState.startPos += readerState.pktlen + 16;
 
-            if (unlikely(readerState.pktlen > 0xffff)) {
+            if (unlikely(readerState.pktlen > ARKIME_PACKET_MAX_LEN)) {
                 readerState.state = ARKIME_SCHEME_PACKET_SKIP;
             } else {
                 readerState.packet->pktlen = readerState.pktlen;
@@ -1200,11 +1200,14 @@ LOCAL int arkime_scheme_cmd_add(int argc, char **argv, gpointer cc, ArkimeScheme
 
     if (opsNum > 0) {
         ops[opsNum] = 0;
-        const char *error = arkime_field_ops_parse(&actions->ops, ARKIME_FIELD_OPS_FLAGS_COPY, ops);
+        char *error = arkime_field_ops_parse(&actions->ops, ARKIME_FIELD_OPS_FLAGS_COPY, ops);
         if (error) {
+            // ops_parse allocates the ops array and copies any ops parsed before the error
+            arkime_field_ops_free(&actions->ops);
             ARKIME_TYPE_FREE(ArkimeSchemeAction_t, actions);
             arkime_command_respond(cc, error, -1);
             arkime_command_respond(cc, "\n", -1);
+            g_free(error);
             return 1;
         }
     }


### PR DESCRIPTION
- Fix pcapNG reader doing a memcpy with a negative length when a skipped packet block's header spanned a read boundary
- Reject tunneled ethernet frames past 2048 bytes instead of wrapping etherOffset
- Set ARKIME_PACKET_MAX_LEN to 0xffff, the largest pktlen can hold, and use it for all packet length checks; fixes pcap-over-ip and snapLen accepting 65536
- Free the ops array and error string when add-file/add-dir gets a bad --op
- Fix arkime_field_ops_free freeing an uninitialized pointer for _closeNow/_flipSrcDst
- Use an explicit flag to pick the named function callback prototype
- Size the NTLM base64 decode buffer from the input limit
- Free the mysql version string when the field is disabled
- Check the imported pointer in the dhcp host name and fqdn options
- Free the previous etag when an S3 response repeats the header for a part
- Exit with an error on a scrubspi setting with no value
- Zero the sockaddr_in before bind in tcphealthcheck

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
