### PR TITLE
Add mcpMaxTagSessions to bound MCP tag changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -50,6 +50,8 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Viewer
   - #4216 Fix multi viewer hanging or failing queries when one cluster is down or unhealthy (thanks @Juwon1405)
   - #4222 Fix session PCAP/CSV export success toast showing "[object Object]"
+  - #4230 Add mcpMaxTagSessions capping how many sessions one MCP tag change may touch, default 10000, -1 for no limit
+  - #4230 The addtags and removetags apis now return count, how many sessions were changed, and the MCP tools report when a change was truncated by mcpMaxTagSessions
 
 6.7.0 2026/08/19
 ## Release

--- a/release/config.ini.sample
+++ b/release/config.ini.sample
@@ -195,11 +195,15 @@ dropGroup=daemon
 # mcpMaxQueryDays caps how much time a query may span, in days, floating point,
 # so 0.5 is 12 hours. Defaults to 7. Use -1 for no limit, which lets an
 # assistant ask for all data and can be expensive on a large cluster.
+# mcpMaxTagSessions caps how many sessions one tag change may touch. Defaults
+# to 10000. Use -1 for no limit. When a change hits the cap the tool says so
+# rather than reporting that the whole expression was applied.
 # See https://arkime.com/settings#mcp for the auth modes, the authJwt* settings
 # and full Okta/Athenz/apache examples.
 #mcpEnabled=true
 #mcpAuthMode=header
 #mcpMaxQueryDays=7
+#mcpMaxTagSessions=10000
 
 # Should we parse HTTP QS Values
 parseQSValue=false

--- a/tests/api-mcp.t
+++ b/tests/api-mcp.t
@@ -1,6 +1,7 @@
-use Test::More tests => 90;
+use Test::More tests => 111;
 use ArkimeTest;
 use JSON;
+use URI::Escape;
 use Test::Differences;
 use Data::Dumper;
 use strict;
