### PR TITLE
Apply the user's forced expression to the entire session pcap download

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -60,6 +60,7 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
 ## Viewer
   - #4216 Fix multi viewer hanging or failing queries when one cluster is down or unhealthy (thanks @Juwon1405)
   - #4222 Fix session PCAP/CSV export success toast showing "[object Object]"
+  - #4241 Fix the entire session pcap download ignoring the user's forced expression on segments
 ## WISE
   - Remove the PassiveTotal source, the API was retired by Microsoft
 

--- a/tests/api-sessions.t
+++ b/tests/api-sessions.t
@@ -1,4 +1,4 @@
-use Test::More tests => 179;
+use Test::More tests => 181;
 use Cwd;
 use URI::Escape;
 use ArkimeTest;
@@ -263,6 +263,23 @@ tcp,1386004309468,1386004309478,10.180.156.185,53533,US,10.180.156.249,1080,US,2
     my $rootId = $longSession->{data}->[0]->{rootId};
     $response = getBinary("/api/session/entire/test/" . $rootId . ".pcap");
     ok(length($response->content) >= 24, "entire pcap has content");
+
+# entire session pcap must apply the user's forced expression to the linked sessions
+    my $entireAll = $response->content;
+
+    viewerPostToken("/api/user", '{"userId": "sac-entire", "userName": "UserName", "enabled":true, "password":"password", "expression":"packets == 1", "roles": ["arkimeUser"]}', $token);
+
+    # long-session.pcap is a 1 packet and a 4 packet segment sharing a rootId,
+    # the forced expression above only allows the 1 packet one
+    my $oneSession = viewerGet("/sessions.json?date=-1&expression=" . uri_escape("file=$pwd/long-session.pcap && packets == 1"));
+    my $oneId = $oneSession->{data}->[0]->{id};
+    my $onePcap = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/test/$oneId/pcap")->content;
+
+    $response = $ArkimeTest::userAgent->get("http://$ArkimeTest::host:8123/api/session/entire/test/$rootId.pcap?arkimeRegressionUser=sac-entire");
+    is (unpack("H*", $response->content), unpack("H*", $onePcap), "entire pcap only has the segment the forced expression allows");
+    ok (length($response->content) < length($entireAll), "entire pcap drops the linked segments the forced expression excludes");
+
+    viewerDeleteToken("/api/user/sac-entire", $token);
 
 # should get error if get pcap can't find sessions from list of ids
     $json = viewerGet("/api/sessions/pcap/sessions.pcap?date=-1&segments=no&ids=nonexistingid");

--- a/tests/esProxy.t
+++ b/tests/esProxy.t
@@ -1,5 +1,5 @@
 # ESProxy
-use Test::More tests => 46;
+use Test::More tests => 51;
 use ArkimeTest;
 use Cwd;
 use URI::Escape;
@@ -174,6 +174,32 @@ $req->header('Content-Type' => 'application/json');
 $req->content($search_rootid);
 $response = $ArkimeTest::userAgent->request($req);
 is ($response->code, 200, "sessions search by rootId allowed");
+
+# Sessions search - rootId filter with the user's forced expression ANDed on is allowed
+my $search_rootid_expr = qq({"size":1000,"_source":["rootId"],"query":{"bool":{"filter":[{"term":{"rootId":"240101-abc"}},{"term":{"tags":"corp"}}]}}});
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/tests_sessions3-2024/_search");
+$req->header('Content-Type' => 'application/json');
+$req->content($search_rootid_expr);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 200, "sessions search by rootId filter allowed");
+
+# Sessions search - a filter not starting with the rootId term is rejected
+my $search_no_rootid = qq({"query":{"bool":{"filter":[{"term":{"node":"foo"}}]}}});
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/tests_sessions3-2024/_search");
+$req->header('Content-Type' => 'application/json');
+$req->content($search_no_rootid);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "sessions search by filter without rootId rejected");
+is ($response->content, "Not authorized for API");
+
+# Sessions search - a should next to the rootId filter could widen it, so is rejected
+my $search_should = qq({"query":{"bool":{"filter":[{"term":{"rootId":"240101-abc"}}],"should":[{"term":{"node":"foo"}}]}}});
+$req = HTTP::Request->new('POST', "http://test:test\@$ArkimeTest::host:7200/tests_sessions3-2024/_search");
+$req->header('Content-Type' => 'application/json');
+$req->content($search_should);
+$response = $ArkimeTest::userAgent->request($req);
+is ($response->code, 400, "sessions search with should next to rootId filter rejected");
+is ($response->content, "Not authorized for API");
 
 # Sessions search - term on any other field is rejected
 my $search_other = qq({"query":{"term":{"node":"foo"}}});

