### PR TITLE
Make every page's nav bands the same height with centered content

### DIFF
--- a/common/common.css
+++ b/common/common.css
@@ -331,7 +331,13 @@ pre {
   left: 0;
   right: 0;
   z-index: 100;
-  padding: var(--px-lg) var(--px-md) var(--px-sm) 13px;
+  /* same 48px band as the viewer's search bar / first .page-subnav, with the
+     title vertically centered -- symmetric padding, height from min-height,
+     not from the content plus lopsided padding */
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+  padding: 0 var(--px-md) 0 13px;
   background-color: rgb(var(--v-theme-secondary-lightest));
   /* drop-shadow only below -- a full all-sides shadow leaks up under
      the primary navbar. */

--- a/common/vueapp/Pagination.vue
+++ b/common/vueapp/Pagination.vue
@@ -76,8 +76,17 @@ SPDX-License-Identifier: Apache-2.0
 .paging-wrapper {
   padding: 0 4px;
 }
+/* fill the group vertically and centre at every level: the list items are
+   `display: list-item`, so left alone their buttons sit on a text baseline
+   and ride a few px low in the sub-navbar band */
+.paging-wrapper :deep(.v-pagination),
 .paging-wrapper :deep(.v-pagination__list) {
+  display: flex;
   height: 100%;
+  align-items: center;
+}
+.paging-wrapper :deep(.v-pagination__list > li) {
+  display: flex;
   align-items: center;
 }
 /* Restyle the v-select to match .arkime-input-group -- override

--- a/common/vueapp/Pagination.vue
+++ b/common/vueapp/Pagination.vue
@@ -36,7 +36,10 @@ SPDX-License-Identifier: Apache-2.0
         @update:model-value="currentPageUpdated" />
     </div>
 
+    <!-- only once the caller has counts: rendering early flashes
+         "showing all 0" before the first response lands -->
     <div
+      v-if="recordsFiltered !== undefined"
       id="pagingInfo"
       class="arkime-input-group paging-info-wrapper cursor-help">
       <span class="arkime-input-label">
@@ -147,13 +150,15 @@ const props = defineProps({
     type: Number,
     default: 50
   },
+  // left undefined until the caller has counts, so the info label can stay
+  // blank instead of flashing "showing all 0" before the first response
   recordsTotal: {
     type: Number,
-    default: 0
+    default: undefined
   },
   recordsFiltered: {
     type: Number,
-    default: 0
+    default: undefined
   }
 });
 
@@ -172,6 +177,7 @@ const pagingInfoTitle = computed(() => {
 });
 
 const totalPages = computed(() => {
+  if (!props.recordsFiltered) { return 1; }
   return Math.max(1, Math.ceil(props.recordsFiltered / pageLength.value));
 });
 

--- a/common/vueapp/ViewConfigPage.vue
+++ b/common/vueapp/ViewConfigPage.vue
@@ -477,7 +477,7 @@ const blindCount = computed(() => counts.value.blind);
   left: 0;
   right: 0;
   z-index: 100;
-  height: 50px;
+  height: 48px;
   padding: 0 var(--px-md) 0 13px;
   background-color: rgb(var(--v-theme-quaternary-lightest));
   box-shadow: 0 8px 16px -8px black;

--- a/common/vueapp/ViewConfigPage.vue
+++ b/common/vueapp/ViewConfigPage.vue
@@ -131,7 +131,7 @@ SPDX-License-Identifier: Apache-2.0
 
     <div
       class="arkime-container-fluid"
-      :style="{ marginTop: `${titlebarHeight + (needTotp ? 0 : 50)}px` }">
+      :style="{ marginTop: `${titlebarHeight + (needTotp ? 0 : 48)}px` }">
       <!-- error -->
       <div
         v-if="error"

--- a/viewer/vueapp/src/App.vue
+++ b/viewer/vueapp/src/App.vue
@@ -360,6 +360,12 @@ body {
   min-height: 48px;
   padding-block: 8px;
 }
+/* …or when the row's own controls are already 44px tall (e.g. size="large"
+   buttons on Arkime/Spiview) -- they already fill the band exactly, so the
+   breathing room meant for 32px controls would only push the band taller. */
+.page-shell .page-subnav.page-subnav--tall {
+  padding-block: 0;
+}
 
 /* page tab strip: a chrome row of pill tabs below the search toolbar, in its
    own tinted band. Lives outside the collapsible so the tabs stay visible when
@@ -422,6 +428,11 @@ body {
 .page-tab-strip .v-btn .v-icon {
   font-size: 15px;
   margin-inline-end: 6px;
+}
+/* the icon+label content sits a hair high relative to its own baseline inside
+   the pill -- independent of how the pill itself is centered in the band */
+.page-tab-strip .v-btn .v-btn__content {
+  transform: translateY(-1px);
 }
 /* +/- collapse indicator for section headers: mark the header `.collapsed`
    when shut and give it a `.when-opened` (mdi-minus) / `.when-closed`

--- a/viewer/vueapp/src/App.vue
+++ b/viewer/vueapp/src/App.vue
@@ -328,31 +328,64 @@ body {
 }
 
 /* page sub-navbar band: the page-specific control row below the search
-   toolbar — a comfortable fixed-height band with vertically-centered
-   content, matching the Sessions paging bar. */
+   toolbar. Every page's band is the same 44px height with its content
+   vertically centered, so the chrome doesn't jump between tabs. The band
+   owns its own flex/height/padding — pages must not add vertical padding
+   or margins to it (they'd push the content off center). It grows past
+   44px only when the controls genuinely wrap to a second row. */
 .page-shell .page-subnav {
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
   min-height: 44px;
+  /* exactly fills the band around a 32px control, so a single row lands at
+     44px and a wrapped one keeps the same breathing room top and bottom */
+  padding-block: 6px;
+}
+/* v-row bands carry Vuetify's negative gutter margin, which paints them 4px
+   above the chrome (clipped under the navbar) and 4px past its bottom, and
+   the cols' block padding inflates the row. Strip both so a v-row band lands
+   on exactly the same box as a plain-div one. */
+.page-shell .page-subnav.v-row {
+  margin-block: 0;
+}
+.page-shell .page-subnav.v-row > .v-col {
+  padding-block: 0;
+}
+/* …except when the band is the page's FIRST chrome row — sitting directly
+   under the navbar with no search toolbar above it. Those match the taller
+   48px band <arkime-search> and .sub-navbar use, so the row under the navbar
+   is the same height on every tab. */
+.page-shell .page-subnav.page-subnav--primary {
+  min-height: 48px;
+  padding-block: 8px;
 }
 
 /* page tab strip: a chrome row of pill tabs below the search toolbar, in its
    own tinted band. Lives outside the collapsible so the tabs stay visible when
    the toolbar is collapsed. Same quaternary-lightest tint as the sub-navbars. */
 .page-tab-bar {
-  padding: 6px 12px;
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 12px;
   background-color: rgb(var(--v-theme-quaternary-lightest));
-  border-bottom: 1px solid rgb(var(--v-theme-neutral-light));
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  /* the tab bar is the last chrome row on the pages that have one, and its
+     opaque background hides .page-toolbar's drop shadow -- carry the shadow
+     here too so the chrome casts onto the content like it does elsewhere.
+     Downward-only (like .sub-navbar) so it doesn't dark-line the band above,
+     and it replaces the hairline border this band used to draw. */
+  box-shadow: 0 8px 16px -8px black;
 }
 /* v-btn-toggle at density="compact" has a baked-in height (~24px) that clips
-   taller children -- pin it to the pill height and let it grow so the active
-   pill isn't cropped. */
+   taller children -- let it size to the pills and centre them, so the strip
+   sits in the middle of the band like every other row of controls. */
 .page-tab-strip {
   background-color: transparent !important;
   border: 0 !important;
   gap: 2px;
   height: auto !important;
-  min-height: 34px !important;
+  align-items: center !important;
   overflow: visible !important;
 }
 /* Strip the button-group chrome (no shared border) so the tabs read as a nav
@@ -370,7 +403,6 @@ body {
   border: 0 !important;
   color: rgb(var(--v-theme-foreground)) !important;
   opacity: 0.78;
-  transform: translateY(3px);
 }
 .page-tab-strip .v-btn:hover {
   background-color: rgb(var(--v-theme-background)) !important;
@@ -386,9 +418,6 @@ body {
 .page-tab-strip .v-btn--active:hover {
   background-color: rgb(var(--v-theme-primary)) !important;
   filter: brightness(1.08);
-}
-.page-tab-strip .v-btn .v-btn__content {
-  transform: translateY(-1px);
 }
 .page-tab-strip .v-btn .v-icon {
   font-size: 15px;

--- a/viewer/vueapp/src/components/arkime/Arkime.vue
+++ b/viewer/vueapp/src/components/arkime/Arkime.vue
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0
             @change-search="loadSummary" />
 
           <!-- toolbar row -->
-          <div class="d-flex justify-start align-center ms-2 gap-2 page-subnav">
+          <div class="d-flex justify-start align-center ms-2 gap-2 page-subnav page-subnav--tall">
             <!-- chart color palette -->
             <v-menu>
               <template #activator="{ props }">

--- a/viewer/vueapp/src/components/connections/ConnectionsGraph.vue
+++ b/viewer/vueapp/src/components/connections/ConnectionsGraph.vue
@@ -1645,6 +1645,13 @@ export default {
   top: 8px;
   right: 10px;
 }
+
+/* icon-only triggers: size="large" reserves ~78px of text-button min-width,
+   which made these two read as oversized next to the 32px controls */
+.field-vis-trigger.v-btn {
+  min-width: 0;
+  padding-inline: 8px;
+}
 </style>
 
 <style>

--- a/viewer/vueapp/src/components/featherprint/Featherprint.vue
+++ b/viewer/vueapp/src/components/featherprint/Featherprint.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
     <template #chrome>
       <ArkimeCollapsible>
         <div class="page-toolbar">
-          <v-row class="g-1 featherprint-form px-1 pt-2 pb-1 align-center justify-start page-subnav">
+          <v-row class="g-1 featherprint-form px-1 align-center justify-start page-subnav page-subnav--primary">
             <!-- tracked: name/ip/mac filter -->
             <v-col v-if="section === 'tracked'">
               <div class="arkime-input-group arkime-input-group--fluid">
@@ -974,10 +974,6 @@ export default {
 .featherprint-form {
   z-index: 6;
   background-color: rgb(var(--v-theme-secondary-lightest));
-  /* reserve a constant height so the tab strip below doesn't shift as the
-     toolbar swaps controls between tabs (alerts adds a select, lookup a
-     full input + select + button) */
-  min-height: 52px;
 }
 
 /* expanded detail row: tinted like the session detail row so it reads as

--- a/viewer/vueapp/src/components/featherprint/FeatherprintAdmin.vue
+++ b/viewer/vueapp/src/components/featherprint/FeatherprintAdmin.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
             dense
             align="center"
             justify="start"
-            class="px-1 pt-2 pb-1 page-subnav">
+            class="px-1 page-subnav page-subnav--primary">
             <v-col cols="auto">
               <h4 class="mb-0">
                 {{ $t('navigation.featherprintadmin') }}

--- a/viewer/vueapp/src/components/files/Files.vue
+++ b/viewer/vueapp/src/components/files/Files.vue
@@ -11,13 +11,13 @@ SPDX-License-Identifier: Apache-2.0
             dense
             align="center"
             justify="start"
-            class="page-subnav">
+            class="page-subnav page-subnav--primary">
+            <!-- d-flex so the inline-flex pager doesn't sit on a text baseline
+                 and stretch the band past the other tabs' 44px -->
             <v-col
               cols="auto"
-              align-self="start"
-              class="mt-2">
+              class="d-flex align-center">
               <arkime-paging
-                v-if="files"
                 :records-total="recordsTotal"
                 :records-filtered="recordsFiltered"
                 @change-paging="changePaging"

--- a/viewer/vueapp/src/components/files/Files.vue
+++ b/viewer/vueapp/src/components/files/Files.vue
@@ -18,6 +18,7 @@ SPDX-License-Identifier: Apache-2.0
               cols="auto"
               class="d-flex align-center">
               <arkime-paging
+                v-if="files"
                 :records-total="recordsTotal"
                 :records-filtered="recordsFiltered"
                 @change-paging="changePaging"

--- a/viewer/vueapp/src/components/files/Files.vue
+++ b/viewer/vueapp/src/components/files/Files.vue
@@ -18,7 +18,6 @@ SPDX-License-Identifier: Apache-2.0
               cols="auto"
               class="d-flex align-center">
               <arkime-paging
-                v-if="files"
                 :records-total="recordsTotal"
                 :records-filtered="recordsFiltered"
                 @change-paging="changePaging"

--- a/viewer/vueapp/src/components/history/History.vue
+++ b/viewer/vueapp/src/components/history/History.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
       <ArkimeCollapsible>
         <div class="page-toolbar">
           <!-- search navbar -->
-          <div class="history-search px-1 pt-2 pb-1 d-flex flex-column gap-2">
+          <div class="history-search px-1 d-flex flex-column justify-center gap-2">
             <!-- search row: cluster + search expression + search button -->
             <div class="d-flex align-center search-row">
               <Clusters />
@@ -103,7 +103,7 @@ SPDX-License-Identifier: Apache-2.0
               :records-filtered="recordsFiltered"
               @change-paging="changePaging" />
             <arkime-toast
-              class="ms-2 mb-3 mt-1 d-inline"
+              class="ms-2 d-inline"
               :message="msg"
               :type="msgType"
               :done="messageDone" />
@@ -682,6 +682,8 @@ export default {
 <style scoped>
 /* navbar styles ------------------- */
 .history-page .history-search {
+  /* same 48px band as <arkime-search> on the other pages */
+  min-height: 48px;
   z-index: 5;
   border: none;
   background-color: rgb(var(--v-theme-secondary-lightest));
@@ -701,11 +703,9 @@ export default {
   height: 32px;
 }
 
-/* navbar with pagination */
+/* navbar with pagination -- sizing/centering comes from .page-subnav */
 .history-page .history-paging {
   z-index: 4;
-  display: flex;
-  align-items: center;
 }
 
 .history-page .history-table {

--- a/viewer/vueapp/src/components/history/History.vue
+++ b/viewer/vueapp/src/components/history/History.vue
@@ -439,9 +439,9 @@ export default {
     return {
       error: '',
       loading: false,
-      history: {},
-      recordsTotal: 0,
-      recordsFiltered: 0,
+      history: undefined, // undefined until loaded; [] once loaded and empty
+      recordsTotal: undefined,
+      recordsFiltered: undefined,
       expandedLogs: { change: false },
       colSpan: 8,
       filters: {},
@@ -628,7 +628,7 @@ export default {
     /* helper functions ------------------------------------------ */
     loadData: function () {
       if (!Utils.checkClusterSelection(this.query.cluster, this.$store.state.esCluster.availableCluster.active, this).valid) {
-        this.history = {};
+        this.history = [];
         return;
       }
 

--- a/viewer/vueapp/src/components/search/ExpressionTypeahead.vue
+++ b/viewer/vueapp/src/components/search/ExpressionTypeahead.vue
@@ -3,9 +3,7 @@ Copyright Yahoo Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 <template>
-  <div
-    class="mb-1"
-    :class="{ 'big-typeahead': bigTypeahead }">
+  <div :class="{ 'big-typeahead': bigTypeahead }">
     <!-- typeahead input -->
     <div class="arkime-input-group arkime-input-group--fluid">
       <span

--- a/viewer/vueapp/src/components/search/Search.vue
+++ b/viewer/vueapp/src/components/search/Search.vue
@@ -135,7 +135,7 @@ SPDX-License-Identifier: Apache-2.0
       <!-- search row: expression input + submit + actions all on one
            flex line. Expression input grows to fill the remaining
            space (via .arkime-input-group--fluid in ExpressionTypeahead). -->
-      <div class="d-flex align-start gap-1 mb-1 search-row">
+      <div class="d-flex align-center gap-1 mb-1 search-row">
         <!-- search box typeahead -->
         <expression-typeahead
           class="flex-grow-1"
@@ -1014,11 +1014,22 @@ form {
 }
 
 /* viz options gear: docked under the right end of the search form (its
-   position-relative parent) so it follows the toolbar chrome in flow */
+   position-relative parent) so it follows the toolbar chrome in flow.
+   It overhangs into the page's 44px sub-navbar band, so span that band
+   exactly and centre in it rather than nudging with a percentage. */
 .viz-options-btn-container {
   position: absolute;
-  top: 108%; /* a nudge past the form bottom centers it in the paging bar */
+  top: 100%;
   right: 4px;
   z-index: 5;
+  display: flex;
+  align-items: center;
+  height: 44px;
+}
+/* Vuetify pins compact button groups to a fixed 36px -- taller than the
+   32px buttons inside, which would leave the visible button sitting high
+   in the band. Let the group size to its buttons. */
+.viz-options-btn-container :deep(.viz-options-btn.v-btn-group) {
+  height: auto;
 }
 </style>

--- a/viewer/vueapp/src/components/sessions/Sessions.vue
+++ b/viewer/vueapp/src/components/sessions/Sessions.vue
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
             @set-columns="loadColumns" /> <!-- /search navbar -->
 
           <!-- paging navbar -->
-          <div class="d-flex justify-start align-center paging-navbar">
+          <div class="d-flex justify-start align-center px-1 page-subnav">
             <arkime-paging
               :records-total="sessions.recordsTotal"
               :records-filtered="sessions.recordsFiltered"
@@ -2408,12 +2408,6 @@ table.sessions-table thead tr th.sessions-options-cell {
 </style>
 
 <style scoped>
-/* paging sub-navbar: fixed band height, controls centered within it */
-.paging-navbar {
-  height: 44px;
-  padding: 0 4px;
-}
-
 .sessions-content {
   min-height: 500px;
 }

--- a/viewer/vueapp/src/components/spigraph/Spigraph.vue
+++ b/viewer/vueapp/src/components/spigraph/Spigraph.vue
@@ -80,7 +80,7 @@ SPDX-License-Identifier: Apache-2.0
               <div
                 v-if="spiGraphType === 'connections'"
                 id="connections-controls-anchor"
-                class="connections-controls-anchor d-flex flex-wrap align-center gap-1 mt-1 mb-1" />
+                class="connections-controls-anchor d-flex flex-wrap align-center gap-1" />
 
               <!-- intensity select (heatmap only) -->
               <div
@@ -175,7 +175,7 @@ SPDX-License-Identifier: Apache-2.0
               <div
                 v-if="['pie', 'table', 'treemap', 'sankey'].includes(spiGraphType)"
                 id="spigraph-subfield-anchor"
-                class="spigraph-subfield-anchor d-flex flex-wrap align-center gap-1 mt-1" />
+                class="spigraph-subfield-anchor d-flex flex-wrap align-center gap-1" />
             </div>
           </div>
         </div>
@@ -736,14 +736,9 @@ export default {
   text-transform: none;
   letter-spacing: normal;
 }
-/* symmetric band padding: even spacing for single-row vs multi-row subnavs */
-.spigraph-page .page-subnav {
-  padding-block: 6px;
-}
 /* "add another field" on its own row: full-width forces a flex-wrap break */
 .spigraph-page .spigraph-subfield-anchor {
   flex: 1 0 100%;
-  padding-bottom: 6px;
 }
 
 /* field typeahead */

--- a/viewer/vueapp/src/components/spiview/Spiview.vue
+++ b/viewer/vueapp/src/components/spiview/Spiview.vue
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0
             :num-matching-sessions="filtered" /> <!-- /search navbar -->
 
           <!-- info navbar -->
-          <div class="d-flex align-center info-nav mx-1 gap-2 page-subnav">
+          <div class="d-flex align-center info-nav mx-1 gap-2 page-subnav page-subnav--tall">
             <div v-if="!dataLoading">
               <!-- field config save button -->
               <v-menu

--- a/viewer/vueapp/src/components/stats/EsAdmin.vue
+++ b/viewer/vueapp/src/components/stats/EsAdmin.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
             dense
             align="center"
             justify="start"
-            class="px-1 pt-2 pb-1 page-subnav">
+            class="px-1 page-subnav page-subnav--primary">
             <v-col cols="auto">
               <h4 class="mb-0">
                 {{ $t('navigation.esadmin') }}

--- a/viewer/vueapp/src/components/stats/Stats.vue
+++ b/viewer/vueapp/src/components/stats/Stats.vue
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
       <ArkimeCollapsible>
         <div class="page-toolbar">
           <!-- stats sub navbar -->
-          <v-row class="g-1 stats-form px-1 pt-2 pb-1 align-center justify-start page-subnav">
+          <v-row class="g-1 stats-form px-1 align-center justify-start page-subnav page-subnav--primary">
             <v-col
               cols="auto"
               class="flex-grow-1">
@@ -960,9 +960,6 @@ export default {
 .stats-form {
   z-index : 6;
   background-color: rgb(var(--v-theme-secondary-lightest));
-  /* reserve a constant height so the tab strip below doesn't shift as sub-tabs
-     show different controls (Capture Graphs has fewer/shorter ones) */
-  min-height: 52px;
 }
 
 /* Vuetify pins compact button groups to a fixed height

--- a/viewer/vueapp/src/components/upload/Upload.vue
+++ b/viewer/vueapp/src/components/upload/Upload.vue
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
         <v-icon icon="mdi-tray-arrow-up" />&nbsp;
         {{ $t('uploads.uploadFile') }}
       </span>
-      <div class="float-right small toast-container">
+      <div class="ms-auto small toast-container">
         <arkime-toast
           class="me-1"
           :message="msg"


### PR DESCRIPTION
- .page-subnav owns its flex/height/padding: 44px, content centered
- .page-subnav--primary is a page's first chrome row: 48px, matching <arkime-search>
- strip Vuetify's negative block margin and col padding from v-row bands, which painted them 4px above the chrome and 4px past its bottom
- center the search row and drop the expression input's stray bottom margin
- dock the viz options button to the sub-navbar instead of nudging it with top:108%
- center v-pagination's buttons, which sat on a text baseline
- center the page tab strip and drop its translateY nudges; give it the chrome drop shadow it was hiding from .page-toolbar
- .sub-navbar (settings/upload/viewconfig) matches the 48px band, centered
- render the files pager unconditionally so it stops popping in after the fetch

## License
I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