@@ -248,6 +249,52 @@ $json = callTool("arkime_create_hunt", '{"name":"mcphunt","search":"zzz","search
 is($json->{result}->{isError}, JSON::true, "arkime_create_hunt requires a time window");
 
 viewerGet("/regressionTests/deleteAllViews");
+
+################################################################################
+# mcpMaxTagSessions - the test viewer sets it to 2, so one tag change can only
+# ever touch 2 sessions however many the expression matches
+################################################################################
+my $pwd = "*/pcap";
+
+# more ids than the cap is refused up front, before anything is tagged
+$json = callTool("arkime_add_tags", '{"date":-1,"tags":"MCPCAPTEST","ids":"a,b,c"}');
+is($json->{result}->{isError}, JSON::true, "arkime_add_tags with more ids than mcpMaxTagSessions is a tool error");
+like($json->{result}->{content}->[0]->{text}, qr/mcpMaxTagSessions is 2/, "and the error names the setting and the limit");
+
+# 3 sessions match the expression, only 2 of them may be tagged
+countTest(0, "date=-1&expression=" . uri_escape("tags==MCPCAPTEST"));
+$json = callTool("arkime_add_tags", "{\"date\":-1,\"expression\":\"file=$pwd/socks-http-example.pcap\",\"tags\":\"MCPCAPTEST\"}");
+is($json->{result}->{isError}, JSON::false, "arkime_add_tags by expression succeeds");
+esGet("/_flush");
+esGet("/_refresh");
+countTest(3, "date=-1&expression=" . uri_escape("file=$pwd/socks-http-example.pcap"));
+countTest(2, "date=-1&expression=" . uri_escape("tags==MCPCAPTEST"));
+
+# a capped change must say it truncated, not report plain success
+is($json->{result}->{structuredContent}->{truncated}, JSON::true, "a capped tag change is reported as truncated");
+is($json->{result}->{structuredContent}->{count}, 2, "and reports how many sessions it touched");
+like($json->{result}->{structuredContent}->{text}, qr/mcpMaxTagSessions is 2/, "and the text names the setting");
+
+# clean up, the tagged sessions are exactly at the cap so one call clears them
+$json = callTool("arkime_remove_tags", '{"date":-1,"expression":"tags==MCPCAPTEST","tags":"MCPCAPTEST"}');
+is($json->{result}->{isError}, JSON::false, "arkime_remove_tags succeeds");
+esGet("/_flush");
+esGet("/_refresh");
+countTest(0, "date=-1&expression=" . uri_escape("tags==MCPCAPTEST"));
+
+# a falsy but present ids must not skip the cap: the api picks its by-query
+# branch with `if (req.body.ids)`, so "" has to be treated as no ids here too
+$json = callTool("arkime_add_tags", "{\"date\":-1,\"expression\":\"file=$pwd/socks-http-example.pcap\",\"tags\":\"MCPCAPEMPTY\",\"ids\":\"\"}");
+is($json->{result}->{isError}, JSON::false, "arkime_add_tags with an empty ids succeeds");
+esGet("/_flush");
+esGet("/_refresh");
+countTest(2, "date=-1&expression=" . uri_escape("tags==MCPCAPEMPTY"));
+
+$json = callTool("arkime_remove_tags", '{"date":-1,"expression":"tags==MCPCAPEMPTY","tags":"MCPCAPEMPTY"}');
+is($json->{result}->{isError}, JSON::false, "arkime_remove_tags cleans up the empty ids tag");
+esGet("/_flush");
+esGet("/_refresh");
+countTest(0, "date=-1&expression=" . uri_escape("tags==MCPCAPEMPTY"));
 
 ################################################################################
 # mcpMaxQueryDays - the test2 viewer on 8124 sets nothing, so this exercises the

--- a/tests/config.test.ini
+++ b/tests/config.test.ini
@@ -76,6 +76,8 @@ packetPortalListen=true
 mcpEnabled=true
 mcpAuthMode=regressionTests
 mcpMaxQueryDays=-1
+# deliberately tiny so api-mcp.t can prove the tag cap is applied
+mcpMaxTagSessions=2
 plugins=test.so;tagger.so;wise.so;scrubspi.so;zeekintel.so
 cronQueries=true
 dontSaveBPFs=port 12345

--- a/viewer/apiMcp.js
+++ b/viewer/apiMcp.js
@@ -103,6 +103,61 @@ class MCPViewerAPIs {
   }
 
   // --------------------------------------------------------------------------
+  /**
+   * How many sessions one tag change may touch, mcpMaxTagSessions, default
+   * 10000, -1 for no limit. parseInt is not enough on its own: it stops at the
+   * first non digit, so '10k' would silently become a cap of 10.
+   */
+  static #maxTagSessions () {
+    const raw = String(ArkimeConfig.get('mcpMaxTagSessions', 10000)).trim();
+    if (!/^-?[0-9]+$/.test(raw)) {
+      console.log('ERROR - mcpMaxTagSessions is not a number, using 10000');
+      return 10000;
+    }
+    return parseInt(raw, 10);
+  }
+
+  // --------------------------------------------------------------------------
+  /**
+   * Build the query for a tag change and cap how many sessions it may touch.
+   * Tagging by expression otherwise inherits the api's own 1000000 default.
+   */
+  static #tagQuery (args) {
+    const query = MCPViewerAPIs.#sessionQuery(args, ['tags', 'ids']);
+    const limit = MCPViewerAPIs.#maxTagSessions();
+
+    if (limit < 0) { return query; } // -1 means no limit
+
+    // Falsy-but-present ids, eg "", still takes the api's by-query branch
+    // (`if (req.body.ids)`), so test it the same way or the cap is skipped
+    if (!query.ids) {
+      // never 0, buildQuery treats that as unset and falls back to its own default
+      query.length = Math.max(1, limit);
+    } else if (String(query.ids).split(',').filter(id => id !== '').length > limit) {
+      throw new MCPToolError(`Too many ids, mcpMaxTagSessions is ${limit}`);
+    }
+
+    return query;
+  }
+
+  // --------------------------------------------------------------------------
+  /**
+   * A capped tag change must not report plain success. The api reports how many
+   * sessions it touched, so say when that is the cap rather than letting the
+   * model believe the whole expression was applied.
+   */
+  static #tagResult (result, query, past, verb) {
+    if (query.length !== undefined && result?.count >= query.length) {
+      return {
+        ...result,
+        truncated: true,
+        text: `Only the first ${result.count} matching sessions were ${past}, because mcpMaxTagSessions is ${query.length}. Narrow the expression, or pass explicit ids, to ${verb} the rest.`
+      };
+    }
+    return result;
+  }
+
+  // --------------------------------------------------------------------------
   static #buildTools (apis) {
     const { SessionAPIs, StatsAPIs, MiscAPIs, ConnectionAPIs, ViewAPIs, HuntAPIs, ShortcutAPIs, HistoryAPIs } = apis;
     const mw = MCPViewerAPIs.#mw;
