### PR TITLE
Set destructiveHint: true on arkime_remove_tags

### DIFF
--- a/viewer/apiMcp.js
+++ b/viewer/apiMcp.js
@@ -407,7 +407,7 @@ class MCPViewerAPIs {
         name: 'arkime_remove_tags',
         title: 'Untag sessions',
         description: 'Remove one or more tags from sessions. Tags only: this does NOT modify packet data, does NOT delete or scrub sessions, and does NOT change any other session field.',
-        annotations: { readOnlyHint: false, destructiveHint: false },
+        annotations: { readOnlyHint: false, destructiveHint: true },
         inputSchema: sessionQuerySchema({
           tags: { type: 'string', description: 'Comma separated tags to remove.' },
           ids: { type: 'string', description: 'Optional comma separated session ids. When omitted, every session matching the expression is untagged.' }


### PR DESCRIPTION
Untagging is unbounded and irreversible when ids is omitted, matching the readOnlyHint: false already set. Left add_tags/create_view/create_hunt as-is — none of them destroy existing data, and marking every write destructive would blur the signal for the one that does.