### PR TITLE
_flipSrcDst now flips the whole session, not just the ips and ports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
           node, they now create a session per talker pair like every other protocol - by src/dst mac for the
           ethernet protocols and by src/dst ip for igmp and pim. Expect more, smaller sessions for these
   - Removed the demoMode setting and User.isDemoMode(); roles do not replace it, so put a shared instance behind an external identity provider
+  - The _flipSrcDst rule op used to only swap the ips and ports, leaving the rest of the session pointing the old way.
+          It now also swaps the per-direction data: packets, bytes, databytes, payload8, mac, oui, dscp, ttl,
+          tcp seq/state tracking and zero window counts, so flipped sessions are saved self consistent
 ## Release
   - #4221 Node 24.20.0
 ## Capture/Viewer

--- a/capture/arkime.h
+++ b/capture/arkime.h
@@ -1454,6 +1454,7 @@ int      arkime_packet_dlt_index(const ArkimePacket_t *packet);
 uint32_t arkime_packet_dlt_to_linktype(int dlt);
 uint32_t arkime_packet_linktype_to_dlt(int linktype);
 void     arkime_packet_drophash_add(ArkimeSession_t *session, int which, int min);
+void     arkime_packet_flip_src_dst(ArkimeSession_t *session);
 
 ArkimePacketRC arkime_packet_run_ethernet_cb(ArkimePacketBatch_t *batch, ArkimePacket_t *const packet, const uint8_t *data, int len, uint16_t type, const char *str);
 void     arkime_packet_set_ethernet_cb(uint16_t type, ArkimePacketEnqueue_cb enqueueCb);
@@ -1687,6 +1688,7 @@ gboolean arkime_field_float_add(int pos, ArkimeSession_t *session, float f);
 void arkime_field_macoui_add(ArkimeSession_t *session, int macField, int ouiField, const uint8_t *mac);
 
 int  arkime_field_count(int pos, ArkimeSession_t *session);
+void arkime_field_swap(int pos1, int pos2, ArkimeSession_t *session);
 void arkime_field_certsinfo_update_extra(void *cert, char *key, char *value);
 GPtrArray *arkime_field_certsinfo_get_extra(const ArkimeSession_t *session, const char *key);
 void arkime_field_free(ArkimeSession_t *session);

--- a/capture/field.c
+++ b/capture/field.c
@@ -1614,6 +1614,23 @@ int arkime_field_count(int pos, ArkimeSession_t *session)
     }
 }
 /******************************************************************************/
+void arkime_field_swap(int pos1, int pos2, ArkimeSession_t *session)
+{
+    if (pos1 < 0 || pos2 < 0 || pos1 >= session->maxFields || pos2 >= session->maxFields)
+        return;
+
+    ArkimeField_t *field = session->fields[pos1];
+    session->fields[pos1] = session->fields[pos2];
+    session->fields[pos2] = field;
+
+    // jsonSize includes the db field name, which can differ in length across the pair
+    const int diff = (int)config.fields[pos1]->dbFieldLen - (int)config.fields[pos2]->dbFieldLen;
+    if (session->fields[pos1])
+        session->fields[pos1]->jsonSize += diff;
+    if (session->fields[pos2])
+        session->fields[pos2]->jsonSize -= diff;
+}
+/******************************************************************************/
 LOCAL int arkime_field_ops_should_run_int_op(const ArkimeFieldOp_t *op, int value)
 {
     switch (op->set) {

--- a/capture/packet.c
+++ b/capture/packet.c
@@ -2608,6 +2608,14 @@ void arkime_packet_drophash_add(ArkimeSession_t *session, int which, int min)
     }
 }
 /******************************************************************************/
+void arkime_packet_flip_src_dst(ArkimeSession_t *session)
+{
+    arkime_field_swap(mac1Field, mac2Field, session);
+    arkime_field_swap(oui1Field, oui2Field, session);
+    arkime_field_swap(dscpField[0], dscpField[1], session);
+    arkime_field_swap(ttlField[0], ttlField[1], session);
+}
+/******************************************************************************/
 void arkime_packet_exit()
 {
     runThreads = 0;

--- a/capture/session.c
+++ b/capture/session.c
@@ -435,18 +435,56 @@ void arkime_session_mark_for_close(ArkimeSession_t *session)
     }
 }
 /******************************************************************************/