--- a/viewer/apiSessions.js
+++ b/viewer/apiSessions.js
@@ -3251,16 +3251,29 @@ class SessionAPIs {
    * @name /session/entire/:nodeName/:id/pcap
    * @returns {pcap} A PCAP file with the session requested
    */
-  static getEntirePCAP (req, res) {
+  static async getEntirePCAP (req, res) {
     ArkimeUtil.noCache(req, res, 'application/vnd.tcpdump.pcap');
 
     const writerOptions = { writeHeader: true };
+
+    const filter = [{ term: { rootId: req.params.id } }];
+
+    // Unlike the other pcap endpoints this one turns a single id into every
+    // linked session, so the forced expression has to be applied here or the
+    // rootId of an allowed session hands out the ones it excludes.
+    try {
+      const userExpression = await BuildQuery.userExpressionQuery(req);
+      if (userExpression) { filter.push(userExpression); }
+    } catch (err) {
+      console.log(`ERROR - Forced expression (${req.user.getExpression()}) doesn't compile -`, util.inspect(err, false, 50));
+      return res.status(403).end();
+    }
 
     const query = {
       size: 1000,
       _source: ['rootId'],
       sort: { lastPacket: { order: 'asc' } },
-      query: { term: { rootId: req.params.id } }
+      query: { bool: { filter } }
     };
 
     if (Config.debug) {

--- a/viewer/buildQuery.js
+++ b/viewer/buildQuery.js
@@ -261,6 +261,42 @@ class BuildQuery {
 
   // --------------------------------------------------------------------------
   /**
+   * Returns the ES query for the user's forced expression, or undefined when
+   * they don't have one. For endpoints that build their own query instead of
+   * going through build(). Throws if the expression doesn't compile.
+   * @ignore
+   * @param {object} req - the client request
+   * @returns {Promise} - resolves with the ES query or undefined
+   */
+  static async userExpressionQuery (req) {
+    const expression = req.user.getExpression();
+    if (!expression) { return undefined; }
+
+    let shortcuts;
+    try {
+      shortcuts = await Db.getShortcutsCache(req.user);
+    } catch (err) {
+      console.log('ERROR - fetching shortcuts cache when building forced expression query', util.inspect(err, false, 50));
+    }
+
+    arkimeparser.parser.yy = {
+      views: req.user.views,
+      fieldsMap: Config.getFieldsMap(),
+      dbFieldsMap: Config.getDBFieldsMap(),
+      prefix: internals.prefix,
+      emailSearch: true, // Expression was set by admin, so assume email search ok
+      shortcuts: shortcuts || {},
+      shortcutTypeMap: internals.shortcutTypeMap
+    };
+
+    const query = arkimeparser.parse(expression);
+    const err = await BuildQuery.lookupQueryItems([query]);
+    if (err) { throw err; }
+    return query;
+  }
+
+  // --------------------------------------------------------------------------
+  /**
    * Builds the session query based on req.query (Promise version)
    * @ignore
    * @name buildPromise

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -505,10 +505,22 @@ const searchRootIdKeys = ['size', '_source', 'sort', 'query', 'profile'];
 function validateSearchRootId (req) {
   try {
     const json = JSON.parse(req.body.toString('utf8'));
-    return Object.keys(json).every(key => searchRootIdKeys.includes(key)) &&
-      Object.keys(json.query).length === 1 &&
-      Object.keys(json.query.term).length === 1 &&
-      ArkimeUtil.isString(json.query.term.rootId);
+    if (!Object.keys(json).every(key => searchRootIdKeys.includes(key))) { return false; }
+    if (Object.keys(json.query).length !== 1) { return false; }
+
+    // pre 6.7.1 viewers sent the bare term
+    if (json.query.term !== undefined) {
+      return Object.keys(json.query.term).length === 1 &&
+        ArkimeUtil.isString(json.query.term.rootId);
+    }
+
+    // filter only, so the user's forced expression is ANDed with the rootId
+    // term and can only narrow what the bare term already allowed
+    const bool = json.query.bool;
+    return Object.keys(bool).length === 1 &&
+      Array.isArray(bool.filter) &&
+      Object.keys(bool.filter[0].term).length === 1 &&
+      ArkimeUtil.isString(bool.filter[0].term.rootId);
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
- getEntirePCAP only constrained on rootId, so the rootId of an allowed session returned packets from every linked session, including ones the forced expression excludes
- Add BuildQuery.userExpressionQuery() for endpoints that build their own query instead of going through build()
- Update the esProxy rootId search validator for the new filter shape, a filter only bool can only narrow what the bare term already allowed
- Add regression tests for both

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
