### PR TITLE
Fix success toast showing [object Object] after PCAP/CSV export

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -42,6 +42,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - #4217 Fix HTTP/2 sessions leaving http.uri empty, only http.uri.path was filled in
 ## Viewer
   - #4216 Fix multi viewer hanging or failing queries when one cluster is down or unhealthy (thanks @Juwon1405)
+  - #4222 Fix session PCAP/CSV export success toast showing "[object Object]"
 
 6.7.0 2026/08/19
 ## Release

--- a/common/vueapp/UserDropdown.vue
+++ b/common/vueapp/UserDropdown.vue
@@ -158,7 +158,7 @@ export default {
         }
       }).catch((error) => {
         this.loading = false;
-        this.error = resolveMessage(error, this.$t);
+        this.error = resolveMessage(error, this.$t) || this.$t('users.unknownErr');
       });
     },
     updateUsers (userId) { // emits both the new array and changed user-value

--- a/common/vueapp/Users.vue
+++ b/common/vueapp/Users.vue
@@ -816,7 +816,7 @@ export default {
         this.dbUserList = JSON.parse(JSON.stringify(response.data));
       }).catch((error) => {
         this.loading = false;
-        this.error = resolveMessage(error, this.$t);
+        this.error = resolveMessage(error, this.$t) || this.$t('users.unknownErr');
       });
     },
     reloadUsers () {
@@ -837,7 +837,7 @@ export default {
         this.dbUserList = JSON.parse(JSON.stringify(response.data));
       }).catch((error) => {
         this.loading = false;
-        this.error = resolveMessage(error, this.$t);
+        this.error = resolveMessage(error, this.$t) || this.$t('users.unknownErr');
       });
     }
   }