+#define FLIP_SWAP(_type, _a, _b) do { _type _tmp = (_a); (_a) = (_b); (_b) = _tmp; } while (0)
+#define FLIP_SWAP2(_type, _arr) FLIP_SWAP(_type, (_arr)[0], (_arr)[1])
+#define FLIP_BITS(_f) (_f) = ((((_f) & 1) << 1) | (((_f) >> 1) & 1))
 void arkime_session_flip_src_dst(ArkimeSession_t *session)
 {
-    struct in6_addr        addr;
-    uint16_t               port;
+    FLIP_SWAP(struct in6_addr, session->addr1, session->addr2);
+    FLIP_SWAP(uint16_t, session->port1, session->port2);
 
-    addr = session->addr1;
-    session->addr1 = session->addr2;
-    session->addr2 = addr;
+    FLIP_SWAP2(uint64_t, session->bytes);
+    FLIP_SWAP2(uint64_t, session->databytes);
+    FLIP_SWAP2(uint64_t, session->totalDatabytes);
+    FLIP_SWAP2(uint32_t, session->packets);
+    FLIP_SWAP2(uint8_t, session->consumed);
+    FLIP_SWAP2(uint8_t, session->firstBytesLen);
 
-    port = session->port1;
-    session->port1 = session->port2;
-    session->port2 = port;
+    char firstBytes[sizeof(session->firstBytes[0])];
+    memcpy(firstBytes, session->firstBytes[0], sizeof(firstBytes));
+    memcpy(session->firstBytes[0], session->firstBytes[1], sizeof(firstBytes));
+    memcpy(session->firstBytes[1], firstBytes, sizeof(firstBytes));
+
+    FLIP_BITS(session->synSet);
+    FLIP_BITS(session->outOfOrder);
+    FLIP_BITS(session->ackedUnseenSegment);
+
+    // tcpData/sctpData are a union, and tcpFlagAckCnt shares one with the
+    // non-directional icmpInfo, so only flip what the ip protocol says is there
+    if (session->ipProtocol == IPPROTO_TCP) {
+        FLIP_SWAP2(uint8_t, session->tcpFlagAckCnt);
+        FLIP_SWAP2(uint32_t, session->tcpData.synSeq);
+        FLIP_SWAP2(uint32_t, session->tcpData.tcpSeq);
+        FLIP_SWAP2(uint32_t, session->tcpData.synAckSeq);
+        FLIP_SWAP2(uint32_t, session->tcpData.synISN);
+        FLIP_SWAP2(char, session->tcpData.tcpState);
+        FLIP_SWAP(uint16_t, session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_SRC_ZERO], session->tcpData.tcpFlagCnt[ARKIME_TCPFLAG_DST_ZERO]);
+        FLIP_BITS(session->tcpData.synSeen);
+        FLIP_BITS(session->tcpData.synAckSeen);
+        FLIP_BITS(session->tcpData.synValidated);
+        FLIP_BITS(session->tcpData.synAckValidated);
+
+        // Queued out of order packets cached their direction
+        ArkimeTcpData_t *ftd;
+        DLL_FOREACH(td_, &session->tcpData, ftd) {
+            ftd->packet->direction ^= 1;
+        }
+    } else if (session->ipProtocol == IPPROTO_SCTP) {
+        FLIP_SWAP2(uint32_t, session->sctpData.tsn);
+        FLIP_SWAP2(uint32_t, session->sctpData.initTag);
+    }
+
+    arkime_packet_flip_src_dst(session);
 }
 /******************************************************************************/
 LOCAL void arkime_session_free(ArkimeSession_t *session)

--- a/tests/pcap/single-packets.test
+++ b/tests/pcap/single-packets.test
@@ -1513,7 +1513,7 @@
        "name" : "GoDaddy.com, LLC"
       }
      },
-     "bytes" : 0,
+     "bytes" : 243,
      "geo" : {
       "city_name" : "Scottsdale",
       "country_iso_code" : "US",
@@ -1521,10 +1521,10 @@
      },
      "ip" : "68.178.213.61",
      "mac" : [
-      "00:0c:29:6f:84:37"
+      "00:50:56:f4:62:21"
      ],
      "mac-cnt" : 1,
-     "packets" : 0,
+     "packets" : 1,
      "port" : 80
     },
     "dstOui" : [
@@ -1532,6 +1532,10 @@
     ],
     "dstOuiCnt" : 1,
     "dstRIR" : "ARIN",
+    "dstTTL" : [
+     128
+    ],
+    "dstTTLCnt" : 1,
     "ethertype" : 2048,
     "fileId" : [],
     "firstPacket" : 1532525539024,
@@ -1606,13 +1610,13 @@
      "bytes" : 0
     },
     "source" : {
-     "bytes" : 243,
+     "bytes" : 0,
      "ip" : "192.168.25.150",
      "mac" : [
-      "00:50:56:f4:62:21"
+      "00:0c:29:6f:84:37"
      ],
      "mac-cnt" : 1,
-     "packets" : 1,
+     "packets" : 0,
      "port" : 49749
     },
     "srcOui" : [
@@ -1620,10 +1624,6 @@
     ],
     "srcOuiCnt" : 1,
     "srcRIR" : "ARIN",
-    "srcTTL" : [
-     128
-    ],
-    "srcTTLCnt" : 1,
     "tags" : [
      "flip test"
     ],


### PR DESCRIPTION
- swap per-direction packets, bytes, databytes, consumed, payload8
- swap tcp seq/state tracking, zero window counts, syn flags and queued packet directions; sctp tsn/initTag
- swap mac, oui, dscp and ttl field pairs with new arkime_field_swap()
- icmp type/code left alone since it shares a union with tcpFlagAckCnt
- regenerate single-packets.test, add BREAKING changelog entry

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