@@ -388,18 +443,19 @@ class MCPViewerAPIs {
         annotations: { readOnlyHint: false, destructiveHint: false },
         inputSchema: sessionQuerySchema({
           tags: { type: 'string', description: 'Comma separated tags to add.' },
-          ids: { type: 'string', description: 'Optional comma separated session ids. When omitted, every session matching the expression is tagged, so always set a narrow expression.' }
+          ids: { type: 'string', description: 'Optional comma separated session ids. When omitted, every session matching the expression is tagged, up to the mcpMaxTagSessions limit, so always set a narrow expression.' }
         }, ['tags']),
         handler: async (args, req) => {
           // addTags reads tags/ids from the body but the expression from the
           // query, so it needs both
-          const q = MCPViewerAPIs.#sessionQuery(args, ['tags', 'ids']);
-          return MCPServer.callApiOrThrow(req, {
+          const q = MCPViewerAPIs.#tagQuery(args);
+          const result = await MCPServer.callApiOrThrow(req, {
             url: '/api/sessions/addtags',
             query: q,
             body: q,
             handlers: [mw.checkHeaderToken, mw.logAction('addTags'), SessionAPIs.addTags]
           });
+          return MCPViewerAPIs.#tagResult(result, q, 'tagged', 'tag');
         }
       },
       {
@@ -409,16 +465,17 @@ class MCPViewerAPIs {
         annotations: { readOnlyHint: false, destructiveHint: false },
         inputSchema: sessionQuerySchema({
           tags: { type: 'string', description: 'Comma separated tags to remove.' },
-          ids: { type: 'string', description: 'Optional comma separated session ids. When omitted, every session matching the expression is untagged.' }
+          ids: { type: 'string', description: 'Optional comma separated session ids. When omitted, every session matching the expression is untagged, up to the mcpMaxTagSessions limit.' }
         }, ['tags']),
         handler: async (args, req) => {
-          const q = MCPViewerAPIs.#sessionQuery(args, ['tags', 'ids']);
-          return MCPServer.callApiOrThrow(req, {
+          const q = MCPViewerAPIs.#tagQuery(args);
+          const result = await MCPServer.callApiOrThrow(req, {
             url: '/api/sessions/removetags',
             query: q,
             body: q,
             handlers: [mw.checkHeaderToken, mw.logAction('removeTags'), User.checkPermissions(['removeEnabled']), SessionAPIs.removeTags]
           });
+          return MCPViewerAPIs.#tagResult(result, q, 'untagged', 'untag');
         }
       },
       {

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -2698,6 +2698,7 @@ class SessionAPIs {
      time - Add tags to segments occurring in the same time period
    * @returns {boolean} success - Whether the add tags operation was successful
    * @returns {string} text - The success/error message to (optionally) display to the user
+   * @returns {number} count - How many sessions were changed
    */
   static addTags (req, res) {
     let tags = [];
@@ -2722,7 +2723,8 @@ class SessionAPIs {
           return res.json({
             success: true,
             text: 'Tags added successfully',
-            i18n: 'api.sessions.tagsAdded'
+            i18n: 'api.sessions.tagsAdded',
+            count: list.length
           });
         });
       });
@@ -2743,7 +2745,8 @@ class SessionAPIs {
           return res.json({
             success: true,
             text: 'Tags added successfully',
-            i18n: 'api.sessions.tagsAdded'
+            i18n: 'api.sessions.tagsAdded',
+            count: total
           });
         });
     }
@@ -2764,6 +2767,7 @@ class SessionAPIs {
      time - Remove tags from segments occurring in the same time period
    * @returns {boolean} success - Whether the remove tags operation was successful
    * @returns {string} text - The success/error message to (optionally) display to the user
+   * @returns {number} count - How many sessions were changed
    */
   static removeTags (req, res) {
     let tags = [];
@@ -2787,7 +2791,8 @@ class SessionAPIs {
           return res.json({
             success: true,
             text: 'Tags removed successfully',
-            i18n: 'api.sessions.tagsRemoved'
+            i18n: 'api.sessions.tagsRemoved',
+            count: list.length
           });
         });
       });
@@ -2807,7 +2812,8 @@ class SessionAPIs {
           return res.json({
             success: true,
             text: 'Tags removed successfully',
-            i18n: 'api.sessions.tagsRemoved'
+            i18n: 'api.sessions.tagsRemoved',
+            count: total
           });
         });
     }


### PR DESCRIPTION
`arkime_add_tags` with no `ids` fell through to the api's own 1000000 default, so one tool call could tag a million sessions — shipped config, no operator error, arguments chosen by a model. Adding tags needs no permission while removing them needs `removeEnabled`, so the caller cannot always undo it.

- Add `mcpMaxTagSessions`, default 10000, `-1` for no limit.
- Test `ids` the way the api does. `addTags`/`removeTags` pick their by-query branch with `if (req.body.ids)`, so a falsy but present `ids` such as `ids:""` skipped the cap and restored the 1000000 default. Nothing validates tool arguments against `inputSchema`, so it was reachable from a tool call.
- `addtags`/`removetags` now return `count`, and the tools report a truncated change instead of plain success — previously a removal could leave 40000 sessions tagged while the assistant reported them cleared.

Config hardening originally in this PR moved to #4233.

Test plan 111, six new assertions. `npm run lint` clean. Not run against a live cluster.
