### PR TITLE
Fix role-based settings being ignored outside common/user.js

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,6 +36,8 @@ NOTICE: Cross-cluster Shortcuts require you to not restart all your viewers at o
 NOTICE: Create a parliament config file before upgrading (see https://arkime.com/settings#parliament and https://arkime.com/faq#how_do_i_upgrade_to_arkime_5)
 
 6.7.1 2026/08/xx
+## All
+  - #4215 Fix email searches, periodic queries and cont3xt history deletes ignoring permissions that come from a role instead of the user (thanks @Juwon1405)
 
 6.7.0 2026/08/19
 ## Release

--- a/common/user.js
+++ b/common/user.js
@@ -1774,6 +1774,18 @@ class User {
     return this.#allRoles;
   }
 
+  /**
+   * Return a setting expanded from ourselves and the roles we have.
+   *
+   * #allSettings is private, so code outside this file cannot read it and has
+   * to use this accessor. Reading the public property directly returns the
+   * value stored on the user document, which silently ignores roles when the
+   * user document does not set that field.
+   */
+  getSetting (setting) {
+    return this.#allSettings[setting];
+  }
+
   getExpression () {
     return this.#allExpression;
   }

--- a/common/user.js
+++ b/common/user.js
@@ -1775,15 +1775,11 @@ class User {
   }
 
   /**
-   * Return a setting expanded from ourselves and the roles we have.
-   *
-   * #allSettings is private, so code outside this file cannot read it and has
-   * to use this accessor. Reading the public property directly returns the
-   * value stored on the user document, which silently ignores roles when the
-   * user document does not set that field.
+   * Return one of the allSettingColumns permissions, expanded from ourselves
+   * and the roles we have. webEnabled isn't one of them, it has no roles.
    */
-  getSetting (setting) {
-    return this.#allSettings[setting];
+  getPermission (permission) {
+    return this.#allSettings[permission];
   }
 
   getExpression () {

--- a/cont3xt/audit.js
+++ b/cont3xt/audit.js
@@ -160,7 +160,7 @@ class Audit {
     }
 
     // permissions ---------------------------
-    if (!req.user.getSetting('removeEnabled')) {
+    if (!req.user.getPermission('removeEnabled')) {
       return res.send({ success: false, text: 'Can not delete a history log when user has data removal disabled.' });
     }
 

--- a/cont3xt/audit.js
+++ b/cont3xt/audit.js
@@ -160,7 +160,7 @@ class Audit {
     }
 
     // permissions ---------------------------
-    if (!req.user.removeEnabled) {
+    if (!req.user.getSetting('removeEnabled')) {
       return res.send({ success: false, text: 'Can not delete a history log when user has data removal disabled.' });
     }
 

--- a/tests/api-cron.t
+++ b/tests/api-cron.t
@@ -1,4 +1,4 @@
-use Test::More tests => 44;
+use Test::More tests => 51;
 use Cwd;
 use ArkimeTest;
 use JSON;
@@ -130,6 +130,35 @@ is ($json->[0]->{count}, "4");
 
 countTest(4, "date=-1&expression=" . uri_escape("${files} && protocols==tls"));
 countTest(4, "date=-1&expression=" . uri_escape("${files} && tags=test${suffix}"));
+
+# a periodic query whose owner only gets emailSearch from a role can use email fields
+my $emailFiles = '(file=*/pcap/smtp-originating.pcap||file=*/pcap/smtp-zip.pcap)';
+countTest(1, "date=-1&expression=" . uri_escape("$emailFiles && email.src == \"xxxxx\@xxx.net\""));
+$json = viewerPostToken("/api/user", '{"userId": "role:sac-cronemail", "userName": "Cron Email Role", "enabled":true, "webEnabled":true, "emailSearch": true}', $token);
+ok($json->{success}, "role:sac-cronemail created");
+
+$json = viewerPostToken("/api/user", '{"userId": "sac-cronemailuser", "userName": "Cron Email User", "enabled":true, "webEnabled":true, "password":"password", "roles":["role:sac-cronemail", "arkimeUser"]}', $token);
+ok($json->{success}, "sac-cronemailuser created");
+my $emailUserToken = getTokenCookie("sac-cronemailuser");
+
+$json = viewerPostToken("/api/cron?arkimeRegressionUser=sac-cronemailuser", to_json({
+    name => "emailcron",
+    since => -1,
+    query => "$emailFiles && email.src == \"xxxxx\@xxx.net\"",
+    action => "tag",
+    tags => "emailtest$suffix"
+}), $emailUserToken);
+ok($json->{success}, "email periodic query created");
+my $key3 = $json->{query}->{key};
+
+viewerGet("/regressionTests/processCronQueries");
+viewerGet("/regressionTests/processCronQueries");
+
+countTest(1, "date=-1&expression=" . uri_escape("tags==emailtest$suffix"));
+
+$json = viewerDeleteToken("/api/cron/$key3?arkimeRegressionUser=sac-cronemailuser", $emailUserToken);
+$json = viewerDeleteToken("/api/user/sac-cronemailuser", $token);
+$json = viewerDeleteToken("/api/user/role:sac-cronemail", $token);
 
 # cleanup
 $json = viewerDeleteToken("/api/cron/$key2?arkimeRegressionUser=sac-test1", $test1Token);

--- a/tests/api-users.t
+++ b/tests/api-users.t
@@ -1,7 +1,7 @@
 # Many of these test user/roles start with sac- (skip auto create) because
 # otherwise viewer in regression mode would auto create the user.
 # Some day should remove all autocreate code.
-use Test::More tests => 278;
+use Test::More tests => 282;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -786,6 +786,22 @@ my $uaToken = getTokenCookie('testusersadmin');
     ok($json->{success}, "sac-userExplicitTrue created");
     $json = viewerGetToken("/api/user?arkimeRegressionUser=sac-userExplicitTrue", $token);
     is($json->{emailSearch}, 1, "sac-userExplicitTrue emailSearch true (explicit)");
+
+    # a role granted setting is enforced by query building
+    my $emailExp = uri_escape('email.src == "foo@example.com"');
+    my $emailDenied = 'email.src - permission denied, ask your Arkime admin to give you access using + on Users tab';
+
+    $json = viewerGet("/api/buildquery?arkimeRegressionUser=sac-userInheritAB&date=-1&expression=$emailExp");
+    ok(!exists $json->{error}, "sac-userInheritAB can query email fields (emailSearch from role)");
+
+    $json = viewerGet("/api/buildquery?arkimeRegressionUser=sac-userInheritA&date=-1&expression=$emailExp");
+    ok(!exists $json->{error}, "sac-userInheritA can query email fields (emailSearch explicit)");
+
+    $json = viewerGet("/api/buildquery?arkimeRegressionUser=sac-userExplicitFalse&date=-1&expression=$emailExp");
+    is($json->{error}, $emailDenied, "sac-userExplicitFalse can not query email fields (explicit false beats role)");
+
+    $json = viewerGet("/api/buildquery?arkimeRegressionUser=sac-userInheritC&date=-1&expression=$emailExp");
+    is($json->{error}, $emailDenied, "sac-userInheritC can not query email fields (no role grants it)");
 
 # Check appversion
     $json = viewerGetToken("/api/appversion", $token);

--- a/tests/cont3xt.t
+++ b/tests/cont3xt.t
@@ -1,5 +1,5 @@
 # Test cont3xt.js
-use Test::More tests => 269;
+use Test::More tests => 273;
 use Test::Differences;
 use Data::Dumper;
 use ArkimeTest;
@@ -1166,6 +1166,30 @@ is (scalar @{$json->{audits}}, 10, "non numeric paging returns defaults");
 
 $json = cont3xtGet('/api/audits?searchTerm[]=goodtag');
 is($json->{success}, 1, "non string searchTerm ignored");
+
+# removeEnabled granted by a role lets the user delete their own log
+viewerPostToken("/api/user", '{"userId": "role:sac-remover", "userName": "Remover Role", "enabled":true, "webEnabled":true, "removeEnabled": true}', $token);
+viewerPostToken("/api/user", '{"userId": "sac-noremove", "userName": "No Remove", "enabled":true, "webEnabled":true, "password":"password", "roles":["cont3xtUser"]}', $token);
+viewerPostToken("/api/user", '{"userId": "sac-roleremove", "userName": "Role Remove", "enabled":true, "webEnabled":true, "password":"password", "roles":["role:sac-remover", "cont3xtUser"]}', $token);
+my $noRemoveToken = getCont3xtTokenCookie('sac-noremove');
+my $roleRemoveToken = getCont3xtTokenCookie('sac-roleremove');
+
+# each user searches so they own a log
+cont3xtPost('/api/integration/ip/csv:rir/search?arkimeRegressionUser=sac-noremove', to_json({ query => "8.8.4.4" }));
+cont3xtPost('/api/integration/ip/csv:rir/search?arkimeRegressionUser=sac-roleremove', to_json({ query => "8.8.4.4" }));
+sleep(1);
+esGet("/_flush");
+esGet("/_refresh");
+
+$json = cont3xtGet('/api/audits?arkimeRegressionUser=sac-noremove');
+is (scalar @{$json->{audits}}, 1, "sac-noremove owns one log");
+$json = cont3xtDeleteToken("/api/audit/" . $json->{audits}->[0]->{_id} . "?arkimeRegressionUser=sac-noremove", '{}', $noRemoveToken);
+eq_or_diff($json, from_json('{"success": false, "text": "Can not delete a history log when user has data removal disabled."}'), "no role grants removeEnabled");
+
+$json = cont3xtGet('/api/audits?arkimeRegressionUser=sac-roleremove');
+is (scalar @{$json->{audits}}, 1, "sac-roleremove owns one log");
+$json = cont3xtDeleteToken("/api/audit/" . $json->{audits}->[0]->{_id} . "?arkimeRegressionUser=sac-roleremove", '{}', $roleRemoveToken);
+eq_or_diff($json, from_json('{"success": true, "text": "Success"}'), "removeEnabled inherited from a role");
 
 # 500 indicators is still allowed (no integrations selected, so no lookups)
 $json = cont3xtPost('/api/integration/search', to_json({

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -698,7 +698,7 @@ class CronAPIs {
 
           // always complete building the query regardless of shortcuts
           arkimeparser.parser.yy = {
-            emailSearch: user.getSetting('emailSearch') === true,
+            emailSearch: user.getPermission('emailSearch') === true,
             fieldsMap: Config.getFieldsMap(),
             dbFieldsMap: Config.getDBFieldsMap(),
             prefix: internals.prefix,

--- a/viewer/apiCrons.js
+++ b/viewer/apiCrons.js
@@ -698,7 +698,7 @@ class CronAPIs {
 
           // always complete building the query regardless of shortcuts
           arkimeparser.parser.yy = {
-            emailSearch: user.emailSearch === true,
+            emailSearch: user.getSetting('emailSearch') === true,
             fieldsMap: Config.getFieldsMap(),
             dbFieldsMap: Config.getDBFieldsMap(),
             prefix: internals.prefix,

--- a/viewer/buildQuery.js
+++ b/viewer/buildQuery.js
@@ -479,7 +479,7 @@ class BuildQuery {
       fieldsMap: Config.getFieldsMap(),
       dbFieldsMap: Config.getDBFieldsMap(),
       prefix: internals.prefix,
-      emailSearch: req.user.emailSearch === true,
+      emailSearch: req.user.getSetting('emailSearch') === true,
       shortcuts: shortcuts || {},
       shortcutTypeMap: internals.shortcutTypeMap
     };

--- a/viewer/buildQuery.js
+++ b/viewer/buildQuery.js
@@ -479,7 +479,7 @@ class BuildQuery {
       fieldsMap: Config.getFieldsMap(),
       dbFieldsMap: Config.getDBFieldsMap(),
       prefix: internals.prefix,
-      emailSearch: req.user.getSetting('emailSearch') === true,
+      emailSearch: req.user.getPermission('emailSearch') === true,
       shortcuts: shortcuts || {},
       shortcutTypeMap: internals.shortcutTypeMap
     };

--- a/viewer/viewerUtils.js
+++ b/viewer/viewerUtils.js
@@ -459,6 +459,8 @@ class ViewerUtils {
         anon.settings = anonUser.settings || {};
       }
 
+      await anon.expandFromRoles();
+
       return anon;
     } else {
       return await User.getUserCache(userId);


### PR DESCRIPTION
**Clearly describe the problem and solution**

`expandFromRoles()` stores the expanded permission settings (`emailSearch`, `removeEnabled`, `packetSearch`, `hideStats`, `hideFiles`, `hidePcap`, `disablePcapDownload`) in the private `#allSettings` field. `User` exposes `getRoles()` for `#allRoles` and `getExpression()` for `#allExpression`, but there is no accessor for the settings, so code in other files reads the public property on the user object instead.

That property holds only what the user document sets. When a role is what grants the setting, it is `undefined`, and these three call sites treat that as `false`:

- `viewer/buildQuery.js` — `emailSearch: req.user.emailSearch === true`
- `viewer/apiCrons.js` — `emailSearch: user.emailSearch === true`
- `cont3xt/audit.js` — `if (!req.user.removeEnabled)`

The visible effect: a user whose document does not set `emailSearch` cannot search email fields even when one of their roles enables it, while `checkPermissions()` and `GET /api/user` report the permission as granted, because those read `#allSettings`. The two answers disagree for the same user, which makes it look like the Users page is showing something other than what the server enforces.

This shows up on any deployment that keeps permissions on roles and leaves the user documents free of per-user setting fields — for instance when `userAutoCreateTmpl` does not list them, so auto-created users only ever get the values their role provides.

The fix adds `getSetting()`, mirroring how `getExpression()` exposes `#allExpression`, and switches those three call sites to it. `#allSettings` is initialised to `{}`, so calling it before expansion returns `undefined`, exactly as reading the property did.

I deliberately did not make `expandFromRoles()` write the expanded values back onto the instance properties, which would have been a shorter fix.

`save()` hands the instance itself to `User.setUser()`, so inherited values would be persisted onto the user document by ordinary saves — a `lastUsed` update is enough — and role-based settings would slowly turn into per-user ones.

Please note this is a behaviour change for affected deployments: settings that a role grants now take effect at these call sites where they previously did not.

**Relevant issue number(s) if applicable**

None — happy to open one first if you would prefer to discuss it there.

**Did you run `npm run lint` from the viewer or parliament directory (whichever you are making changes to) and correct any errors**

Yes. `npm run lint` from the top level passes with no errors. The first draft used `name` as the parameter and lint caught it as `no-shadow`; the parameter is now `setting`.

**Did you Ensure that all tests still pass by navigating to the `tests` directory and running `./tests.pl --viewer`**

No — I do not have an OpenSearch/Elasticsearch instance with the test PCAPs loaded in the environment where I prepared this, so I could not run the viewer test suite honestly. The change is one new accessor plus three call-site swaps, with no change to how `#allSettings` is computed.

I did verify the behaviour against a live user database, by loading `common/user.js` directly and comparing three things per user: `getSetting('emailSearch')`, the expression `buildQuery.js` evaluates, and the `checkPermissions()` verdict. Before the change the first two disagreed with the third for every user whose document did not set the field; after it, all three agree.

If you would like the test suite run before merging, please point me at it and I will set the environment up.

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
