### PR TITLE
Combine registerValidated and registerSecrets into registerSettings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -63,6 +63,9 @@ NOTICE: Create a parliament config file before upgrading (see https://arkime.com
   - The _flipSrcDst rule op used to only swap the ips and ports, leaving the rest of the session pointing the old way.
           It now also swaps the per-direction data: packets, bytes, databytes, payload8, mac, oui, dscp, ttl,
           tcp seq/state tracking and zero window counts, so flipped sessions are saved self consistent
+  - More settings are validated at startup, so a value that used to be silently ignored now refuses to start. Booleans
+          must be true or false (not 0, 1 or False), rotateIndex must be one capture accepts, freeSpaceG must be a
+          number or a percentage, and the hunt/tshark limits, timeouts and ports must be numbers in range
 ## Release
   - #4221 Node 24.20.0
 ## All

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -354,6 +354,9 @@ class ArkimeConfig {
    *   re         - must match `re`, with `help` naming the shape for the error
    *   cidrs      - every entry must be a usable CIDR
    *   urls       - every entry must be a url, the scheme may be left off
+   *   sections   - also validate the setting's value in these named sections,
+   *                eg 'tee', which can hold their own override and are never
+   *                part of the default section chain `get`/`getArray` walk
    *
    * @param {object} specs - setting name, without a section, to its spec
    */
@@ -376,15 +379,19 @@ class ArkimeConfig {
   }
 
   // ----------------------------------------------------------------------------
-  static #validateSetting (key, spec) {
+  // section is the extra named section to validate instead of the default
+  // section chain, eg 'tee' - undefined means the normal get()/getArray() walk
+  static #validateSetting (key, spec, section) {
+    const label = section === undefined ? key : `[${section}] ${key}`;
+
     if (spec.type === 'cidrs') {
-      const list = ArkimeConfig.getArray(key);
+      const list = section === undefined ? ArkimeConfig.getArray(key) : ArkimeConfig.getFullArray(section, key);
       // An empty list is how 'not set' looks, leave that to the caller
       if (list === undefined || list.length === 0) { return undefined; }
 
       const { bad } = ArkimeUtil.buildIpTrie(list);
       if (bad.length) {
-        return `${key} has ${bad.length} unusable entr${bad.length === 1 ? 'y' : 'ies'}: ` +
+        return `${label} has ${bad.length} unusable entr${bad.length === 1 ? 'y' : 'ies'}: ` +
           bad.map(b => `'${ArkimeUtil.sanitizeStr(b)}'`).join(', ') +
           ". Each entry must be a full address with an optional in range prefix length, eg '10.0.0.1/32' or '10.0.0.0/8'.";
       }
@@ -392,50 +399,50 @@ class ArkimeConfig {
     }
 
     if (spec.type === 'urls') {
-      const list = ArkimeConfig.getArray(key);
+      const list = section === undefined ? ArkimeConfig.getArray(key) : ArkimeConfig.getFullArray(section, key);
       if (list === undefined || list.length === 0) { return undefined; }
 
       const bad = list.filter(url => ArkimeUtil.parseUrl(url) === undefined);
       if (bad.length) {
-        return `${key} has ${bad.length} unusable entr${bad.length === 1 ? 'y' : 'ies'}: ` +
+        return `${label} has ${bad.length} unusable entr${bad.length === 1 ? 'y' : 'ies'}: ` +
           bad.map(b => `'${ArkimeUtil.sanitizeStr(b)}'`).join(', ') +
           ". Each entry must be a url, eg 'http://localhost:9200' or 'localhost:9200'.";
       }
       return undefined;
     }
 
-    const raw = ArkimeConfig.get(key);
+    const raw = section === undefined ? ArkimeConfig.get(key) : ArkimeConfig.getFull(section, key);
     if (raw === undefined || raw === '') { return undefined; } // empty is unset
 
     if (spec.type === 'bool') {
       // exactly what getFull coerces - anything else stays a truthy string, so
       // an operator turning a switch off with 0 or False would turn it on
       if (typeof raw === 'boolean' || raw === 'true' || raw === 'false') { return undefined; }
-      return `${key} is '${ArkimeUtil.sanitizeStr(raw)}', which is not a boolean. Use true or false.`;
+      return `${label} is '${ArkimeUtil.sanitizeStr(raw)}', which is not a boolean. Use true or false.`;
     }
 
     if (spec.type === 'enum') {
       if (spec.values.includes(raw)) { return undefined; }
-      return `${key} is '${ArkimeUtil.sanitizeStr(raw)}', which must be one of ${spec.values.join(', ')}.`;
+      return `${label} is '${ArkimeUtil.sanitizeStr(raw)}', which must be one of ${spec.values.join(', ')}.`;
     }
 
     if (spec.type === 're') {
       // match and not test, so a global regex can't carry lastIndex between settings
       if (String(raw).match(spec.re)) { return undefined; }
-      return `${key} is '${ArkimeUtil.sanitizeStr(raw)}', which must be ${spec.help}.`;
+      return `${label} is '${ArkimeUtil.sanitizeStr(raw)}', which must be ${spec.help}.`;
     }
 
     const value = ArkimeConfig.#parseNumeric(raw, spec.type === 'int');
     if (value === undefined) {
-      return `${key} is '${ArkimeUtil.sanitizeStr(raw)}', which is not ${spec.type === 'int' ? 'an integer' : 'a number'}.`;
+      return `${label} is '${ArkimeUtil.sanitizeStr(raw)}', which is not ${spec.type === 'int' ? 'an integer' : 'a number'}.`;
     }
     if (value !== spec.unlimited) {
       const unlimited = spec.unlimited !== undefined ? `. Use ${spec.unlimited} for no limit.` : '.';
       if (spec.min !== undefined && value < spec.min) {
-        return `${key} is ${value}, which is below the minimum of ${spec.min}${unlimited}`;
+        return `${label} is ${value}, which is below the minimum of ${spec.min}${unlimited}`;
       }
       if (spec.max !== undefined && value > spec.max) {
-        return `${key} is ${value}, which is above the maximum of ${spec.max}${unlimited}`;
+        return `${label} is ${value}, which is above the maximum of ${spec.max}${unlimited}`;
       }
     }
     return undefined;
@@ -451,8 +458,14 @@ class ArkimeConfig {
 
     for (const [key, spec] of Object.entries(ArkimeConfig.#SETTINGS)) {
       if (spec.type === undefined) { continue; } // secret only, nothing to check
-      const error = ArkimeConfig.#validateSetting(key, spec);
+      let error = ArkimeConfig.#validateSetting(key, spec);
       if (error) { errors.push(error); }
+      // sections aren't part of the default section chain, so a broken
+      // override there would otherwise silently start
+      for (const section of spec.sections ?? []) {
+        error = ArkimeConfig.#validateSetting(key, spec, section);
+        if (error) { errors.push(error); }
+      }
     }
 
     if (errors.length === 0) { return; }

--- a/common/arkimeConfig.js
+++ b/common/arkimeConfig.js
@@ -337,37 +337,31 @@ class ArkimeConfig {
   }
 
   // ----------------------------------------------------------------------------
-  static #VALIDATED = {};
-
-  /**
-   * Register settings to validate at config load, so a broken access control
-   * or resource bound stops the process instead of being ignored. Owners
-   * register their own. Call before initialize().
-   *
-   *   int/float  - must parse and satisfy min. `unlimited` names the one value
-   *                allowed below min, eg -1 for no limit.
-   *   cidrs      - every entry must be a usable CIDR
-   *   urls       - every entry must be a url, the scheme may be left off
-   */
-  static registerValidated (specs) {
-    Object.assign(ArkimeConfig.#VALIDATED, specs);
-  }
-
-  // ----------------------------------------------------------------------------
+  static #SETTINGS = {};
   static #SECRETS = new Set();
 
   /**
-   * Register settings that hold a credential, so anything showing the config
-   * hides them. Owners register their own, the same way they register what to
-   * validate - guessing from the name is only a backstop.
+   * Register what is known about settings, so a broken access control or
+   * resource bound stops the process instead of being ignored, and anything
+   * showing the config hides credentials. Owners register their own, a spec
+   * may say both. Call before initialize().
    *
-   * @param {string[]} keys - the setting names, without a section
+   *   secret     - holds a credential, guessing from the name is a backstop
+   *   int/float  - must parse and satisfy min and max. `unlimited` names the
+   *                one value allowed outside them, eg -1 for no limit.
+   *   bool       - must be true or false, the only spellings getFull coerces
+   *   enum       - must be one of `values`
+   *   re         - must match `re`, with `help` naming the shape for the error
+   *   cidrs      - every entry must be a usable CIDR
+   *   urls       - every entry must be a url, the scheme may be left off
+   *
+   * @param {object} specs - setting name, without a section, to its spec
    */
-  static registerSecrets (keys) {
-    for (const key of keys ?? []) {
-      if (typeof key === 'string' && key !== '') {
-        ArkimeConfig.#SECRETS.add(key.toLowerCase());
-      }
+  static registerSettings (specs) {
+    for (const [key, spec] of Object.entries(specs ?? {})) {
+      if (key === '' || spec === undefined) { continue; }
+      ArkimeConfig.#SETTINGS[key] = { ...ArkimeConfig.#SETTINGS[key], ...spec };
+      if (spec.secret) { ArkimeConfig.#SECRETS.add(key.toLowerCase()); }
     }
   }
 
@@ -413,13 +407,36 @@ class ArkimeConfig {
     const raw = ArkimeConfig.get(key);
     if (raw === undefined || raw === '') { return undefined; } // empty is unset
 
+    if (spec.type === 'bool') {
+      // exactly what getFull coerces - anything else stays a truthy string, so
+      // an operator turning a switch off with 0 or False would turn it on
+      if (typeof raw === 'boolean' || raw === 'true' || raw === 'false') { return undefined; }
+      return `${key} is '${ArkimeUtil.sanitizeStr(raw)}', which is not a boolean. Use true or false.`;
+    }
+
+    if (spec.type === 'enum') {
+      if (spec.values.includes(raw)) { return undefined; }
+      return `${key} is '${ArkimeUtil.sanitizeStr(raw)}', which must be one of ${spec.values.join(', ')}.`;
+    }
+
+    if (spec.type === 're') {
+      // match and not test, so a global regex can't carry lastIndex between settings
+      if (String(raw).match(spec.re)) { return undefined; }
+      return `${key} is '${ArkimeUtil.sanitizeStr(raw)}', which must be ${spec.help}.`;
+    }
+
     const value = ArkimeConfig.#parseNumeric(raw, spec.type === 'int');
     if (value === undefined) {
       return `${key} is '${ArkimeUtil.sanitizeStr(raw)}', which is not ${spec.type === 'int' ? 'an integer' : 'a number'}.`;
     }
-    if (value < spec.min && value !== spec.unlimited) {
-      return `${key} is ${value}, which is below the minimum of ${spec.min}` +
-        (spec.unlimited !== undefined ? `. Use ${spec.unlimited} for no limit.` : '.');
+    if (value !== spec.unlimited) {
+      const unlimited = spec.unlimited !== undefined ? `. Use ${spec.unlimited} for no limit.` : '.';
+      if (spec.min !== undefined && value < spec.min) {
+        return `${key} is ${value}, which is below the minimum of ${spec.min}${unlimited}`;
+      }
+      if (spec.max !== undefined && value > spec.max) {
+        return `${key} is ${value}, which is above the maximum of ${spec.max}${unlimited}`;
+      }
     }
     return undefined;
   }
@@ -432,7 +449,8 @@ class ArkimeConfig {
   static #validateSettings () {
     const errors = [];
 
-    for (const [key, spec] of Object.entries(ArkimeConfig.#VALIDATED)) {
+    for (const [key, spec] of Object.entries(ArkimeConfig.#SETTINGS)) {
+      if (spec.type === undefined) { continue; } // secret only, nothing to check
       const error = ArkimeConfig.#validateSetting(key, spec);
       if (error) { errors.push(error); }
     }
@@ -831,5 +849,18 @@ class ConfigHttp {
 }
 ArkimeConfig.registerScheme('http', ConfigHttp);
 ArkimeConfig.registerScheme('https', ConfigHttp);
+
+// The elasticsearch connection is spread over arkimeUtil, every app's db layer
+// and the cli tools, with no one module owning it, so it is registered here
+// instead of by each of the four apps
+ArkimeConfig.registerSettings({
+  elasticsearchAPIKey: { secret: true },
+  elasticsearchBasicAuth: { secret: true },
+  esClientKeyPass: { secret: true },
+  usersElasticsearchAPIKey: { secret: true },
+  usersElasticsearchBasicAuth: { secret: true },
+  elasticsearch: { type: 'urls' },
+  usersElasticsearch: { type: 'urls' }
+});
 
 module.exports = ArkimeConfig;

--- a/common/auth.js
+++ b/common/auth.js
@@ -1613,9 +1613,10 @@ const User = require('../common/user');
 const ArkimeUtil = require('../common/arkimeUtil');
 const ArkimeConfig = require('../common/arkimeConfig');
 
-ArkimeConfig.registerSecrets(['passwordSecret', 'serverSecret']);
-
-ArkimeConfig.registerValidated({
+ArkimeConfig.registerSettings({
+  passwordSecret: { secret: true },
+  serverSecret: { secret: true },
+  authClientSecret: { secret: true },
   userAuthIps: { type: 'cidrs' },
   // A non numeric skew becomes NaN, and jose compares exp against NaN, which is
   // always false - so an expired token would verify forever

--- a/common/mcpServer.js
+++ b/common/mcpServer.js
@@ -15,7 +15,8 @@ const { EventEmitter } = require('events');
 const ArkimeConfig = require('./arkimeConfig');
 const ArkimeUtil = require('./arkimeUtil');
 
-ArkimeConfig.registerValidated({
+ArkimeConfig.registerSettings({
+  mcpEnabled: { type: 'bool' },
   mcpAllowedIps: { type: 'cidrs' },
   mcpMaxQueryDays: { type: 'float', min: 0, unlimited: -1 }
 });

--- a/cont3xt/cont3xt.js
+++ b/cont3xt/cont3xt.js
@@ -612,16 +612,6 @@ async function setupAuth () {
 }
 
 async function main () {
-  ArkimeConfig.registerSecrets([
-    'elasticsearchAPIKey', 'elasticsearchBasicAuth', 'esClientKeyPass',
-    'usersElasticsearchAPIKey', 'usersElasticsearchBasicAuth'
-  ]);
-
-  ArkimeConfig.registerValidated({
-    elasticsearch: { type: 'urls' },
-    usersElasticsearch: { type: 'urls' }
-  });
-
   try {
     await ArkimeConfig.initialize({
       defaultConfigFile: `${version.config_prefix}/etc/cont3xt.ini`,

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -94,6 +94,15 @@ class Integration {
       return;
     }
 
+    // a setting marked password is this integration saying it holds a
+    // credential, so View Config hides it without having to guess from the
+    // name - do this before the disabled check below, so a leftover
+    // credential in a disabled integration's config still gets redacted
+    ArkimeConfig.registerSettings(Object.fromEntries(
+      Object.entries(integration.settings ?? {})
+        .filter(([, setting]) => setting?.password)
+        .map(([key]) => [key, { secret: true }])));
+
     // Can disable an integration globally
     const disabled = integration.getConfig('disabled', false);
     if (disabled === true || disabled === 'true') {
@@ -105,13 +114,6 @@ class Integration {
       console.log('Can not have both configName and section set', integration.name, integration.configName, integration.section);
       return;
     }
-
-    // a setting marked password is this integration saying it holds a
-    // credential, so View Config hides it without having to guess from the name
-    ArkimeConfig.registerSettings(Object.fromEntries(
-      Object.entries(integration.settings ?? {})
-        .filter(([, setting]) => setting?.password)
-        .map(([key]) => [key, { secret: true }])));
 
     integration.cacheable ??= true;
     integration.noStats ??= false;

--- a/cont3xt/integration.js
+++ b/cont3xt/integration.js
@@ -108,8 +108,10 @@ class Integration {
 
     // a setting marked password is this integration saying it holds a
     // credential, so View Config hides it without having to guess from the name
-    ArkimeConfig.registerSecrets(Object.keys(integration.settings ?? {})
-      .filter(setting => integration.settings[setting]?.password));
+    ArkimeConfig.registerSettings(Object.fromEntries(
+      Object.entries(integration.settings ?? {})
+        .filter(([, setting]) => setting?.password)
+        .map(([key]) => [key, { secret: true }])));
 
     integration.cacheable ??= true;
     integration.noStats ??= false;

--- a/cont3xt/integrations/arkime/index.js
+++ b/cont3xt/integrations/arkime/index.js
@@ -9,6 +9,11 @@ const ArkimeConfig = require('../../../common/arkimeConfig');
 const ArkimeUtil = require('../../../common/arkimeUtil');
 const { Client } = require('@elastic/elasticsearch');
 
+ArkimeConfig.registerSettings({
+  elasticsearchAPIKey: { secret: true },
+  elasticsearchBasicAuth: { secret: true }
+});
+
 class ArkimeIntegration extends Integration {
   name;
   section;

--- a/cont3xt/integrations/arkime/index.js
+++ b/cont3xt/integrations/arkime/index.js
@@ -9,11 +9,6 @@ const ArkimeConfig = require('../../../common/arkimeConfig');
 const ArkimeUtil = require('../../../common/arkimeUtil');
 const { Client } = require('@elastic/elasticsearch');
 
-ArkimeConfig.registerSettings({
-  elasticsearchAPIKey: { secret: true },
-  elasticsearchBasicAuth: { secret: true }
-});
-
 class ArkimeIntegration extends Integration {
   name;
   section;

--- a/cont3xt/integrations/databricks/index.js
+++ b/cont3xt/integrations/databricks/index.js
@@ -8,6 +8,10 @@ const Integration = require('../../integration.js');
 const ArkimeConfig = require('../../../common/arkimeConfig');
 const { DBSQLClient } = require('@databricks/sql');
 
+ArkimeConfig.registerSettings({
+  token: { secret: true }
+});
+
 class DatabricksIntegration extends Integration {
   // Integration Items
   name;

--- a/cont3xt/integrations/elasticsearch/index.js
+++ b/cont3xt/integrations/elasticsearch/index.js
@@ -9,6 +9,11 @@ const ArkimeConfig = require('../../../common/arkimeConfig');
 const ArkimeUtil = require('../../../common/arkimeUtil');
 const { Client } = require('@elastic/elasticsearch');
 
+ArkimeConfig.registerSettings({
+  apiKey: { secret: true },
+  basicAuth: { secret: true }
+});
+
 class ElasticsearchIntegration extends Integration {
   // Integration Items
   name;

--- a/parliament/parliament.js
+++ b/parliament/parliament.js
@@ -1174,8 +1174,6 @@ async function initializeParliament () {
     prefix: ArkimeConfig.get('usersPrefix')
   });
 
-  ArkimeConfig.registerSecrets(['usersElasticsearchAPIKey', 'usersElasticsearchBasicAuth']);
-
   ViewConfig.initialize({ appAdminRole: 'parliamentAdmin' });
   Banner.initialize({ app: 'parliament', prefix: ArkimeConfig.get('usersPrefix') });
 
@@ -2255,11 +2253,6 @@ app.use((req, res, next) => {
 // MAIN
 // ----------------------------------------------------------------------------
 async function main () {
-  ArkimeConfig.registerValidated({
-    elasticsearch: { type: 'urls' },
-    usersElasticsearch: { type: 'urls' }
-  });
-
   try {
     await ArkimeConfig.initialize({
       defaultConfigFile: `${version.config_prefix}/etc/parliament.ini`,

--- a/tests/config-validate.t
+++ b/tests/config-validate.t
@@ -1,4 +1,4 @@
-use Test::More tests => 75;
+use Test::More tests => 84;
 use ArkimeTest;
 use strict;
 
@@ -32,7 +32,15 @@ ArkimeConfig.registerSettings({
   viewPort: { type: 'int', min: 1, max: 65535 },
   freeSpaceG: { type: 're', re: /^-?(\d+(\.\d*)?|\.\d+)%?$/, help: 'a number of gigabytes or a percentage of the disk, eg 5 or 5%' },
   rotateIndex: { type: 'enum', values: ['hourly', 'hourly2', 'hourly3', 'hourly4', 'hourly6', 'hourly8', 'hourly12', 'daily', 'weekly', 'monthly'] },
-  multiES: { type: 'bool' }
+  multiES: { type: 'bool' },
+  // both consuming readers only apply these when truthy, so 0 already means
+  // "no override" - it must not be a boot failure
+  esMaxConcurrentShardRequests: { type: 'int', min: 1, unlimited: 0 },
+  packetPortalPort: { type: 'int', min: 1, max: 65535, unlimited: 0 },
+  // [tee] holds its own override of these, which isn't part of the default
+  // section chain get()/getArray() walk
+  esProxySigV4: { type: 'bool', sections: ['tee'] },
+  elasticsearch: { sections: ['tee'] }
 });
 
 const mode = process.argv[4];
@@ -175,6 +183,37 @@ is($code, 1, "multiES=0 refuses to start rather than reading as on");
 
 ($code, $out) = tryConfig("multiES=False");
 is($code, 1, "a capitalised False refuses to start rather than reading as on");
+
+################################################################################
+# unlimited as a sentinel for "no override", not just "no limit" - the
+# consuming code already treats 0 as unset, so validation must allow it too
+################################################################################
+($code, $out) = tryConfig("esMaxConcurrentShardRequests=0");
+is($code, 0, "esMaxConcurrentShardRequests=0 starts, it already means no override");
+
+($code, $out) = tryConfig("esMaxConcurrentShardRequests=-1");
+is($code, 1, "esMaxConcurrentShardRequests below the minimum and not the sentinel still refuses to start");
+
+($code, $out) = tryConfig("packetPortalPort=0");
+is($code, 0, "packetPortalPort=0 starts, it already means shared mode");
+
+($code, $out) = tryConfig("packetPortalPort=70000");
+is($code, 1, "packetPortalPort above the maximum still refuses to start");
+
+################################################################################
+# sections. [tee] holds its own elasticsearch/esProxySigV4 override, which
+# isn't part of the default section chain get()/getArray() walk
+################################################################################
+($code, $out) = tryConfig("esProxySigV4=true\n[tee]\nesProxySigV4=false");
+is($code, 0, "a valid esProxySigV4 in both the default and [tee] sections starts");
+
+($code, $out) = tryConfig("[tee]\nesProxySigV4=1");
+is($code, 1, "a non boolean esProxySigV4 under [tee] refuses to start");
+like($out, qr/\[tee\] esProxySigV4 is '1', which is not a boolean/, "and names the section and the setting");
+
+($code, $out) = tryConfig("elasticsearch=http://es1:9200\n[tee]\nelasticsearch=http://es2 :9200");
+is($code, 1, "a malformed elasticsearch url under [tee] refuses to start");
+like($out, qr/\[tee\] elasticsearch has 1 unusable entry: 'http:\/\/es2 :9200'/, "and names the section and quotes the bad entry");
 
 ################################################################################
 # a valid allow list must still match the right peers. Both allow lists had

--- a/tests/config-validate.t
+++ b/tests/config-validate.t
@@ -1,4 +1,4 @@
-use Test::More tests => 56;
+use Test::More tests => 75;
 use ArkimeTest;
 use strict;
 
@@ -24,12 +24,15 @@ const ArkimeUtil = require(path.join(common, 'arkimeUtil'));
 // apps do: viewer.js/cont3xt.js require mcpServer, and auth registers its own.
 require(path.join(common, 'mcpServer'));
 require(path.join(common, 'auth'));
-// viewer/config.js registers these before calling initialize
-ArkimeConfig.registerValidated({
+// viewer/config.js registers these before calling initialize, the elasticsearch
+// urls come with arkimeConfig itself
+ArkimeConfig.registerSettings({
   uploadFileSizeLimit: { type: 'int', min: 0 },
   maxSessionsQueried: { type: 'int', min: 0 },
-  elasticsearch: { type: 'urls' },
-  usersElasticsearch: { type: 'urls' }
+  viewPort: { type: 'int', min: 1, max: 65535 },
+  freeSpaceG: { type: 're', re: /^-?(\d+(\.\d*)?|\.\d+)%?$/, help: 'a number of gigabytes or a percentage of the disk, eg 5 or 5%' },
+  rotateIndex: { type: 'enum', values: ['hourly', 'hourly2', 'hourly3', 'hourly4', 'hourly6', 'hourly8', 'hourly12', 'daily', 'weekly', 'monthly'] },
+  multiES: { type: 'bool' }
 });
 
 const mode = process.argv[4];
@@ -109,6 +112,69 @@ is($code, 0, "uploadFileSizeLimit=0 starts");
 # an empty value means unset, which is a common container idiom
 ($code, $out) = tryConfig("uploadFileSizeLimit=");
 is($code, 0, "an empty numeric value is treated as unset");
+
+################################################################################
+# max, so a port that can never be bound is caught at load and not at listen
+################################################################################
+($code, $out) = tryConfig("viewPort=8005");
+is($code, 0, "a viewPort in range starts");
+
+($code, $out) = tryConfig("viewPort=70000");
+is($code, 1, "a viewPort above the maximum refuses to start");
+like($out, qr/viewPort is 70000, which is above the maximum of 65535/, "and names the setting and the bound");
+
+($code, $out) = tryConfig("viewPort=0");
+is($code, 1, "a viewPort below the minimum refuses to start");
+
+################################################################################
+# enum. capture CONFIGEXITs on an unknown rotateIndex, viewer used to guess instead
+################################################################################
+($code, $out) = tryConfig("rotateIndex=hourly6");
+is($code, 0, "a known rotateIndex starts");
+
+($code, $out) = tryConfig("rotateIndex=hourly5");
+is($code, 1, "an hourly step capture does not support refuses to start");
+like($out, qr/rotateIndex is 'hourly5', which must be one of hourly, hourly2, .*monthly/, "and lists every rotation capture accepts");
+
+################################################################################
+# re. freeSpaceG is parseFloat'd, so a unit suffix quietly changes the target and
+# a word makes it NaN, which stops expiry from ever running
+################################################################################
+($code, $out) = tryConfig("freeSpaceG=5");
+is($code, 0, "freeSpaceG as gigabytes starts");
+
+($code, $out) = tryConfig("freeSpaceG=5%");
+is($code, 0, "freeSpaceG as a percent starts");
+
+($code, $out) = tryConfig("freeSpaceG=0.5%");
+is($code, 0, "a fractional percent starts");
+
+($code, $out) = tryConfig("freeSpaceG=5G");
+is($code, 1, "a unit suffix refuses to start");
+like($out, qr/freeSpaceG is '5G', which must be a number of gigabytes or a percentage of the disk, eg 5 or 5%/, "and says what the shape is");
+
+($code, $out) = tryConfig("freeSpaceG=five");
+is($code, 1, "a word refuses to start rather than becoming NaN");
+
+################################################################################
+# bool. Only true and false are coerced, so anything else an operator writes to
+# turn a switch off is a truthy string that turns it on - catch it at load
+################################################################################
+($code, $out) = tryConfig("multiES=false");
+is($code, 0, "multiES=false starts");
+
+($code, $out) = tryConfig("multiES=true");
+is($code, 0, "multiES=true starts");
+
+($code, $out) = tryConfig("multiES=maybe");
+is($code, 1, "a non boolean multiES refuses to start");
+like($out, qr/multiES is 'maybe', which is not a boolean/, "and names the setting");
+
+($code, $out) = tryConfig("multiES=0");
+is($code, 1, "multiES=0 refuses to start rather than reading as on");
+
+($code, $out) = tryConfig("multiES=False");
+is($code, 1, "a capitalised False refuses to start rather than reading as on");
 
 ################################################################################
 # a valid allow list must still match the right peers. Both allow lists had

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -329,7 +329,8 @@ class Config {
       huntThrottleMs: { type: 'int', min: 0 },
       maxAggSize: { type: 'int', min: 1 },
       spiDataMaxIndices: { type: 'int', min: 1, unlimited: -1 },
-      esMaxConcurrentShardRequests: { type: 'int', min: 1 },
+      // db.js only applies this when truthy, so 0 already means "no override"
+      esMaxConcurrentShardRequests: { type: 'int', min: 1, unlimited: 0 },
       tsharkMaxConcurrent: { type: 'int', min: 0 },
       tsharkMaxPackets: { type: 'int', min: 1 },
       tsharkMemoryLimitMB: { type: 'int', min: 0, unlimited: -1 },
@@ -342,7 +343,9 @@ class Config {
       viewPort: { type: 'int', min: 1, max: 65535 },
       esProxyPort: { type: 'int', min: 1, max: 65535 },
       multiESPort: { type: 'int', min: 1, max: 65535 },
-      packetPortalPort: { type: 'int', min: 1, max: 65535 },
+      // packetPortal.js only starts a dedicated listener when truthy, so 0
+      // already means "no dedicated port, fall back to packetPortalListen"
+      packetPortalPort: { type: 'int', min: 1, max: 65535, unlimited: 0 },
       // both readers parseFloat it, so '5G' silently becomes 5 and 'five' becomes
       // NaN, which no comparison is ever true for - the disk then never expires
       freeSpaceG: {
@@ -358,10 +361,18 @@ class Config {
       multiES: { type: 'bool' },
       queryAllIndices: { type: 'bool' },
       valueAutoComplete: { type: 'bool' },
-      esProxySigV4: { type: 'bool' },
+      // esProxy.js also reads these under [tee] for the secondary ES output,
+      // which isn't part of the default section chain get()/getArray() walk
+      esProxySigV4: { type: 'bool', sections: ['tee'] },
       hstsHeader: { type: 'bool' },
       postPcapFetch: { type: 'bool' },
       packetPortalListen: { type: 'bool' }
+    });
+
+    // elasticsearchAPIKey/elasticsearchBasicAuth are secret-only (no type), so
+    // there's nothing for #validateSettings to check under [tee] for them
+    ArkimeConfig.registerSettings({
+      elasticsearch: { sections: ['tee'] }
     });
 
     await ArkimeConfig.initialize({

--- a/viewer/config.js
+++ b/viewer/config.js
@@ -313,18 +313,55 @@ class Config {
       }
     }, true);
 
-    ArkimeConfig.registerSecrets([
-      'elasticsearchAPIKey', 'elasticsearchBasicAuth', 'esClientKeyPass',
-      'usersElasticsearchAPIKey', 'usersElasticsearchBasicAuth', 'multiESBasicAuth',
-      'esProxySigV4SecretAccessKey', 'esProxySigV4SessionToken',
-      's3SecretAccessKey', 'sqsSecretAccessKey', 'clickhousePassword'
-    ]);
-
-    ArkimeConfig.registerValidated({
+    ArkimeConfig.registerSettings({
+      multiESBasicAuth: { secret: true },
+      esProxySigV4SecretAccessKey: { secret: true },
+      esProxySigV4SessionToken: { secret: true },
+      s3SecretAccessKey: { secret: true },
+      sqsSecretAccessKey: { secret: true },
+      clickhousePassword: { secret: true },
+      kafkaSSLKeyPassword: { secret: true },
       uploadFileSizeLimit: { type: 'int', min: 0 },
       maxSessionsQueried: { type: 'int', min: 0 },
-      elasticsearch: { type: 'urls' },
-      usersElasticsearch: { type: 'urls' }
+      huntLimit: { type: 'int', min: 0 },
+      huntAdminLimit: { type: 'int', min: 0 },
+      huntWarn: { type: 'int', min: 0 },
+      huntThrottleMs: { type: 'int', min: 0 },
+      maxAggSize: { type: 'int', min: 1 },
+      spiDataMaxIndices: { type: 'int', min: 1, unlimited: -1 },
+      esMaxConcurrentShardRequests: { type: 'int', min: 1 },
+      tsharkMaxConcurrent: { type: 'int', min: 0 },
+      tsharkMaxPackets: { type: 'int', min: 1 },
+      tsharkMemoryLimitMB: { type: 'int', min: 0, unlimited: -1 },
+      tsharkTimeoutMs: { type: 'int', min: 1 },
+      summaryChunkDelay: { type: 'int', min: 0 },
+      turnOffGraphDays: { type: 'int', min: 0 },
+      elasticsearchTimeout: { type: 'int', min: 1 },
+      elasticsearchScrollTimeout: { type: 'int', min: 1 },
+      dbFlushTimeout: { type: 'int', min: 0 },
+      viewPort: { type: 'int', min: 1, max: 65535 },
+      esProxyPort: { type: 'int', min: 1, max: 65535 },
+      multiESPort: { type: 'int', min: 1, max: 65535 },
+      packetPortalPort: { type: 'int', min: 1, max: 65535 },
+      // both readers parseFloat it, so '5G' silently becomes 5 and 'five' becomes
+      // NaN, which no comparison is ever true for - the disk then never expires
+      freeSpaceG: {
+        type: 're',
+        re: /^-?(\d+(\.\d*)?|\.\d+)%?$/,
+        help: 'a number of gigabytes or a percentage of the disk, eg 5 or 5%'
+      },
+      // capture exits on anything else, viewer would silently guess the index length
+      rotateIndex: {
+        type: 'enum',
+        values: ['hourly', 'hourly2', 'hourly3', 'hourly4', 'hourly6', 'hourly8', 'hourly12', 'daily', 'weekly', 'monthly']
+      },
+      multiES: { type: 'bool' },
+      queryAllIndices: { type: 'bool' },
+      valueAutoComplete: { type: 'bool' },
+      esProxySigV4: { type: 'bool' },
+      hstsHeader: { type: 'bool' },
+      postPcapFetch: { type: 'bool' },
+      packetPortalListen: { type: 'bool' }
     });
 
     await ArkimeConfig.initialize({

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -83,7 +83,7 @@ ArkimeConfig.loaded(() => {
     }
   }
 
-  const sigV4Enabled = Config.get('esProxySigV4', false) === 'true' || Config.get('esProxySigV4', false) === true;
+  const sigV4Enabled = Config.get('esProxySigV4', false);
   if (sigV4Enabled) {
     const region = Config.get('esProxySigV4Region');
     const service = Config.get('esProxySigV4Service', 'es');
@@ -124,7 +124,7 @@ ArkimeConfig.loaded(() => {
     }
   }
 
-  const teeSigV4Enabled = Config.sectionGet('tee', 'esProxySigV4', false) === 'true' || Config.sectionGet('tee', 'esProxySigV4', false) === true;
+  const teeSigV4Enabled = Config.sectionGet('tee', 'esProxySigV4', false);
   if (teeSigV4Enabled) {
     const teeRegion = Config.sectionGet('tee', 'esProxySigV4Region');
     const teeService = Config.sectionGet('tee', 'esProxySigV4Service', 'es');

--- a/viewer/esProxy.js
+++ b/viewer/esProxy.js
@@ -83,7 +83,8 @@ ArkimeConfig.loaded(() => {
     }
   }
 
-  const sigV4Enabled = Config.get('esProxySigV4', false);
+  // getFull turns 'true'/'false' into booleans, anything else stays a string
+  const sigV4Enabled = Config.get('esProxySigV4', false) === true;
   if (sigV4Enabled) {
     const region = Config.get('esProxySigV4Region');
     const service = Config.get('esProxySigV4Service', 'es');
@@ -124,7 +125,7 @@ ArkimeConfig.loaded(() => {
     }
   }
 
-  const teeSigV4Enabled = Config.sectionGet('tee', 'esProxySigV4', false);
+  const teeSigV4Enabled = Config.sectionGet('tee', 'esProxySigV4', false) === true;
   if (teeSigV4Enabled) {
     const teeRegion = Config.sectionGet('tee', 'esProxySigV4Region');
     const teeService = Config.sectionGet('tee', 'esProxySigV4Service', 'es');

--- a/wiseService/wiseService.js
+++ b/wiseService/wiseService.js
@@ -634,13 +634,13 @@ class WISESourceAPI {
  * what anything showing the config goes by - covers the static wiseService
  * and cache defs as well as every source's. */
 function registerConfigDefSecrets () {
-  const names = [];
+  const settings = {};
   for (const configDef of Object.values(internals.configDefs)) {
     for (const field of configDef?.fields ?? []) {
-      if (field.password && field.name) { names.push(field.name); }
+      if (field.password && field.name) { settings[field.name] = { secret: true }; }
     }
   }
-  ArkimeConfig.registerSecrets(names);
+  ArkimeConfig.registerSettings(settings);
 }
 
 // ----------------------------------------------------------------------------
@@ -1816,16 +1816,6 @@ function main () {
 }
 
 async function buildConfigAndStart () {
-  ArkimeConfig.registerSecrets([
-    'elasticsearchAPIKey', 'elasticsearchBasicAuth',
-    'usersElasticsearchAPIKey', 'usersElasticsearchBasicAuth'
-  ]);
-
-  ArkimeConfig.registerValidated({
-    elasticsearch: { type: 'urls' },
-    usersElasticsearch: { type: 'urls' }
-  });
-
   // Load config
   await ArkimeConfig.initialize({
     defaultConfigFile: `${version.config_prefix}/etc/wiseService.ini`,


### PR DESCRIPTION
- One registry keyed by setting name, a spec can say both secret and a type
- Add max to int/float, plus bool, enum and re types
- Register the shared elasticsearch connection settings once in arkimeConfig instead of in each of the four apps
- Register the cont3xt elasticsearch/databricks/arkime integration credentials and authClientSecret instead of leaving them to the name heuristic
- Validate viewer's hunt/tshark/agg limits, timeouts and ports, and rotateIndex against the set capture accepts
- Validate freeSpaceG, which both readers parseFloat, so '5G' quietly meant 5 gigabytes and 'five' became NaN and stopped expiry from ever running
- Drop the dead esProxySigV4 string comparisons, getFull already coerces true/false

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