--- a/common/vueapp/locales/de.json
+++ b/common/vueapp/locales/de.json
@@ -953,6 +953,7 @@
     "uploadWorked": "Datei erfolgreich hochgeladen"
   },
   "users": {
+    "unknownErr": "Beim Laden der Benutzer ist ein unerwarteter Fehler aufgetreten.",
     "searchPlaceholder": "Beginnen Sie mit der Eingabe, um nach Benutzern nach Name, ID oder Rolle zu suchen (!Rolle schließt Benutzer mit dieser Rolle aus)",
     "searchUserPlaceholder": "Beginnen Sie mit der Eingabe, um nach Benutzern nach Name oder ID zu suchen",
     "downloadCSVTip": "CSV herunterladen",

--- a/common/vueapp/locales/en.json
+++ b/common/vueapp/locales/en.json
@@ -953,6 +953,7 @@
     "uploadWorked": "File sucessfully uploaded"
   },
   "users": {
+    "unknownErr": "An unexpected error occurred while loading users.",
     "searchPlaceholder": "Begin typing to search for users by name, id, or role (!role excludes users with that role)",
     "searchUserPlaceholder": "Begin typing to search for users by name or id",
     "downloadCSVTip": "Download CSV",

--- a/common/vueapp/locales/es.json
+++ b/common/vueapp/locales/es.json
@@ -953,6 +953,7 @@
     "uploadWorked": "Archivo subido exitosamente"
   },
   "users": {
+    "unknownErr": "Ocurrió un error inesperado al cargar los usuarios.",
     "searchPlaceholder": "Comience a escribir para buscar usuarios por nombre, ID o rol (!rol excluye usuarios con ese rol)",
     "searchUserPlaceholder": "Comience a escribir para buscar usuarios por nombre o ID",
     "downloadCSVTip": "Descargar CSV",

--- a/common/vueapp/locales/et.json
+++ b/common/vueapp/locales/et.json
@@ -953,6 +953,7 @@
     "uploadWorked": "Fail edukalt üles laaditud"
   },
   "users": {
+    "unknownErr": "Kasutajate laadimisel ilmnes ootamatu viga.",
     "searchPlaceholder": "Alusta tippimist, et otsida kasutajaid nime, ID või rolli järgi (!roll välistab selle rolliga kasutajad)",
     "searchUserPlaceholder": "Alusta tippimist, et otsida kasutajaid nime või ID järgi",
     "downloadCSVTip": "Laadi alla CSV",

--- a/common/vueapp/locales/fr.json
+++ b/common/vueapp/locales/fr.json
@@ -953,6 +953,7 @@
     "uploadWorked": "Fichier téléchargé avec succès"
   },
   "users": {
+    "unknownErr": "Une erreur inattendue s'est produite lors du chargement des utilisateurs.",
     "searchPlaceholder": "Commencer à taper pour rechercher des utilisateurs par nom, ID ou rôle (!rôle exclut les utilisateurs ayant ce rôle)",
     "searchUserPlaceholder": "Commencer à taper pour rechercher des utilisateurs par nom ou ID",
     "downloadCSVTip": "Télécharger CSV",

--- a/common/vueapp/locales/ja.json
+++ b/common/vueapp/locales/ja.json
@@ -953,6 +953,7 @@
     "uploadWorked": "ファイルが正常にアップロードされました"
   },
   "users": {
+    "unknownErr": "ユーザーの読み込み中に予期しないエラーが発生しました。",
     "searchPlaceholder": "名前、ID、またはロールでユーザーを検索するには入力を開始してください（!ロールでそのロールを持つユーザーを除外）",
     "searchUserPlaceholder": "名前または ID でユーザーを検索するには入力を開始してください",
     "downloadCSVTip": "CSV をダウンロード",

--- a/common/vueapp/locales/ko.json
+++ b/common/vueapp/locales/ko.json
@@ -953,6 +953,7 @@
     "uploadWorked": "파일이 성공적으로 업로드되었습니다"
   },
   "users": {
+    "unknownErr": "사용자 로딩 중 예상치 못한 오류가 발생했습니다.",
     "searchPlaceholder": "이름, ID 또는 역할로 사용자 검색을 위해 입력을 시작하세요 (!역할은 해당 역할을 가진 사용자를 제외합니다)",
     "searchUserPlaceholder": "이름 또는 ID로 사용자 검색을 위해 입력을 시작하세요",
     "downloadCSVTip": "CSV 다운로드",

--- a/common/vueapp/locales/pt-BR.json
+++ b/common/vueapp/locales/pt-BR.json
@@ -953,6 +953,7 @@
     "uploadWorked": "Arquivo enviado com sucesso"
   },
   "users": {
+    "unknownErr": "Ocorreu um erro inesperado ao carregar os usuários.",
     "searchPlaceholder": "Comece a digitar para pesquisar usuários por nome, ID ou função (!função exclui usuários com essa função)",
     "searchUserPlaceholder": "Comece a digitar para pesquisar usuários por nome ou ID",
     "downloadCSVTip": "Baixar CSV",

--- a/common/vueapp/locales/x-pl.json
+++ b/common/vueapp/locales/x-pl.json
@@ -954,6 +954,7 @@
     "uploadWorked": "IleFay ucessfullysay uploadedway"
   },
   "users": {
+    "unknownErr": "Anway unexpectedway errorway occurredway ilewhay oadinglay usersway.",
     "searchPlaceholder": "EginBay ypingtay otay earchsay orfay usersway ybay amenay, idway, orway oleray (!oleray excludesway usersway ithway atthay oleray)",
     "searchUserPlaceholder": "EginBay ypingtay otay earchsay orfay usersway ybay amenay orway idway",
     "downloadCSVTip": "Ownloadday SVCAY",

--- a/common/vueapp/locales/zh.json
+++ b/common/vueapp/locales/zh.json
@@ -953,6 +953,7 @@
     "uploadWorked": "文件成功上传"
   },
   "users": {
+    "unknownErr": "加载用户时发生意外错误。",
     "searchPlaceholder": "开始输入以按名称、ID 或角色搜索用户（!角色可排除具有该角色的用户）",
     "searchUserPlaceholder": "开始输入以按名称或 ID 搜索用户",
     "downloadCSVTip": "下载 CSV",

--- a/common/vueapp/resolveI18nMessage.js
+++ b/common/vueapp/resolveI18nMessage.js
@@ -1,15 +1,16 @@
 /**
  * Resolves a translated message from an object with i18n fields.
- * Falls back to `text`, `message`, or String(obj) when no translation exists.
+ * Falls back to `text`, `message`, the string itself, or '' when nothing resolves.
  *
- * @param {Object} obj - An object with optional i18n, i18nParams, text, or message fields
+ * @param {Object|string} obj - A string, or an object with optional i18n, i18nParams, text, or message fields
  * @param {Function} t - The i18n translation function (e.g., this.$t)
- * @returns {string} The resolved message
+ * @returns {string} The resolved message, or '' if none could be resolved
  */
 export function resolveMessage (obj, t) {
   if (obj?.i18n && t) {
     const translated = t(obj.i18n, obj.i18nParams || {});
     if (translated !== obj.i18n) { return translated; }
   }
-  return obj?.text || obj?.message || String(obj);
+  if (typeof obj === 'string') { return obj; }
+  return obj?.text || obj?.message || '';
 }


### PR DESCRIPTION
## Summary

After exporting sessions to PCAP or CSV, the success toast displayed the literal text `[object Object]` instead of a real message (or nothing).

`SessionsService.exportPcap`/`exportCsv` trigger the download via a hidden link click rather than a real fetch response, so they resolve with a bare `{ success: true }` object — no `text`, `message`, or `i18n` field. The shared `resolveMessage()` helper fell back to `String(obj)` whenever none of those fields were present, and `String({ success: true })` evaluates to the literal string `"[object Object]"`, which then got rendered verbatim in the toast.

## Fix

`resolveMessage()` now passes strings through unchanged and returns `''` instead of stringifying the object when there's nothing to show. This matches how the vast majority of call sites already use the helper (`resolveMessage(x, t) || 'default message'`), so callers that want a message on success (or a fallback on error) already handle the empty case correctly — no other call sites needed to change.

## Test plan
- [x] `npx eslint common/vueapp/resolveI18nMessage.js` passes
- [ ] Export a PCAP and a CSV from the sessions view and confirm the success toast no longer reads `[object Object]`